### PR TITLE
refactor: zustand standalone actions

### DIFF
--- a/src/components/FileFilter.tsx
+++ b/src/components/FileFilter.tsx
@@ -2,7 +2,12 @@ import React from 'react'
 import { View, Text, Pressable, StyleSheet } from 'react-native'
 import { colors, palette, whiteA } from '../styles/colors'
 import { Square, CheckSquare, Filter as FilterIcon } from 'lucide-react-native'
-import { type Category, useFilesView } from '../stores/files'
+import {
+  type Category,
+  clearCategories,
+  toggleCategory,
+  useFilesView,
+} from '../stores/files'
 import ActionSheet from '../components/ActionSheet'
 import { closeSheet, openSheet, useSheetOpen } from '../stores/sheets'
 
@@ -10,7 +15,7 @@ const CATEGORIES: Category[] = ['Video', 'Image', 'Audio', 'Files']
 
 export function FileFilter(): React.ReactElement {
   const isOpen = useSheetOpen('fileFilter')
-  const { selectedCategories, toggleCategory, clearCategories } = useFilesView()
+  const { selectedCategories } = useFilesView()
 
   const Row = ({ cat }: { cat: Category }) => {
     const checked = selectedCategories.has(cat)

--- a/src/components/FileSorter.tsx
+++ b/src/components/FileSorter.tsx
@@ -2,13 +2,18 @@ import React from 'react'
 import { View, Text, Pressable, StyleSheet } from 'react-native'
 import { palette } from '../styles/colors'
 import { ArrowUp, ArrowDown, SortAsc, SortDesc } from 'lucide-react-native'
-import { SortBy, useFilesView } from '../stores/files'
+import {
+  setSortCategory,
+  SortBy,
+  toggleDir,
+  useFilesView,
+} from '../stores/files'
 import ActionSheet from '../components/ActionSheet'
 import { closeSheet, useSheetOpen } from '../stores/sheets'
 import { openSheet } from '../stores/sheets'
 
 export function FileSorter(): React.ReactElement {
-  const { sortBy, sortDir, setSortCategory, toggleDir } = useFilesView()
+  const { sortBy, sortDir } = useFilesView()
   const isOpen = useSheetOpen('fileSorter')
 
   const onPick = (nextSortBy: SortBy) => {

--- a/src/managers/uploadScanner.ts
+++ b/src/managers/uploadScanner.ts
@@ -11,7 +11,7 @@ import {
   SCANNER_ADD_TO_QUEUE_FACTOR,
   SCANNER_INTERVAL,
 } from '../config'
-import { useAuthStore } from '../stores/auth'
+import { getIsConnected } from '../stores/auth'
 import {
   getAutoScanUploads,
   getMaxTransfers,
@@ -30,7 +30,7 @@ function startUploadScanner(): void {
       const maxTransfers = await getMaxTransfers()
       const maxTotalUploads = SCANNER_MAX_TOTAL_UPLOADS_FACTOR * maxTransfers
       const maxToAdd = SCANNER_ADD_TO_QUEUE_FACTOR * maxTransfers
-      if (!useAuthStore.getState().isConnected) return
+      if (!getIsConnected()) return
       if (getTransferCounts().total >= maxTotalUploads) {
         return
       }

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -10,6 +10,7 @@ import {
   getIndexerURL,
 } from './settings'
 import { getAppKey } from '../lib/appKey'
+import { createGetterAndSelector } from '../lib/selectors'
 
 export type AuthState = {
   sdk: Sdk | null
@@ -17,152 +18,125 @@ export type AuthState = {
   isConnected: boolean
   connectionError: string | null
   isAuthing: boolean
-  reconnect: () => Promise<boolean | undefined>
-  initSdk: () => Promise<Sdk | null>
-  tryToConnectAndSet: (nextIndexerURL: string) => Promise<boolean>
-  resetApp: () => Promise<void>
-  initAuth: () => Promise<void>
 }
 
-export const useAuthStore = create<AuthState>((set, get) => {
+const useAuthStore = create<AuthState>(() => {
   return {
     sdk: null,
     isInitializing: true,
     isConnected: false,
     connectionError: null,
     isAuthing: false,
-
-    reconnect: async () => {
-      logger.log('Reconnecting...')
-      const isAuthing = get().isAuthing
-      if (isAuthing) {
-        return false
-      }
-      const sdk = get().sdk || (await get().initSdk())
-
-      if (!sdk) {
-        set({ connectionError: 'Failed to initialize SDK' })
-        return false
-      }
-
-      const connected = await sdk.connect()
-      set({
-        isConnected: connected,
-        connectionError: connected ? null : 'Failed to connect to indexer',
-      })
-      return connected
-    },
-
-    initSdk: async () => {
-      try {
-        const indexerURL = await getIndexerURL()
-        const appKey = await getAppKey()
-        const sdk = new Sdk(indexerURL, appKey)
-        set({ sdk })
-        return sdk
-      } catch (err) {
-        logger.log('Error initializing SDK', err)
-        return null
-      }
-    },
-
-    initAuth: async () => {
-      const hasOnboarded = await getHasOnboarded()
-      if (hasOnboarded) {
-        await get().initSdk()
-        get().reconnect()
-      }
-      set({ isInitializing: false })
-    },
-
-    tryToConnectAndSet: async (newIndexerURL: string) => {
-      set({
-        isAuthing: true,
-      })
-      try {
-        logger.log(`Creating candidate SDK for ${newIndexerURL}...`)
-        const appKey = await getAppKey()
-        const candidate = new Sdk(newIndexerURL, appKey)
-
-        logger.log('Calling connect...')
-        const connected = await candidate.connect()
-
-        if (!connected) {
-          logger.log('No connection. Requesting app connection...')
-          const url = await candidate.requestAppConnection({
-            name: 'Test',
-            description: 'Test',
-            serviceUrl: 'https://sia.storage',
-            callbackUrl: 'siamobile://callback',
-            logoUrl: 'https://sia.storage/logo.png',
-          })
-
-          authApp(url.responseUrl)
-
-          const authorized = await candidate.waitForConnect(url)
-          if (!authorized) {
-            logger.log('App not authorized')
-            set({
-              isAuthing: false,
-            })
-            return false
-          }
-        }
-
-        logger.log('Connected. Setting active indexer.')
-        set({
-          sdk: candidate,
-          isConnected: true,
-          isAuthing: false,
-        })
-        await setHasOnboarded(true)
-        return true
-      } catch (err) {
-        logger.log('Error connecting to indexer', err)
-        set({ isAuthing: false })
-        return false
-      }
-    },
-
-    resetApp: async () => {
-      await deleteAllFileRecords()
-      const newSeed = generateRecoveryPhrase()
-      await setRecoveryPhrase(newSeed)
-      await setHasOnboarded(false)
-      set({
-        isConnected: false,
-        sdk: null,
-        isAuthing: false,
-        connectionError: null,
-      })
-    },
   }
 })
 
-// actions
+const { getState, setState } = useAuthStore
 
-export function authReconnect() {
-  return useAuthStore.getState().reconnect()
+export async function reconnect() {
+  logger.log('Reconnecting...')
+  const isAuthing = getState().isAuthing
+  if (isAuthing) {
+    return false
+  }
+  const sdk = getState().sdk || (await initSdk())
+  if (!sdk) {
+    setState({ connectionError: 'Failed to initialize SDK' })
+    return false
+  }
+  const connected = await sdk.connect()
+  setState({
+    isConnected: connected,
+    connectionError: connected ? null : 'Failed to connect to indexer',
+  })
+  return connected
 }
 
-export function authInitSdk() {
-  return useAuthStore.getState().initSdk()
+export async function initSdk() {
+  try {
+    const indexerURL = await getIndexerURL()
+    const appKey = await getAppKey()
+    const sdk = new Sdk(indexerURL, appKey)
+    setState({ sdk })
+    return sdk
+  } catch (err) {
+    logger.log('Error initializing SDK', err)
+    return null
+  }
 }
 
 export function useSdk(): Sdk | null {
   return useAuthStore((s) => s.sdk)
 }
 
-export function resetApp() {
-  return useAuthStore.getState().resetApp()
+export async function resetApp() {
+  await deleteAllFileRecords()
+  const newSeed = generateRecoveryPhrase()
+  await setRecoveryPhrase(newSeed)
+  await setHasOnboarded(false)
+  setState({
+    isConnected: false,
+    sdk: null,
+    isAuthing: false,
+    connectionError: null,
+  })
 }
 
-export function tryToConnectAndSet(newIndexerURL: string) {
-  return useAuthStore.getState().tryToConnectAndSet(newIndexerURL)
+export async function tryToConnectAndSet(newIndexerURL: string) {
+  setState({
+    isAuthing: true,
+  })
+  try {
+    logger.log(`Creating candidate SDK for ${newIndexerURL}...`)
+    const appKey = await getAppKey()
+    const candidate = new Sdk(newIndexerURL, appKey)
+
+    logger.log('Calling connect...')
+    const connected = await candidate.connect()
+
+    if (!connected) {
+      logger.log('No connection. Requesting app connection...')
+      const url = await candidate.requestAppConnection({
+        name: 'Test',
+        description: 'Test',
+        serviceUrl: 'https://sia.storage',
+        callbackUrl: 'siamobile://callback',
+        logoUrl: 'https://sia.storage/logo.png',
+      })
+
+      authApp(url.responseUrl)
+
+      const authorized = await candidate.waitForConnect(url)
+      if (!authorized) {
+        logger.log('App not authorized')
+        setState({
+          isAuthing: false,
+        })
+        return false
+      }
+    }
+
+    logger.log('Connected. Setting active indexer.')
+    setState({
+      sdk: candidate,
+      isConnected: true,
+      isAuthing: false,
+    })
+    await setHasOnboarded(true)
+    return true
+  } catch (err) {
+    logger.log('Error connecting to indexer', err)
+    setState({ isAuthing: false })
+    return false
+  }
 }
 
-export function initAuth() {
-  return useAuthStore.getState().initAuth()
+export async function initAuth() {
+  const hasOnboarded = await getHasOnboarded()
+  if (hasOnboarded) {
+    await initSdk()
+    await reconnect()
+  }
+  setState({ isInitializing: false })
 }
 
 // selectors
@@ -171,9 +145,10 @@ export function useIsInitializing(): boolean {
   return useAuthStore((s) => s.isInitializing)
 }
 
-export function useIsConnected(): boolean {
-  return useAuthStore((s) => s.isConnected)
-}
+export const [getIsConnected, useIsConnected] = createGetterAndSelector(
+  useAuthStore,
+  (s) => s.isConnected
+)
 
 export function useIsAuthing(): boolean {
   return useAuthStore((s) => s.isAuthing)

--- a/src/stores/files.ts
+++ b/src/stores/files.ts
@@ -293,23 +293,38 @@ type FilesViewState = {
   sortBy: SortBy
   sortDir: SortDir
   selectedCategories: Set<Category>
-  setSortCategory: (by: SortBy) => void
-  toggleDir: () => void
-  toggleCategory: (c: Category) => void
-  clearCategories: () => void
 }
 
-export const useFilesView = create<FilesViewState>((set, get) => ({
+export const useFilesView = create<FilesViewState>(() => ({
   sortBy: 'DATE',
   sortDir: 'DESC',
   selectedCategories: new Set<Category>(),
-  setSortCategory: (sortBy) =>
-    set({ sortBy, sortDir: sortBy === 'NAME' ? 'ASC' : 'DESC' }),
-  toggleDir: () => set({ sortDir: get().sortDir === 'ASC' ? 'DESC' : 'ASC' }),
-  toggleCategory: (c) => {
-    const next = new Set(get().selectedCategories)
-    next.has(c) ? next.delete(c) : next.add(c)
-    set({ selectedCategories: next })
-  },
-  clearCategories: () => set({ selectedCategories: new Set() }),
 }))
+
+const { setState } = useFilesView
+
+export function setSortCategory(sortBy: SortBy) {
+  setState(() => {
+    return { sortBy, sortDir: sortBy === 'NAME' ? 'ASC' : 'DESC' }
+  })
+}
+
+export function toggleDir() {
+  setState((state) => {
+    return { sortDir: state.sortDir === 'ASC' ? 'DESC' : 'ASC' }
+  })
+}
+
+export function toggleCategory(c: Category) {
+  setState((state) => {
+    const next = new Set(state.selectedCategories)
+    next.has(c) ? next.delete(c) : next.add(c)
+    return { selectedCategories: next }
+  })
+}
+
+export function clearCategories() {
+  setState(() => {
+    return { selectedCategories: new Set() }
+  })
+}

--- a/src/stores/logs.ts
+++ b/src/stores/logs.ts
@@ -5,37 +5,28 @@ import { logger } from '../lib/logger'
 
 export type LogsState = {
   logs: string[]
-  append: (...args: unknown[]) => void
-  clear: () => void
 }
 
-export const useLogsStore = create<LogsState>((set) => ({
+export const useLogsStore = create<LogsState>(() => ({
   logs: [],
-  append: (...args: unknown[]) =>
-    set((state) => {
-      const line = `${new Date().toLocaleTimeString()} ${args
-        .map(String)
-        .join(' ')}`
-      const next = [...state.logs.slice(-100), line]
-      return { logs: next }
-    }),
-  clear: () => set({ logs: [] }),
 }))
 
-// actions
+const { setState } = useLogsStore
 
 export function appendLogLine(...args: unknown[]): void {
-  useLogsStore.getState().append(...args)
+  setState((state) => {
+    const line = `${new Date().toLocaleTimeString()} ${args
+      .map(String)
+      .join(' ')}`
+    const next = [...state.logs.slice(-100), line]
+    return { logs: next }
+  })
 }
 
 export function clearLogs(): void {
-  useLogsStore.getState().clear()
-}
-
-// selectors
-
-export function useLogs(): string[] {
-  return useLogsStore(useShallow((s) => s.logs))
+  setState(() => {
+    return { logs: [] }
+  })
 }
 
 let hasInit = false
@@ -61,4 +52,10 @@ export function useInitLogger(): void {
   useEffect(() => {
     initLogger()
   }, [])
+}
+
+// selectors
+
+export function useLogs(): string[] {
+  return useLogsStore(useShallow((s) => s.logs))
 }

--- a/src/stores/sheets.ts
+++ b/src/stores/sheets.ts
@@ -2,40 +2,27 @@ import { create } from 'zustand'
 
 type SheetsState = {
   openName: string
-  open: (name: string) => void
-  close: () => void
-  toggle: (name: string) => void
-  isOpen: (name: string) => boolean
 }
 
-export const useSheetsStore = create<SheetsState>((set, get) => ({
+export const useSheetsStore = create<SheetsState>(() => ({
   openName: '',
-  open: (name) =>
-    set(() => {
-      return { openName: name }
-    }),
-  close: () =>
-    set(() => {
-      return { openName: '' }
-    }),
-  toggle: (name) =>
-    set((state) => {
-      const next = state.openName
-      if (next === name) return { openName: '' }
-      else return { openName: name }
-    }),
-  isOpen: (name) => get().openName === name,
 }))
 
-export function useSheetOpen(name: string): boolean {
-  return useSheetsStore((s) => s.openName === name)
-}
+const { setState } = useSheetsStore
 
 export function openSheet(name: string): void {
-  useSheetsStore.getState().open(name)
+  setState(() => {
+    return { openName: name }
+  })
 }
 
 export async function closeSheet(): Promise<void> {
-  useSheetsStore.getState().close()
+  setState(() => {
+    return { openName: '' }
+  })
   await new Promise((resolve) => setTimeout(resolve, 220))
+}
+
+export function useSheetOpen(name: string): boolean {
+  return useSheetsStore((s) => s.openName === name)
 }

--- a/src/stores/transfers.ts
+++ b/src/stores/transfers.ts
@@ -11,7 +11,7 @@ export type TransferStatus = 'queued' | 'running' | 'done' | 'error'
 export type TransferState = {
   id: string
   kind: TransferKind
-  controller?: AbortController
+  controller: AbortController
   status: TransferStatus
   progress: number
   error?: string
@@ -19,91 +19,28 @@ export type TransferState = {
 
 type TransfersStore = {
   transfers: Record<string, TransferState>
-  add: (record: Omit<TransferState, 'status' | 'progress'>) => void
-  updateState: (
-    id: string,
-    kind: TransferKind,
-    status: TransferStatus,
-    progress: number,
-    error?: string
-  ) => void
-  updateProgress: (id: string, kind: TransferKind, progress: number) => void
-  remove: (id: string, kind: TransferKind) => void
-  cancelAll: () => void
 }
 
-export const useTransfersStore = create<TransfersStore>((set, get) => ({
+export const useTransfersStore = create<TransfersStore>(() => ({
   transfers: {},
-  add: (record) =>
-    set((state) => {
-      const key = makeTransferKey(record.kind, record.id)
-      const prev = state.transfers[key]
-      const next: TransferState = {
-        id: record.id,
-        kind: record.kind,
-        controller: record.controller ?? prev?.controller,
-        status: prev?.status ?? 'queued',
-        progress: prev?.progress ?? 0,
-      }
-      return { transfers: { ...state.transfers, [key]: next } }
-    }),
-  updateState: (id, kind, status, progress, err) =>
-    set((state) => {
-      const key = makeTransferKey(kind, id)
-      const prev = state.transfers[key]
-      const next: TransferState = {
-        id,
-        kind: kind ?? prev?.kind ?? 'upload',
-        controller: prev?.controller,
-        status,
-        progress,
-        error: status === 'error' ? err ?? prev?.error ?? '' : undefined,
-      }
-      return { transfers: { ...state.transfers, [key]: next } }
-    }),
-  updateProgress: (id, kind, progress) =>
-    set((state) => {
-      const key = makeTransferKey(kind, id)
-      const prev = state.transfers[key]
-      const next: TransferState = {
-        id,
-        kind: kind ?? prev?.kind ?? 'upload',
-        controller: prev?.controller,
-        status: prev?.status ?? 'queued',
-        progress,
-        error: prev?.error,
-      }
-      return { transfers: { ...state.transfers, [key]: next } }
-    }),
-  remove: (id, kind) =>
-    set((state) => {
-      const key = makeTransferKey(kind, id)
-      const { [key]: _, ...rest } = state.transfers
-      return { transfers: rest }
-    }),
-  cancelAll: () => {
-    const current = get().transfers
-    Object.values(current).forEach((r) => {
-      try {
-        logger.log('aborting transfer', r.id)
-        r.controller?.abort()
-      } catch (e) {
-        logger.log('error aborting transfer', r.id, e)
-        // Ignore.
-      }
-    })
-    set({ transfers: {} })
-  },
 }))
+
+const { getState, setState } = useTransfersStore
 
 function registerTransfer(id: string, kind: TransferKind): AbortController {
   const controller = new AbortController()
-  useTransfersStore.getState().add({ id, kind, controller })
+  setState((state) => {
+    const key = makeTransferKey(kind, id)
+    const next: TransferState = {
+      id,
+      kind,
+      controller,
+      status: 'queued',
+      progress: 0,
+    }
+    return { transfers: { ...state.transfers, [key]: next } }
+  })
   return controller
-}
-
-export function cancelAllTransfers() {
-  return useTransfersStore.getState().cancelAll()
 }
 
 function setTransferState(
@@ -111,11 +48,21 @@ function setTransferState(
   kind: TransferKind,
   status: TransferStatus,
   progress: number,
-  error?: string
+  err?: string
 ) {
-  return useTransfersStore
-    .getState()
-    .updateState(id, kind, status, progress, error)
+  setState((state) => {
+    const key = makeTransferKey(kind, id)
+    const prev = state.transfers[key]
+    const next: TransferState = {
+      id,
+      kind,
+      controller: prev.controller,
+      status,
+      progress,
+      error: status === 'error' ? err ?? prev.error ?? '' : undefined,
+    }
+    return { transfers: { ...state.transfers, [key]: next } }
+  })
 }
 
 function updateTransferProgress(
@@ -123,7 +70,41 @@ function updateTransferProgress(
   kind: TransferKind,
   progress: number
 ) {
-  return useTransfersStore.getState().updateProgress(id, kind, progress)
+  setState((state) => {
+    const key = makeTransferKey(kind, id)
+    const prev = state.transfers[key]
+    const next: TransferState = {
+      id,
+      kind,
+      controller: prev.controller,
+      status: prev.status,
+      progress,
+      error: prev.error,
+    }
+    return { transfers: { ...state.transfers, [key]: next } }
+  })
+}
+
+function removeTransfer(id: string, kind: TransferKind) {
+  setState((state) => {
+    const key = makeTransferKey(kind, id)
+    const { [key]: _, ...rest } = state.transfers
+    return { transfers: rest }
+  })
+}
+
+export function cancelAllTransfers() {
+  const current = getState().transfers
+  Object.values(current).forEach((r) => {
+    try {
+      logger.log('aborting transfer', r.id)
+      r.controller?.abort()
+    } catch (e) {
+      logger.log('error aborting transfer', r.id, e)
+      // Ignore.
+    }
+  })
+  useTransfersStore.setState({ transfers: {} })
 }
 
 export type TransferCounts = {
@@ -177,29 +158,6 @@ export const [getTransferCounts, useTransferCounts] = createGetterAndSelector(
   }
 )
 
-export function makeTransferKey(kind: TransferKind, id: string): string {
-  return `${kind}:${id}`
-}
-
-export const [getActiveUploads, useActiveUploads] = createGetterAndSelector(
-  useTransfersStore,
-  (state): TransferState[] => {
-    return Object.values(state.transfers).filter((rec) => rec.kind === 'upload')
-  }
-)
-
-export const [getActiveUploadCount, useActiveUploadCount] =
-  createGetterAndSelector(
-    useTransfersStore,
-    (): number => getActiveUploads().length
-  )
-
-export const [getHasActiveUploads, useHasActiveUploads] =
-  createGetterAndSelector(
-    useTransfersStore,
-    (): boolean => getActiveUploads().length > 0
-  )
-
 export async function runTransferWithSlot<T>(params: {
   id: string
   kind: TransferKind
@@ -214,7 +172,7 @@ export async function runTransferWithSlot<T>(params: {
     setTransferState(id, kind, 'running', 0)
     const result = await task(controller.signal)
     logger.log('transfer success', id, kind)
-    useTransfersStore.getState().remove(id, kind)
+    removeTransfer(id, kind)
     return result
   } catch (e) {
     logger.log('transfer error', id, kind, e)
@@ -223,8 +181,12 @@ export async function runTransferWithSlot<T>(params: {
     throw e
   } finally {
     release()
-    useTransfersStore.getState().remove(id, kind)
+    removeTransfer(id, kind)
   }
+}
+
+export function makeTransferKey(kind: TransferKind, id: string): string {
+  return `${kind}:${id}`
 }
 
 export function updateUploadProgress(id: string, progress: number) {
@@ -248,3 +210,22 @@ export function useDownloadState(id: string): TransferState | undefined {
     useShallow((state) => (key ? state.transfers[key] : undefined))
   )
 }
+
+export const [getActiveUploads, useActiveUploads] = createGetterAndSelector(
+  useTransfersStore,
+  (state): TransferState[] => {
+    return Object.values(state.transfers).filter((rec) => rec.kind === 'upload')
+  }
+)
+
+export const [getActiveUploadCount, useActiveUploadCount] =
+  createGetterAndSelector(
+    useTransfersStore,
+    (): number => getActiveUploads().length
+  )
+
+export const [getHasActiveUploads, useHasActiveUploads] =
+  createGetterAndSelector(
+    useTransfersStore,
+    (): boolean => getActiveUploads().length > 0
+  )


### PR DESCRIPTION
- This PR moves store actions out of the actual store state and defines them only as separate functions that call getState and setState.
- Having the methods in the store state meant that we either had to:
    - Import the entire store everywhere and awkwardly call acitons like: `useFooStore.getState().action()`​.
    - To avoid this I had added wrappers so that we could export individual actions.
    - But this meant that we end up redefining the method and signature many times- in the store type, in the store itself, and the wrapper.
    - This felt very redundant and made jump to definition and search annoying.
- These changes means we only have to update methods in one single place and import/usage is very clear.