### PR TITLE
fix: onboarding does not pre-populate seed

### DIFF
--- a/src/components/InputArea.tsx
+++ b/src/components/InputArea.tsx
@@ -31,7 +31,7 @@ export function InputArea({
   placeholderTextColor,
   height = 80,
   ellipsizeMode = 'tail',
-  align = 'right',
+  align = 'left',
   labelWidth,
   ...textInputProps
 }: Props) {
@@ -55,7 +55,9 @@ export function InputArea({
         clearButtonMode={textInputProps.clearButtonMode ?? 'while-editing'}
         autoCapitalize={textInputProps.autoCapitalize ?? 'none'}
         underlineColorAndroid="transparent"
-        textAlign="left"
+        multiline={true}
+        textAlign={align}
+        textAlignVertical="top"
         {...textInputProps}
       />
     </View>
@@ -66,13 +68,14 @@ const styles = StyleSheet.create({
   container: {
     paddingHorizontal: 14,
     paddingVertical: 12,
+    gap: 4,
   },
   rowDivider: {
     borderTopColor: colors.borderMutedLight,
     borderTopWidth: StyleSheet.hairlineWidth,
   },
   rowLabel: {
-    color: palette.gray[500],
+    color: palette.gray[300],
     marginRight: 8,
   },
   input: {

--- a/src/components/SettingsRecoveryPhrase.tsx
+++ b/src/components/SettingsRecoveryPhrase.tsx
@@ -19,6 +19,7 @@ export function SettingsRecoveryPhrase() {
           label="Recovery phrase"
           value={isHidden ? '•'.repeat(80) : recoveryPhrase.data}
           editable={false}
+          height={80}
           isMonospace
         />
       </InfoCard>

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -1,20 +1,11 @@
-import {
-  ActivityIndicator,
-  Image,
-  Pressable,
-  StyleSheet,
-  Text,
-  View,
-} from 'react-native'
+import { ActivityIndicator, Image, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { colors, palette, whiteA } from '../styles/colors'
-import { SettingsIcon } from 'lucide-react-native'
-import { useState } from 'react'
 import { useToast } from '../lib/toastContext'
 import { InputRow } from '../components/InputRow'
 import { InfoCard } from '../components/InfoCard'
 import { Button } from '../components/Button'
-import { setRecoveryPhrase, useRecoveryPhrase } from '../stores/settings'
+import { setRecoveryPhrase } from '../stores/settings'
 import { useChangeIndexer } from '../hooks/useChangeIndexer'
 import { useControlledInputValue } from '../hooks/useInputValue'
 import { generateRecoveryPhrase } from 'react-native-sia'
@@ -22,8 +13,6 @@ import { useCopyRecoveryPhrase } from '../hooks/useCopyRecoveryPhrase'
 import { InputArea } from '../components/InputArea'
 
 export default function OnboardingScreen() {
-  const [isUsingCustomURL, setIsUsingCustomURL] = useState(false)
-  const recoveryPhrase = useRecoveryPhrase()
   const toast = useToast()
   const copyRecoveryPhrase = useCopyRecoveryPhrase()
 
@@ -31,7 +20,7 @@ export default function OnboardingScreen() {
     useChangeIndexer()
 
   const newRecoveryPhraseInputProps = useControlledInputValue({
-    value: recoveryPhrase.data ?? '',
+    value: '',
     save: (text) => {
       try {
         setRecoveryPhrase(text)
@@ -48,9 +37,6 @@ export default function OnboardingScreen() {
           style={styles.image}
           source={require('../../assets/icon-bleed.png')}
         />
-        <Pressable onPress={() => setIsUsingCustomURL((current) => !current)}>
-          <SettingsIcon size={20} color={palette.gray[100]} />
-        </Pressable>
       </View>
       {isWaiting ? (
         <View style={styles.center}>
@@ -72,39 +58,37 @@ export default function OnboardingScreen() {
                 ? 'Something went wrong. Please check your password and try again.'
                 : null}
             </Text>
-            {isUsingCustomURL ? (
-              <>
-                <InfoCard>
-                  <InputRow label="Indexer URL" {...newIndexerInputProps} />
-                </InfoCard>
-                <InfoCard>
-                  <InputArea
-                    label="Recovery phrase"
-                    {...newRecoveryPhraseInputProps}
-                    isMonospace
-                  />
-                </InfoCard>
-                <View style={styles.actions}>
-                  <Button
-                    variant="secondary"
-                    onPress={async () => {
-                      await setRecoveryPhrase(generateRecoveryPhrase())
-                      toast.show('Recovery phrase regenerated')
-                    }}
-                    style={styles.button}
-                  >
-                    Regenerate phrase
-                  </Button>
-                  <Button
-                    variant="secondary"
-                    onPress={copyRecoveryPhrase}
-                    style={styles.button}
-                  >
-                    Copy phrase
-                  </Button>
-                </View>
-              </>
-            ) : null}
+            <InfoCard>
+              <InputRow label="Indexer URL" {...newIndexerInputProps} />
+            </InfoCard>
+            <InfoCard>
+              <InputArea
+                placeholder="tiger harvest heart shine code feed monitor maple rug spend lemon trouble"
+                label="Recovery phrase"
+                {...newRecoveryPhraseInputProps}
+                height={80}
+                isMonospace
+              />
+            </InfoCard>
+            <View style={styles.actions}>
+              <Button
+                variant="secondary"
+                onPress={async () => {
+                  await setRecoveryPhrase(generateRecoveryPhrase())
+                  toast.show('Recovery phrase regenerated')
+                }}
+                style={styles.button}
+              >
+                Regenerate phrase
+              </Button>
+              <Button
+                variant="secondary"
+                onPress={copyRecoveryPhrase}
+                style={styles.button}
+              >
+                Copy phrase
+              </Button>
+            </View>
             <Button onPress={saveAndOnboard}>Authorize & Connect</Button>
           </View>
         </View>

--- a/src/screens/SettingsAdvancedScreen.tsx
+++ b/src/screens/SettingsAdvancedScreen.tsx
@@ -53,12 +53,12 @@ export function SettingsAdvancedScreen(_props: Props) {
           variant="danger"
           onPress={() => {
             Alert.alert(
-              'Reset App',
-              'This will delete all local metadata and reset your app seed. This cannot be undone.',
+              'Reset Application',
+              'This will delete all local metadata. This cannot be undone.',
               [
                 { text: 'Cancel', style: 'cancel' },
                 {
-                  text: 'Delete',
+                  text: 'Permanently reset',
                   style: 'destructive',
                   onPress: () => resetApp(),
                 },
@@ -66,7 +66,7 @@ export function SettingsAdvancedScreen(_props: Props) {
             )
           }}
         >
-          Reset app
+          Reset application
         </Button>
       </View>
     </SettingsLayout>

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -10,7 +10,6 @@ import { buildSWRHelpers } from '../lib/swr'
 import { setTransfersMaxSlots } from '../managers/transfersPool'
 import { DEFAULT_INDEXER_URL, DEFAULT_MAX_TRANSFERS } from '../config'
 import { logger } from '../lib/logger'
-import { generateRecoveryPhrase } from 'react-native-sia'
 
 const { getKey, triggerChange } = buildSWRHelpers('secureStore')
 
@@ -18,15 +17,7 @@ const { getKey, triggerChange } = buildSWRHelpers('secureStore')
 
 export const [getRecoveryPhrase, useRecoveryPhrase] = createGetterAndSWRHook(
   getKey('recoveryPhrase'),
-  async (): Promise<string> => {
-    const recoveryPhrase = await getSecureStoreString('recoveryPhrase')
-    if (!recoveryPhrase) {
-      const newRecoveryPhrase = generateRecoveryPhrase()
-      await setRecoveryPhrase(newRecoveryPhrase)
-      return newRecoveryPhrase
-    }
-    return recoveryPhrase
-  }
+  async () => getSecureStoreString('recoveryPhrase')
 )
 
 export async function setRecoveryPhrase(


### PR DESCRIPTION
- App onboarding no longer populates seed field.
- App onboarding now always displays input fields.
- Adjust InputArea styling and props to enable multiline editing.

![Screenshot 2025-10-09 at 5.39.48 PM.png](https://app.graphite.dev/user-attachments/assets/9934b519-55a5-457d-b65b-a8772abd6eb5.png)