### PR TITLE
feat: hide advanced data

### DIFF
--- a/src/components/FileActionsSheet.tsx
+++ b/src/components/FileActionsSheet.tsx
@@ -187,56 +187,61 @@ export function FileActionsSheet({ route, navigation }: Props) {
   const handleDownload = useDownload(file)
   return (
     <ActionSheet visible={isMenuOpen} onRequestClose={closeMenu}>
-      <ActionSheetButton
-        disabled={!status.isDownloaded}
-        variant="primary"
-        icon={<Link2Icon size={18} />}
-        onPress={handlePressAndClose(handleShareURL)}
-      >
-        Copy link
-      </ActionSheetButton>
-      <ActionSheetButton
-        disabled={!status.isDownloaded}
-        variant="primary"
-        icon={<ShareIcon size={18} />}
-        onPress={handleShareFile}
-      >
-        Share file
-      </ActionSheetButton>
-      <ActionSheetButton
-        disabled={
-          status.isDownloading || status.isDownloaded || status.fileIsGone
-        }
-        variant="primary"
-        icon={<ArrowDownToLineIcon size={18} />}
-        onPress={handlePressAndClose(handleDownload)}
-      >
-        Download file
-      </ActionSheetButton>
-      <ActionSheetButton
-        disabled={status.isUploading || !status.isDownloaded}
-        variant="primary"
-        icon={<CloudUploadIcon size={18} />}
-        onPress={handlePressAndClose(handleReupload)}
-      >
-        Reupload file
-      </ActionSheetButton>
-      <ActionSheetButton
-        disabled={!status.cachedUri}
-        variant="primary"
-        icon={<EraserIcon size={18} />}
-        onPress={handlePressAndClose(handleRemoveCache)}
-      >
-        Remove from cache
-      </ActionSheetButton>
-      <ActionSheetButton
-        disabled={!status.isUploaded}
-        variant="primary"
-        icon={<CloudOffIcon size={18} />}
-        onPress={handlePressAndClose(handleRemoveFromNetwork)}
-      >
-        Remove from network
-      </ActionSheetButton>
+      {status.isUploaded && (
+        <>
+          <ActionSheetButton
+            disabled={!status.isDownloaded}
+            variant="primary"
+            icon={<Link2Icon size={18} />}
+            onPress={handlePressAndClose(handleShareURL)}
+          >
+            Copy link
+          </ActionSheetButton>
+          <ActionSheetButton
+            variant="primary"
+            icon={<ShareIcon size={18} />}
+            onPress={handleShareFile}
+          >
+            Share file
+          </ActionSheetButton>
+        </>
+      )}
+      {!status.isDownloaded && !status.isDownloading && !status.fileIsGone && (
+        <ActionSheetButton
+          variant="primary"
+          icon={<ArrowDownToLineIcon size={18} />}
+          onPress={handlePressAndClose(handleDownload)}
+        >
+          Download file
+        </ActionSheetButton>
+      )}
+      {!status.isUploaded && !status.isUploading && !status.fileIsGone && (
+        <ActionSheetButton
+          variant="primary"
+          icon={<CloudUploadIcon size={18} />}
+          onPress={handlePressAndClose(handleReupload)}
+        >
+          Upload file
+        </ActionSheetButton>
+      )}
+      {status.cachedUri && status.isUploaded && (
+        <ActionSheetButton
+          variant="primary"
+          icon={<EraserIcon size={18} />}
+          onPress={handlePressAndClose(handleRemoveCache)}
+        >
+          Remove from device
+        </ActionSheetButton>
+      )}
+      {status.isUploaded && (
+        <ActionSheetButton
+          variant="primary"
+          icon={<CloudOffIcon size={18} />}
+          onPress={handlePressAndClose(handleRemoveFromNetwork)}
+        >
+          Remove from network
+        </ActionSheetButton>
+      )}
       <ActionSheetButton
         variant="danger"
         icon={<Trash2Icon size={18} />}

--- a/src/components/FileDetails/FileMeta.tsx
+++ b/src/components/FileDetails/FileMeta.tsx
@@ -4,10 +4,10 @@ import { type FileRecord } from '../../stores/files'
 import { FileStatus } from '../../lib/file'
 import { InfoCard } from '../InfoCard'
 import { LabeledValueRow } from '../LabeledValueRow'
-import { arrayBufferToHex } from '../../lib/hex'
 import { RowGroup, RowSubGroup } from '../Group'
 import { humanSize } from '../../lib/humanSize'
 import { decodeFileMetadata } from '../../encoding/fileMetadata'
+import { useShowAdvanced } from '../../stores/settings'
 
 export function FileMeta({
   file,
@@ -16,6 +16,7 @@ export function FileMeta({
   file: FileRecord
   status: FileStatus
 }) {
+  const showAdvanced = useShowAdvanced()
   const fileSize = useMemo(() => {
     return humanSize(file.fileSize)
   }, [file.fileSize])
@@ -25,25 +26,29 @@ export function FileMeta({
     <View style={styles.container}>
       <RowGroup title="Details">
         <InfoCard>
-          <LabeledValueRow
-            label="ID"
-            value={file.id}
-            isMonospace
-            numberOfLines={1}
-          />
-          <LabeledValueRow
-            label="Cached URL"
-            value={status.cachedUri ?? 'Not available'}
-            isMonospace
-            numberOfLines={1}
-            ellipsizeMode="middle"
-            canCopy={!!status.cachedUri}
-            showDividerTop
-          />
+          {showAdvanced.data && (
+            <LabeledValueRow
+              label="ID"
+              value={file.id}
+              isMonospace
+              numberOfLines={1}
+            />
+          )}
+          {showAdvanced.data && (
+            <LabeledValueRow
+              label="Cached URL"
+              value={status.cachedUri ?? 'Not available'}
+              isMonospace
+              numberOfLines={1}
+              ellipsizeMode="middle"
+              canCopy={!!status.cachedUri}
+              showDividerTop
+            />
+          )}
           <LabeledValueRow
             label="Size"
             value={fileSize ?? '—'}
-            showDividerTop
+            showDividerTop={showAdvanced.data}
           />
           <LabeledValueRow
             label="Created"
@@ -55,76 +60,86 @@ export function FileMeta({
             value={file.fileType ?? '—'}
             showDividerTop
           />
-          <LabeledValueRow
-            label="Encryption Key"
-            value={file.encryptionKey}
-            isMonospace
-            showDividerTop
-          />
+          {showAdvanced.data && (
+            <LabeledValueRow
+              label="Encryption Key"
+              value={file.encryptionKey}
+              isMonospace
+              showDividerTop
+            />
+          )}
         </InfoCard>
       </RowGroup>
-      {pinnedObjectsList.length > 1 && (
-        <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Pinned Objects</Text>
-        </View>
-      )}
-      {pinnedObjectsList.map(([indexerURL, po]) => (
-        <Fragment key={indexerURL}>
-          <RowGroup title="Pinned Object">
-            <InfoCard>
-              <LabeledValueRow
-                label="Indexer URL"
-                value={indexerURL}
-                isMonospace
-                numberOfLines={1}
-              />
-              <LabeledValueRow
-                label="Created"
-                value={new Date(po.createdAt).toLocaleString()}
-              />
-              <LabeledValueRow
-                label="Updated"
-                value={new Date(po.updatedAt).toLocaleString()}
-                showDividerTop
-              />
-              <LabeledValueRow
-                label="Key"
-                value={po.key}
-                isMonospace
-                numberOfLines={1}
-                showDividerTop
-              />
-              <LabeledValueRow
-                label="Metadata"
-                value={JSON.stringify(decodeFileMetadata(po.metadata), null, 2)}
-                numberOfLines={10}
-                isMonospace
-                align="left"
-                showDividerTop
-              />
-            </InfoCard>
-          </RowGroup>
-          <View style={styles.verticalSmallGap}>
-            <RowSubGroup title={`Slabs (${po.slabs.length})`}>
-              <InfoCard>
-                {po.slabs.map((s, i) => (
+      {showAdvanced.data && (
+        <>
+          {pinnedObjectsList.length > 1 && (
+            <View style={styles.section}>
+              <Text style={styles.sectionTitle}>Pinned Objects</Text>
+            </View>
+          )}
+          {pinnedObjectsList.map(([indexerURL, po]) => (
+            <Fragment key={indexerURL}>
+              <RowGroup title="Pinned Object">
+                <InfoCard>
                   <LabeledValueRow
-                    key={s.id}
-                    label="Slab"
-                    value={s.id}
+                    label="Indexer URL"
+                    value={indexerURL}
                     isMonospace
                     numberOfLines={1}
-                    showDividerTop={i > 0}
                   />
-                ))}
-              </InfoCard>
-            </RowSubGroup>
-            {/* <InfoCard>
+                  <LabeledValueRow
+                    label="Created"
+                    value={new Date(po.createdAt).toLocaleString()}
+                  />
+                  <LabeledValueRow
+                    label="Updated"
+                    value={new Date(po.updatedAt).toLocaleString()}
+                    showDividerTop
+                  />
+                  <LabeledValueRow
+                    label="Key"
+                    value={po.key}
+                    isMonospace
+                    numberOfLines={1}
+                    showDividerTop
+                  />
+                  <LabeledValueRow
+                    label="Metadata"
+                    value={JSON.stringify(
+                      decodeFileMetadata(po.metadata),
+                      null,
+                      2
+                    )}
+                    numberOfLines={10}
+                    isMonospace
+                    align="left"
+                    showDividerTop
+                  />
+                </InfoCard>
+              </RowGroup>
+              <View style={styles.verticalSmallGap}>
+                <RowSubGroup title={`Slabs (${po.slabs.length})`}>
+                  <InfoCard>
+                    {po.slabs.map((s, i) => (
+                      <LabeledValueRow
+                        key={s.id}
+                        label="Slab"
+                        value={s.id}
+                        isMonospace
+                        numberOfLines={1}
+                        showDividerTop={i > 0}
+                      />
+                    ))}
+                  </InfoCard>
+                </RowSubGroup>
+                {/* <InfoCard>
               <FileMap />
             </InfoCard> */}
-          </View>
-        </Fragment>
-      ))}
+              </View>
+            </Fragment>
+          ))}
+        </>
+      )}
     </View>
   )
 }

--- a/src/lib/swr.ts
+++ b/src/lib/swr.ts
@@ -1,0 +1,24 @@
+import { mutate } from 'swr'
+
+/**
+ * Builds SWR helpers for a given base key.
+ *
+ * Example:
+ * ```
+ * const { getKey, triggerChange } = buildSWRHelpers('key')
+ * ```
+ */
+export function buildSWRHelpers(baseKey: string) {
+  const getKey = (id?: string) => {
+    return id ? `${baseKey}/${id}` : `${baseKey}`
+  }
+  const triggerChange = async (keyPath?: string) => {
+    await mutate((key: string) => {
+      return typeof key === 'string' && key.startsWith(getKey(keyPath))
+    })
+  }
+  return {
+    getKey,
+    triggerChange,
+  }
+}

--- a/src/screens/SettingsHomeScreen.tsx
+++ b/src/screens/SettingsHomeScreen.tsx
@@ -1,11 +1,13 @@
-import { View, Text, Pressable, StyleSheet, Alert } from 'react-native'
+import { View, Text, Pressable, StyleSheet, Alert, Switch } from 'react-native'
 import { type NativeStackScreenProps } from '@react-navigation/native-stack'
 import { type SettingsStackParamList } from '../stacks/types'
 import { resetApp } from '../stores/auth'
+import { setShowAdvanced, useShowAdvanced } from '../stores/settings'
 
 type Props = NativeStackScreenProps<SettingsStackParamList, 'SettingsHome'>
 
 export function SettingsHomeScreen({ navigation }: Props) {
+  const showAdvanced = useShowAdvanced()
   return (
     <View style={styles.panel}>
       <View style={styles.listGroup}>
@@ -42,6 +44,13 @@ export function SettingsHomeScreen({ navigation }: Props) {
             <Text style={styles.rowChevron}>›</Text>
           </View>
         </Pressable>
+        <View style={styles.rowItem}>
+          <Text style={styles.rowLabel}>Show advanced information</Text>
+          <Switch
+            value={showAdvanced.data}
+            onValueChange={(val) => setShowAdvanced(val)}
+          />
+        </View>
       </View>
       <View style={styles.footerGroup}>
         <Pressable

--- a/src/stores/fileCache.ts
+++ b/src/stores/fileCache.ts
@@ -1,7 +1,10 @@
 import { Directory, File, Paths } from 'expo-file-system'
-import useSWR, { mutate } from 'swr'
+import useSWR from 'swr'
 import { Ext } from '../lib/fileTypes'
 import { logger } from '../lib/logger'
+import { buildSWRHelpers } from '../lib/swr'
+
+const { getKey, triggerChange } = buildSWRHelpers('cache/files')
 
 const CACHE_DIR = new Directory(Paths.cache, 'files-cache')
 
@@ -49,7 +52,7 @@ export async function removeFromCache(id: string, ext: Ext): Promise<void> {
   if (info.exists) {
     f.delete()
   }
-  triggerFileCacheUpdate(id)
+  triggerChange(id)
 }
 
 export async function readCachedUri(
@@ -72,7 +75,7 @@ export async function writeToCache(
   const writer = f.writableStream().getWriter()
   await writer.write(new Uint8Array(data))
   await writer.close()
-  triggerFileCacheUpdate(id)
+  triggerChange(id)
   return f.uri
 }
 
@@ -88,7 +91,7 @@ export async function copyUriToCache(
   if (exists) f.delete()
   const srcFile = new File(sourceUri)
   srcFile.copy(f)
-  triggerFileCacheUpdate(id)
+  triggerChange(id)
   return f.uri
 }
 
@@ -103,20 +106,8 @@ export async function copyFileToCache(
   const exists = f.info().exists
   if (exists) f.delete()
   sourceFile.copy(f)
-  triggerFileCacheUpdate(id)
+  triggerChange(id)
   return f.uri
-}
-
-const KEY = 'cache/files'
-
-function getKey(id: string): string {
-  return `${KEY}/${id}`
-}
-
-function triggerFileCacheUpdate(id: string): void {
-  mutate((key: string) => {
-    return typeof key === 'string' && key.startsWith(getKey(id))
-  })
 }
 
 export function useCachedUri(id: string, ext: Ext) {

--- a/src/stores/files.ts
+++ b/src/stores/files.ts
@@ -6,9 +6,12 @@ import {
 } from '../encoding/pinnedObjects'
 import { logger } from '../lib/logger'
 import { db } from '../db'
-import useSWR, { mutate } from 'swr'
+import useSWR from 'swr'
 import { fileHasAPinnedObject } from '../lib/file'
 import { createGetterAndSWRHook } from '../lib/selectors'
+import { buildSWRHelpers } from '../lib/swr'
+
+const { getKey, triggerChange } = buildSWRHelpers('db/files')
 
 export type FileRecord = {
   id: string
@@ -44,7 +47,7 @@ export async function createFileRecord(
   )
   await updateFilePinnedObjects(id, pinnedObjects)
   if (triggerUpdate) {
-    await triggerFileListUpdate()
+    await triggerChange()
   }
 }
 
@@ -56,7 +59,7 @@ export async function createManyFileRecords(
       await createFileRecord(fr, false)
     }
   })
-  await triggerFileListUpdate()
+  await triggerChange()
 }
 
 export async function readAllFileRecords(): Promise<FileRecord[]> {
@@ -114,17 +117,17 @@ export async function updateFileRecord(fileRecord: FileRecord): Promise<void> {
     id
   )
   await updateFilePinnedObjects(id, pinnedObjects)
-  await triggerFileListUpdate()
+  await triggerChange()
 }
 
 export async function deleteFileRecord(id: string): Promise<void> {
   await db().runAsync('DELETE FROM files WHERE id = ?', id)
-  await triggerFileListUpdate()
+  await triggerChange()
 }
 
 export async function deleteAllFileRecords(): Promise<void> {
   await db().runAsync('DELETE FROM files')
-  await triggerFileListUpdate()
+  await triggerChange()
 }
 
 export async function updateFilePinnedObjects(
@@ -141,7 +144,7 @@ export async function updateFilePinnedObjects(
     serializedPinnedObjects,
     id
   )
-  await triggerFileListUpdate()
+  await triggerChange()
 }
 
 export async function updateFilePinnedObject(
@@ -166,7 +169,7 @@ export async function updateFilePinnedObject(
     serializedPinnedObjects,
     id
   )
-  await triggerFileListUpdate()
+  await triggerChange()
 }
 
 function transformRow(row: {
@@ -188,18 +191,6 @@ function transformRow(row: {
     pinnedObjects: pinnedObjects ?? {},
     encryptionKey: row.encryptionKey,
   }
-}
-
-const KEY = 'db/files'
-
-const getKey = (id?: string) => {
-  return id ? `${KEY}/${id}` : `${KEY}`
-}
-
-export function triggerFileListUpdate() {
-  return mutate((key: string) => {
-    return typeof key === 'string' && key.startsWith(getKey())
-  })
 }
 
 export function useFileList() {

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -1,0 +1,15 @@
+import { setSecureStoreBoolean, getSecureStoreBoolean } from './secureStore'
+import { createGetterAndSWRHook } from '../lib/selectors'
+import { buildSWRHelpers } from '../lib/swr'
+
+const { getKey, triggerChange } = buildSWRHelpers('secureStore')
+
+export async function setShowAdvanced(value: boolean) {
+  await setSecureStoreBoolean('showAdvanced', value)
+  triggerChange('showAdvanced')
+}
+
+export const [getShowAdvanced, useShowAdvanced] = createGetterAndSWRHook(
+  getKey('showAdvanced'),
+  () => getSecureStoreBoolean('showAdvanced')
+)


### PR DESCRIPTION
- The default experience now shows less advanced metadata. Users can opt in to see additional data via a setting.
- This PR also refined some of the file action naming and made them only appear when enabled.
- PR refines and abstracts out a builder for swr key and change emitter methods.

<img width="402" height="649" alt="Screenshot 2025-09-26 at 5 28 45 PM" src="https://github.com/user-attachments/assets/57e281f9-a639-4a5f-99fd-022c1a6297ee" />
<img width="412" height="436" alt="Screenshot 2025-09-26 at 5 29 04 PM" src="https://github.com/user-attachments/assets/476656d7-e31e-406f-909c-3b4265bb4bf5" />
<img width="408" height="841" alt="Screenshot 2025-09-26 at 5 18 41 PM" src="https://github.com/user-attachments/assets/a8d04f9d-e4b7-4c7e-92a9-d0d7c67d3556" />
<img width="413" height="845" alt="Screenshot 2025-09-26 at 5 18 19 PM" src="https://github.com/user-attachments/assets/e4b56d79-a127-467c-bcd4-30192e579292" />
<img width="421" height="843" alt="Screenshot 2025-09-26 at 5 18 02 PM" src="https://github.com/user-attachments/assets/6375867e-da90-4c9c-86c5-7eaa9dfae716" />
