### PR TITLE
fix: file details import types

### DIFF
--- a/src/components/FileDetailsImport/index.tsx
+++ b/src/components/FileDetailsImport/index.tsx
@@ -3,7 +3,6 @@ import { colors } from '../../styles/colors'
 import { useFileStatus } from '../../lib/file'
 import { FileMetaImport } from './FileMetaImport'
 import { FileViewer } from '../FileViewer'
-import { FileRecord } from '../../stores/files'
 import { useDownloadFromShareURL } from '../../managers/downloader'
 import {
   detailsShouldAutoDownload,
@@ -30,14 +29,12 @@ export function FileDetailsImport({
   // smartly do this depending on whether a user is on wifi, etc.
   useAutoDownloadFromShareURL(file, detailsShouldAutoDownload, shareUrl)
 
-  const potentialFile: FileRecord = {
+  const potentialFile = {
     id: file.id,
-    cid: null,
     fileName: file.fileName,
     fileSize: file.fileSize,
-    createdAt: new Date().getTime(),
     fileType: file.fileType,
-    sealedObjects: {},
+    objects: null,
   }
 
   return (

--- a/src/components/FileViewer/index.tsx
+++ b/src/components/FileViewer/index.tsx
@@ -1,5 +1,4 @@
 import { StyleSheet, Text, TouchableHighlight, View } from 'react-native'
-import { FileRecord } from '../../stores/files'
 import { useFileStatus } from '../../lib/file'
 import { CloudDownloadIcon, FileIcon } from 'lucide-react-native'
 import { ImageViewer } from '../MediaConsumers/ImageViewer'
@@ -13,6 +12,7 @@ import { useDownload } from '../../managers/downloader'
 import { useDownloadState } from '../../stores/downloads'
 import { colors } from '../../styles/colors'
 import { useCallback, useMemo } from 'react'
+import { LocalObjectsMap } from '../../encoding/localObject'
 
 export function FileViewer({
   file,
@@ -20,7 +20,13 @@ export function FileViewer({
   fullscreen = true,
   customDownloader,
 }: {
-  file: FileRecord
+  file: {
+    id: string
+    fileName: string | null
+    fileType: string | null
+    fileSize: number | null
+    objects: LocalObjectsMap | null
+  }
   header?: React.ReactNode
   fullscreen?: boolean
   customDownloader?: () => void

--- a/src/hooks/usePinnedObjects.tsx
+++ b/src/hooks/usePinnedObjects.tsx
@@ -5,11 +5,11 @@ import { FileRecord } from '../stores/files'
 
 export function usePinnedObjects(file: FileRecord) {
   return useSWR<{ indexerURL: string; pinnedObject: PinnedObjectInterface }[]>(
-    ['sealedObjects', file.id],
+    ['pinnedObjects', file.id],
     async () => {
-      const sealedObjects = Object.entries(file.objects)
+      const objects = Object.entries(file.objects)
       return await Promise.all(
-        sealedObjects.map(async ([indexerURL, so]) => ({
+        objects.map(async ([indexerURL, so]) => ({
           indexerURL,
           pinnedObject: PinnedObject.open(await getAppKey(), so),
         }))

--- a/src/stores/library.ts
+++ b/src/stores/library.ts
@@ -1,7 +1,7 @@
 import { db } from '../db'
 import { create } from 'zustand'
 import useSWRInfinite from 'swr/infinite'
-import { FileRecord, transformRow } from './files'
+import { FileRecord, FileRecordRow, transformRow } from './files'
 import { readLocalObjectsForFiles } from './localObjects'
 import { buildSWRHelpers } from '../lib/swr'
 
@@ -63,15 +63,7 @@ async function readOrderedFileRecords(
     pageClause = ` LIMIT ${limit | 0} OFFSET ${offset | 0}`
   }
 
-  const rows = await db().getAllAsync<{
-    id: string
-    fileName: string | null
-    fileSize: number | null
-    createdAt: number
-    updatedAt: number
-    fileType: string
-    sealedObjects: string | null
-  }>(
+  const rows = await db().getAllAsync<FileRecordRow>(
     `SELECT id, fileName, fileSize, createdAt, updatedAt, fileType
      FROM files
      ${where}


### PR DESCRIPTION
- Fix shape of passed file type. We no longer use a sealedObjects field, and not all fields are necessary. I'll take a look at all these partial file types and see if they can be cleaned up further.