### PR TITLE
feat: sync down objects

### DIFF
--- a/src/components/FileActionsSheet.tsx
+++ b/src/components/FileActionsSheet.tsx
@@ -84,8 +84,8 @@ export function FileActionsSheet({
     try {
       // TODO: in the future if a file is synced with multiple indexers,
       // we will need to delete the object from each indexer.
-      if (file.key) {
-        await sdk?.deleteObject(file.key)
+      if (file.cid) {
+        await sdk?.deleteObject(file.cid)
       }
       await updateFileSealedObjects(file.id, {})
       toast.show('Removed from network')
@@ -100,8 +100,8 @@ export function FileActionsSheet({
     if (!file) return
     try {
       await deleteFileRecord(file.id)
-      if (file.key) {
-        await sdk?.deleteObject(file.key)
+      if (file.cid) {
+        await sdk?.deleteObject(file.cid)
       }
       await removeFromCache(file.id, extFromMime(file.fileType))
       toast.show('Deleted file')

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -21,3 +21,5 @@ export const SCANNER_MAX_TOTAL_UPLOADS_FACTOR = 2
 export const SCANNER_ADD_TO_QUEUE_FACTOR = 2
 // Scan interval.
 export const SCANNER_INTERVAL = 5_000 // 5 seconds
+// Sync objects interval.
+export const SYNC_OBJECTS_INTERVAL = 10_000 // 10 seconds

--- a/src/db/migrations/0001_init_schema.ts
+++ b/src/db/migrations/0001_init_schema.ts
@@ -12,6 +12,7 @@ async function up(db: SQLite.SQLiteDatabase): Promise<void> {
   await db.execAsync(
     `CREATE TABLE IF NOT EXISTS files (
       id TEXT PRIMARY KEY,
+      cid TEXT UNIQUE,
       fileName TEXT,
       fileSize INTEGER,
       createdAt INTEGER NOT NULL,

--- a/src/encoding/index.ts
+++ b/src/encoding/index.ts
@@ -1,0 +1,10 @@
+import z from 'zod'
+
+export const epochOrIsoToDate = z.codec(
+  z.union([z.number(), z.string()]),
+  z.date(),
+  {
+    decode: (value) => new Date(value as any),
+    encode: (date) => date.toISOString(),
+  }
+)

--- a/src/encoding/sealedObjects.ts
+++ b/src/encoding/sealedObjects.ts
@@ -3,15 +3,11 @@ import { hexToUint8, arrayBufferToHex } from '../lib/hex'
 import { z } from 'zod'
 import { logger } from '../lib/logger'
 import { MaybeError } from '../lib/types'
+import { epochOrIsoToDate } from '.'
 
 const hexArrayBuffer = z.codec(z.hex(), z.instanceof(ArrayBuffer), {
   decode: (hex) => hexToUint8(hex).slice().buffer as ArrayBuffer,
   encode: (buf) => arrayBufferToHex(buf),
-})
-
-const epochOrIsoToDate = z.codec(z.union([z.number(), z.string()]), z.date(), {
-  decode: (value) => new Date(value as any),
-  encode: (date) => date.toISOString(),
 })
 
 const slabSchema = z.object({

--- a/src/hooks/useChangeIndexer.tsx
+++ b/src/hooks/useChangeIndexer.tsx
@@ -1,8 +1,8 @@
-import { tryToConnectAndSet } from '../stores/sdk'
 import { useCallback, useState } from 'react'
 import { useToast } from '../lib/toastContext'
 import { setIndexerURL, useIndexerURL } from '../stores/settings'
 import { useInputValue } from './useInputValue'
+import { onboardIndexer } from '../stores/app'
 
 function validateURL(url: string) {
   try {
@@ -23,7 +23,7 @@ export function useChangeIndexer() {
     value: indexerURL.data ?? '',
   })
 
-  const saveIndexerURL = useCallback(async () => {
+  const saveAndOnboard = useCallback(async () => {
     const newUrl = newIndexerInputProps.value
     setIsWaiting(true)
     const isValid = validateURL(newUrl)
@@ -32,7 +32,7 @@ export function useChangeIndexer() {
       setIsWaiting(false)
       return
     }
-    const success = await tryToConnectAndSet(newUrl)
+    const success = await onboardIndexer(newUrl)
     if (!success) {
       toast.show('Failed to connect')
       setHasErrored(true)
@@ -45,7 +45,7 @@ export function useChangeIndexer() {
 
   return {
     newIndexerInputProps,
-    saveIndexerURL,
+    saveAndOnboard,
     isWaiting,
     hasErrored,
   }

--- a/src/managers/syncDownObjects.ts
+++ b/src/managers/syncDownObjects.ts
@@ -1,0 +1,137 @@
+import { logger } from '../lib/logger'
+import { SYNC_OBJECTS_INTERVAL } from '../config'
+import { getIsConnected, getSdk } from '../stores/sdk'
+import { getAutoSyncDownObjects, getIndexerURL } from '../stores/settings'
+import { getAppKey } from '../lib/appKey'
+import {
+  insertOrReplaceFileRecord,
+  FileRecord,
+  readFileRecordByCid,
+} from '../stores/files'
+import { decodeFileMetadata } from '../encoding/fileMetadata'
+import { uniqueId } from '../lib/uniqueId'
+import { type ObjectsCursor } from 'react-native-sia'
+import { createServiceInterval } from '../lib/serviceInterval'
+import { z } from 'zod'
+import { getSecureStoreJSON, setSecureStoreJSON } from '../stores/secureStore'
+import { epochOrIsoToDate } from '../encoding'
+
+const batchSize = 30
+
+/**
+ * Syncs down objects from the indexer to the local database. The service works by
+ * starting with a cursor saved in secure store. The service will sync down the next
+ * batch of objects and save the cursor to secure store. If there are no objects to
+ * sync, the cursor is reset. The service checks if files are already in the database
+ * by cid. The service runs a batch every SYNC_OBJECTS_INTERVAL milliseconds.
+ */
+async function syncDownObjects(): Promise<void> {
+  const isConnected = getIsConnected()
+  if (!isConnected) {
+    logger.log('[syncDownObjects] not connected to indexer, skipping sync')
+    return
+  }
+  try {
+    const sdk = getSdk()
+    if (!sdk) {
+      logger.log('[syncDownObjects] no sdk, skipping sync')
+      return
+    }
+    const indexerURL = await getIndexerURL()
+    const cursor = await getSyncDownCursor()
+    logger.log('[syncDownObjects] syncing batch', cursor)
+    let existingCount = 0
+    let newCount = 0
+    const objects = await sdk.objects(cursor, batchSize)
+    if (objects.length === 0) {
+      logger.log('[syncDownObjects] no objects to sync, resetting cursor')
+      await setSyncDownCursor(undefined)
+      return
+    }
+    for (const { object, deleted, key } of objects) {
+      if (deleted) continue
+      if (!object) continue
+      const existingFileRecord = await readFileRecordByCid(key)
+      const metadata = decodeFileMetadata(object.metadata())
+      const sealedObject = object.seal(await getAppKey())
+      if (existingFileRecord) {
+        existingCount += 1
+        tryToAddFileRecord({
+          ...existingFileRecord,
+          sealedObjects: {
+            ...existingFileRecord?.sealedObjects,
+            [indexerURL]: sealedObject,
+          },
+        })
+      } else {
+        newCount += 1
+        tryToAddFileRecord({
+          id: uniqueId(),
+          cid: key,
+          fileName: metadata.name ?? null,
+          fileSize: metadata.size ?? null,
+          createdAt: object.createdAt().getTime(),
+          fileType: metadata.fileType ?? null,
+          sealedObjects: {
+            [indexerURL]: sealedObject,
+          },
+        })
+      }
+    }
+    logger.log('[syncDownObjects] synced', existingCount, 'existing objects')
+    logger.log('[syncDownObjects] synced', newCount, 'new objects')
+    await setSyncDownCursor({
+      key: objects[objects.length - 1].key,
+      after: objects[objects.length - 1].object?.updatedAt() ?? new Date(),
+    })
+  } catch (e) {
+    logger.log('[syncDownObjects] sync error', e)
+  }
+}
+
+export const initSyncDownObjects = createServiceInterval({
+  name: 'syncDownObjects',
+  worker: syncDownObjects,
+  getState: getAutoSyncDownObjects,
+  interval: SYNC_OBJECTS_INTERVAL,
+})
+
+function tryToAddFileRecord(fileRecord: FileRecord): void {
+  try {
+    insertOrReplaceFileRecord(fileRecord)
+  } catch (e) {
+    logger.log('[syncDownObjects] error adding file record', fileRecord.cid, e)
+  }
+}
+
+// Persistent cursor saved for next batch.
+
+const objectsCursorCodec = z.codec(
+  z.object({
+    key: z.string(),
+    after: z.union([z.string(), z.number()]),
+  }),
+  z.object({
+    key: z.string(),
+    after: z.date(),
+  }),
+  {
+    decode: (stored) => ({
+      key: stored.key,
+      after: epochOrIsoToDate.decode(stored.after),
+    }),
+    encode: (cursor) => ({
+      key: cursor.key,
+      after: epochOrIsoToDate.encode(cursor.after),
+    }),
+  }
+)
+
+async function getSyncDownCursor(): Promise<ObjectsCursor | undefined> {
+  const decoded = await getSecureStoreJSON('syncDownCursor', objectsCursorCodec)
+  return decoded == null ? undefined : (decoded as unknown as ObjectsCursor)
+}
+
+export async function setSyncDownCursor(value: ObjectsCursor | undefined) {
+  await setSecureStoreJSON('syncDownCursor', value, objectsCursorCodec)
+}

--- a/src/managers/uploader.ts
+++ b/src/managers/uploader.ts
@@ -37,6 +37,7 @@ export function useUploader() {
           )
           fileRecords.push({
             id: asset.id,
+            cid: null,
             fileName: asset.fileName,
             fileSize: asset.fileSize,
             createdAt: asset.createdAt,

--- a/src/screens/ImportFileScreen.tsx
+++ b/src/screens/ImportFileScreen.tsx
@@ -74,6 +74,7 @@ export function ImportFileScreen({ route }: Props) {
     const sealedObject = pinnedObject.seal(await getAppKey())
     await insertOrReplaceFileRecord({
       ...sharedFile.data,
+      cid: sealedObject.id,
       createdAt: new Date().getTime(),
       sealedObjects: { [indexerURL]: sealedObject },
     })

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -27,7 +27,7 @@ export default function OnboardingScreen() {
   const toast = useToast()
   const copyRecoveryPhrase = useCopyRecoveryPhrase()
 
-  const { newIndexerInputProps, saveIndexerURL, isWaiting, hasErrored } =
+  const { newIndexerInputProps, saveAndOnboard, isWaiting, hasErrored } =
     useChangeIndexer()
 
   const newRecoveryPhraseInputProps = useControlledInputValue({
@@ -105,7 +105,7 @@ export default function OnboardingScreen() {
                 </View>
               </>
             ) : null}
-            <Button onPress={saveIndexerURL}>Authorize & Connect</Button>
+            <Button onPress={saveAndOnboard}>Authorize & Connect</Button>
           </View>
         </View>
       )}

--- a/src/screens/SettingsIndexerScreen.tsx
+++ b/src/screens/SettingsIndexerScreen.tsx
@@ -21,7 +21,7 @@ type Props = NativeStackScreenProps<SettingsStackParamList, 'Indexer'>
 export function SettingsIndexerScreen(_props: Props) {
   const isConnected = useIsConnected()
   const currentIndexerURL = useIndexerURL()
-  const { newIndexerInputProps, saveIndexerURL, isWaiting } = useChangeIndexer()
+  const { newIndexerInputProps, saveAndOnboard, isWaiting } = useChangeIndexer()
   useSettingsHeader()
   const account = useAccount()
   return (
@@ -80,7 +80,7 @@ export function SettingsIndexerScreen(_props: Props) {
             />
           </InfoCard>
         </RowGroup>
-        <Button onPress={saveIndexerURL}>
+        <Button onPress={saveAndOnboard}>
           {currentIndexerURL.data === newIndexerInputProps.value
             ? isWaiting
               ? 'Reconnecting...'

--- a/src/screens/SettingsSyncScreen.tsx
+++ b/src/screens/SettingsSyncScreen.tsx
@@ -10,7 +10,9 @@ import { InputRow } from '../components/InputRow'
 import {
   setMaxTransfers,
   toggleAutoScanUploads,
+  toggleAutoSyncDownObjects,
   useAutoScanUploads,
+  useAutoSyncDownObjects,
   useMaxTransfers,
 } from '../stores/settings'
 import { useInputValue } from '../hooks/useInputValue'
@@ -25,6 +27,7 @@ export function SettingsSyncScreen(_props: Props) {
   const counts = useTransferCounts()
   const autoScan = useAutoScanUploads()
   const maxSlots = useMaxTransfers()
+  const autoSync = useAutoSyncDownObjects()
 
   const maxTransfersInputProps = useInputValue({
     value: String(maxSlots.data),
@@ -45,6 +48,16 @@ export function SettingsSyncScreen(_props: Props) {
               <Switch
                 value={autoScan.data ?? false}
                 onValueChange={toggleAutoScanUploads}
+              />
+            }
+          />
+          <LabeledValueRow
+            label="Auto sync down objects"
+            labelWidth={200}
+            value={
+              <Switch
+                value={autoSync.data ?? false}
+                onValueChange={toggleAutoSyncDownObjects}
               />
             }
           />

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -3,12 +3,13 @@ import { generateRecoveryPhrase } from 'react-native-sia'
 import { deleteAllFileRecords } from './files'
 import { getHasOnboarded, setRecoveryPhrase, setHasOnboarded } from './settings'
 import * as SplashScreen from 'expo-splash-screen'
-import { initSdk, reconnect, resetSdk } from './sdk'
+import { initSdk, reconnect, resetSdk, tryToConnectAndSet } from './sdk'
 import { initUploadScanner } from '../managers/uploadScanner'
 import { cancelAllTransfers } from './transfers'
 import { initLogger } from './logs'
 import { ensureCacheDir } from './fileCache'
 import { resetDb } from '../db'
+import { initSyncDownObjects } from '../managers/syncDownObjects'
 
 export type AppState = {
   isInitializing: boolean
@@ -32,7 +33,18 @@ export async function initApp() {
   }
   setState({ isInitializing: false })
   await SplashScreen.hideAsync()
-  await initUploadScanner()
+  initUploadScanner()
+  initSyncDownObjects()
+}
+
+export async function onboardIndexer(indexerURL: string) {
+  const success = await tryToConnectAndSet(indexerURL)
+  if (!success) {
+    return false
+  }
+
+  await setHasOnboarded(true)
+  return success
 }
 
 export function shutdownApp() {

--- a/src/stores/files.ts
+++ b/src/stores/files.ts
@@ -24,6 +24,7 @@ async function triggerChange() {
 
 export type FileRecord = {
   id: string
+  cid: string | null
   fileName: string | null
   fileSize: number | null
   createdAt: number
@@ -35,11 +36,12 @@ export async function insertOrReplaceFileRecord(
   fileRecord: FileRecord,
   triggerUpdate: boolean = true
 ): Promise<void> {
-  const { id, fileName, fileSize, createdAt, fileType, sealedObjects } =
+  const { id, cid, fileName, fileSize, createdAt, fileType, sealedObjects } =
     fileRecord
   await db().runAsync(
-    'INSERT OR REPLACE INTO files (id, fileName, fileSize, createdAt, fileType) VALUES (?, ?, ?, ?, ?)',
+    'INSERT OR REPLACE INTO files (id, cid, fileName, fileSize, createdAt, fileType) VALUES (?, ?, ?, ?, ?, ?)',
     id,
+    cid,
     fileName,
     fileSize,
     createdAt,
@@ -65,13 +67,14 @@ export async function insertOrReplaceManyFileRecords(
 export async function readAllFileRecords(): Promise<FileRecord[]> {
   const rows = await db().getAllAsync<{
     id: string
+    cid: string
     fileName: string | null
     fileSize: number | null
     createdAt: number
     fileType: string
     sealedObjects: string | null
   }>(
-    'SELECT id, fileName, fileSize, createdAt, fileType, sealedObjects FROM files ORDER BY createdAt DESC'
+    'SELECT id, cid, fileName, fileSize, createdAt, fileType, sealedObjects FROM files ORDER BY createdAt DESC'
   )
   return rows.map(transformRow)
 }
@@ -129,13 +132,14 @@ export async function readOrderedFileRecords(
 
   const rows = await db().getAllAsync<{
     id: string
+    cid: string
     fileName: string | null
     fileSize: number | null
     createdAt: number
     fileType: string
     sealedObjects: string | null
   }>(
-    `SELECT id, fileName, fileSize, createdAt, fileType, sealedObjects
+    `SELECT id, cid, fileName, fileSize, createdAt, fileType, sealedObjects
      FROM files
      ${where}
      ORDER BY ${orderExpr}${pageClause}`,
@@ -145,16 +149,54 @@ export async function readOrderedFileRecords(
   return rows.map(transformRow)
 }
 
-export async function readFileRecord(id: string): Promise<FileRecord | null> {
+export async function readFileRecordByCid(
+  cid: string
+): Promise<FileRecord | null> {
   const row = await db().getFirstAsync<{
     id: string
+    cid: string
     fileName: string | null
     fileSize: number | null
     createdAt: number
     fileType: string
     sealedObjects: string | null
   }>(
-    'SELECT id, fileName, fileSize, createdAt, fileType, sealedObjects FROM files WHERE id = ?',
+    `SELECT id, cid, fileName, fileSize, createdAt, fileType, sealedObjects FROM files WHERE cid = ?`,
+    cid
+  )
+  return row ? transformRow(row) : null
+}
+
+export async function readFileRecordsByCid(
+  cids: string[]
+): Promise<FileRecord[]> {
+  const rows = await db().getAllAsync<{
+    id: string
+    cid: string
+    fileName: string | null
+    fileSize: number | null
+    createdAt: number
+    fileType: string
+    sealedObjects: string | null
+  }>(
+    `SELECT id, cid, fileName, fileSize, createdAt, fileType, sealedObjects FROM files WHERE cid IN (${cids
+      .map(() => '?')
+      .join(',')})`
+  )
+  return rows.map(transformRow)
+}
+
+export async function readFileRecord(id: string): Promise<FileRecord | null> {
+  const row = await db().getFirstAsync<{
+    id: string
+    cid: string
+    fileName: string | null
+    fileSize: number | null
+    createdAt: number
+    fileType: string
+    sealedObjects: string | null
+  }>(
+    'SELECT id, cid, fileName, fileSize, createdAt, fileType, sealedObjects FROM files WHERE id = ?',
     id
   )
   if (!row) {
@@ -165,10 +207,11 @@ export async function readFileRecord(id: string): Promise<FileRecord | null> {
 }
 
 export async function updateFileRecord(fileRecord: FileRecord): Promise<void> {
-  const { id, fileName, fileSize, createdAt, fileType, sealedObjects } =
+  const { id, cid, fileName, fileSize, createdAt, fileType, sealedObjects } =
     fileRecord
   await db().runAsync(
-    'UPDATE files SET fileName = ?, fileSize = ?, createdAt = ?, fileType = ? WHERE id = ?',
+    'UPDATE files SET cid = ?, fileName = ?, fileSize = ?, createdAt = ?, fileType = ? WHERE id = ?',
+    cid,
     fileName,
     fileSize,
     createdAt,
@@ -235,6 +278,7 @@ export async function updateFileSealedObject(
 
 function transformRow(row: {
   id: string
+  cid: string
   fileName: string | null
   fileSize: number | null
   createdAt: number
@@ -244,6 +288,7 @@ function transformRow(row: {
   const [sealedObjects] = deserializeSealedObjects(row.id, row.sealedObjects)
   return {
     id: row.id,
+    cid: row.cid,
     fileName: row.fileName,
     fileSize: row.fileSize,
     createdAt: row.createdAt,

--- a/src/stores/sdk.ts
+++ b/src/stores/sdk.ts
@@ -5,6 +5,7 @@ import { logger } from '../lib/logger'
 import { setHasOnboarded, getIndexerURL } from './settings'
 import { getAppKey } from '../lib/appKey'
 import { createGetterAndSelector } from '../lib/selectors'
+import { onboardIndexer } from './app'
 
 export type SdkState = {
   sdk: Sdk | null
@@ -123,7 +124,6 @@ export async function tryToConnectAndSet(newIndexerURL: string) {
       isConnected: true,
       isAuthing: false,
     })
-    await setHasOnboarded(true)
     return true
   } catch (err) {
     logger.log('Error connecting to indexer', err)

--- a/src/stores/secureStore.ts
+++ b/src/stores/secureStore.ts
@@ -65,3 +65,47 @@ export async function getSecureStoreString(key: string, fallback = '') {
     return fallback
   }
 }
+
+export type JsonCodec<TStorage, TDomain> = {
+  encode: (domain: TDomain) => TStorage
+  decode: (storage: TStorage) => TDomain
+}
+
+export async function setSecureStoreJSON<TStorage, TDomain>(
+  key: string,
+  value: TDomain | undefined,
+  codec: JsonCodec<TStorage, TDomain>
+) {
+  if (!/^[a-zA-Z0-9._-]+$/.test(key)) {
+    throw new Error(
+      'SecureStore key must contain only alphanumeric characters, dots, hyphens, and underscores'
+    )
+  }
+  if (value == null) {
+    return SecureStore.setItemAsync(key, '')
+  }
+  try {
+    const encoded = codec.encode(value)
+    const json = JSON.stringify(encoded)
+    return SecureStore.setItemAsync(key, json)
+  } catch {
+    return SecureStore.setItemAsync(key, '')
+  }
+}
+
+export async function getSecureStoreJSON<TStorage, TDomain>(
+  key: string,
+  codec: JsonCodec<TStorage, TDomain>,
+  fallback?: TDomain
+): Promise<TDomain | undefined> {
+  try {
+    const found = await SecureStore.getItemAsync(key)
+    if (typeof found !== 'string' || found.trim().length === 0) {
+      return fallback
+    }
+    const parsed = JSON.parse(found) as TStorage
+    return codec.decode(parsed)
+  } catch {
+    return fallback
+  }
+}

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -111,3 +111,21 @@ export async function toggleAutoScanUploads() {
   const next = !current
   await setAutoScanUploads(next)
 }
+
+// Auto Sync Down Objects
+
+export const [getAutoSyncDownObjects, useAutoSyncDownObjects] =
+  createGetterAndSWRHook(getKey('autoSyncDownObjects'), () =>
+    getSecureStoreBoolean('autoSyncDownObjects')
+  )
+
+export async function setAutoSyncDownObjects(value: boolean) {
+  await setSecureStoreBoolean('autoSyncDownObjects', value)
+  triggerChange('autoSyncDownObjects')
+}
+
+export async function toggleAutoSyncDownObjects() {
+  const current = await getAutoSyncDownObjects()
+  const next = !current
+  await setAutoSyncDownObjects(next)
+}


### PR DESCRIPTION
- Adds a service that syncs down the objects/events list and updates the local db with any new files.
- The service checks if files are equivalent using a new unique `cid`​ field on the files table.

[sync.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/e1de389f-89ac-4799-923e-40b8492d4e86.mp4" />](https://app.graphite.dev/user-attachments/video/e1de389f-89ac-4799-923e-40b8492d4e86.mp4)