### PR TITLE
feat: improve auto download

### DIFF
--- a/src/components/FileThumbnail.tsx
+++ b/src/components/FileThumbnail.tsx
@@ -3,6 +3,10 @@ import { FileRecord } from '../stores/files'
 import { useFileStatus } from '../lib/file'
 import { FileTextIcon, FileVideoIcon, ImageIcon } from 'lucide-react-native'
 import { palette } from '../styles/colors'
+import {
+  thumbnailShouldAutoDownload,
+  useAutoDownload,
+} from '../hooks/useAutoDownload'
 
 export function FileThumbnail({
   file,
@@ -14,6 +18,7 @@ export function FileThumbnail({
   iconColor?: string
 }) {
   const status = useFileStatus(file)
+  useAutoDownload(file, thumbnailShouldAutoDownload)
   if (file.fileType?.includes('image')) {
     if (status.cachedUri) {
       return (

--- a/src/components/FileViewer/index.tsx
+++ b/src/components/FileViewer/index.tsx
@@ -8,7 +8,10 @@ import { useDownload } from '../../managers/downloader'
 import { VideoViewer } from './VideoViewer'
 import { CircularProgress } from '../CircularProgress'
 import { SealedObject } from 'react-native-sia'
-import { useEffect } from 'react'
+import {
+  detailsShouldAutoDownload,
+  useAutoDownload,
+} from '../../hooks/useAutoDownload'
 
 export function FileViewer({
   file,
@@ -25,11 +28,7 @@ export function FileViewer({
 
   const isVideo = file.fileType?.startsWith('video')
 
-  useEffect(() => {
-    if (!status.isDownloaded) {
-      handleDownload()
-    }
-  }, [file.id])
+  useAutoDownload(file, detailsShouldAutoDownload)
 
   return (
     <View style={[styles.container]}>

--- a/src/components/FileViewerImport/index.tsx
+++ b/src/components/FileViewerImport/index.tsx
@@ -7,6 +7,10 @@ import { VideoViewer } from './VideoViewer'
 import { CircularProgress } from '../CircularProgress'
 import { useDownloadFromShareURL } from '../../managers/downloader'
 import { useEffect } from 'react'
+import {
+  detailsShouldAutoDownload,
+  useAutoDownloadFromShareURL,
+} from '../../hooks/useAutoDownload'
 
 export function FileViewerImport({
   file,
@@ -15,6 +19,7 @@ export function FileViewerImport({
   file: {
     id: string
     fileType: string | null
+    fileSize: number | null
   }
   shareUrl: string
 }) {
@@ -23,11 +28,12 @@ export function FileViewerImport({
 
   const isVideo = file.fileType?.startsWith('video')
 
+  useAutoDownloadFromShareURL(file, detailsShouldAutoDownload, shareUrl)
   useEffect(() => {
     if (!status.isDownloaded) {
       handleDownload(file.id, shareUrl)
     }
-  }, [file.id])
+  }, [file.id, shareUrl])
 
   return (
     <View style={[styles.container]}>

--- a/src/hooks/useAutoDownload.ts
+++ b/src/hooks/useAutoDownload.ts
@@ -1,0 +1,89 @@
+import { useEffect } from 'react'
+import { useFileStatus } from '../lib/file'
+import { useIsInitializing } from '../stores/app'
+import { useIsConnected } from '../stores/sdk'
+import { useDownload, useDownloadFromShareURL } from '../managers/downloader'
+import { SealedObjectsMap } from '../encoding/sealedObjects'
+
+/**
+ * When a file is rendered in a thumbnail view, auto download it if:
+ * its an image or PDF.
+ */
+export function thumbnailShouldAutoDownload(file: {
+  fileType: string | null
+  fileSize: number | null
+}): boolean {
+  const isImage = file.fileType?.startsWith('image') ?? false
+  const isPdf = (file.fileType ?? '').includes('pdf')
+  return isImage || isPdf
+}
+
+/**
+ * When a file is rendered in a detail view, auto download it if:
+ * its an image, PDF, or its less than 4 MB.
+ */
+export function detailsShouldAutoDownload(file: {
+  fileType: string | null
+  fileSize: number | null
+}): boolean {
+  const isImage = file.fileType?.startsWith('image') ?? false
+  const isPdf = (file.fileType ?? '').includes('pdf')
+  const sizeOk = (file.fileSize ?? Infinity) <= 4 * 1000 * 1000 // 4 MB
+  return isImage || isPdf || sizeOk
+}
+
+export function useAutoDownload(
+  file: {
+    id: string
+    fileType: string | null
+    fileSize: number | null
+    sealedObjects: SealedObjectsMap | null
+  },
+  shouldDownload: (file: {
+    fileType: string | null
+    fileSize: number | null
+  }) => boolean
+): void {
+  const isInitializing = useIsInitializing()
+  const isConnected = useIsConnected()
+  const download = useDownload(file)
+  const status = useFileStatus(file ?? undefined)
+  useEffect(() => {
+    if (isInitializing) return
+    if (!isConnected) return
+    if (!file) return
+    if (!status.isUploaded) return
+    if (status.isDownloaded) return
+    if (status.isDownloading) return
+    if (!shouldDownload(file)) return
+    download()
+  }, [isInitializing, isConnected, status.isUploaded])
+}
+
+export function useAutoDownloadFromShareURL(
+  file: {
+    id: string
+    fileType: string | null
+    fileSize: number | null
+  },
+  shouldDownload: (file: {
+    fileType: string | null
+    fileSize: number | null
+  }) => boolean,
+  shareUrl: string
+): void {
+  const isInitializing = useIsInitializing()
+  const isConnected = useIsConnected()
+  const download = useDownloadFromShareURL()
+  const status = useFileStatus(file ?? undefined)
+  useEffect(() => {
+    if (isInitializing) return
+    if (!isConnected) return
+    if (!file) return
+    if (!status.isUploaded) return
+    if (status.isDownloaded) return
+    if (status.isDownloading) return
+    if (!shouldDownload(file)) return
+    download(file.id, shareUrl)
+  }, [isInitializing, isConnected, status.isUploaded])
+}


### PR DESCRIPTION
- When a file thumbnail view is rendered, if it is an image or PDF it is auto downloaded.
- When the full file details view is rendered, if it is an image, PDF, or the files is less than 4MB, it is auto downloaded.
- This adds a central place where we can continue to configure these behaviours.