### PR TITLE
fix: secure storage key name and validation

### DIFF
--- a/src/stores/secureStore.ts
+++ b/src/stores/secureStore.ts
@@ -1,6 +1,11 @@
 import * as SecureStore from 'expo-secure-store'
 
 export async function setSecureStoreBoolean(key: string, value: boolean) {
+  if (!/^[a-zA-Z0-9._-]+$/.test(key)) {
+    throw new Error(
+      'SecureStore key must contain only alphanumeric characters, dots, hyphens, and underscores'
+    )
+  }
   return SecureStore.setItemAsync(key, value ? 'true' : 'false')
 }
 

--- a/src/stores/uploadScanner.ts
+++ b/src/stores/uploadScanner.ts
@@ -16,7 +16,7 @@ type UploadScannerState = {
 }
 
 const MAX_BACKGROUND_UPLOADS = 5
-const SECURE_STORE_AUTO_SCAN_KEY = 'uploadScanner/autoScan'
+const SECURE_STORE_AUTO_SCAN_KEY = 'uploadScanner.autoScan'
 
 let scanTimer: NodeJS.Timeout | null = null
 


### PR DESCRIPTION
- SecureStore keys can only contain alphanumeric characters, dots, hyphens, and underscores.