### PR TITLE
fix: flip library view icons in LibraryControlBar

### DIFF
--- a/src/components/LibraryControlBar.tsx
+++ b/src/components/LibraryControlBar.tsx
@@ -35,7 +35,7 @@ export function LibraryControlBar({ route, navigation }: Props) {
           }}
         >
           <IconButton onPress={toggleLibraryViewMode}>
-            {viewMode.data === 'gallery' ? (
+            {viewMode.data === 'list' ? (
               <Grid2X2Icon color={iconColors.white} />
             ) : (
               <ListIcon color={iconColors.white} />


### PR DESCRIPTION
[Screen Recording 2025-10-22 at 1.05.02 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/672fe0f7-33b7-47b0-90ca-eee083ed2b9f.mov" />](https://app.graphite.dev/user-attachments/video/672fe0f7-33b7-47b0-90ca-eee083ed2b9f.mov)

This may not be a fix and more of a preference, but my instinct says that this button in the bottom left should display the icon that represents what would happen if you press it. I don't think a user would otherwise know what it does.