### PR TITLE
fix: thumbnail downloading state

### DIFF
--- a/src/components/CenteredProgress.tsx
+++ b/src/components/CenteredProgress.tsx
@@ -1,0 +1,31 @@
+import { CircularProgress } from './CircularProgress'
+import { FileStatus } from '../lib/file'
+import { View, StyleSheet } from 'react-native'
+
+export function CenteredProgress({
+  status,
+  size = 44,
+}: {
+  status: FileStatus
+  size?: number
+}) {
+  return (
+    <View style={styles.container}>
+      <CircularProgress progress={status.downloadProgress ?? 0} size={size} />
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    top: 0,
+    bottom: 0,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 10,
+    zIndex: 2,
+  },
+})

--- a/src/components/FileThumbnail.tsx
+++ b/src/components/FileThumbnail.tsx
@@ -13,6 +13,7 @@ import {
   thumbnailShouldAutoDownload,
   useAutoDownload,
 } from '../hooks/useAutoDownload'
+import { CenteredProgress } from './CenteredProgress'
 
 export function FileThumbnail({
   file,
@@ -25,6 +26,15 @@ export function FileThumbnail({
 }) {
   const status = useFileStatus(file)
   useAutoDownload(file, thumbnailShouldAutoDownload)
+
+  if (status.isDownloading) {
+    return (
+      <View style={styles.thumbnailImage}>
+        <CenteredProgress status={status} size={iconSize} />
+      </View>
+    )
+  }
+
   if (file.fileType?.includes('image')) {
     if (status.cachedUri) {
       return (

--- a/src/components/FileViewer/index.tsx
+++ b/src/components/FileViewer/index.tsx
@@ -23,12 +23,6 @@ export function FileViewer({
   header?: React.ReactNode
   fullscreen?: boolean
   customDownloader?: () => void
-  // file: {
-  //   id: string
-  //   fileType: string | null
-  //   objects: Record<string, LocalObject> | null
-  //   fileSize: number | null
-  // }
 }) {
   const { fileType } = file
   const status = useFileStatus(file)


### PR DESCRIPTION
- Adds circular loader to thumbnails in downloading state.

![Screenshot 2025-10-19 at 3.27.46 PM.png](https://app.graphite.dev/user-attachments/assets/01f8b816-890b-4121-953a-b83735fa803c.png)

