### PR TITLE
chore: update app name, readme, upgrade react-native-sia to 0.6.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# sia-mobile-demo
+# Sia Mobile
 
-This repo contains the Sia Mobile Demo app. The project demonstrates how to use the `react-native-sia` library to interact directly with the Sia host network.
-
-## Install
+Mobile cloud storage app that stores files on the Sia host network.
 
 ```
 bun install
@@ -30,7 +28,7 @@ bun run android
 
 > 🚧 The web target is not yet supported in `react-native-sia`. The library needs a WASM-based entrypoint for browser environments.
 
-React Native can also compile for the web.
+In the future, we may also support the web.
 
 ```
 bun run web
@@ -39,5 +37,5 @@ bun run web
 ## Running the dev client
 
 ```
-bun start
+bun run start
 ```

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "expo": {
-    "name": "Sia Mobile Demo",
+    "name": "Sia Mobile",
     "slug": "siamobile",
     "scheme": "siamobile",
     "version": "1.0.0",
@@ -15,7 +15,7 @@
     },
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "storage.sia.mobiledemo",
+      "bundleIdentifier": "storage.sia.siamobile",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSPhotoLibraryUsageDescription": "Allow $(PRODUCT_NAME) to access your photo library to select and upload photos.",

--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
         "react-native-nitro-modules": "0.26.4",
         "react-native-safe-area-context": "^5.6.1",
         "react-native-screens": "^4.16.0",
-        "react-native-sia": "0.6.9",
+        "react-native-sia": "0.6.10",
         "react-native-svg": "^15.2.0",
         "readable-stream": "^4.7.0",
         "swr": "^2.3.6",
@@ -1032,7 +1032,7 @@
 
     "react-native-screens": ["react-native-screens@4.16.0", "", { "dependencies": { "react-freeze": "^1.0.0", "react-native-is-edge-to-edge": "^1.2.1", "warn-once": "^0.1.0" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q=="],
 
-    "react-native-sia": ["react-native-sia@0.6.9", "", { "dependencies": { "uniffi-bindgen-react-native": "^0.29.3-1" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-TJ2XNLaDZ0FN6HwD3uqR0znHMzDAdVFvvRIMg4g0rjdRDKheKs6H0XtexVfYh8J1HBq22oH5ftkoJ2UGN0tuGQ=="],
+    "react-native-sia": ["react-native-sia@0.6.10", "", { "dependencies": { "uniffi-bindgen-react-native": "^0.29.3-1" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-LPFjw1CEBv4oRZL+mwdFdozLifgDbWdPuyBoc/Aq7QVVB0AGDzrwvdDEvxMuJElNQUGgglvvrG44x1TVXusqgQ=="],
 
     "react-native-svg": ["react-native-svg@15.13.0", "", { "dependencies": { "css-select": "^5.1.0", "css-tree": "^1.1.3", "warn-once": "0.1.1" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-/YPK+PAAXg4T0x2d2vYPvqqAhOYid2bRKxUVT7STIyd1p2JxWmsGQkfZxXCkEFN7TwLfIyVlT5RimT91Pj/qXw=="],
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "expo start --dev-client",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "fresh": "bunx rimraf .expo android ios node_modules && bun install && bun run build"
   },
   "dependencies": {
     "@azure/core-asynciterator-polyfill": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "react-native-nitro-modules": "0.26.4",
     "react-native-safe-area-context": "^5.6.1",
     "react-native-screens": "^4.16.0",
-    "react-native-sia": "0.6.9",
+    "react-native-sia": "0.6.10",
     "react-native-svg": "^15.2.0",
     "readable-stream": "^4.7.0",
     "swr": "^2.3.6",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Sia Mobile Demo",
+  "name": "Sia Mobile",
   "main": "index.ts",
   "scripts": {
     "build": "expo prebuild",


### PR DESCRIPTION
- Sia Mobile Demo => Sia Mobile
- Bunde ID storage.sia.mobiledemo => storage.sia.siamobile
  - Do we like this name? We will probably need to adjust publishing / testflight.
- react-native-sia v0.6.10