### PR TITLE
fix: library list gallery bottom padding

### DIFF
--- a/src/components/FileGallery.tsx
+++ b/src/components/FileGallery.tsx
@@ -9,14 +9,12 @@ type Props = {
   onPressItem: (item: FileRecord) => void
   setItemRef?: (id: string, ref: any) => void
   numColumns?: number
-  topPadding?: number
 }
 
 export function FileGallery({
   onPressItem,
   setItemRef,
   numColumns = 3,
-  topPadding = 0,
 }: Props) {
   const { data: files, size, setSize, isValidating, hasMore } = useFileList()
   const { isLoadingMore, handleEndReached } = useFlatListControls({
@@ -37,10 +35,7 @@ export function FileGallery({
       automaticallyAdjustContentInsets={false}
       automaticallyAdjustKeyboardInsets={false}
       automaticallyAdjustsScrollIndicatorInsets={false}
-      contentContainerStyle={[
-        styles.galleryContent,
-        { paddingTop: topPadding },
-      ]}
+      contentContainerStyle={styles.galleryContent}
       renderItem={({ item }) => (
         <FileGalleryItem
           file={item}
@@ -61,5 +56,5 @@ export function FileGallery({
 }
 
 const styles = StyleSheet.create({
-  galleryContent: { padding: 0 },
+  galleryContent: { paddingTop: 130, paddingBottom: 130 },
 })

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -8,10 +8,9 @@ import { useFlatListControls } from '../hooks/useFlatListControls'
 type Props = {
   onPressItem: (item: FileRecord) => void
   setItemRef?: (id: string, ref: any) => void
-  topPadding?: number
 }
 
-export function FileList({ onPressItem, setItemRef, topPadding = 0 }: Props) {
+export function FileList({ onPressItem, setItemRef }: Props) {
   const { data: files, size, setSize, isValidating, hasMore } = useFileList()
   const { isLoadingMore, handleEndReached } = useFlatListControls({
     data: files,
@@ -31,9 +30,9 @@ export function FileList({ onPressItem, setItemRef, topPadding = 0 }: Props) {
       automaticallyAdjustKeyboardInsets={false}
       automaticallyAdjustsScrollIndicatorInsets={false}
       contentContainerStyle={{
-        paddingTop: topPadding,
+        paddingTop: 130,
         gap: 8,
-        paddingBottom: 16,
+        paddingBottom: 130,
       }}
       renderItem={({ item }) => (
         <FileListItem

--- a/src/screens/LibraryScreen.tsx
+++ b/src/screens/LibraryScreen.tsx
@@ -133,9 +133,9 @@ export function LibraryScreen() {
       ) : !!fileCount.data ? (
         files.data && files.data.length > 0 ? (
           viewMode.data == 'gallery' ? (
-            <FileGallery onPressItem={handleOpenDetail} topPadding={130} />
+            <FileGallery onPressItem={handleOpenDetail} />
           ) : (
-            <FileList onPressItem={handleOpenDetail} topPadding={130} />
+            <FileList onPressItem={handleOpenDetail} />
           )
         ) : (
           <View style={styles.emptyWrap}>


### PR DESCRIPTION
- Adds padding to the bottom of library gallery and list view so that the last row of images is fully visible.

![Screenshot 2025-10-19 at 3.28.54 PM.png](https://app.graphite.dev/user-attachments/assets/0bce0704-2c0e-4e5c-b987-07899a23f718.png)

![Screenshot 2025-10-19 at 3.29.02 PM.png](https://app.graphite.dev/user-attachments/assets/56009bb3-b144-48ae-8e5f-7636cc0cba68.png)

