### PR TITLE
refactor: file uri cache

### DIFF
--- a/src/components/FileActionsSheet.tsx
+++ b/src/components/FileActionsSheet.tsx
@@ -11,9 +11,8 @@ import {
 } from 'lucide-react-native'
 import { useToast } from '../lib/toastContext'
 import { ArrowDownToLineIcon } from 'lucide-react-native'
-import { removeFromCache } from '../stores/fileCache'
+import { removeFileFromCache } from '../stores/fileCache'
 import { useDownload } from '../managers/downloader'
-import { extFromMime } from '../lib/fileTypes'
 import { getSdk, useSdk } from '../stores/sdk'
 import { useFileStatus } from '../lib/file'
 import { useReuploadFile } from '../managers/uploader'
@@ -55,7 +54,7 @@ export function FileActionsSheet({
   const handleRemoveCache = useCallback(async () => {
     if (!file) return
     try {
-      await removeFromCache(file.id, extFromMime(file.fileType))
+      await removeFileFromCache(file)
       toast.show('Removed from cache')
       closeSheet()
     } catch (e) {
@@ -96,7 +95,7 @@ export function FileActionsSheet({
       await deleteFileRecord(file.id)
       await deleteAllIndexerObjects(file)
       await deleteLocalObjects(file.id)
-      await removeFromCache(file.id, extFromMime(file.fileType))
+      await removeFileFromCache(file)
       toast.show('Deleted file')
       closeSheet()
       navigation.goBack()
@@ -127,25 +126,29 @@ export function FileActionsSheet({
       >
         Export file
       </ActionSheetButton>
-      {!status.isDownloaded && !status.isDownloading && !status.fileIsGone && (
-        <ActionSheetButton
-          variant="primary"
-          icon={<ArrowDownToLineIcon size={18} />}
-          onPress={handlePressAndClose(handleDownload)}
-        >
-          Download file
-        </ActionSheetButton>
-      )}
-      {!status.isUploaded && !status.isUploading && !status.fileIsGone && (
-        <ActionSheetButton
-          variant="primary"
-          icon={<CloudUploadIcon size={18} />}
-          onPress={handlePressAndClose(handleReupload)}
-        >
-          Upload file
-        </ActionSheetButton>
-      )}
-      {status.cachedUri && status.isUploaded && (
+      {!status.data?.isDownloaded &&
+        !status.data?.isDownloading &&
+        !status.data?.fileIsGone && (
+          <ActionSheetButton
+            variant="primary"
+            icon={<ArrowDownToLineIcon size={18} />}
+            onPress={handlePressAndClose(handleDownload)}
+          >
+            Download file
+          </ActionSheetButton>
+        )}
+      {!status.data?.isUploaded &&
+        !status.data?.isUploading &&
+        !status.data?.fileIsGone && (
+          <ActionSheetButton
+            variant="primary"
+            icon={<CloudUploadIcon size={18} />}
+            onPress={handlePressAndClose(handleReupload)}
+          >
+            Upload file
+          </ActionSheetButton>
+        )}
+      {status.data?.fileUri && status.data?.isUploaded && (
         <ActionSheetButton
           variant="primary"
           icon={<EraserIcon size={18} />}
@@ -154,7 +157,7 @@ export function FileActionsSheet({
           Remove from device
         </ActionSheetButton>
       )}
-      {status.isUploaded && (
+      {status.data?.isUploaded && (
         <ActionSheetButton
           variant="primary"
           icon={<CloudOffIcon size={18} />}

--- a/src/components/FileDetails/FileMeta.tsx
+++ b/src/components/FileDetails/FileMeta.tsx
@@ -61,11 +61,11 @@ export function FileMeta({
           )}
           {showAdvanced.data && (
             <LabeledValueRow
-              label="Cached URL"
-              value={status.cachedUri ?? 'Not available'}
+              label="File URI"
+              value={status.fileUri ?? 'Not available'}
               isMonospace
               ellipsizeMode="middle"
-              canCopy={!!status.cachedUri}
+              canCopy={!!status.fileUri}
               showDividerTop
             />
           )}

--- a/src/components/FileDetails/index.tsx
+++ b/src/components/FileDetails/index.tsx
@@ -24,7 +24,7 @@ export function FileDetails({
           <FileMap file={file} />
         </View>
         <View style={styles.metaContainer}>
-          <FileMeta file={file} status={status} />
+          {status.data ? <FileMeta file={file} status={status.data} /> : null}
         </View>
       </ScrollView>
     </View>

--- a/src/components/FileDetailsImport/FileMetaImport.tsx
+++ b/src/components/FileDetailsImport/FileMetaImport.tsx
@@ -43,10 +43,10 @@ export function FileMetaImport({
             value={file.fileType ?? '—'}
             showDividerTop
           />
-          {showAdvanced.data && status.cachedUri && (
+          {showAdvanced.data && status.fileUri && (
             <LabeledValueRow
-              label="Cached URL"
-              value={status.cachedUri}
+              label="File URI"
+              value={status.fileUri}
               showDividerTop
             />
           )}

--- a/src/components/FileDetailsImport/index.tsx
+++ b/src/components/FileDetailsImport/index.tsx
@@ -57,7 +57,9 @@ export function FileDetailsImport({
             }}
           />
         </View>
-        <FileMetaImport file={file} status={status} />
+        {status.data ? (
+          <FileMetaImport file={file} status={status.data} />
+        ) : null}
       </ScrollView>
     </View>
   )

--- a/src/components/FileIndicators.tsx
+++ b/src/components/FileIndicators.tsx
@@ -22,17 +22,23 @@ export function FileIndicators({
   const status = useFileStatus(file)
   return (
     <>
-      {status.isUploading ? (
+      {status.data?.isUploading ? (
         <View style={styles.thumbProgressTrack}>
           <View
             style={[
               styles.thumbProgressFill,
-              { width: `${Math.round(status.uploadProgress * 100)}%` },
+              { width: `${Math.round(status.data?.uploadProgress * 100)}%` },
             ]}
           />
         </View>
       ) : null}
-      <StatusBadges status={status} size={size} interactive={interactive} />
+      {status.data ? (
+        <StatusBadges
+          status={status.data}
+          size={size}
+          interactive={interactive}
+        />
+      ) : null}
     </>
   )
 }

--- a/src/components/FileListItem.tsx
+++ b/src/components/FileListItem.tsx
@@ -32,14 +32,18 @@ function FileListItemComponent({ file, onPressItem, setItemRef }: Props) {
             {file.fileName}
           </Text>
           <View style={styles.fileMetaData}>
-            <UploadStatusIcon
-              size={12}
-              status={status}
-              interactive={false}
-              color="gray"
-              variant="icon"
-            />
-            <DotIcon size={16} color="grey" />
+            {status.data ? (
+              <>
+                <UploadStatusIcon
+                  size={12}
+                  status={status.data}
+                  interactive={false}
+                  color="gray"
+                  variant="icon"
+                />
+                <DotIcon size={16} color="grey" />
+              </>
+            ) : null}
             <Text style={styles.fileText}>{humanSize(file.fileSize)}</Text>
             <DotIcon size={16} color="grey" />
             <Text style={styles.fileText}>{file.fileType}</Text>

--- a/src/components/FileThumbnail.tsx
+++ b/src/components/FileThumbnail.tsx
@@ -28,19 +28,19 @@ export function FileThumbnail({
   const status = useFileStatus(file)
   useAutoDownload(file, thumbnailShouldAutoDownload)
 
-  if (status.isDownloading) {
+  if (status.data?.isDownloading) {
     return (
       <View style={styles.thumbnailImage}>
-        <CenteredProgress status={status} size={iconSize} />
+        <CenteredProgress status={status.data} size={iconSize} />
       </View>
     )
   }
 
   if (file.fileType?.includes('image')) {
-    if (status.cachedUri) {
+    if (status.data?.fileUri) {
       return (
         <Image
-          source={{ uri: status.cachedUri }}
+          source={{ uri: status.data?.fileUri }}
           style={styles.thumbnailImage}
         />
       )
@@ -52,10 +52,10 @@ export function FileThumbnail({
     )
   }
   if (file.fileType?.includes('pdf')) {
-    if (status.cachedUri) {
+    if (status.data?.fileUri) {
       return (
         <Image
-          source={{ uri: status.cachedUri }}
+          source={{ uri: status.data?.fileUri }}
           style={styles.thumbnailImage}
         />
       )

--- a/src/components/FileViewer/index.tsx
+++ b/src/components/FileViewer/index.tsx
@@ -34,7 +34,7 @@ export function FileViewer({
 }) {
   const { fileType, fileName } = file
   const status = useFileStatus(file)
-  const { cachedUri, isDownloaded, isDownloading } = status
+  const { fileUri, isDownloaded, isDownloading } = status.data ?? {}
   const fileDownload = useDownload(file)
   const fileDownloadState = useDownloadState(file.id)
 
@@ -76,12 +76,12 @@ export function FileViewer({
   }, [fullscreen, onDownloadPress, isDownloading, fileDownloadState?.progress])
 
   const MediaDisplayElement = useMemo(() => {
-    if (!isDownloaded || !cachedUri) return DownloadPanel
+    if (!isDownloaded || !fileUri) return DownloadPanel
 
     if (fileType?.includes('image')) {
       return (
         <ImageViewer
-          uri={cachedUri}
+          uri={fileUri}
           style={fullscreen ? styles.mediaWithPadding : styles.media}
         />
       )
@@ -89,7 +89,7 @@ export function FileViewer({
     if (fileType?.includes('video')) {
       return (
         <VideoPlayer
-          source={cachedUri}
+          source={fileUri}
           style={fullscreen ? styles.mediaWithPadding : styles.media}
         />
       )
@@ -97,14 +97,14 @@ export function FileViewer({
     if (fileType?.includes('audio')) {
       return (
         <AudioPlayer
-          source={cachedUri}
+          source={fileUri}
           filename={fileName}
           style={fullscreen ? styles.mediaWithPadding : styles.media}
         />
       )
     }
     if (fileType?.includes('pdf') || lowerCasedFileName.endsWith('.pdf')) {
-      return <PDFViewer source={cachedUri} style={styles.media} />
+      return <PDFViewer source={fileUri} style={styles.media} />
     }
     if (
       fileType?.includes('application/json') ||
@@ -112,7 +112,7 @@ export function FileViewer({
     ) {
       return (
         <JSONViewer
-          uri={cachedUri}
+          uri={fileUri}
           fileSize={file.fileSize}
           style={styles.media}
         />
@@ -123,7 +123,7 @@ export function FileViewer({
       lowerCasedFileName.endsWith('.md') ||
       lowerCasedFileName.endsWith('.markdown')
     ) {
-      return <MarkdownViewer uri={cachedUri} style={styles.media} />
+      return <MarkdownViewer uri={fileUri} style={styles.media} />
     }
     if (
       fileType?.includes('text/plain') ||
@@ -131,7 +131,7 @@ export function FileViewer({
     ) {
       return (
         <TextViewer
-          uri={cachedUri}
+          uri={fileUri}
           fileSize={file.fileSize}
           style={styles.media}
         />
@@ -150,7 +150,7 @@ export function FileViewer({
       </View>
     )
   }, [
-    cachedUri,
+    fileUri,
     isDownloaded,
     fileType,
     lowerCasedFileName,

--- a/src/hooks/useAutoDownload.ts
+++ b/src/hooks/useAutoDownload.ts
@@ -49,18 +49,19 @@ export function useAutoDownload(
   const isInitializing = useIsInitializing()
   const isConnected = useIsConnected()
   const download = useDownload(file)
-  const status = useFileStatus(file ?? undefined)
+  const status = useFileStatus(file)
   useEffect(() => {
     if (isInitializing) return
     if (!isConnected) return
     if (!file) return
-    if (!status.isUploaded) return
-    if (status.isDownloaded) return
-    if (status.isDownloading) return
+    if (!status.data) return
+    if (!status.data.isUploaded) return
+    if (status.data.isDownloaded) return
+    if (status.data.isDownloading) return
     if (file.localId) return
     if (!shouldDownload(file)) return
     download()
-  }, [isInitializing, isConnected, status.isUploaded])
+  }, [isInitializing, isConnected, status.data])
 }
 
 export function useAutoDownloadFromShareURL(
@@ -78,15 +79,16 @@ export function useAutoDownloadFromShareURL(
   const isInitializing = useIsInitializing()
   const isConnected = useIsConnected()
   const download = useDownloadFromShareURL()
-  const status = useFileStatus(file ?? undefined)
+  const status = useFileStatus(file)
   useEffect(() => {
     if (isInitializing) return
     if (!isConnected) return
     if (!file) return
-    if (!status.isUploaded) return
-    if (status.isDownloaded) return
-    if (status.isDownloading) return
+    if (!status.data) return
+    if (!status.data.isUploaded) return
+    if (status.data.isDownloaded) return
+    if (status.data.isDownloading) return
     if (!shouldDownload(file)) return
     download(file.id, shareUrl)
-  }, [isInitializing, isConnected, status.isUploaded])
+  }, [isInitializing, isConnected, status.data])
 }

--- a/src/hooks/useCameraCapture.ts
+++ b/src/hooks/useCameraCapture.ts
@@ -21,7 +21,6 @@ export function useCameraCapture() {
       const result = await ImagePicker.launchCamera({
         mediaType: 'mixed',
         includeExtra: true,
-        includeBase64: true,
         saveToPhotos: false,
       })
 

--- a/src/hooks/useDocumentPicker.ts
+++ b/src/hooks/useDocumentPicker.ts
@@ -47,7 +47,6 @@ export function useDocumentPicker() {
 
       const assets: PickerAsset[] = assetsWithRequiredFields.map((a) => ({
         id: uniqueId(),
-        uri: a.uri,
         fileName: a.name,
         fileSize: a.size ?? 0,
         createdAt: Date.now(),

--- a/src/hooks/useImagePicker.ts
+++ b/src/hooks/useImagePicker.ts
@@ -1,10 +1,10 @@
 import * as ImagePicker from 'react-native-image-picker'
 import { useCallback, useRef } from 'react'
-import { mimeFromAssetUri } from '../lib/fileTypes'
 import { uniqueId } from '../lib/uniqueId'
 import { logger } from '../lib/logger'
 import { useToast } from '../lib/toastContext'
 import { useUploader } from '../managers/uploader'
+import { mimeFromAssetUri } from '../lib/fileTypes'
 
 export type PickerAsset = {
   id: string
@@ -13,7 +13,6 @@ export type PickerAsset = {
   fileSize: number
   createdAt: number
   fileType: string
-  cacheUri?: string
 }
 
 export function useImagePicker() {
@@ -31,7 +30,6 @@ export function useImagePicker() {
         mediaType: 'mixed',
         selectionLimit: 0, // 0 => unlimited on iOS; Android uses picker default multi-select UI if available.
         includeExtra: true,
-        includeBase64: true,
       })
 
       if (result.didCancel) {

--- a/src/hooks/useShareAction.tsx
+++ b/src/hooks/useShareAction.tsx
@@ -38,11 +38,11 @@ export function useShareAction({ fileId }: { fileId: string }) {
   const handleShareFile = useCallback(async () => {
     if (!file) return
     if (!file.fileType) return
-    if (!status.cachedUri) return
+    if (!status.data?.fileUri) return
 
     try {
       await Share.open({
-        url: status.cachedUri,
+        url: status.data.fileUri,
         type: file.fileType,
         filename: file.fileName ?? undefined,
         subject: `Sia Mobile - ${file.fileType}`,
@@ -52,10 +52,10 @@ export function useShareAction({ fileId }: { fileId: string }) {
         logger.log('File sharing failed:', e)
       }
     }
-  }, [file, status.cachedUri])
+  }, [file, status.data?.fileUri])
 
   return {
-    canShare: status.isUploaded,
+    canShare: status.data?.isUploaded,
     handleShareURL,
     handleShareFile,
   }

--- a/src/lib/file.ts
+++ b/src/lib/file.ts
@@ -4,8 +4,7 @@ import { type DownloadState } from '../stores/downloads'
 import { FileRecord } from '../stores/files'
 import { useDownloadState } from '../stores/downloads'
 import { useUploadState } from '../stores/uploads'
-import { useCachedUri } from '../stores/fileCache'
-import { extFromMime } from './fileTypes'
+import { useFileUri } from '../stores/fileCache'
 import {
   PinnedObject,
   PinnedObjectInterface,
@@ -13,6 +12,8 @@ import {
 } from 'react-native-sia'
 import { LocalObject, LocalObjectsMap } from '../encoding/localObject'
 import { getAppKey } from './appKey'
+import { SWRResponse } from 'swr'
+import useSWR from 'swr'
 
 export function fileHasASealedObject(file: {
   objects?: LocalObjectsMap | null
@@ -30,7 +31,7 @@ export type FileStatus = {
   downloadProgress: number
   isUploadQueued: boolean
   isDownloadQueued: boolean
-  cachedUri: string | null
+  fileUri: string | null
   fileIsGone: boolean
   errorText: string | null
 }
@@ -39,7 +40,7 @@ function computeFileStatus({
   file,
   uploadState,
   downloadState,
-  cachedUri,
+  fileUri,
   errorText,
 }: {
   file: {
@@ -47,7 +48,7 @@ function computeFileStatus({
   }
   uploadState: UploadState | undefined
   downloadState: DownloadState | undefined
-  cachedUri: string | null
+  fileUri: string | null
   errorText: string | null
 }) {
   const isUploading =
@@ -61,14 +62,13 @@ function computeFileStatus({
     isUploadQueued: uploadState?.status === 'queued',
     isDownloadQueued: downloadState?.status === 'queued',
     isUploaded: hasSealedObject,
-    isDownloaded: !!cachedUri,
+    isDownloaded: !!fileUri,
     isErrored:
       uploadState?.status === 'error' || downloadState?.status === 'error',
     uploadProgress: uploadState?.progress ?? 0,
     downloadProgress: downloadState?.progress ?? 0,
-    cachedUri,
-    fileIsGone:
-      !isUploading && !isDownloading && !hasSealedObject && !cachedUri,
+    fileUri,
+    fileIsGone: !isUploading && !isDownloading && !hasSealedObject && !fileUri,
     errorText,
   }
 }
@@ -76,21 +76,22 @@ function computeFileStatus({
 export function useFileStatus(file?: {
   id: string
   fileType: string | null
+  localId?: string | null
   objects?: LocalObjectsMap | null
-}): FileStatus {
+}): SWRResponse<FileStatus, Error> {
   const uploadState = useUploadState(file?.id || '')
   const downloadState = useDownloadState(file?.id || '')
-  const cachedUri = useCachedUri(file?.id || '', extFromMime(file?.fileType))
-  return useMemo(
+  const fileUri = useFileUri(file)
+  return useSWR(
+    [file?.id, file?.localId || '', file?.objects || '', fileUri.data || ''],
     () =>
       computeFileStatus({
         file: file ?? { objects: null },
         uploadState,
         downloadState,
-        cachedUri: cachedUri.data ?? null,
+        fileUri: fileUri.data ?? null,
         errorText: uploadState?.error || downloadState?.error || null,
-      }),
-    [uploadState, downloadState, cachedUri, file]
+      })
   )
 }
 

--- a/src/lib/fileTypes.ts
+++ b/src/lib/fileTypes.ts
@@ -29,9 +29,12 @@ export type Mime =
 
 export function mimeFromAssetUri(a: ImagePicker.Asset): Mime {
   const name = a.fileName ?? ''
+  return mimeFromFileName(name)
+}
+
+export function mimeFromFileName(name: string): Mime {
   const ext = name.split('?')[0].split('#')[0].split('.').pop()?.toLowerCase()
   if (!ext) return 'application/octet-stream'
-
   const map: Record<string, Mime> = {
     // video
     mov: 'video/quicktime',
@@ -57,7 +60,6 @@ export function mimeFromAssetUri(a: ImagePicker.Asset): Mime {
     json: 'application/json',
     pdf: 'application/pdf',
   }
-
   return map[ext] ?? 'application/octet-stream'
 }
 

--- a/src/managers/downloader.ts
+++ b/src/managers/downloader.ts
@@ -1,5 +1,9 @@
 import { useToast } from '../lib/toastContext'
-import { copyFileToCache, getOrCreateCachedFile } from '../stores/fileCache'
+import {
+  copyFileToCache,
+  getOrCreateCacheFile,
+  getOrCreateCacheTmpFile,
+} from '../stores/fileCache'
 import {
   getDownloadState,
   updateDownloadProgress,
@@ -8,7 +12,6 @@ import {
 import { useSdk } from '../stores/sdk'
 import { PinnedObject } from 'react-native-sia'
 import { useCallback } from 'react'
-import { extFromMime, type Ext } from '../lib/fileTypes'
 import { getOneSealedObject } from '../lib/file'
 import { logger } from '../lib/logger'
 import { decodeFileMetadata } from '../encoding/fileMetadata'
@@ -55,18 +58,16 @@ export function useDownload(
           }
         )
         await streamToCache({
-          id: file.id,
-          targetExt: '.tmp',
+          file: {
+            id: file.id,
+            fileType: null,
+          },
           getNextChunk: () => downloader.readChunk({ signal }),
           totalSize: Array.isArray(sealedObject.slabs)
             ? sealedObject.slabs.reduce((acc, s) => acc + (s?.length ?? 0), 0)
             : undefined,
           onAfterClose: async (targetFile) => {
-            await copyFileToCache(
-              file.id,
-              targetFile,
-              extFromMime(file.fileType)
-            )
+            await copyFileToCache(file, targetFile)
           },
           signal,
         })
@@ -91,15 +92,19 @@ export function useDownloadFromShareURL() {
             length: undefined,
           })
           await streamToCache({
-            id,
-            targetExt: '.tmp',
+            file: {
+              id,
+              fileType: null,
+            },
             getNextChunk: () => downloader.readChunk({ signal }),
             totalSize: Number(sharedObject.size()),
             onAfterClose: async (targetFile) => {
               await copyFileToCache(
-                id,
-                targetFile,
-                extFromMime(metadata.fileType)
+                {
+                  id,
+                  fileType: metadata.fileType,
+                },
+                targetFile
               )
             },
             signal,
@@ -112,18 +117,19 @@ export function useDownloadFromShareURL() {
 }
 
 async function streamToCache(params: {
-  id: string
-  targetExt: Ext
+  file: {
+    id: string
+    fileType: string | null
+  }
   totalSize?: number
   getNextChunk: () => Promise<ArrayBuffer | undefined>
   onAfterClose?: (
-    targetFile: Awaited<ReturnType<typeof getOrCreateCachedFile>>
+    targetFile: Awaited<ReturnType<typeof getOrCreateCacheFile>>
   ) => Promise<void>
   signal: AbortSignal
 }): Promise<void> {
-  const { id, targetExt, totalSize, getNextChunk, onAfterClose, signal } =
-    params
-  const targetFile = await getOrCreateCachedFile(id, targetExt)
+  const { file, totalSize, getNextChunk, onAfterClose, signal } = params
+  const targetFile = await getOrCreateCacheTmpFile(file)
   logger.log('[streamToCache] writing to cache path:', targetFile.uri)
   const writer = targetFile.writableStream().getWriter()
   let total = 0
@@ -136,7 +142,7 @@ async function streamToCache(params: {
         break
       }
       const chunk = await getNextChunk()
-      if (!chunk || (chunk as ArrayBuffer).byteLength === 0) {
+      if (!chunk || chunk.byteLength === 0) {
         logger.log(
           '[streamToCache] download stream ended. chunks=',
           chunks,
@@ -150,9 +156,9 @@ async function streamToCache(params: {
       chunks += 1
       await writer.write(buf)
       if (typeof totalSize === 'number' && totalSize > 0) {
-        updateDownloadProgress(id, Math.min(1, total / totalSize))
+        updateDownloadProgress(file.id, Math.min(1, total / totalSize))
       } else if (chunks % 5 === 0) {
-        updateDownloadProgress(id, Math.min(0.99, (chunks % 20) / 20))
+        updateDownloadProgress(file.id, Math.min(0.99, (chunks % 20) / 20))
       }
       if (chunks % 10 === 0)
         logger.log('[streamToCache] downloaded', total, 'bytes so far')

--- a/src/managers/syncDownEvents.ts
+++ b/src/managers/syncDownEvents.ts
@@ -21,8 +21,10 @@ import { getSecureStoreJSON, setSecureStoreJSON } from '../stores/secureStore'
 import { isoToEpochCodec } from '../encoding/date'
 import { pinnedObjectToLocalObject } from '../lib/localObjects'
 import { upsertLocalObject } from '../stores/localObjects'
-import { removeFromCache } from '../stores/fileCache'
-import { extFromMime } from '../lib/fileTypes'
+import {
+  removeFileFromCache,
+  removeTmpFileFromCache,
+} from '../stores/fileCache'
 
 const batchSize = 100
 
@@ -120,12 +122,9 @@ async function handleDeleteEvent(key: string, counts: Counts): Promise<void> {
   if (existingFileRecord) {
     await Promise.all([
       // Remove the file from the cache.
-      removeFromCache(
-        existingFileRecord.id,
-        extFromMime(existingFileRecord.fileType)
-      ),
+      removeFileFromCache(existingFileRecord),
       // Remove any tmp file from the cache.
-      removeFromCache(existingFileRecord.id, '.tmp'),
+      removeTmpFileFromCache(existingFileRecord),
       // Remove the file from the database.
       deleteFileRecord(existingFileRecord.id),
     ])

--- a/src/managers/uploader.ts
+++ b/src/managers/uploader.ts
@@ -1,14 +1,9 @@
 import { uploadToIndexer } from './uploadToIndexer'
-import {
-  writeToCache,
-  copyUriToCache,
-  readCachedUri,
-} from '../stores/fileCache'
+import { getFileUri, getLocalUri } from '../stores/fileCache'
 import * as FileSystem from 'expo-file-system'
 import { useCallback } from 'react'
 import { useSdk, getSdk } from '../stores/sdk'
 import { getIndexerURL } from '../stores/settings'
-import { extFromMime } from '../lib/fileTypes'
 import {
   createManyFileRecords,
   FileRecord,
@@ -52,24 +47,18 @@ export function useUploader() {
             logger.log(
               `[uploader] processing media ${index + 1}/$${assets.length}...`
             )
-            const cacheUri = asset.uri
-              ? await copyUriToCache(
-                  asset.id,
-                  asset.uri,
-                  extFromMime(asset.fileType)
-                )
-              : await writeToCache(
-                  asset.id,
-                  await readArrayBuffer(asset),
-                  extFromMime(asset.fileType)
-                )
-            logger.log(`[uploader] cached file ${asset.id} -> ${cacheUri}`)
+            const fileUri = await getLocalUri(asset.localId)
+            if (!fileUri) {
+              logger.log(`[uploader] file not found ${asset.id}`)
+              return
+            }
+            logger.log(`[uploader] cached file ${asset.id} -> ${fileUri}`)
             runUploadWithSlot({
               id: asset.id,
               task: async (signal) => {
                 const indexerURL = await getIndexerURL()
                 logger.log(`[uploader] uploading ${asset.id} to hosts...`)
-                const fileBytes = await new FileSystem.File(cacheUri).bytes()
+                const fileBytes = await new FileSystem.File(fileUri).bytes()
                 await uploadToIndexer({
                   file: {
                     id: asset.id,
@@ -111,15 +100,12 @@ export function useReuploadFile() {
           if (!file) {
             throw new Error('File not found')
           }
-          const cacheUri = await readCachedUri(
-            fileId,
-            extFromMime(file.fileType)
-          )
-          if (!cacheUri) {
-            throw new Error('File not cached')
+          const fileUri = await getFileUri(file)
+          if (!fileUri) {
+            throw new Error('File not available locally')
           }
           logger.log(`[uploader] uploading ${fileId}...`)
-          const fileBytes = await new FileSystem.File(cacheUri).bytes()
+          const fileBytes = await new FileSystem.File(fileUri).bytes()
           await uploadToIndexer({
             file: {
               id: fileId,
@@ -144,15 +130,15 @@ export function useReuploadFile() {
 export async function queueUploadForFileId(fileId: string): Promise<void> {
   const file = await readFileRecord(fileId)
   if (!file) return
-  const cachedUri = await readCachedUri(fileId, extFromMime(file.fileType))
-  if (!cachedUri) return
+  const fileUri = await getFileUri(file)
+  if (!fileUri) return
   const indexerURL = await getIndexerURL()
   const sdk = getSdk()
   if (!sdk) return
   await runUploadWithSlot({
     id: fileId,
     task: async (signal) => {
-      const fileBytes = await new FileSystem.File(cachedUri).bytes()
+      const fileBytes = await new FileSystem.File(fileUri).bytes()
       await uploadToIndexer({
         file: {
           id: fileId,
@@ -164,22 +150,9 @@ export async function queueUploadForFileId(fileId: string): Promise<void> {
         },
         indexerURL,
         sdk,
-        data: fileBytes.buffer as ArrayBuffer,
+        data: fileBytes.buffer,
         signal,
       })
     },
   })
-}
-
-async function readArrayBuffer(asset: PickerAsset): Promise<ArrayBuffer> {
-  const uri = asset.uri as string
-  try {
-    const response = await fetch(uri)
-    return await response.arrayBuffer()
-  } catch {
-    // Fallback for content:// URIs on Android.
-    const file = new FileSystem.File(uri)
-    const bytes = await file.bytes()
-    return bytes.buffer as ArrayBuffer
-  }
 }

--- a/src/stores/fileCache.ts
+++ b/src/stores/fileCache.ts
@@ -1,6 +1,7 @@
 import { Directory, File, Paths } from 'expo-file-system'
+import * as MediaLibrary from 'expo-media-library'
 import useSWR from 'swr'
-import { Ext } from '../lib/fileTypes'
+import { extFromMime } from '../lib/fileTypes'
 import { logger } from '../lib/logger'
 import { buildSWRHelpers } from '../lib/swr'
 
@@ -15,15 +16,22 @@ export async function ensureCacheDir(): Promise<void> {
   }
 }
 
-export async function getCachedFileForId(id: string, ext: Ext): Promise<File> {
-  return new File(CACHE_DIR, `${id}${ext}`)
+async function getCacheFileForId(file: {
+  id: string
+  fileType: string | null
+}): Promise<File> {
+  return new File(CACHE_DIR, `${file.id}${extFromMime(file.fileType)}`)
 }
 
-export async function getOrCreateCachedFile(
-  id: string,
-  ext: Ext
-): Promise<File> {
-  const f = await getCachedFileForId(id, ext)
+async function getCacheTmpFileForId(file: { id: string }): Promise<File> {
+  return new File(CACHE_DIR, `${file.id}.tmp`)
+}
+
+export async function getOrCreateCacheFile(file: {
+  id: string
+  fileType: string | null
+}): Promise<File> {
+  const f = await getCacheFileForId(file)
   const info = f.info()
   if (!info.exists) {
     f.create({ intermediates: true })
@@ -31,81 +39,111 @@ export async function getOrCreateCachedFile(
   return f
 }
 
-export async function getCachedPathForId(
-  id: string,
-  ext: Ext
-): Promise<string> {
-  const f = await getCachedFileForId(id, ext)
-  return f.uri
-}
-
-export async function isFileCached(id: string, ext: Ext): Promise<boolean> {
-  const f = await getCachedFileForId(id, ext)
+export async function getOrCreateCacheTmpFile(file: {
+  id: string
+}): Promise<File> {
+  const f = await getCacheTmpFileForId(file)
   const info = f.info()
-  return info.exists === true
+  if (!info.exists) {
+    f.create({ intermediates: true })
+  }
+  return f
 }
 
-export async function removeFromCache(id: string, ext: Ext): Promise<void> {
-  const f = await getCachedFileForId(id, ext)
+export async function removeFileFromCache(file: {
+  id: string
+  fileType: string | null
+}): Promise<void> {
+  const f = await getCacheFileForId(file)
   const info = f.info()
   if (info.exists) {
     f.delete()
   }
-  triggerChange(id)
+  triggerChange(file.id)
 }
 
-export async function readCachedUri(
-  id: string,
-  ext: Ext
-): Promise<string | null> {
-  const f = await getCachedFileForId(id, ext)
+export async function removeTmpFileFromCache(file: {
+  id: string
+}): Promise<void> {
+  const f = await getCacheTmpFileForId(file)
+  const info = f.info()
+  if (info.exists) {
+    f.delete()
+  }
+}
+
+async function readCacheUri(file: {
+  id: string
+  fileType: string | null
+}): Promise<string | null> {
+  const f = await getCacheFileForId(file)
   const info = f.info()
   return info.exists ? f.uri : null
 }
 
-export async function writeToCache(
-  id: string,
-  data: ArrayBuffer,
-  ext: Ext
-): Promise<string> {
-  logger.log('writeToCache', id)
-  const f = await getOrCreateCachedFile(id, ext)
-  const writer = f.writableStream().getWriter()
-  await writer.write(new Uint8Array(data))
-  await writer.close()
-  triggerChange(id)
-  return f.uri
-}
-
-export async function copyUriToCache(
-  id: string,
-  sourceUri: string,
-  ext: Ext
-): Promise<string> {
-  logger.log('copyUriToCache', id, sourceUri, ext)
-  const f = await getOrCreateCachedFile(id, ext)
-  const exists = f.info().exists
-  if (exists) f.delete()
-  const srcFile = new File(sourceUri)
-  srcFile.copy(f)
-  triggerChange(id)
-  return f.uri
-}
-
 export async function copyFileToCache(
-  id: string,
-  sourceFile: File,
-  ext: Ext
+  file: {
+    id: string
+    fileType: string | null
+  },
+  sourceFile: File
 ): Promise<string> {
-  logger.log('copyFileToCache', id, sourceFile.uri)
-  const f = await getOrCreateCachedFile(id, ext)
+  logger.log('copyFileToCache', file.id, sourceFile.uri)
+  const f = await getOrCreateCacheFile(file)
   const exists = f.info().exists
   if (exists) f.delete()
   sourceFile.copy(f)
-  triggerChange(id)
+  triggerChange(file.id)
   return f.uri
 }
 
-export function useCachedUri(id: string, ext: Ext) {
-  return useSWR(getKey(id), () => readCachedUri(id, ext))
+/**
+ * Get the local URI for a file record. If the file has a local ID, use the
+ * local URI from the MediaLibrary. The media may need to be downloaded from
+ * the network if it is not already cached.
+ */
+export async function getLocalUri(
+  localId: string | null
+): Promise<string | null> {
+  if (!localId) return null
+  try {
+    const asset = await MediaLibrary.getAssetInfoAsync(localId, {
+      shouldDownloadFromNetwork: true,
+    })
+    return asset.localUri ?? null
+  } catch (e) {
+    return null
+  }
+}
+
+/**
+ * Get the URI for a file record. If the file has a local ID, use the local
+ * URI from the MediaLibrary. Otherwise, check the file cache.
+ */
+export async function getFileUri(file: {
+  id: string
+  fileType: string | null
+  localId?: string | null
+}): Promise<string | null> {
+  if (file.localId) {
+    const localUri = await getLocalUri(file.localId)
+    if (localUri) {
+      return localUri
+    }
+  }
+  return await readCacheUri(file)
+}
+
+/**
+ * Get the URI for a file record. If the file has a local ID, use the local
+ * URI from the MediaLibrary. Otherwise, check the file cache.
+ */
+export function useFileUri(file?: {
+  id: string
+  fileType: string | null
+  localId?: string | null
+}) {
+  return useSWR([...getKey(file?.id), file?.localId], () => {
+    return file ? getFileUri(file) : null
+  })
 }


### PR DESCRIPTION
> This PR improves how the app handles file URIs and the file cache.

- The app now makes use of existing local URI's when available instead of copying every file into the app-specific cache. This means most files added from the device will not need to be copied or re-downloaded as often. Files that are not from the device photo library are still downloaded into the file cache.
    - This change required making useFileStatus and useFileUri async hooks.
- PR also moves all cache path building into fileCache.ts methods so callers don't have to worry about passing the correct ext.