### PR TITLE
feat: seed onboarding and settings

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -5,20 +5,34 @@ export function Button({
   disabled,
   onPress,
   children,
+  variant = 'primary',
 }: {
   style?: StyleProp<ViewStyle>
   disabled?: boolean
   onPress: () => void
   children: React.ReactNode
+  variant?: 'primary' | 'secondary'
 }) {
   return (
     <Pressable
       accessibilityRole="button"
-      style={[styles.primaryButton, style]}
+      style={[
+        styles.primaryButton,
+        variant === 'secondary' && styles.secondaryButton,
+        style,
+      ]}
       disabled={disabled}
       onPress={onPress}
     >
-      <Text style={styles.primaryButtonText}>{children}</Text>
+      <Text
+        style={
+          variant === 'secondary'
+            ? styles.secondaryButtonText
+            : styles.primaryButtonText
+        }
+      >
+        {children}
+      </Text>
     </Pressable>
   )
 }
@@ -30,5 +44,13 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     alignItems: 'center',
   },
+  secondaryButton: {
+    backgroundColor: '#fff',
+    boxShadow: '0 0 0 1px rgba(0,0,0,0.02)',
+    borderRadius: 10,
+    paddingVertical: 12,
+    alignItems: 'center',
+  },
   primaryButtonText: { color: '#ffffff', fontWeight: '700' },
+  secondaryButtonText: { color: '#0a84ff', fontWeight: '700' },
 })

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -10,12 +10,19 @@ import {
   useIndexerURL,
   setIndexerURL,
   tryToConnectAndSet,
+  useAppSeed,
+  setAppSeed,
 } from '../stores/auth'
 import { SettingsIcon } from 'lucide-react-native'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useToast } from '../lib/toastContext'
 import { InputRow } from '../components/InputRow'
 import { InfoCard } from '../components/InfoCard'
+import { encryptionKeyUint8ToHex } from '../lib/encryptionKey'
+import { createSeed } from '../lib/seed'
+import { Button } from '../components/Button'
+import { hexToUint8 } from '../lib/hex'
+import Clipboard from '@react-native-clipboard/clipboard'
 
 function validateURL(url: string) {
   try {
@@ -31,7 +38,14 @@ export default function OnboardingScreen() {
   const [isWaiting, setIsWaiting] = useState(false)
   const [hasErrored, setHasErrored] = useState(false)
   const indexerURL = useIndexerURL()
+  const appSeed = useAppSeed()
   const toast = useToast()
+  const [inputSeed, setInputSeed] = useState(encryptionKeyUint8ToHex(appSeed))
+
+  // Sync input seed with app seed when app seed changes
+  useEffect(() => {
+    setInputSeed(encryptionKeyUint8ToHex(appSeed))
+  }, [appSeed])
 
   return (
     <View>
@@ -65,16 +79,53 @@ export default function OnboardingScreen() {
                 : null}
             </Text>
             {isUsingCustomURL ? (
-              <InfoCard>
-                <InputRow
-                  label="Indexer URL"
-                  value={indexerURL}
-                  onChangeText={setIndexerURL}
-                />
-              </InfoCard>
+              <>
+                <InfoCard>
+                  <InputRow
+                    label="Indexer URL"
+                    value={indexerURL}
+                    onChangeText={setIndexerURL}
+                  />
+                  <InputRow
+                    showDividerTop
+                    label="Seed"
+                    value={inputSeed}
+                    onChangeText={(text) => {
+                      try {
+                        const seed = hexToUint8(text)
+                        setAppSeed(seed)
+                      } catch {
+                        toast.show('Invalid seed')
+                      }
+                    }}
+                    isMonospace
+                  />
+                </InfoCard>
+                <View style={styles.actions}>
+                  <Button
+                    variant="secondary"
+                    onPress={async () => {
+                      await setAppSeed(createSeed())
+                      toast.show('Seed regenerated')
+                    }}
+                    style={styles.button}
+                  >
+                    Regenerate seed
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    onPress={() => {
+                      Clipboard.setString(inputSeed)
+                      toast.show('Copied seed')
+                    }}
+                    style={styles.button}
+                  >
+                    Copy seed
+                  </Button>
+                </View>
+              </>
             ) : null}
-            <Pressable
-              style={styles.button}
+            <Button
               onPress={async () => {
                 setIsWaiting(true)
                 const isValid = validateURL(indexerURL)
@@ -91,8 +142,8 @@ export default function OnboardingScreen() {
                 setIsWaiting(false)
               }}
             >
-              <Text style={styles.buttonText}>Authorize & Connect</Text>
-            </Pressable>
+              Authorize & Connect
+            </Button>
           </View>
         </View>
       )}
@@ -122,17 +173,11 @@ const styles = StyleSheet.create({
     color: '#57606a',
     fontSize: 12,
   },
-  button: {
-    width: '100%',
-    backgroundColor: '#0969da',
-    borderRadius: 8,
-    paddingVertical: 12,
-  },
-  buttonText: { color: '#ffffff', fontWeight: '700', textAlign: 'center' },
   image: {
     width: 15,
     height: 15,
   },
+  actions: { flexDirection: 'row', gap: 8, width: '100%' },
   header: {
     height: 44,
     paddingHorizontal: 16,
@@ -157,4 +202,5 @@ const styles = StyleSheet.create({
     paddingTop: 250,
     gap: 16,
   },
+  button: { flex: 1 },
 })

--- a/src/screens/SettingsHomeScreen.tsx
+++ b/src/screens/SettingsHomeScreen.tsx
@@ -36,6 +36,12 @@ export function SettingsHomeScreen({ navigation }: Props) {
             <Text style={styles.rowChevron}>›</Text>
           </View>
         </Pressable>
+        <Pressable onPress={() => navigation.navigate('Seed')}>
+          <View style={styles.rowItem}>
+            <Text style={styles.rowLabel}>Seed</Text>
+            <Text style={styles.rowChevron}>›</Text>
+          </View>
+        </Pressable>
       </View>
       <View style={styles.footerGroup}>
         <Pressable

--- a/src/screens/SettingsSeedScreen.tsx
+++ b/src/screens/SettingsSeedScreen.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react'
+import { View, StyleSheet } from 'react-native'
+import { RowGroup } from '../components/Group'
+import { InfoCard } from '../components/InfoCard'
+import { InputRow } from '../components/InputRow'
+import { Button } from '../components/Button'
+import { useAppSeed } from '../stores/auth'
+import { encryptionKeyUint8ToHex } from '../lib/encryptionKey'
+import Clipboard from '@react-native-clipboard/clipboard'
+import { useToast } from '../lib/toastContext'
+
+export function SettingsSeedScreen() {
+  const appSeed = useAppSeed()
+  const [isHidden, setIsHidden] = useState(true)
+  const toast = useToast()
+
+  const seedHex = encryptionKeyUint8ToHex(appSeed)
+
+  return (
+    <View style={styles.container}>
+      <InfoCard>
+        <InputRow
+          label="Seed"
+          value={isHidden ? '••••••••••••••••' : seedHex}
+          editable={false}
+          isMonospace
+        />
+      </InfoCard>
+      <View style={styles.actions}>
+        <Button
+          variant="secondary"
+          onPress={() => setIsHidden((current) => !current)}
+          style={styles.button}
+        >
+          {isHidden ? 'Show' : 'Hide'} seed
+        </Button>
+        <Button
+          variant="secondary"
+          onPress={() => {
+            Clipboard.setString(seedHex)
+            toast.show('Copied seed')
+          }}
+          style={styles.button}
+        >
+          Copy seed
+        </Button>
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#f6f8fa', padding: 16 },
+  actions: { flexDirection: 'row', gap: 8, marginTop: 12 },
+  button: { flex: 1 },
+})

--- a/src/stacks/SettingsStack.tsx
+++ b/src/stacks/SettingsStack.tsx
@@ -5,6 +5,7 @@ import { HostListScreen } from '../screens/HostListScreen'
 import { HostDetailScreen } from '../screens/HostDetailScreen'
 import { SettingsIndexerScreen } from '../screens/SettingsIndexerScreen'
 import { SettingsTransfersScreen } from '../screens/SettingsTransfersScreen'
+import { SettingsSeedScreen } from '../screens/SettingsSeedScreen'
 import { type SettingsStackParamList } from './types'
 
 const Stack = createNativeStackNavigator<SettingsStackParamList>()
@@ -36,6 +37,11 @@ export function SettingsStack() {
         name="Transfers"
         component={SettingsTransfersScreen}
         options={{ title: 'Transfers' }}
+      />
+      <Stack.Screen
+        name="Seed"
+        component={SettingsSeedScreen}
+        options={{ title: 'Seed' }}
       />
     </Stack.Navigator>
   )

--- a/src/stacks/types.ts
+++ b/src/stacks/types.ts
@@ -10,6 +10,7 @@ export type SettingsStackParamList = {
   HostDetail: { publicKey: string }
   Indexer: undefined
   Transfers: undefined
+  Seed: undefined
 }
 
 export type AuthStackParamList = {


### PR DESCRIPTION
### Changes
- Ability to view, regenerate, copy or set custom seed during onboarding.
- Ability to view and copy seed in Seed settings screen.
- Added secondary button variant.


https://github.com/user-attachments/assets/68c79f4b-71a4-4066-9878-75b56a7a3d1f

