### PR TITLE
fix: scroll performance

### DIFF
--- a/src/components/FileListItem.tsx
+++ b/src/components/FileListItem.tsx
@@ -6,6 +6,7 @@ import { humanSize } from '../lib/humanSize'
 import { DotIcon } from 'lucide-react-native'
 import { UploadStatusIcon } from './UploadStatusIcon'
 import { FileThumbnail } from './FileThumbnail'
+import { memo } from 'react'
 
 type Props = {
   file: FileRecord
@@ -13,7 +14,7 @@ type Props = {
   setItemRef?: (id: string, ref: any) => void
 }
 
-export function FileListItem({ file, onPressItem, setItemRef }: Props) {
+function FileListItemComponent({ file, onPressItem, setItemRef }: Props) {
   const status = useFileStatus(file)
   return (
     <Pressable
@@ -49,6 +50,14 @@ export function FileListItem({ file, onPressItem, setItemRef }: Props) {
     </Pressable>
   )
 }
+
+export const FileListItem = memo(FileListItemComponent, (prev, next) => {
+  return (
+    prev.file === next.file &&
+    prev.onPressItem === next.onPressItem &&
+    prev.setItemRef === next.setItemRef
+  )
+})
 
 const styles = StyleSheet.create({
   container: {

--- a/src/components/GalleryItem.tsx
+++ b/src/components/GalleryItem.tsx
@@ -5,6 +5,7 @@ import { useToast } from '../lib/toastContext'
 import { type FileRecord } from '../stores/files'
 import { FileIndicators } from './FileIndicators'
 import { FileThumbnail } from './FileThumbnail'
+import { memo } from 'react'
 
 type Props = {
   file: FileRecord
@@ -12,7 +13,7 @@ type Props = {
   setItemRef?: (id: string, ref: any) => void
 }
 
-export function GalleryItem({ file, onPressItem, setItemRef }: Props) {
+function GalleryItemComponent({ file, onPressItem, setItemRef }: Props) {
   const toast = useToast()
   return (
     <View
@@ -36,9 +37,17 @@ export function GalleryItem({ file, onPressItem, setItemRef }: Props) {
   )
 }
 
+export const GalleryItem = memo(GalleryItemComponent, (prev, next) => {
+  return (
+    prev.file === next.file &&
+    prev.onPressItem === next.onPressItem &&
+    prev.setItemRef === next.setItemRef
+  )
+})
+
 const styles = StyleSheet.create({
   thumbCell: {
-    flex: 1,
+    width: '33.33%',
     aspectRatio: 1,
     margin: 0,
     backgroundColor: colors.bgSurface,

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -7,6 +7,7 @@ import { initSdk, reconnect, resetSdk } from './sdk'
 import { initUploadScanner, stopUploadScanner } from '../managers/uploadScanner'
 import { cancelAllTransfers } from './transfers'
 import { initLogger } from './logs'
+import { ensureCacheDir } from './fileCache'
 
 export type AppState = {
   isInitializing: boolean
@@ -22,6 +23,7 @@ const { setState } = useAppStore
 
 export async function initApp() {
   initLogger()
+  await ensureCacheDir()
   const hasOnboarded = await getHasOnboarded()
   if (hasOnboarded) {
     await initSdk()

--- a/src/stores/fileCache.ts
+++ b/src/stores/fileCache.ts
@@ -8,7 +8,7 @@ const { getKey, triggerChange } = buildSWRHelpers('cache/files')
 
 const CACHE_DIR = new Directory(Paths.cache, 'files-cache')
 
-async function ensureCacheDir(): Promise<void> {
+export async function ensureCacheDir(): Promise<void> {
   const info = CACHE_DIR.info()
   if (!info.exists) {
     CACHE_DIR.create({ intermediates: true })
@@ -16,7 +16,6 @@ async function ensureCacheDir(): Promise<void> {
 }
 
 export async function getCachedFileForId(id: string, ext: Ext): Promise<File> {
-  await ensureCacheDir()
   return new File(CACHE_DIR, `${id}${ext}`)
 }
 
@@ -70,7 +69,6 @@ export async function writeToCache(
   ext: Ext
 ): Promise<string> {
   logger.log('writeToCache', id)
-  await ensureCacheDir()
   const f = await getOrCreateCachedFile(id, ext)
   const writer = f.writableStream().getWriter()
   await writer.write(new Uint8Array(data))
@@ -85,7 +83,6 @@ export async function copyUriToCache(
   ext: Ext
 ): Promise<string> {
   logger.log('copyUriToCache', id, sourceUri, ext)
-  await ensureCacheDir()
   const f = await getOrCreateCachedFile(id, ext)
   const exists = f.info().exists
   if (exists) f.delete()
@@ -101,7 +98,6 @@ export async function copyFileToCache(
   ext: Ext
 ): Promise<string> {
   logger.log('copyFileToCache', id, sourceFile.uri)
-  await ensureCacheDir()
   const f = await getOrCreateCachedFile(id, ext)
   const exists = f.info().exists
   if (exists) f.delete()


### PR DESCRIPTION
This PR includes two perf improvements to the main library list view.

- ensureCacheDir was being called by many of our filesystem methods, this PR moves this to a single call on app init.
- Memoized the FlatList components that are rendered and re-rendered often and quickly.
- The thumbnails components still make some file system calls but this change combined with the memoization removes all noticeable delays. We can optimize further if necessary.
- Also make all gallery items 1/3 width, which will be less janky when items are dynamically added.