### PR TITLE
fix: potential image duplication

### DIFF
--- a/src/encoding/fileMetadata.ts
+++ b/src/encoding/fileMetadata.ts
@@ -1,6 +1,7 @@
 import { logger } from '../lib/logger'
 
 export type FileMetadata = {
+  id: string
   name?: string
   fileType?: string
   size?: number
@@ -9,6 +10,7 @@ export type FileMetadata = {
 export function encodeFileMetadata(params: FileMetadata): ArrayBuffer {
   return new TextEncoder().encode(
     JSON.stringify({
+      id: params.id,
       name: params.name,
       fileType: params.fileType,
       size: params.size,
@@ -21,6 +23,6 @@ export function decodeFileMetadata(buffer?: ArrayBuffer): FileMetadata {
     return JSON.parse(new TextDecoder().decode(buffer)) as FileMetadata
   } catch (e) {
     logger.log('Error converting file metadata from buffer', e)
-    return {}
+    return { id: '' }
   }
 }

--- a/src/managers/syncDownObjects.ts
+++ b/src/managers/syncDownObjects.ts
@@ -4,9 +4,11 @@ import { getIsConnected, getSdk } from '../stores/sdk'
 import { getAutoSyncDownObjects, getIndexerURL } from '../stores/settings'
 import { getAppKey } from '../lib/appKey'
 import {
-  insertOrReplaceFileRecord,
+  createFileRecord,
   FileRecord,
+  readFileRecord,
   readFileRecordByCid,
+  updateFileRecord,
 } from '../stores/files'
 import { decodeFileMetadata } from '../encoding/fileMetadata'
 import { uniqueId } from '../lib/uniqueId'
@@ -51,31 +53,48 @@ async function syncDownObjects(): Promise<void> {
     for (const { object, deleted, key } of objects) {
       if (deleted) continue
       if (!object) continue
-      const existingFileRecord = await readFileRecordByCid(key)
       const metadata = decodeFileMetadata(object.metadata())
+      let existingFileRecord: FileRecord | null = null
+      // Try to find the file record by id first.
+      // This should always succeed.
+      if (metadata.id) {
+        existingFileRecord = await readFileRecord(metadata.id)
+      }
+      // If not found, try to find by cid.
+      if (!existingFileRecord) {
+        existingFileRecord = await readFileRecordByCid(key)
+      }
       const sealedObject = object.seal(await getAppKey())
       if (existingFileRecord) {
         existingCount += 1
-        tryToAddFileRecord({
-          ...existingFileRecord,
-          sealedObjects: {
-            ...existingFileRecord?.sealedObjects,
-            [indexerURL]: sealedObject,
-          },
-        })
+        try {
+          updateFileRecord({
+            ...existingFileRecord,
+            sealedObjects: {
+              ...existingFileRecord?.sealedObjects,
+              [indexerURL]: sealedObject,
+            },
+          })
+        } catch (e) {
+          logger.log('[syncDownObjects] error updating file record', key, e)
+        }
       } else {
         newCount += 1
-        tryToAddFileRecord({
-          id: uniqueId(),
-          cid: key,
-          fileName: metadata.name ?? null,
-          fileSize: metadata.size ?? null,
-          createdAt: object.createdAt().getTime(),
-          fileType: metadata.fileType ?? null,
-          sealedObjects: {
-            [indexerURL]: sealedObject,
-          },
-        })
+        try {
+          createFileRecord({
+            id: uniqueId(),
+            cid: key,
+            fileName: metadata.name ?? null,
+            fileSize: metadata.size ?? null,
+            createdAt: object.createdAt().getTime(),
+            fileType: metadata.fileType ?? null,
+            sealedObjects: {
+              [indexerURL]: sealedObject,
+            },
+          })
+        } catch (e) {
+          logger.log('[syncDownObjects] error adding file record', key, e)
+        }
       }
     }
     logger.log('[syncDownObjects] synced', existingCount, 'existing objects')
@@ -95,14 +114,6 @@ export const initSyncDownObjects = createServiceInterval({
   getState: getAutoSyncDownObjects,
   interval: SYNC_OBJECTS_INTERVAL,
 })
-
-function tryToAddFileRecord(fileRecord: FileRecord): void {
-  try {
-    insertOrReplaceFileRecord(fileRecord)
-  } catch (e) {
-    logger.log('[syncDownObjects] error adding file record', fileRecord.cid, e)
-  }
-}
 
 // Persistent cursor saved for next batch.
 

--- a/src/managers/uploadToIndexer.ts
+++ b/src/managers/uploadToIndexer.ts
@@ -34,6 +34,7 @@ export async function uploadToIndexer(params: {
     dataShards: UPLOAD_DATA_SHARDS,
     parityShards: UPLOAD_PARITY_SHARDS,
     metadata: encodeFileMetadata({
+      id: file.id,
       name: file.fileName ?? '',
       fileType: file.fileType ?? '',
       size: data.byteLength,

--- a/src/managers/uploader.ts
+++ b/src/managers/uploader.ts
@@ -10,7 +10,7 @@ import { useSdk, getSdk } from '../stores/sdk'
 import { getIndexerURL } from '../stores/settings'
 import { extFromMime } from '../lib/fileTypes'
 import {
-  insertOrReplaceManyFileRecords,
+  createManyFileRecords,
   FileRecord,
   readFileRecord,
 } from '../stores/files'
@@ -45,7 +45,7 @@ export function useUploader() {
             sealedObjects: {},
           })
         }
-        await insertOrReplaceManyFileRecords(fileRecords)
+        await createManyFileRecords(fileRecords)
         await Promise.all(
           assets.map(async (asset: PickerAsset, index: number) => {
             logger.log(

--- a/src/screens/ImportFileScreen.tsx
+++ b/src/screens/ImportFileScreen.tsx
@@ -16,7 +16,7 @@ import {
 } from '../stacks/types'
 import { useToast } from '../lib/toastContext'
 import { useSdk } from '../stores/sdk'
-import { insertOrReplaceFileRecord } from '../stores/files'
+import { createFileRecord } from '../stores/files'
 import { uniqueId } from '../lib/uniqueId'
 import { FileDetailsImport } from '../components/FileDetailsImport'
 import { logger } from '../lib/logger'
@@ -72,7 +72,7 @@ export function ImportFileScreen({ route }: Props) {
     const indexerURL = await getIndexerURL()
     const pinnedObject = await sdk.pinShared(sharedObject.data)
     const sealedObject = pinnedObject.seal(await getAppKey())
-    await insertOrReplaceFileRecord({
+    await createFileRecord({
       ...sharedFile.data,
       cid: sealedObject.id,
       createdAt: new Date().getTime(),

--- a/src/stores/files.ts
+++ b/src/stores/files.ts
@@ -32,7 +32,7 @@ export type FileRecord = {
   sealedObjects: Record<string, SealedObject>
 }
 
-export async function insertOrReplaceFileRecord(
+export async function createFileRecord(
   fileRecord: FileRecord,
   triggerUpdate: boolean = true
 ): Promise<void> {
@@ -43,7 +43,7 @@ export async function insertOrReplaceFileRecord(
     throw error
   }
   await db().runAsync(
-    'INSERT OR REPLACE INTO files (id, cid, fileName, fileSize, createdAt, fileType, sealedObjects) VALUES (?, ?, ?, ?, ?, ?, ?)',
+    'INSERT INTO files (id, cid, fileName, fileSize, createdAt, fileType, sealedObjects) VALUES (?, ?, ?, ?, ?, ?, ?)',
     id,
     cid,
     fileName,
@@ -57,12 +57,12 @@ export async function insertOrReplaceFileRecord(
   }
 }
 
-export async function insertOrReplaceManyFileRecords(
+export async function createManyFileRecords(
   files: FileRecord[]
 ): Promise<void> {
   await db().withTransactionAsync(async () => {
     for (const fr of files) {
-      await insertOrReplaceFileRecord(fr, false)
+      await createFileRecord(fr, false)
     }
   })
   await triggerChange()
@@ -286,11 +286,22 @@ export async function updateFileSealedObject(
   if (error) {
     throw error
   }
-  await db().runAsync(
-    'UPDATE files SET sealedObjects = ? WHERE id = ?',
-    serializedSealedObjects,
-    id
-  )
+
+  // If the file has no cid yet, set it to the new sealed object's id.
+  if (file.cid == null) {
+    await db().runAsync(
+      'UPDATE files SET cid = ?, sealedObjects = ? WHERE id = ?',
+      sealedObject.id,
+      serializedSealedObjects,
+      id
+    )
+  } else {
+    await db().runAsync(
+      'UPDATE files SET sealedObjects = ? WHERE id = ?',
+      serializedSealedObjects,
+      id
+    )
+  }
   await triggerChange()
 }
 


### PR DESCRIPTION
- Swaps out combined `INSERT OR REPLACE`​ with explicit insert and update methods. This should make the operations more clear.
- Ensure `cid`​ column is being set when a file is finished uploading and the sealed object is being saved to the database.
- Move primary existence check to be based on a client `id`​ stored in object metadata to avoid issues where the sync is occurring before the `cid`​ is saved.