### PR TITLE
fix: host detail screen

### DIFF
--- a/src/screens/HostDetailScreen.tsx
+++ b/src/screens/HostDetailScreen.tsx
@@ -36,41 +36,48 @@ export function HostDetailScreen({ route }: Props) {
     )
   }
   return (
-    <SettingsLayout>
-      <RowGroup title="Details">
+    <SettingsLayout style={styles.container}>
+      <RowGroup title="Info">
         <InfoCard>
           <LabeledValueRow label="Public Key" value={publicKey} />
-          <LabeledValueRow label="Country" value={host.data.countryCode} />
           <LabeledValueRow
             label="Addresses"
             value={host.data.addresses.map((a) => a.address).join(', ')}
           />
+        </InfoCard>
+      </RowGroup>
+      <RowGroup title="Location">
+        <InfoCard style={{ height: 400 }}>
+          <LabeledValueRow label="Country" value={host.data.countryCode} />
           <LabeledValueRow
             label="Location"
             value={`${host.data.latitude}, ${host.data.longitude}`}
           />
+          <Map region={region}>
+            <MapMarker
+              size={10}
+              key={publicKey}
+              coordinate={{
+                latitude: host.data.latitude,
+                longitude: host.data.longitude,
+              }}
+              title={publicKey}
+              description={host.data.countryCode}
+            />
+          </Map>
         </InfoCard>
       </RowGroup>
-      <InfoCard style={{ height: 400 }}>
-        <Map region={region}>
-          <MapMarker
-            size={10}
-            key={publicKey}
-            coordinate={{
-              latitude: host.data.latitude,
-              longitude: host.data.longitude,
-            }}
-            title={publicKey}
-            description={host.data.countryCode}
-          />
-        </Map>
-      </InfoCard>
     </SettingsLayout>
   )
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, padding: 16, gap: 8, backgroundColor: colors.bgCanvas },
+  container: {
+    paddingHorizontal: 16,
+    paddingTop: 24,
+    paddingBottom: 24,
+    gap: 24,
+  },
   card: {
     backgroundColor: colors.bgSurface,
     borderColor: colors.borderMutedLight,


### PR DESCRIPTION
- Small change to make the padding consistent with the other settings screens.
- Also adjusts the groups and titles.

![Screenshot 2025-10-15 at 11.17.14 AM.png](https://app.graphite.dev/user-attachments/assets/a22ad89f-4b87-4787-8c6c-5fc4c7438d66.png)

