### PR TITLE
feat: add sorting and filtering

### DIFF
--- a/src/components/FileFilter.tsx
+++ b/src/components/FileFilter.tsx
@@ -1,0 +1,97 @@
+import React, { useMemo, useState } from 'react'
+import { View, Text, Pressable, StyleSheet } from 'react-native'
+import { Square, CheckSquare } from 'lucide-react-native'
+import { type Category, useFilesView } from '../stores/files'
+import ActionSheet from '../components/ActionSheet'
+
+const CATEGORIES: Category[] = ['Video', 'Image', 'Audio', 'Files']
+
+export function FileFilter(): React.ReactElement {
+  const [open, setOpen] = useState(false)
+  const { selectedCategories, toggleCategory, clearCategories } = useFilesView()
+
+  const pressableText = useMemo(() => {
+    const n = selectedCategories.size
+    return n ? `Filter • ${n}` : 'Filter'
+  }, [selectedCategories])
+
+  const Row = ({ cat }: { cat: Category }) => {
+    const checked = selectedCategories.has(cat)
+    const Icon = checked ? CheckSquare : Square
+    return (
+      <Pressable
+        style={styles.modalRow}
+        onPress={() => toggleCategory(cat)}
+        accessibilityRole="button"
+        accessibilityLabel={checked ? `Unselect ${cat}` : `Select ${cat}`}
+      >
+        <Text style={styles.label}>{cat}</Text>
+        <Icon size={20} />
+      </Pressable>
+    )
+  }
+
+  return (
+    <>
+      <Pressable
+        style={styles.pressable}
+        onPress={() => setOpen(true)}
+        accessibilityRole="button"
+      >
+        <Text style={styles.pressableText}>{pressableText}</Text>
+      </Pressable>
+
+      <ActionSheet visible={open} onRequestClose={() => setOpen(false)}>
+        {CATEGORIES.map((c, i) => (
+          <View key={c}>
+            <Row cat={c} />
+            {i < CATEGORIES.length - 1 && <View style={styles.separator} />}
+          </View>
+        ))}
+
+        <View style={styles.footer}>
+          <Pressable onPress={clearCategories} accessibilityRole="button">
+            <Text style={styles.clear}>Clear</Text>
+          </Pressable>
+
+          <Pressable onPress={() => setOpen(false)} accessibilityRole="button">
+            <Text style={styles.done}>Done</Text>
+          </Pressable>
+        </View>
+      </ActionSheet>
+    </>
+  )
+}
+
+const styles = StyleSheet.create({
+  pressable: {
+    alignSelf: 'flex-start',
+    paddingVertical: 8,
+    paddingHorizontal: 8,
+    borderRadius: 4,
+    backgroundColor: 'white',
+  },
+  pressableText: { fontSize: 14 },
+  modalRow: {
+    paddingVertical: 14,
+    paddingHorizontal: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  label: { fontSize: 16 },
+  separator: {
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: '#ddd',
+    marginHorizontal: 12,
+  },
+  footer: {
+    paddingTop: 8,
+    marginTop: 8,
+    paddingHorizontal: 12,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  clear: { fontSize: 14, color: '#cc0000' },
+  done: { fontSize: 14, fontWeight: '600' },
+})

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -1,5 +1,5 @@
 import { FlatList } from 'react-native'
-import { FileRecord, useFileList } from '../stores/files'
+import { FileRecord, useOrderedFileList } from '../stores/files'
 import { FileListItem } from './FileListItem'
 
 type Props = {
@@ -8,7 +8,7 @@ type Props = {
 }
 
 export function FileList({ onPressItem, setItemRef }: Props) {
-  const { data: files } = useFileList()
+  const { data: files } = useOrderedFileList()
   return (
     <FlatList
       data={files}

--- a/src/components/FileSorter.tsx
+++ b/src/components/FileSorter.tsx
@@ -1,0 +1,91 @@
+import React, { useMemo, useState } from 'react'
+import { View, Text, Pressable, StyleSheet } from 'react-native'
+import { ArrowUp, ArrowDown } from 'lucide-react-native'
+import { SortBy, useFilesView } from '../stores/files'
+import ActionSheet from '../components/ActionSheet'
+
+export function FileSorter(): React.ReactElement {
+  const [open, setOpen] = useState(false)
+
+  const { sortBy, sortDir, setSortCategory, toggleDir } = useFilesView()
+
+  const pressableText = useMemo(() => {
+    const label = sortBy === 'NAME' ? 'Name' : 'Date'
+    const showUpArrow =
+      sortBy === 'NAME' ? sortDir === 'ASC' : sortDir === 'DESC'
+    return `${label} ${showUpArrow ? '↑' : '↓'}`
+  }, [sortBy, sortDir])
+
+  const onPick = (nextSortBy: SortBy) => {
+    if (sortBy === nextSortBy) {
+      toggleDir()
+    } else {
+      setSortCategory(nextSortBy)
+    }
+    setOpen(false)
+  }
+
+  const ArrowIndicator = ({ row }: { row: SortBy }) => {
+    if (sortBy !== row) return null
+    const showUpIcon = row === 'NAME' ? sortDir === 'ASC' : sortDir === 'DESC'
+    return showUpIcon ? <ArrowUp size={20} /> : <ArrowDown size={20} />
+  }
+
+  return (
+    <>
+      <Pressable
+        style={styles.pressable}
+        onPress={() => setOpen(true)}
+        accessibilityRole="button"
+      >
+        <Text style={styles.pressableText}>{pressableText}</Text>
+      </Pressable>
+
+      <ActionSheet visible={open} onRequestClose={() => setOpen(false)}>
+        <Pressable
+          style={styles.modalRow}
+          onPress={() => onPick('DATE')}
+          accessibilityRole="button"
+        >
+          <Text style={styles.label}>Date</Text>
+          <ArrowIndicator row="DATE" />
+        </Pressable>
+
+        <View style={styles.separator} />
+
+        <Pressable
+          style={styles.modalRow}
+          onPress={() => onPick('NAME')}
+          accessibilityRole="button"
+        >
+          <Text style={styles.label}>Name</Text>
+          <ArrowIndicator row="NAME" />
+        </Pressable>
+      </ActionSheet>
+    </>
+  )
+}
+
+const styles = StyleSheet.create({
+  pressable: {
+    alignSelf: 'flex-start',
+    paddingVertical: 8,
+    paddingHorizontal: 8,
+    borderRadius: 4,
+    backgroundColor: 'white',
+  },
+  pressableText: { fontSize: 14 },
+  modalRow: {
+    paddingVertical: 14,
+    paddingHorizontal: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  label: { fontSize: 16 },
+  separator: {
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: '#ddd',
+    marginHorizontal: 12,
+  },
+})

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -1,5 +1,5 @@
 import { FlatList, StyleSheet } from 'react-native'
-import { useFileList, type FileRecord } from '../stores/files'
+import { useOrderedFileList, type FileRecord } from '../stores/files'
 import { GalleryItem } from './GalleryItem'
 
 type Props = {
@@ -9,7 +9,7 @@ type Props = {
 }
 
 export function Gallery({ onPressItem, setItemRef, numColumns = 3 }: Props) {
-  const { data: files } = useFileList()
+  const { data: files } = useOrderedFileList()
   return (
     <FlatList
       data={files}

--- a/src/screens/FileListScreen.tsx
+++ b/src/screens/FileListScreen.tsx
@@ -18,6 +18,8 @@ import { useImagePickerAndUpload } from '../hooks/useImagePicker'
 import { useCameraCaptureAndUpload } from '../hooks/useCameraCapture'
 import { useDocumentPickerAndUpload } from '../hooks/useDocumentPicker'
 import { Menu, MenuItem } from '../components/Menu'
+import { FileSorter } from '../components/FileSorter'
+import { FileFilter } from '../components/FileFilter'
 
 export function FileListScreen() {
   const [viewMode, setViewMode] = useState<'gallery' | 'list'>('gallery')
@@ -96,6 +98,12 @@ export function FileListScreen() {
           </Pressable>
         </View>
       </View>
+      {files.data?.length && files.data?.length > 1 && (
+        <View style={styles.sortFilterRow}>
+          <FileFilter />
+          <FileSorter />
+        </View>
+      )}
       {!files.isLoading && files.data?.length === 0 ? (
         <View style={styles.emptyWrap}>
           <Text style={styles.emptyTitle}>No uploads yet</Text>
@@ -200,5 +208,13 @@ const styles = StyleSheet.create({
   },
   togglePressed: {
     opacity: 0.7,
+  },
+  sortFilterRow: {
+    display: 'flex',
+    flexDirection: 'row',
+    gap: 4,
+    justifyContent: 'flex-end',
+    padding: 8,
+    backgroundColor: '#f2f2f2',
   },
 })

--- a/src/stores/files.ts
+++ b/src/stores/files.ts
@@ -10,6 +10,7 @@ import useSWR from 'swr'
 import { fileHasAPinnedObject } from '../lib/file'
 import { createGetterAndSWRHook } from '../lib/selectors'
 import { buildSWRHelpers } from '../lib/swr'
+import { create } from 'zustand'
 
 const { getKey, triggerChange } = buildSWRHelpers('db/files')
 
@@ -74,6 +75,63 @@ export async function readAllFileRecords(): Promise<FileRecord[]> {
   }>(
     'SELECT id, fileName, fileSize, createdAt, fileType, pinnedObjects, encryptionKey FROM files ORDER BY createdAt DESC'
   )
+  return rows.map(transformRow)
+}
+
+const CATEGORY_TO_PREFIX: Record<Category, string> = {
+  Video: 'video/',
+  Image: 'image/',
+  Audio: 'audio/',
+  Files: 'application/',
+}
+
+export type FileOrderParams = {
+  sortBy?: SortBy
+  sortDir?: SortDir
+  categories?: Category[]
+}
+
+export async function readOrderedFileRecords(
+  opts?: FileOrderParams
+): Promise<FileRecord[]> {
+  const { sortBy = 'DATE', sortDir, categories = [] } = opts ?? {}
+  const dir: SortDir = sortDir ?? (sortBy === 'NAME' ? 'ASC' : 'DESC')
+
+  const prefixes = categories.map((c) => CATEGORY_TO_PREFIX[c]).filter(Boolean)
+
+  const whereParts: string[] = []
+  const params: any[] = []
+
+  if (prefixes.length) {
+    for (const p of prefixes) {
+      whereParts.push(`fileType LIKE ?`)
+      params.push(`${p}%`)
+    }
+  }
+
+  const where = whereParts.length ? `WHERE (${whereParts.join(' OR ')})` : ''
+
+  const orderExpr =
+    sortBy === 'NAME'
+      ? `fileName IS NULL, fileName COLLATE NOCASE ${dir}`
+      : `createdAt ${dir}`
+
+  const rows = await db().getAllAsync<{
+    id: string
+    fileName: string | null
+    fileSize: number | null
+    createdAt: number
+    fileType: string
+    pinnedObjects: string | null
+    encryptionKey: string
+  }>(
+    `SELECT id, fileName, fileSize, createdAt, fileType, pinnedObjects, encryptionKey
+     FROM files
+     ${where}
+     ORDER BY ${orderExpr}`,
+    ...params
+  )
+
   return rows.map(transformRow)
 }
 
@@ -197,6 +255,24 @@ export function useFileList() {
   return useSWR(getKey(), readAllFileRecords)
 }
 
+export function useOrderedFileList() {
+  const { sortBy, sortDir, selectedCategories } = useFilesView()
+  const dir = sortDir ?? (sortBy === 'NAME' ? 'ASC' : 'DESC')
+
+  const cats = Array.from(selectedCategories ?? new Set())
+  const catsKey = cats.length ? cats.slice().sort().join(',') : ''
+
+  const key = getKey(`list:${sortBy}:${dir}:${catsKey}`)
+
+  return useSWR(key, () =>
+    readOrderedFileRecords({
+      sortBy,
+      sortDir: dir,
+      categories: cats.length ? cats : undefined,
+    })
+  )
+}
+
 export function useFileCountAll() {
   return useSWR(getKey('count'), () =>
     readAllFileRecords().then((f) => f.length)
@@ -220,3 +296,32 @@ export const [getFileCountLocalOnly, useFileCountLocalOnly] =
 export function useFileDetails(id: string) {
   return useSWR(getKey(id), () => readFileRecord(id))
 }
+
+export type SortBy = 'NAME' | 'DATE'
+export type SortDir = 'ASC' | 'DESC'
+export type Category = 'Video' | 'Image' | 'Audio' | 'Files'
+
+type FilesViewState = {
+  sortBy: SortBy
+  sortDir: SortDir
+  selectedCategories: Set<Category>
+  setSortCategory: (by: SortBy) => void
+  toggleDir: () => void
+  toggleCategory: (c: Category) => void
+  clearCategories: () => void
+}
+
+export const useFilesView = create<FilesViewState>((set, get) => ({
+  sortBy: 'DATE',
+  sortDir: 'DESC',
+  selectedCategories: new Set<Category>(),
+  setSortCategory: (sortBy) =>
+    set({ sortBy, sortDir: sortBy === 'NAME' ? 'ASC' : 'DESC' }),
+  toggleDir: () => set({ sortDir: get().sortDir === 'ASC' ? 'DESC' : 'ASC' }),
+  toggleCategory: (c) => {
+    const next = new Set(get().selectedCategories)
+    next.has(c) ? next.delete(c) : next.add(c)
+    set({ selectedCategories: next })
+  },
+  clearCategories: () => set({ selectedCategories: new Set() }),
+}))


### PR DESCRIPTION
[Screen Recording 2025-10-01 at 1.12.56 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/d3195682-fe1c-47f6-aaa9-99e0d52745d0.mov" />](https://app.graphite.dev/user-attachments/video/d3195682-fe1c-47f6-aaa9-99e0d52745d0.mov)

Adds these features to the Gallery and List views. At this point, we could in theory deleted `useFileList` because `useOrderedFileList` can take no parameters and does the same, but I didn't want to pull that trigger myself. I also of course welcome any naming, organization, or style suggestions. On style, I see this space between the header menu and gallery/list view where I'm putting these two buttons as changing quite rapidly as we add search and make bigger decisions about how this should, so I kept this styling pretty basic for now.

One more thing: I couldn't properly get a "file" in here to test that filter functionality. I assume it works but I was getting invalid signature stuff from the sdk. I at least can tell that the file filter is exclusive to the other categories.