### PR TITLE
feat: online status

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
         "@azure/core-asynciterator-polyfill": "^1.0.2",
         "@bacons/text-decoder": "^0.0.0",
         "@react-native-clipboard/clipboard": "^1.16.3",
-        "@react-native-community/netinfo": "11.4.1",
+        "@react-native-community/netinfo": "^11.4.1",
         "@react-native/new-app-screen": "0.81.0",
         "@react-navigation/bottom-tabs": "^7.4.7",
         "@react-navigation/native": "^7.1.17",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@azure/core-asynciterator-polyfill": "^1.0.2",
     "@bacons/text-decoder": "^0.0.0",
     "@react-native-clipboard/clipboard": "^1.16.3",
-    "@react-native-community/netinfo": "11.4.1",
+    "@react-native-community/netinfo": "^11.4.1",
     "@react-native/new-app-screen": "0.81.0",
     "@react-navigation/bottom-tabs": "^7.4.7",
     "@react-navigation/native": "^7.1.17",

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -11,12 +11,14 @@ import { useEffect } from 'react'
 import { initApp, shutdownApp } from './stores/app'
 import * as SplashScreen from 'expo-splash-screen'
 import useLinkedURL from './hooks/useLinkedURL'
+import { useReconnectIndexer } from './hooks/useReconnectIndexer'
 import { RootTabs } from './stacks/RootTabs'
 
 SplashScreen.preventAutoHideAsync()
 
 export function Root() {
   const navigationRef = useNavigationContainerRef<any>()
+  useReconnectIndexer()
 
   useEffect(() => {
     initApp()

--- a/src/hooks/useAppStatus.tsx
+++ b/src/hooks/useAppStatus.tsx
@@ -5,6 +5,7 @@ import { useIsConnected } from '../stores/sdk'
 import { useIsInitializing } from '../stores/app'
 import { useHasOnboarded } from '../stores/settings'
 import { useUploadScannerStatus } from '../managers/uploadScanner'
+import { useIsOnline } from './useIsOnline'
 
 export type AppStatus = {
   visible: boolean
@@ -19,9 +20,19 @@ export function useAppStatus(): AppStatus {
   const isConnected = useIsConnected()
   const hasOnboarded = useHasOnboarded()
   const uploadsProgress = useUploadScannerStatus()
+  const isOnline = useIsOnline()
 
   if (!hasOnboarded || isInitializing) {
     return { visible: false, message: '', icon: null, level: 'info' }
+  }
+
+  if (typeof isOnline.data === 'boolean' && !isOnline.data) {
+    return {
+      visible: true,
+      message: 'No internet connection',
+      icon: <TriangleAlertIcon size={14} color={palette.yellow[400]} />,
+      level: 'warning',
+    }
   }
 
   if (!isConnected) {

--- a/src/hooks/useIsOnline.ts
+++ b/src/hooks/useIsOnline.ts
@@ -1,0 +1,33 @@
+import { useEffect } from 'react'
+import NetInfo, { type NetInfoState } from '@react-native-community/netinfo'
+import { logger } from '../lib/logger'
+import useSWR from 'swr'
+
+export function getIsOnline(state: NetInfoState): boolean {
+  const reachable = state.isInternetReachable
+  if (reachable !== null) return Boolean(reachable)
+  return Boolean(state.isConnected)
+}
+
+export function useIsOnline() {
+  const isOnline = useSWR('onlineStatus', async () => {
+    const state = await NetInfo.fetch()
+    return getIsOnline(state)
+  })
+
+  useEffect(() => {
+    const unsubscribe = NetInfo.addEventListener(() => {
+      isOnline.mutate()
+    })
+    return () => unsubscribe()
+  }, [isOnline])
+
+  useEffect(() => {
+    if (isOnline.isLoading) {
+      return
+    }
+    logger.log(`[netinfo] app is now ${isOnline.data ? 'online' : 'offline'}`)
+  }, [isOnline.data])
+
+  return isOnline
+}

--- a/src/hooks/useReconnectIndexer.ts
+++ b/src/hooks/useReconnectIndexer.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from 'react'
+import NetInfo from '@react-native-community/netinfo'
+import { reconnect, useIsConnected } from '../stores/sdk'
+import { logger } from '../lib/logger'
+import { getIsOnline } from './useIsOnline'
+import { useIsInitializing } from '../stores/app'
+
+export function useReconnectIndexer() {
+  const reconnectingRef = useRef(false)
+  const isIndexerConnected = useIsConnected()
+  const isInitializing = useIsInitializing()
+
+  useEffect(() => {
+    const unsubscribe = NetInfo.addEventListener((state) => {
+      const isOnline = getIsOnline(state)
+
+      if (
+        !isInitializing &&
+        !isIndexerConnected &&
+        isOnline &&
+        !reconnectingRef.current
+      ) {
+        reconnectingRef.current = true
+        logger.log('[netinfo] app is now online, reconnecting...')
+        void reconnect().finally(() => {
+          reconnectingRef.current = false
+        })
+      }
+    })
+    return () => unsubscribe()
+  }, [])
+}

--- a/src/stores/transfers.ts
+++ b/src/stores/transfers.ts
@@ -178,6 +178,9 @@ export async function runTransferWithSlot<T>(params: {
   } catch (e) {
     logger.log('transfer error', id, kind, e)
     const message = e instanceof Error ? e.message : String(e)
+    if (message.includes('Error connecting to indexer')) {
+      setIsConnected(false)
+    }
     setTransferState(id, kind, 'error', 0, message)
     throw e
   } finally {


### PR DESCRIPTION
- Show offline status.
- Try to reconnect indexer when transitioning to online.
- Set indexer as disconnected when any transfer throws a connection error.

![Screenshot 2025-10-07 at 4.12.32 PM.png](https://app.graphite.dev/user-attachments/assets/3fb45306-cda1-43f5-b1d0-a52406b65ed6.png)![Screenshot 2025-10-07 at 4.12.39 PM.png](https://app.graphite.dev/user-attachments/assets/c37667fb-0d38-400f-b4bb-503946610c9e.png)

