### PR TITLE
refactor: refine fileviewer download state and unknown file preview

### DIFF
--- a/src/components/FileThumbnail.tsx
+++ b/src/components/FileThumbnail.tsx
@@ -3,6 +3,7 @@ import { FileRecord } from '../stores/files'
 import { useFileStatus } from '../lib/file'
 import {
   FileAudioIcon,
+  FileIcon,
   FileJsonIcon,
   FileTextIcon,
   FileVideoIcon,
@@ -107,7 +108,11 @@ export function FileThumbnail({
       </View>
     )
   }
-  return null
+  return (
+    <View style={styles.thumbnailImage}>
+      <FileIcon size={iconSize} color={iconColor} />
+    </View>
+  )
 }
 
 const styles = StyleSheet.create({

--- a/src/components/FileViewer/index.tsx
+++ b/src/components/FileViewer/index.tsx
@@ -31,7 +31,7 @@ export function FileViewer({
   const fileDownload = useDownload(file)
   const fileDownloadState = useDownloadState(file.id)
 
-  const handleLongPress = useCallback(() => {
+  const onDownloadPress = useCallback(() => {
     if (isDownloading) return
     if (customDownloader) customDownloader()
     else fileDownload()
@@ -50,25 +50,23 @@ export function FileViewer({
           { justifyContent: 'center', alignItems: 'center', gap: 20 },
         ]}
       >
-        <TouchableHighlight onLongPress={handleLongPress}>
+        <TouchableHighlight onPress={onDownloadPress}>
           <CloudDownloadIcon color={colors.textPrimary} size={40} />
         </TouchableHighlight>
 
         {!isDownloading ? (
-          <Text style={{ color: colors.textPrimary }}>
-            Long press to download
-          </Text>
+          <Text style={{ color: colors.textPrimary }}>Press to download</Text>
         ) : null}
 
         {isDownloading ? (
           <Text style={{ color: colors.textPrimary }}>
-            Downloading: {((fileDownloadState?.progress || 0) * 100).toFixed(2)}
+            Downloading: {((fileDownloadState?.progress || 0) * 100).toFixed(0)}
             %
           </Text>
         ) : null}
       </View>
     )
-  }, [fullscreen, handleLongPress, isDownloading, fileDownloadState?.progress])
+  }, [fullscreen, onDownloadPress, isDownloading, fileDownloadState?.progress])
 
   const MediaDisplayElement = useMemo(() => {
     if (!isDownloaded || !cachedUri) return DownloadPanel
@@ -137,11 +135,11 @@ export function FileViewer({
       <View
         style={[
           fullscreen ? styles.mediaWithPadding : styles.media,
-          { justifyContent: 'center', alignItems: 'center', gap: 10 },
+          { justifyContent: 'center', alignItems: 'center', gap: 20 },
         ]}
       >
-        <FileIcon />
-        <Text>Preview not available</Text>
+        <FileIcon color={colors.textPrimary} size={40} />
+        <Text style={{ color: colors.textPrimary }}>Preview not supported</Text>
       </View>
     )
   }, [
@@ -152,6 +150,7 @@ export function FileViewer({
     fullscreen,
     fileName,
     file.fileSize,
+    DownloadPanel,
   ])
 
   return (


### PR DESCRIPTION


![Screenshot 2025-10-22 at 12.49.05 PM.png](https://app.graphite.dev/user-attachments/assets/99e74163-05da-43e1-a77d-bec38435772c.png)


[Screen Recording 2025-10-22 at 12.49.20 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/5daa53ea-ec02-4879-8dbb-71889af4d7c3.mov" />](https://app.graphite.dev/user-attachments/video/5daa53ea-ec02-4879-8dbb-71889af4d7c3.mov)

Closes [#141](https://github.com/SiaFoundation/sia-mobile/issues/141)