### PR TITLE
fix: revert to always showing share actions

### DIFF
--- a/src/components/FileActionsSheet.tsx
+++ b/src/components/FileActionsSheet.tsx
@@ -187,25 +187,22 @@ export function FileActionsSheet({ route, navigation }: Props) {
   const handleDownload = useDownload(file)
   return (
     <ActionSheet visible={isMenuOpen} onRequestClose={closeMenu}>
-      {status.isUploaded && (
-        <>
-          <ActionSheetButton
-            disabled={!status.isDownloaded}
-            variant="primary"
-            icon={<Link2Icon size={18} />}
-            onPress={handlePressAndClose(handleShareURL)}
-          >
-            Copy link
-          </ActionSheetButton>
-          <ActionSheetButton
-            variant="primary"
-            icon={<ShareIcon size={18} />}
-            onPress={handleShareFile}
-          >
-            Share file
-          </ActionSheetButton>
-        </>
-      )}
+      <ActionSheetButton
+        disabled={!status.isUploaded}
+        variant="primary"
+        icon={<Link2Icon size={18} />}
+        onPress={handlePressAndClose(handleShareURL)}
+      >
+        Copy link
+      </ActionSheetButton>
+      <ActionSheetButton
+        disabled={!status.isUploaded}
+        variant="primary"
+        icon={<ShareIcon size={18} />}
+        onPress={handleShareFile}
+      >
+        Share file
+      </ActionSheetButton>
       {!status.isDownloaded && !status.isDownloading && !status.fileIsGone && (
         <ActionSheetButton
           variant="primary"


### PR DESCRIPTION
- Adjust file action sheet back to showing the new share actions when disabled, so its clear those options exist but the file needs to be uploaded first. I had changed it to match the other options but those ones effectively are 1 dynamic action that always shows, upload vs download etc.