### PR TITLE
refactor: move import to its own nav stack

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -35,7 +35,7 @@ export function Root() {
       if (host === 'new-file' || path === 'new-file') {
         const shareUrl = url.searchParams.get('shareUrl') ?? undefined
         if (shareUrl && navigationRef.isReady()) {
-          navigationRef.navigate('MainTab', {
+          navigationRef.navigate('ImportTab', {
             screen: 'ImportFile',
             params: { shareUrl },
           })

--- a/src/components/FileDetailScreenHeader.tsx
+++ b/src/components/FileDetailScreenHeader.tsx
@@ -1,17 +1,21 @@
 import React from 'react'
 import { View, StyleSheet, Text, Pressable } from 'react-native'
-import { NativeStackNavigationProp } from '@react-navigation/native-stack'
-import { type MainStackParamList } from '../stacks/types'
+import { type NavigationProp } from '@react-navigation/native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import { ArrowLeftIcon } from 'lucide-react-native'
-import { colors, overlay, palette, whiteA } from '../styles/colors'
+import { ArrowLeftIcon, XIcon } from 'lucide-react-native'
+import { overlay, palette } from '../styles/colors'
 
 type Props = {
   title: string
-  navigation: NativeStackNavigationProp<MainStackParamList>
+  navigation: NavigationProp<Record<string, object | undefined>>
+  icon?: 'back' | 'close'
 }
 
-export function FileDetailScreenHeader({ title, navigation }: Props) {
+export function FileDetailScreenHeader({
+  title,
+  navigation,
+  icon = 'back',
+}: Props) {
   const insets = useSafeAreaInsets()
   return (
     <View style={[styles.headerContainer, { paddingTop: insets.top + 2 }]}>
@@ -22,7 +26,11 @@ export function FileDetailScreenHeader({ title, navigation }: Props) {
           style={styles.headerIcon}
         >
           <View style={styles.pill}>
-            <ArrowLeftIcon color={palette.gray[50]} size={16} />
+            {icon === 'back' ? (
+              <ArrowLeftIcon color={palette.gray[50]} size={16} />
+            ) : (
+              <XIcon color={palette.gray[50]} size={16} />
+            )}
           </View>
         </Pressable>
         <Text style={styles.title} numberOfLines={1} ellipsizeMode="tail">

--- a/src/screens/ImportFileScreen.tsx
+++ b/src/screens/ImportFileScreen.tsx
@@ -1,7 +1,5 @@
-import {
-  NativeStackNavigationProp,
-  type NativeStackScreenProps,
-} from '@react-navigation/native-stack'
+import { type NativeStackScreenProps } from '@react-navigation/native-stack'
+import { useNavigation, type NavigationProp } from '@react-navigation/native'
 import React, { useCallback } from 'react'
 import useSWR from 'swr'
 import {
@@ -12,11 +10,13 @@ import {
   View,
   Platform,
 } from 'react-native'
-import { type MainStackParamList } from '../stacks/types'
+import {
+  type ImportStackParamList,
+  type RootTabParamList,
+} from '../stacks/types'
 import { useToast } from '../lib/toastContext'
 import { useSdk } from '../stores/sdk'
 import { createFileRecord } from '../stores/files'
-import { useNavigation } from '@react-navigation/native'
 import { uniqueId } from '../lib/uniqueId'
 import { FileDetailsImport } from '../components/FileDetailsImport'
 import { logger } from '../lib/logger'
@@ -28,11 +28,10 @@ import { PlusIcon } from 'lucide-react-native'
 import { FileDetailScreenHeader } from '../components/FileDetailScreenHeader'
 import { colors } from '../styles/colors'
 
-type Props = NativeStackScreenProps<MainStackParamList, 'ImportFile'>
+type Props = NativeStackScreenProps<ImportStackParamList, 'ImportFile'>
 
 export function ImportFileScreen({ route }: Props) {
-  const navigation =
-    useNavigation<NativeStackNavigationProp<MainStackParamList>>()
+  const navigation = useNavigation<NavigationProp<RootTabParamList>>()
   const toast = useToast()
   const shareUrl = route.params?.shareUrl
   const sdk = useSdk()
@@ -79,12 +78,19 @@ export function ImportFileScreen({ route }: Props) {
       sealedObjects: { [indexerURL]: sealedObject },
     })
     toast.show('File added')
-    navigation.navigate('FileDetail', { id: sharedFile.data.id })
+    navigation.navigate('MainTab', {
+      screen: 'FileDetail',
+      params: { id: sharedFile.data.id },
+    })
   }, [sharedFile.data, sdk, toast, navigation])
 
   return (
     <View style={styles.container}>
-      <FileDetailScreenHeader title="Import File" navigation={navigation} />
+      <FileDetailScreenHeader
+        title="Import File"
+        navigation={navigation}
+        icon="close"
+      />
       <ScrollView contentContainerStyle={styles.content}>
         {sharedFile.isValidating ? (
           <View style={styles.center}>

--- a/src/stacks/ImportStack.tsx
+++ b/src/stacks/ImportStack.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { createNativeStackNavigator } from '@react-navigation/native-stack'
+import { ImportFileScreen } from '../screens/ImportFileScreen'
+import { type ImportStackParamList } from './types'
+
+const Stack = createNativeStackNavigator<ImportStackParamList>()
+
+export function ImportStack() {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen
+        name="ImportFile"
+        component={ImportFileScreen}
+        options={{ title: 'Import File', headerShown: false }}
+      />
+    </Stack.Navigator>
+  )
+}

--- a/src/stacks/MainStack.tsx
+++ b/src/stacks/MainStack.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import { LibraryScreen } from '../screens/LibraryScreen'
 import { FileDetailScreen } from '../screens/FileDetailScreen'
-import { ImportFileScreen } from '../screens/ImportFileScreen'
 import { type MainStackParamList } from './types'
 
 const Stack = createNativeStackNavigator<MainStackParamList>()
@@ -19,11 +18,6 @@ export function MainStack() {
         name="FileDetail"
         component={FileDetailScreen}
         options={{ title: 'Media', headerShown: false }}
-      />
-      <Stack.Screen
-        name="ImportFile"
-        component={ImportFileScreen}
-        options={{ title: 'Import File', headerShown: false }}
       />
     </Stack.Navigator>
   )

--- a/src/stacks/RootTabs.tsx
+++ b/src/stacks/RootTabs.tsx
@@ -5,6 +5,7 @@ import { SettingsStack } from './SettingsStack'
 import { type RootTabParamList } from './types'
 import { AuthStack } from './AuthStack'
 import { useHasOnboarded } from '../stores/settings'
+import { ImportStack } from './ImportStack'
 
 const Tab = createBottomTabNavigator<RootTabParamList>()
 
@@ -17,6 +18,12 @@ export function RootTabs() {
     <Tab.Navigator screenOptions={{ headerShown: false }}>
       <Tab.Screen name="MainTab" options={{ tabBarStyle: { display: 'none' } }}>
         {() => <MainStack />}
+      </Tab.Screen>
+      <Tab.Screen
+        name="ImportTab"
+        options={{ tabBarStyle: { display: 'none' } }}
+      >
+        {() => <ImportStack />}
       </Tab.Screen>
       <Tab.Screen
         name="SettingsTab"

--- a/src/stacks/types.ts
+++ b/src/stacks/types.ts
@@ -1,7 +1,8 @@
+import { type NavigatorScreenParams } from '@react-navigation/native'
+
 export type MainStackParamList = {
   LibraryHome: undefined
   FileDetail: { id: string }
-  ImportFile: { shareUrl?: string }
 }
 
 export type SettingsStackParamList = {
@@ -18,8 +19,12 @@ export type AuthStackParamList = {
   Connect: undefined
 }
 
+export type ImportStackParamList = {
+  ImportFile: { shareUrl?: string }
+}
+
 export type RootTabParamList = {
-  MainTab: undefined
-  SettingsTab: undefined
-  LogsTab: undefined
+  MainTab: NavigatorScreenParams<MainStackParamList> | undefined
+  SettingsTab: NavigatorScreenParams<SettingsStackParamList> | undefined
+  ImportTab: NavigatorScreenParams<ImportStackParamList> | undefined
 }


### PR DESCRIPTION
- Moves the import screen to a separate tab/stack.
- Previously if you added a file and then navigated back you would get back to the import screen.
- This change separates it so that adding the file or closing navigates back to the main stack and resumes that navigation history.

![Screenshot 2025-10-08 at 10.15.12 AM.png](https://app.graphite.dev/user-attachments/assets/879eb054-fd73-4f86-bbf9-da6517eb172c.png)

