### PR TITLE
feat: add connect lifecycle helpers

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,6 +2,7 @@
   "expo": {
     "name": "siastarterreactnative",
     "slug": "siastarterreactnative",
+    "scheme": "siastorage",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",

--- a/src/hooks/useLinkedURL.ts
+++ b/src/hooks/useLinkedURL.ts
@@ -1,0 +1,13 @@
+import { useEffect } from 'react'
+import { Linking } from 'react-native'
+
+// This hook listens for linked or referred URLs that interact with the app.
+// Need to do a bit more testing on everywhere this applies (think it may run on dev URLs right now).
+// But we accept a callback function to run on each received URL.
+export default function useLinkedURL(onUrl: (url: string) => void) {
+  useEffect(() => {
+    const sub = Linking.addEventListener('url', ({ url }) => onUrl(url))
+    Linking.getInitialURL().then((u) => u && onUrl(u))
+    return () => sub.remove()
+  }, [onUrl])
+}

--- a/src/settings.tsx
+++ b/src/settings.tsx
@@ -7,8 +7,10 @@ import {
   ScrollView,
   Pressable,
   Platform,
+  Linking,
 } from 'react-native'
 import { getHostSettings, setLogger, clearLogger } from 'react-native-sia'
+import useLinkedURL from './hooks/useLinkedURL'
 
 export default function HostSettings() {
   const [hostSettings, setHostSettings] = useState<string | null>(null)
@@ -17,6 +19,8 @@ export default function HostSettings() {
   )
   const [port, setPort] = useState('9984')
   const [logs, setLogs] = useState<string[]>([])
+
+  useLinkedURL((url) => console.log('from useLinkedURL', url))
 
   useEffect(() => {
     const logger = {
@@ -112,6 +116,15 @@ export default function HostSettings() {
           ))}
         </ScrollView>
       </View>
+      {/* Demonstrates how to navigate to a URL */}
+      <Pressable
+        style={styles.button}
+        onPress={() => {
+          Linking.openURL('https://www.google.com') // To go wherever.
+        }}
+      >
+        <Text style={styles.buttonText}>ACCOUNT CONNECT</Text>
+      </Pressable>
     </View>
   )
 }


### PR DESCRIPTION
This is quite barebones but provides the fundamental methods/hook/config needed for the connect app auth cycle. We may need other things or these things may change as our needs become more clear.

Be sure the /ios folder is deleted and a clean `bun run build` and `bun run ios` is completed before expected the native "siastorage" link to open the app.