### PR TITLE
refactor: remove pull to refresh

### DIFF
--- a/src/components/FileGallery.tsx
+++ b/src/components/FileGallery.tsx
@@ -18,8 +18,13 @@ export function FileGallery({
   topPadding = 0,
 }: Props) {
   const { data: files, size, setSize, isValidating, hasMore } = useFileList()
-  const { isRefreshing, isLoadingMore, handleEndReached, handleRefresh } =
-    useFlatListControls({ data: files, size, setSize, isValidating, hasMore })
+  const { isLoadingMore, handleEndReached } = useFlatListControls({
+    data: files,
+    size,
+    setSize,
+    isValidating,
+    hasMore,
+  })
 
   return (
     <FlatList
@@ -44,8 +49,6 @@ export function FileGallery({
       )}
       onEndReachedThreshold={0.95}
       onEndReached={handleEndReached}
-      refreshing={isRefreshing}
-      onRefresh={handleRefresh}
       initialNumToRender={36}
       windowSize={9}
       maxToRenderPerBatch={20}

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -12,8 +12,13 @@ type Props = {
 
 export function FileList({ onPressItem, setItemRef, topPadding = 0 }: Props) {
   const { data: files, size, setSize, isValidating, hasMore } = useFileList()
-  const { isRefreshing, isLoadingMore, handleEndReached, handleRefresh } =
-    useFlatListControls({ data: files, size, setSize, isValidating, hasMore })
+  const { isLoadingMore, handleEndReached } = useFlatListControls({
+    data: files,
+    size,
+    setSize,
+    isValidating,
+    hasMore,
+  })
 
   return (
     <FlatList
@@ -38,8 +43,6 @@ export function FileList({ onPressItem, setItemRef, topPadding = 0 }: Props) {
       )}
       onEndReachedThreshold={0.9}
       onEndReached={handleEndReached}
-      refreshing={isRefreshing}
-      onRefresh={handleRefresh}
       initialNumToRender={36}
       windowSize={9}
       maxToRenderPerBatch={20}

--- a/src/hooks/useFlatListControls.tsx
+++ b/src/hooks/useFlatListControls.tsx
@@ -15,16 +15,11 @@ export function useFlatListControls<T>({
   isValidating,
   hasMore,
 }: Params<T>) {
-  const isRefreshing = !!data && isValidating && size === 1
   const isLoadingMore = !!data && isValidating && hasMore
 
   const handleEndReached = React.useCallback(() => {
     if (!isLoadingMore && hasMore) setSize(size + 1)
   }, [isLoadingMore, hasMore, setSize, size])
 
-  const handleRefresh = React.useCallback(() => {
-    setSize(1)
-  }, [setSize])
-
-  return { isRefreshing, isLoadingMore, handleEndReached, handleRefresh }
+  return { isLoadingMore, handleEndReached }
 }


### PR DESCRIPTION
Left the flatlistcontrols hook, even though it's abstraction power was a bit reduced. We may end up expanding it or coming up with new views so it's probably worth keeping, at least for now.