### PR TITLE
feat: add native file sharing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,6 +31,7 @@
         "react-native-nitro-modules": "0.26.4",
         "react-native-safe-area-context": "^5.6.1",
         "react-native-screens": "^4.16.0",
+        "react-native-share": "^12.2.0",
         "react-native-sia": "0.6.10",
         "react-native-svg": "^15.2.0",
         "readable-stream": "^4.7.0",
@@ -1031,6 +1032,8 @@
     "react-native-safe-area-context": ["react-native-safe-area-context@5.6.1", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-/wJE58HLEAkATzhhX1xSr+fostLsK8Q97EfpfMDKo8jlOc1QKESSX/FQrhk7HhQH/2uSaox4Y86sNaI02kteiA=="],
 
     "react-native-screens": ["react-native-screens@4.16.0", "", { "dependencies": { "react-freeze": "^1.0.0", "react-native-is-edge-to-edge": "^1.2.1", "warn-once": "^0.1.0" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q=="],
+
+    "react-native-share": ["react-native-share@12.2.0", "", {}, "sha512-f6MB9BsKa9xVvu0DKbxq5jw4IyYHqQeqUlCNkD8eAFoJx6SD31ObPAn7SQ6NG9AOuhCy6aYuSJYJvx25DaoMZQ=="],
 
     "react-native-sia": ["react-native-sia@0.6.10", "", { "dependencies": { "uniffi-bindgen-react-native": "^0.29.3-1" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-LPFjw1CEBv4oRZL+mwdFdozLifgDbWdPuyBoc/Aq7QVVB0AGDzrwvdDEvxMuJElNQUGgglvvrG44x1TVXusqgQ=="],
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-native-nitro-modules": "0.26.4",
     "react-native-safe-area-context": "^5.6.1",
     "react-native-screens": "^4.16.0",
+    "react-native-share": "^12.2.0",
     "react-native-sia": "0.6.10",
     "react-native-svg": "^15.2.0",
     "readable-stream": "^4.7.0",

--- a/src/components/FileActionsSheet.tsx
+++ b/src/components/FileActionsSheet.tsx
@@ -29,7 +29,6 @@ import {
   updateFilePinnedObjects,
 } from '../stores/files'
 import Share from 'react-native-share'
-
 type Props = NativeStackScreenProps<MainStackParamList, 'FileDetail'>
 
 export function FileActionsSheet({ route, navigation }: Props) {
@@ -168,9 +167,6 @@ export function FileActionsSheet({ route, navigation }: Props) {
     navigation.setOptions({
       headerRight: () => (
         <View style={{ flexDirection: 'row', gap: 14 }}>
-          {isUploaded && (
-            <Link2Icon color="#0969da" size={20} onPress={handleShareURL} />
-          )}
           <MoreVerticalIcon
             color="#0969da"
             size={20}
@@ -190,6 +186,14 @@ export function FileActionsSheet({ route, navigation }: Props) {
   const handleDownload = useDownload(file)
   return (
     <ActionSheet visible={isMenuOpen} onRequestClose={closeMenu}>
+      <ActionSheetButton
+        disabled={!status.isDownloaded}
+        variant="primary"
+        icon={<Link2Icon size={18} />}
+        onPress={handlePressAndClose(handleShareURL)}
+      >
+        Copy link
+      </ActionSheetButton>
       <ActionSheetButton
         disabled={!status.isDownloaded}
         variant="primary"

--- a/src/components/FileActionsSheet.tsx
+++ b/src/components/FileActionsSheet.tsx
@@ -3,11 +3,12 @@ import { type MainStackParamList } from '../stacks/types'
 import { useCallback, useLayoutEffect, useState } from 'react'
 import {
   MoreVerticalIcon,
-  Share2Icon,
   Trash2Icon,
   CloudOffIcon,
   EraserIcon,
   CloudUploadIcon,
+  ShareIcon,
+  Link2Icon,
 } from 'lucide-react-native'
 import Clipboard from '@react-native-clipboard/clipboard'
 import { useToast } from '../lib/toastContext'
@@ -27,6 +28,7 @@ import {
   deleteFileRecord,
   updateFilePinnedObjects,
 } from '../stores/files'
+import Share from 'react-native-share'
 
 type Props = NativeStackScreenProps<MainStackParamList, 'FileDetail'>
 
@@ -59,14 +61,33 @@ export function FileActionsSheet({ route, navigation }: Props) {
     return `siamobile://new-file?shareUrl=${encodeURIComponent(shareUrl)}`
   }, [file, sdk])
 
-  const handleCopyShareUrl = useCallback(() => {
+  const handleShareURL = useCallback(async () => {
     if (!file) return
     if (!sdk) return
     const shareUrl = getShareUrl()
     if (!shareUrl) return
     Clipboard.setString(shareUrl)
-    toast.show('Share URL copied to clipboard')
+    toast.show('URL Copied')
   }, [file, sdk, getShareUrl, toast])
+
+  const handleShareFile = useCallback(async () => {
+    if (!file) return
+    if (!file.fileType) return
+    if (!status.cachedUri) return
+
+    try {
+      await Share.open({
+        url: status.cachedUri,
+        type: file.fileType,
+        filename: file.fileName ?? undefined,
+        subject: `Sia Mobile - ${file.fileType}`,
+      })
+    } catch (e) {
+      if (typeof e === 'string' && !e.includes('User did not share')) {
+        console.warn('File sharing failed:', e)
+      }
+    }
+  }, [file, status.cachedUri])
 
   const handleOpenDeepLink = useCallback(() => {
     if (!file) return
@@ -148,11 +169,7 @@ export function FileActionsSheet({ route, navigation }: Props) {
       headerRight: () => (
         <View style={{ flexDirection: 'row', gap: 14 }}>
           {isUploaded && (
-            <Share2Icon
-              color="#0969da"
-              size={20}
-              onPress={handleCopyShareUrl}
-            />
+            <Link2Icon color="#0969da" size={20} onPress={handleShareURL} />
           )}
           <MoreVerticalIcon
             color="#0969da"
@@ -164,7 +181,7 @@ export function FileActionsSheet({ route, navigation }: Props) {
     })
   }, [
     navigation,
-    handleCopyShareUrl,
+    handleShareURL,
     handleOpenDeepLink,
     handleOpenMenu,
     isUploaded,
@@ -173,6 +190,14 @@ export function FileActionsSheet({ route, navigation }: Props) {
   const handleDownload = useDownload(file)
   return (
     <ActionSheet visible={isMenuOpen} onRequestClose={closeMenu}>
+      <ActionSheetButton
+        disabled={!status.isDownloaded}
+        variant="primary"
+        icon={<ShareIcon size={18} />}
+        onPress={handleShareFile}
+      >
+        Share file
+      </ActionSheetButton>
       <ActionSheetButton
         disabled={
           status.isDownloading || status.isDownloaded || status.fileIsGone

--- a/src/components/FileActionsSheet.tsx
+++ b/src/components/FileActionsSheet.tsx
@@ -29,6 +29,7 @@ import {
   updateFilePinnedObjects,
 } from '../stores/files'
 import Share from 'react-native-share'
+import { logger } from '../lib/logger'
 type Props = NativeStackScreenProps<MainStackParamList, 'FileDetail'>
 
 export function FileActionsSheet({ route, navigation }: Props) {
@@ -83,7 +84,7 @@ export function FileActionsSheet({ route, navigation }: Props) {
       })
     } catch (e) {
       if (typeof e === 'string' && !e.includes('User did not share')) {
-        console.warn('File sharing failed:', e)
+        logger.log('File sharing failed:', e)
       }
     }
   }, [file, status.cachedUri])


### PR DESCRIPTION

https://github.com/user-attachments/assets/c0a4ca71-dc71-4286-8d73-5e4c0c20d98a

Two types of sharing may come to mind here:

1. Sharing a link to a file on the Sia network. I went out and tried to get a feel for this kind of feature in other apps. I found broad support for what we already do--copy the URL to the clipboard and throw a toast-like notification to the user. If, in the future, we support expiry or links that are encrypted until they have the key, we could expand out into some other custom view where settings are modified.
2. Sharing a *file* in the Sia mobile app via the native iOS share sheet - this is now supported.

I also moved the copy link into the actions menu. I think that's where a user expects it to be.