### PR TITLE
feat: swr hook helper args support

### DIFF
--- a/src/lib/selectors.ts
+++ b/src/lib/selectors.ts
@@ -44,9 +44,15 @@ export function createGetterAndSelector<T, R, Args extends any[] = []>(
  * )
  * ```
  */
-export function createGetterAndSWRHook<T>(
-  key: string,
-  fetcher: () => Promise<T>
-): [() => Promise<T>, () => SWRResponse<T, any, any>] {
-  return [() => fetcher(), () => useSWR(key, () => fetcher())]
+export function createGetterAndSWRHook<T, Args extends any[] = []>(
+  key: string[],
+  fetcher: (...args: Args) => Promise<T>
+): [
+  (...args: Args) => Promise<T>,
+  (...args: Args) => SWRResponse<T, any, any>
+] {
+  return [
+    (...args: Args) => fetcher(...args),
+    (...args: Args) => useSWR([...key, ...args], () => fetcher(...args)),
+  ]
 }

--- a/src/lib/swr.ts
+++ b/src/lib/swr.ts
@@ -9,16 +9,35 @@ import { mutate } from 'swr'
  * ```
  */
 export function buildSWRHelpers(baseKey: string) {
+  const changeCallbacks = new Map<string, () => void>()
+
+  const addChangeCallback = (key: string, callback: () => void) => {
+    changeCallbacks.set(key, callback)
+  }
+
+  const removeChangeCallback = (key: string) => {
+    changeCallbacks.delete(key)
+  }
+
   const getKey = (id?: string) => {
-    return id ? `${baseKey}/${id}` : `${baseKey}`
+    return id ? [`${baseKey}/${id}`] : [`${baseKey}`]
   }
+
   const triggerChange = async (keyPath?: string) => {
-    await mutate((key: string) => {
-      return typeof key === 'string' && key.startsWith(getKey(keyPath))
+    await mutate((key: string[]) => {
+      if (!Array.isArray(key) || typeof key[0] !== 'string') {
+        return false
+      }
+      const first = key[0]
+      return first.startsWith(getKey(keyPath)[0])
     })
+    changeCallbacks.forEach((callback) => callback())
   }
+
   return {
     getKey,
     triggerChange,
+    addChangeCallback,
+    removeChangeCallback,
   }
 }


### PR DESCRIPTION
- Adds support for creating getters / swr hooks with parameters. eg:

```
export const [getFilesLocalOnly, useFilesLocalOnly] = createGetterAndSWRHook(
  filesViewSwr.getKey('localOnly'),
  async ({ limit, order }: { limit?: number; order: 'ASC' | 'DESC' }) => {
```

- Without this change the useFilesLocalOnly hook would not revalidate when the parameters changed.