### PR TITLE
feat: allow toggling sdk logs

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,21 +1,24 @@
 export const rustLogger = {
   hasInitialized: false,
   debug: (message: string) => {
-    logger.log('[rust][debug]', message)
+    logger.sdk('[rust][debug]', message)
   },
   info: (message: string) => {
-    logger.log('[rust][info]', message)
+    logger.sdk('[rust][info]', message)
   },
   warn: (message: string) => {
-    logger.log('[rust][warn]', message)
+    logger.sdk('[rust][warn]', message)
   },
   error: (message: string) => {
-    logger.log('[rust][error]', message)
+    logger.sdk('[rust][error]', message)
   },
 }
 
 export const logger = {
   log: (...args: any[]) => {
+    console.log(...args)
+  },
+  sdk: (...args: any[]) => {
     console.log(...args)
   },
   clear: () => {},

--- a/src/screens/SettingsLogsScreen.tsx
+++ b/src/screens/SettingsLogsScreen.tsx
@@ -1,22 +1,41 @@
 import { LogView } from '../components/LogView'
-import { clearLogs, useLogs } from '../stores/logs'
+import {
+  clearLogs,
+  toggleEnableSdkLogs,
+  useLogs,
+  useLogsStore,
+  useSDKLogsEnabled,
+} from '../stores/logs'
 import { type NativeStackScreenProps } from '@react-navigation/native-stack'
 import { type SettingsStackParamList } from '../stacks/types'
 import { SettingsLayout } from '../components/SettingsLayout'
 import { useSettingsHeader } from '../hooks/useSettingsHeader'
 import { BottomControlBar, iconColors } from '../components/BottomControlBar'
-import { TrashIcon } from 'lucide-react-native'
+import { EyeIcon, EyeOffIcon, TrashIcon } from 'lucide-react-native'
 
 type Props = NativeStackScreenProps<SettingsStackParamList, 'Logs'>
 
 export function SettingsLogsScreen({ navigation }: Props) {
   const logs = useLogs()
+  const sdkLogsEnabled = useSDKLogsEnabled()
   useSettingsHeader()
   return (
     <SettingsLayout>
       <LogView logs={logs} />
       <BottomControlBar
         width="dynamic"
+        right={[
+          {
+            id: 'enableSdkLogs',
+            label: 'SDK',
+            icon: sdkLogsEnabled ? (
+              <EyeIcon size={22} color={iconColors.white} />
+            ) : (
+              <EyeOffIcon size={22} color={iconColors.white} />
+            ),
+            onPress: toggleEnableSdkLogs,
+          },
+        ]}
         left={[
           {
             id: 'clear',

--- a/src/stores/logs.ts
+++ b/src/stores/logs.ts
@@ -1,17 +1,20 @@
 import { create } from 'zustand'
 import { useShallow } from 'zustand/react/shallow'
-import { useEffect } from 'react'
 import { logger } from '../lib/logger'
+import { getSecureStoreBoolean, setSecureStoreBoolean } from './secureStore'
+import { createGetterAndSelector } from '../lib/selectors'
 
 export type LogsState = {
   logs: string[]
+  enableSdkLogs: boolean
 }
 
 export const useLogsStore = create<LogsState>(() => ({
   logs: [],
+  enableSdkLogs: false,
 }))
 
-const { setState } = useLogsStore
+const { setState, getState } = useLogsStore
 
 export function appendLogLine(...args: unknown[]): void {
   setState((state) => {
@@ -31,16 +34,31 @@ export function clearLogs(): void {
 
 let hasInit = false
 
-export function initLogger(): void {
+export async function initLogger(): Promise<void> {
   if (hasInit) {
     logger.log('[logs] initLogger already called, skipping')
     return
   }
   logger.log('[logs] initLogger called')
-  // Wire the global logger to the logs store and console once.
+
+  // Init state with secure store value so that we can use an in memory value
+  // in the logger callbacks.
+  const enableSdkLogs = await getSecureStorageEnableSdkLogs()
+  setState((state) => {
+    return { ...state, enableSdkLogs }
+  })
+
+  // Wire the global logger to the logs store.
   logger.log = (...args: unknown[]) => {
     console.log(...args)
     appendLogLine(...args)
+  }
+  logger.sdk = (...args: unknown[]) => {
+    const state = getState()
+    if (state.enableSdkLogs) {
+      console.log(...args)
+      appendLogLine(...args)
+    }
   }
   logger.clear = () => {
     clearLogs()
@@ -52,4 +70,29 @@ export function initLogger(): void {
 
 export function useLogs(): string[] {
   return useLogsStore(useShallow((s) => s.logs))
+}
+
+// Get the enable SDK logs flag from the store state.
+export const [getSDKLogsEnabled, useSDKLogsEnabled] = createGetterAndSelector(
+  useLogsStore,
+  (state) => state.enableSdkLogs
+)
+
+// Get the enable SDK logs flag from the secure store.
+async function getSecureStorageEnableSdkLogs(): Promise<boolean> {
+  return getSecureStoreBoolean('enableSdkLogs', false)
+}
+
+// Set the enable SDK logs flag in both the secure store and the store state.
+export async function setEnableSdkLogs(value: boolean): Promise<void> {
+  await setSecureStoreBoolean('enableSdkLogs', value)
+  setState((state) => {
+    return { ...state, enableSdkLogs: value }
+  })
+}
+
+// Toggle the enable SDK logs flag in both the secure store and the store state.
+export async function toggleEnableSdkLogs(): Promise<void> {
+  const value = !getSDKLogsEnabled()
+  await setEnableSdkLogs(value)
 }


### PR DESCRIPTION
- Added an option to toggle on and off logs coming out of the SDK. In the future we could make this based on log level, but for now just wanted a way to test the app without those logs.

![Screenshot 2025-10-20 at 11.09.22 AM.png](https://app.graphite.dev/user-attachments/assets/66e5a6c6-172f-412d-adba-faaeb8d6fd76.png)

