### PR TITLE
feat: dismissable keyboards and search bar states

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -13,6 +13,7 @@ import * as SplashScreen from 'expo-splash-screen'
 import useLinkedURL from './hooks/useLinkedURL'
 import { useReconnectIndexer } from './hooks/useReconnectIndexer'
 import { RootTabs } from './stacks/RootTabs'
+import { KeyboardDismissArea } from './components/KeyboardDismissArea'
 
 SplashScreen.preventAutoHideAsync()
 
@@ -57,9 +58,11 @@ export function Root() {
           })}
         />
         <ToastProvider>
-          <NavigationContainer ref={navigationRef}>
-            <RootTabs />
-          </NavigationContainer>
+          <KeyboardDismissArea>
+            <NavigationContainer ref={navigationRef}>
+              <RootTabs />
+            </NavigationContainer>
+          </KeyboardDismissArea>
         </ToastProvider>
       </SafeAreaView>
     </SafeAreaProvider>

--- a/src/components/FileSearchBar.tsx
+++ b/src/components/FileSearchBar.tsx
@@ -3,20 +3,17 @@ import {
   View,
   TextInput,
   Pressable,
-  Text,
   StyleSheet,
   Keyboard,
+  Platform,
+  EmitterSubscription,
 } from 'react-native'
 import { SearchIcon, XIcon } from 'lucide-react-native'
 import { palette, whiteA } from '../styles/colors'
 import { clearSearchQuery, setSearchQuery, useFilesView } from '../stores/files'
 import { useDebouncedValue } from '../hooks/useDebouncedValue'
 
-export function FileSearchBar({
-  onExit,
-}: {
-  onExit?: () => void
-}): React.ReactElement {
+export function FileSearchBar({ onExit }: { onExit: () => void }) {
   const { searchQuery } = useFilesView()
   const [text, setText] = useState(searchQuery ?? '')
   const inputRef = useRef<TextInput | null>(null)
@@ -30,6 +27,22 @@ export function FileSearchBar({
     setSearchQuery(debounced)
   }, [debounced])
 
+  useEffect(() => {
+    let sub: EmitterSubscription | null = null
+    // Delay the subscription to avoid race conditions with the keyboard.
+    const timeout = setTimeout(() => {
+      const hideEvent =
+        Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide'
+      sub = Keyboard.addListener(hideEvent, () => {
+        onExit()
+      })
+    }, 200)
+    return () => {
+      if (sub) sub.remove()
+      clearTimeout(timeout)
+    }
+  }, [onExit])
+
   return (
     <View style={styles.wrap}>
       <View style={styles.inputRow}>
@@ -38,11 +51,6 @@ export function FileSearchBar({
           ref={inputRef}
           value={text}
           onChangeText={setText}
-          onBlur={() => {
-            if ((text ?? '').trim().length === 0) {
-              onExit?.()
-            }
-          }}
           placeholder="Search files"
           placeholderTextColor={whiteA.a50}
           style={styles.input}

--- a/src/components/FileSearchControl.tsx
+++ b/src/components/FileSearchControl.tsx
@@ -1,25 +1,24 @@
 import React from 'react'
-import { View, Pressable, StyleSheet } from 'react-native'
+import { View, StyleSheet } from 'react-native'
 import { SearchIcon } from 'lucide-react-native'
 import { palette, whiteA } from '../styles/colors'
 import { useFilesView } from '../stores/files'
+import { IconButton } from './IconButton'
 
 export function FileSearchControl({
   onOpen,
 }: {
   onOpen?: () => void
 }): React.ReactElement {
-  const { searchQuery } = useFilesView()
-  const applied = (searchQuery?.trim().length ?? 0) > 0
+  const { searchQuery, selectedCategories } = useFilesView()
+  const hasQuery = (searchQuery?.trim().length ?? 0) > 0
+  const hasFilters = (selectedCategories?.size ?? 0) > 0
+  const applied = hasQuery || hasFilters
   return (
-    <Pressable
-      accessibilityRole="button"
-      onPress={onOpen}
-      style={styles.iconButton}
-    >
+    <IconButton onPress={onOpen}>
       <SearchIcon size={18} color={applied ? palette.blue[400] : whiteA.a70} />
       {applied && <View style={styles.dot} />}
-    </Pressable>
+    </IconButton>
   )
 }
 

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import { Pressable, StyleSheet } from 'react-native'
+import { palette, whiteA } from '../styles/colors'
+import { type StyleProp, type ViewStyle } from 'react-native'
+
+type Props = {
+  onPress?: () => void
+  children: React.ReactNode
+  style?: StyleProp<ViewStyle>
+  disabled?: boolean
+  selected?: boolean
+  size?: number
+  accessibilityLabel?: string
+}
+
+export function IconButton({
+  onPress,
+  children,
+  style,
+  disabled = false,
+  selected = false,
+  size = 36,
+  accessibilityLabel,
+}: Props) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      hitSlop={6}
+      onPress={onPress}
+      disabled={disabled}
+      style={({ pressed }) => [
+        styles.base,
+        styles.ghost,
+        selected && styles.selected,
+        { width: size, height: size, borderRadius: 10 },
+        pressed && styles.pressed,
+        disabled && styles.disabled,
+        style,
+      ]}
+    >
+      {children}
+    </Pressable>
+  )
+}
+
+const styles = StyleSheet.create({
+  base: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  ghost: {
+    backgroundColor: 'transparent',
+  },
+  selected: {
+    backgroundColor: palette.gray[800],
+  },
+  pressed: {
+    backgroundColor: whiteA.a08,
+  },
+  disabled: {
+    opacity: 0.5,
+  },
+})

--- a/src/components/KeyboardDismissArea.tsx
+++ b/src/components/KeyboardDismissArea.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Keyboard, TouchableWithoutFeedback, View } from 'react-native'
+
+type Props = {
+  children: React.ReactNode
+  disabled?: boolean
+}
+
+export function KeyboardDismissArea({ children, disabled = false }: Props) {
+  if (disabled) return <>{children}</>
+  return (
+    <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+      <View style={{ flex: 1 }}>{children}</View>
+    </TouchableWithoutFeedback>
+  )
+}

--- a/src/components/LibraryControls.tsx
+++ b/src/components/LibraryControls.tsx
@@ -1,182 +1,49 @@
 import React, { useState } from 'react'
-import { View, Pressable, Text, ScrollView } from 'react-native'
-import {
-  Grid2X2Icon,
-  ListIcon,
-  ArrowUp,
-  ArrowDown,
-  XIcon,
-} from 'lucide-react-native'
+import { View, Text } from 'react-native'
+import { Grid2X2Icon, ListIcon } from 'lucide-react-native'
 import { BottomControlBar, iconColors } from './BottomControlBar'
 import { FileSearchControl } from './FileSearchControl'
 import { FileSearchBar } from './FileSearchBar'
-import {
-  clearCategories,
-  toggleCategory,
-  useFilesView,
-  setSortCategory,
-  toggleDir,
-  type Category,
-} from '../stores/files'
-import { palette, whiteA } from '../styles/colors'
-import { Pill } from './Pill'
+import { palette } from '../styles/colors'
 import { toggleLibraryViewMode, useLibraryViewMode } from '../stores/settings'
 import { openSheet } from '../stores/sheets'
+import { IconButton } from './IconButton'
+import { LibraryControlsSearchMenus } from './LibraryControlsSearchMenus'
 
 export function LibraryControls() {
   const viewMode = useLibraryViewMode()
   const [searchActive, setSearchActive] = useState(false)
-  const { selectedCategories, sortBy, sortDir } = useFilesView()
 
   return (
-    <>
-      <BottomControlBar
-        keyboardAware
-        overlayTop={
-          searchActive ? (
-            <View style={{ width: '90%', alignSelf: 'center', gap: 6 }}>
-              <ScrollView
-                horizontal
-                showsHorizontalScrollIndicator={false}
-                contentContainerStyle={{
-                  paddingHorizontal: 6,
-                  gap: 8,
-                  alignItems: 'center',
-                }}
-                style={{ overflow: 'visible' }}
-                bounces
-              >
-                <Pill onPress={() => toggleDir()}>
-                  {sortDir === 'ASC' ? (
-                    <ArrowUp size={14} color={palette.gray[50]} />
-                  ) : (
-                    <ArrowDown size={14} color={palette.gray[50]} />
-                  )}
-                  <Text
-                    style={{
-                      color: palette.gray[50],
-                      fontSize: 12,
-                      fontWeight: '600',
-                    }}
-                  >
-                    {sortDir === 'ASC' ? 'Asc' : 'Desc'}
-                  </Text>
-                </Pill>
-                <Pill
-                  onPress={() => setSortCategory('DATE')}
-                  selected={sortBy === 'DATE'}
-                >
-                  <Text
-                    style={{
-                      color: palette.gray[50],
-                      fontSize: 12,
-                      fontWeight: '600',
-                    }}
-                  >
-                    Date
-                  </Text>
-                </Pill>
-                <Pill
-                  onPress={() => setSortCategory('NAME')}
-                  selected={sortBy === 'NAME'}
-                >
-                  <Text
-                    style={{
-                      color: palette.gray[50],
-                      fontSize: 12,
-                      fontWeight: '600',
-                    }}
-                  >
-                    Name
-                  </Text>
-                </Pill>
-              </ScrollView>
-              <ScrollView
-                horizontal
-                showsHorizontalScrollIndicator={false}
-                contentContainerStyle={{
-                  paddingHorizontal: 6,
-                  gap: 8,
-                  alignItems: 'center',
-                }}
-                style={{ overflow: 'visible' }}
-                bounces
-              >
-                {(['Video', 'Image', 'Audio', 'Files'] as Category[]).map(
-                  (cat) => {
-                    const selected = selectedCategories.has(cat)
-                    return (
-                      <Pill
-                        key={cat}
-                        onPress={() => toggleCategory(cat)}
-                        selected={selected}
-                      >
-                        <Text
-                          style={{
-                            color: palette.gray[50],
-                            fontSize: 12,
-                            fontWeight: '600',
-                          }}
-                        >
-                          {cat}
-                        </Text>
-                      </Pill>
-                    )
-                  }
-                )}
-                {!!selectedCategories.size && (
-                  <Pill onPress={clearCategories}>
-                    <XIcon size={14} color={whiteA.a70} />
-                  </Pill>
-                )}
-              </ScrollView>
-            </View>
-          ) : null
-        }
-        content={
-          searchActive ? (
-            <FileSearchBar onExit={() => setSearchActive(false)} />
-          ) : (
-            <View
-              style={{
-                flex: 1,
-                flexDirection: 'row',
-                justifyContent: 'space-between',
-                alignItems: 'center',
-              }}
-            >
-              <View style={{ flexDirection: 'row', gap: 12 }}>
-                <Pressable
-                  accessibilityRole="button"
-                  onPress={toggleLibraryViewMode}
-                >
-                  {viewMode.data === 'gallery' ? (
-                    <Grid2X2Icon size={18} color={iconColors.active} />
-                  ) : (
-                    <ListIcon size={18} color={iconColors.active} />
-                  )}
-                </Pressable>
-              </View>
-              <Pressable
-                accessibilityRole="button"
-                onPress={() => openSheet('addFile')}
-              >
-                <Text style={{ color: palette.gray[50], fontSize: 22 }}>+</Text>
-              </Pressable>
-              <View style={{ flexDirection: 'row', gap: 12 }}>
-                <Pressable
-                  accessibilityRole="button"
-                  onPress={() => setSearchActive((s) => !s)}
-                >
-                  <FileSearchControl
-                    onOpen={() => setSearchActive((s) => !s)}
-                  />
-                </Pressable>
-              </View>
-            </View>
-          )
-        }
-      />
-    </>
+    <BottomControlBar
+      keyboardAware
+      overlayTop={searchActive ? <LibraryControlsSearchMenus /> : null}
+      content={
+        searchActive ? (
+          <FileSearchBar onExit={() => setSearchActive(false)} />
+        ) : (
+          <View
+            style={{
+              flex: 1,
+              flexDirection: 'row',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+            }}
+          >
+            <IconButton onPress={toggleLibraryViewMode}>
+              {viewMode.data === 'gallery' ? (
+                <Grid2X2Icon size={18} color={iconColors.active} />
+              ) : (
+                <ListIcon size={18} color={iconColors.active} />
+              )}
+            </IconButton>
+            <IconButton onPress={() => openSheet('addFile')}>
+              <Text style={{ color: palette.gray[50], fontSize: 22 }}>+</Text>
+            </IconButton>
+            <FileSearchControl onOpen={() => setSearchActive((s) => !s)} />
+          </View>
+        )
+      }
+    />
   )
 }

--- a/src/components/LibraryControlsSearchMenus.tsx
+++ b/src/components/LibraryControlsSearchMenus.tsx
@@ -1,0 +1,117 @@
+import React from 'react'
+import { View, Text, ScrollView } from 'react-native'
+import { ArrowUp, ArrowDown, XIcon } from 'lucide-react-native'
+import {
+  clearCategories,
+  toggleCategory,
+  useFilesView,
+  setSortCategory,
+  toggleDir,
+  categories,
+} from '../stores/files'
+import { palette, whiteA } from '../styles/colors'
+import { Pill } from './Pill'
+
+export function LibraryControlsSearchMenus() {
+  const { selectedCategories, sortBy, sortDir } = useFilesView()
+
+  return (
+    <View style={{ width: '90%', alignSelf: 'center', gap: 6 }}>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={{
+          paddingHorizontal: 12,
+          gap: 8,
+          alignItems: 'center',
+        }}
+        style={{ overflow: 'visible' }}
+        bounces
+        keyboardShouldPersistTaps="always"
+      >
+        <Pill onPress={() => toggleDir()}>
+          {sortDir === 'ASC' ? (
+            <ArrowUp size={14} color={palette.gray[50]} />
+          ) : (
+            <ArrowDown size={14} color={palette.gray[50]} />
+          )}
+          <Text
+            style={{
+              color: palette.gray[50],
+              fontSize: 12,
+              fontWeight: '600',
+            }}
+          >
+            {sortDir === 'ASC' ? 'Asc' : 'Desc'}
+          </Text>
+        </Pill>
+        <Pill
+          onPress={() => setSortCategory('DATE')}
+          selected={sortBy === 'DATE'}
+        >
+          <Text
+            style={{
+              color: palette.gray[50],
+              fontSize: 12,
+              fontWeight: '600',
+            }}
+          >
+            Date
+          </Text>
+        </Pill>
+        <Pill
+          onPress={() => setSortCategory('NAME')}
+          selected={sortBy === 'NAME'}
+        >
+          <Text
+            style={{
+              color: palette.gray[50],
+              fontSize: 12,
+              fontWeight: '600',
+            }}
+          >
+            Name
+          </Text>
+        </Pill>
+      </ScrollView>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={{
+          paddingHorizontal: 12,
+          gap: 8,
+          alignItems: 'center',
+        }}
+        style={{ overflow: 'visible' }}
+        bounces
+        keyboardShouldPersistTaps="always"
+      >
+        {categories.map((cat) => {
+          const selected = selectedCategories.has(cat)
+          return (
+            <Pill
+              key={cat}
+              onPress={() => toggleCategory(cat)}
+              selected={selected}
+            >
+              <Text
+                style={{
+                  color: palette.gray[50],
+                  fontSize: 12,
+                  fontWeight: '600',
+                }}
+              >
+                {cat}
+              </Text>
+            </Pill>
+          )
+        })}
+        {!!selectedCategories.size && (
+          <Pill onPress={clearCategories}>
+            <XIcon size={14} color={whiteA.a70} />
+          </Pill>
+        )}
+      </ScrollView>
+    </View>
+  )
+}

--- a/src/stores/files.ts
+++ b/src/stores/files.ts
@@ -394,6 +394,7 @@ export function useFileDetails(id: string) {
 export type SortBy = 'NAME' | 'DATE'
 export type SortDir = 'ASC' | 'DESC'
 export type Category = 'Video' | 'Image' | 'Audio' | 'Files'
+export const categories = ['Video', 'Image', 'Audio', 'Files'] as const
 
 type FilesViewState = {
   sortBy: SortBy


### PR DESCRIPTION
Improvements related to keyboard behaviors and search bar states.

- Makes all keyboards dismissible by pressing anywhere else on the screen, unless otherwise overriden.
- Search bar goes back into closed state when keyboard is closed.
- Search icon shows indicator if a search query or filter is applied.
- Adds IconButton with larger tap target. Icon button tap targets were too small.