### PR TITLE
feat: content hash

### DIFF
--- a/src/db/migrations/0003_add_file_content_hash.ts
+++ b/src/db/migrations/0003_add_file_content_hash.ts
@@ -1,0 +1,33 @@
+import * as SQLite from 'expo-sqlite'
+import { type Migration } from './types'
+import { logger } from '../../lib/logger'
+
+/**
+ * Adds a contentHash column to the files table.
+ * The contentHash is a unique identifier for each file.
+ * More details can be found in the calculateContentHash function.
+ * It is unique across devices, so it can be used to track whether
+ * incoming files from any source have already been imported.
+ */
+async function up(db: SQLite.SQLiteDatabase): Promise<void> {
+  try {
+    const cols = await db.getAllAsync<{ name: string }>(
+      "PRAGMA table_info('files')"
+    )
+    const hasContentHash = cols.some((c) => c.name === 'contentHash')
+    if (!hasContentHash) {
+      await db.execAsync(`ALTER TABLE files ADD COLUMN contentHash TEXT`)
+      await db.execAsync(
+        `CREATE UNIQUE INDEX IF NOT EXISTS idx_files_contentHash ON files(contentHash)`
+      )
+    }
+  } catch (e) {
+    logger.log('[db] error running migration 0003_add_file_content_hash', e)
+    throw e
+  }
+}
+
+export const migration_0003_add_file_content_hash: Migration = {
+  id: '0003_add_file_content_hash',
+  up,
+}

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -21,10 +21,12 @@ import { logger } from '../../lib/logger'
 import { type Migration } from './types'
 import { migration_0001_init_schema } from './0001_init_schema'
 import { migration_0002_add_file_local_id } from './0002_add_file_local_id'
+import { migration_0003_add_file_content_hash } from './0003_add_file_content_hash'
 
 const migrations: Migration[] = [
   migration_0001_init_schema,
   migration_0002_add_file_local_id,
+  migration_0003_add_file_content_hash,
 ]
 
 export async function runMigrations(db: SQLite.SQLiteDatabase): Promise<void> {

--- a/src/encoding/fileMetadata.ts
+++ b/src/encoding/fileMetadata.ts
@@ -8,6 +8,7 @@ export type FileMetadata = {
   updatedAt: number
   createdAt: number
   localId: string | null
+  contentHash: string | null
 }
 
 export function encodeFileMetadata(
@@ -22,6 +23,7 @@ export function encodeFileMetadata(
       updatedAt: params.updatedAt,
       createdAt: params.createdAt,
       localId: params.localId,
+      contentHash: params.contentHash,
     })
   ).buffer as ArrayBuffer
 }
@@ -38,6 +40,7 @@ export function decodeFileMetadata(buffer?: ArrayBuffer): FileMetadata {
       updatedAt: 0,
       createdAt: 0,
       localId: null,
+      contentHash: null,
     }
   }
 }

--- a/src/lib/__snapshots__/contentHash.test.ts.snap
+++ b/src/lib/__snapshots__/contentHash.test.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`calculateContentHash falls back to whole-file read when stat/read fail 1`] = `"sha256|BYTESv1|bef57ec7f53a6d40beb640a780a639c83bc29ac8a9816f1fc6c5c6dcd93c4721"`;
+
+exports[`calculateContentHash hashes images via IMGv1-RGBA scheme with canonical pixels 1`] = `"sha256|IMGv1-RGBA|8d48680f2defa6ce83cef6bfc64dbdf8b2f5a510274989cc741f4676e8d24bb0"`;
+
+exports[`calculateContentHash hashes non-images via BYTESv1 scheme using streaming 1`] = `"sha256|BYTESv1|c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2"`;

--- a/src/lib/contentHash.test.ts
+++ b/src/lib/contentHash.test.ts
@@ -1,0 +1,73 @@
+import { calculateContentHash } from './contentHash'
+
+type RNFSMocks = {
+  rnfsStat: jest.Mock
+  rnfsRead: jest.Mock
+  rnfsReadFile: jest.Mock
+}
+type SkiaMocks = { makeImageFromEncoded: jest.Mock }
+
+function getMocks(): { rnfs: RNFSMocks; skia: SkiaMocks } {
+  const rnfs = (global as unknown as { __rnfs: RNFSMocks }).__rnfs
+  const skia = (global as unknown as { __skia: SkiaMocks }).__skia
+  return { rnfs, skia }
+}
+
+beforeEach(() => {
+  const { rnfs, skia } = getMocks()
+  rnfs.rnfsStat.mockReset()
+  rnfs.rnfsRead.mockReset()
+  rnfs.rnfsReadFile.mockReset()
+  skia.makeImageFromEncoded.mockReset()
+})
+
+describe('calculateContentHash', () => {
+  it('hashes images via IMGv1-RGBA scheme with canonical pixels', async () => {
+    // Arrange image decode path.
+    const { rnfs, skia } = getMocks()
+    rnfs.rnfsReadFile.mockResolvedValueOnce(
+      Buffer.from('fake-image').toString('base64')
+    )
+    skia.makeImageFromEncoded.mockReturnValueOnce({
+      width: () => 2,
+      height: () => 1,
+      // Two pixels (RGBA per pixel): [255,0,0,255] [0,255,0,255]
+      readPixels: () => new Uint8Array([255, 0, 0, 255, 0, 255, 0, 255]),
+    })
+
+    const res = await calculateContentHash('file:///test.heic')
+    expect(res).toMatchSnapshot()
+  })
+
+  it('hashes non-images via BYTESv1 scheme using streaming', async () => {
+    // Arrange non-image path: force decode to null and stream bytes.
+    const { rnfs, skia } = getMocks()
+    rnfs.rnfsReadFile.mockResolvedValueOnce(
+      Buffer.from('not-an-image').toString('base64')
+    )
+    skia.makeImageFromEncoded.mockReturnValueOnce(null)
+    rnfs.rnfsStat.mockResolvedValueOnce({ size: 6 })
+    rnfs.rnfsRead.mockResolvedValueOnce(
+      Buffer.from('foobar').toString('base64')
+    )
+
+    const res = await calculateContentHash('file:///video.mov')
+    expect(res).toMatchSnapshot()
+  })
+
+  it('falls back to whole-file read when stat/read fail', async () => {
+    const { rnfs, skia } = getMocks()
+    rnfs.rnfsReadFile.mockResolvedValueOnce(
+      Buffer.from('not-an-image').toString('base64')
+    )
+    skia.makeImageFromEncoded.mockReturnValueOnce(null)
+    rnfs.rnfsStat.mockRejectedValueOnce(new Error('no stat'))
+    rnfs.rnfsRead.mockRejectedValueOnce(new Error('no read'))
+    rnfs.rnfsReadFile.mockResolvedValueOnce(
+      Buffer.from('abcdef').toString('base64')
+    )
+
+    const res = await calculateContentHash('content://weird')
+    expect(res).toMatchSnapshot()
+  })
+})

--- a/src/lib/contentHash.ts
+++ b/src/lib/contentHash.ts
@@ -1,0 +1,107 @@
+import RNFS from 'react-native-fs'
+import QuickCrypto from 'react-native-quick-crypto'
+import { Skia, SkImage } from '@shopify/react-native-skia'
+import { Buffer } from 'buffer'
+
+export type HashResult =
+  | `sha256|IMGv1-RGBA|${string}`
+  | `sha256|BYTESv1|${string}`
+
+/**
+ * Calculate a content hash for a file.
+ * - Images: Pixel-hash in canonical sRGB RGBA8 to ignore EXIF/metadata differences.
+ * - Others (video, audio, documents): Raw byte SHA-256 for exact file identity.
+ */
+export async function calculateContentHash(
+  uri: string
+): Promise<HashResult | null> {
+  if (!uri || uri === '') {
+    return null
+  }
+  const img = await tryDecodeImage(uri)
+  if (img) {
+    const hex = await hashImagePixels(img)
+    return `sha256|IMGv1-RGBA|${hex}`
+  }
+  const hex = await sha256File(uri)
+  return `sha256|BYTESv1|${hex}`
+}
+
+/** Try to decode with Skia. If decode fails, return null. */
+async function tryDecodeImage(uri: string): Promise<SkImage | null> {
+  try {
+    // Skia decode requires the full encoded image bytes.
+    const b64 = await RNFS.readFile(uri, 'base64')
+    const data = Skia.Data.fromBase64(b64)
+    const img = Skia.Image.MakeImageFromEncoded(data)
+    return img ?? null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Canonical pixel hash for images.
+ * - Decoded to sRGB RGBA8 by Skia, normalizing EXIF orientation and color space.
+ * - Prelude encodes a stable header: tag + width + height + pixel format.
+ * - Hash is SHA-256 over prelude || raw RGBA pixel data.
+ */
+async function hashImagePixels(img: SkImage): Promise<string> {
+  const width = img.width()
+  const height = img.height()
+
+  // Read pixel data. Skia returns Uint8Array (RGBA8) or Float32Array (rare HDR paths).
+  const pixelData = img.readPixels()
+  if (!pixelData) throw new Error('readPixels failed')
+
+  // If Float32Array, reinterpret to bytes in native order.
+  const pixels =
+    pixelData instanceof Uint8Array
+      ? pixelData
+      : new Uint8Array(pixelData.buffer)
+
+  // Build stable prelude: "IMG1" + width/height (u32 LE) + tag "RGBA".
+  const prelude = new Uint8Array(4 + 4 + 4 + 4)
+  prelude.set([0x49, 0x4d, 0x47, 0x31], 0) // "IMG1".
+  new DataView(prelude.buffer).setUint32(4, width, true)
+  new DataView(prelude.buffer).setUint32(8, height, true)
+  prelude.set([0x52, 0x47, 0x42, 0x41], 12) // "RGBA".
+
+  const h = QuickCrypto.createHash('sha256')
+  const preludeBuf = Buffer.from(prelude)
+  h.update(sliceBuffer(preludeBuf))
+
+  const pixelsBuf = Buffer.from(pixels)
+  h.update(sliceBuffer(pixelsBuf))
+  return h.digest('hex')
+}
+
+/** Streamed SHA-256 for non-images and big files. */
+async function sha256File(uri: string): Promise<string> {
+  const h = QuickCrypto.createHash('sha256')
+  const chunkSize = 1 * 1024 * 1024 // 1MB
+
+  try {
+    const stat = await RNFS.stat(uri)
+    let pos = 0
+    while (pos < stat.size) {
+      const len = Math.min(chunkSize, stat.size - pos)
+      const b64 = await RNFS.read(uri, len, pos, 'base64')
+      const buf = Buffer.from(b64, 'base64')
+      h.update(sliceBuffer(buf))
+      pos += len
+    }
+  } catch {
+    // Fallback for URIs where stat/ranged read is unsupported (some content:// cases):
+    // Read entire file. Prefer avoiding this for very large files but ensures correctness.
+    const b64 = await RNFS.readFile(uri, 'base64')
+    const buf = Buffer.from(b64, 'base64')
+    h.update(sliceBuffer(buf))
+  }
+  return h.digest('hex')
+}
+
+// Extract the exact ArrayBuffer slice to avoid extra capacity bytes.
+function sliceBuffer(buf: Buffer<ArrayBuffer>): ArrayBuffer {
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)
+}

--- a/src/managers/syncDownEvents.ts
+++ b/src/managers/syncDownEvents.ts
@@ -165,6 +165,7 @@ async function handleUpdateEvent(
       updatedAt: object.updatedAt().getTime(),
       fileType: metadata.fileType ?? null,
       localId: metadata.localId ?? null,
+      contentHash: metadata.contentHash ?? null,
     })
     const localObject = await pinnedObjectToLocalObject(
       fileId,

--- a/src/managers/uploader.ts
+++ b/src/managers/uploader.ts
@@ -12,6 +12,7 @@ import {
 import { logger } from '../lib/logger'
 import { PickerAsset } from '../hooks/useImagePicker'
 import { runUploadWithSlot } from '../stores/uploads'
+import { calculateContentHash } from '../lib/contentHash'
 
 export function useUploader() {
   const sdk = useSdk()
@@ -30,6 +31,7 @@ export function useUploader() {
             asset.fileName,
             asset.fileType
           )
+          const contentHash = await calculateContentHash(asset.uri)
           fileRecords.push({
             id: asset.id,
             fileName: asset.fileName,
@@ -38,6 +40,7 @@ export function useUploader() {
             createdAt: asset.createdAt,
             fileType: asset.fileType,
             localId: asset.localId,
+            contentHash: contentHash,
             objects: {},
           })
         }

--- a/src/stores/files.ts
+++ b/src/stores/files.ts
@@ -8,17 +8,6 @@ import { LocalObjectRow } from '../encoding/localObject'
 import { getIndexerURL } from './settings'
 import { librarySwr } from './library'
 
-export type FileRecord = {
-  id: string
-  fileName: string | null
-  fileSize: number | null
-  createdAt: number
-  updatedAt: number
-  fileType: string | null
-  objects: Record<string, LocalObject>
-  localId: string | null
-}
-
 export type FileRecordRow = {
   id: string
   fileName: string | null
@@ -27,23 +16,37 @@ export type FileRecordRow = {
   updatedAt: number
   fileType: string | null
   localId: string | null
+  contentHash: string | null
+}
+
+export type FileRecord = FileRecordRow & {
+  objects: Record<string, LocalObject>
 }
 
 export async function createFileRecord(
   fileRecord: Omit<FileRecord, 'objects'>,
   triggerUpdate: boolean = true
 ): Promise<void> {
-  const { id, fileName, fileSize, createdAt, updatedAt, fileType, localId } =
-    fileRecord
-  await db().runAsync(
-    'INSERT INTO files (id, fileName, fileSize, createdAt, updatedAt, fileType, localId) VALUES (?, ?, ?, ?, ?, ?, ?)',
+  const {
     id,
     fileName,
     fileSize,
     createdAt,
     updatedAt,
     fileType,
-    localId ?? null
+    localId,
+    contentHash,
+  } = fileRecord
+  await db().runAsync(
+    'INSERT INTO files (id, fileName, fileSize, createdAt, updatedAt, fileType, localId, contentHash) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+    id,
+    fileName,
+    fileSize,
+    createdAt,
+    updatedAt,
+    fileType,
+    localId,
+    contentHash
   )
   if (triggerUpdate) {
     await librarySwr.triggerChange()
@@ -152,7 +155,7 @@ export async function readAllFileRecords(opts: {
         objectUpdatedAt: number
       }
   >(
-    `SELECT f.id, f.fileName, f.fileSize, f.createdAt, f.updatedAt, f.fileType, f.localId,
+    `SELECT f.id, f.fileName, f.fileSize, f.createdAt, f.updatedAt, f.fileType, f.localId, f.contentHash,
             o.fileId as fileId, o.indexerURL as indexerURL, o.id as objectId, o.slabs as slabs,
             o.encryptedMasterKey as encryptedMasterKey, o.encryptedMetadata as encryptedMetadata,
             o.signature as signature, o.createdAt as objectCreatedAt, o.updatedAt as objectUpdatedAt
@@ -192,16 +195,8 @@ export async function readAllFileRecords(opts: {
 export async function readFileRecordByObjectId(
   objectId: string
 ): Promise<FileRecord | null> {
-  const row = await db().getFirstAsync<{
-    id: string
-    fileName: string | null
-    fileSize: number | null
-    createdAt: number
-    updatedAt: number
-    fileType: string
-    localId: string | null
-  }>(
-    `SELECT id, fileName, fileSize, createdAt, updatedAt, fileType, localId FROM files WHERE id IN (SELECT fileId FROM objects WHERE id = ?) LIMIT 1`,
+  const row = await db().getFirstAsync<FileRecordRow>(
+    `SELECT id, fileName, fileSize, createdAt, updatedAt, fileType, localId, contentHash FROM files WHERE id IN (SELECT fileId FROM objects WHERE id = ?) LIMIT 1`,
     objectId
   )
   if (!row) return null
@@ -213,7 +208,7 @@ export async function readFileRecordsByLocalIds(
   localIds: string[]
 ): Promise<FileRecord[]> {
   const rows = await db().getAllAsync<FileRecordRow>(
-    `SELECT id, fileName, fileSize, createdAt, updatedAt, fileType, localId FROM files WHERE localId IN (${localIds
+    `SELECT id, fileName, fileSize, createdAt, updatedAt, fileType, localId, contentHash FROM files WHERE localId IN (${localIds
       .map((_) => `?`)
       .join(',')})`,
     ...localIds
@@ -225,7 +220,7 @@ export async function readFileRecordsByLocalIds(
 
 export async function readFileRecord(id: string): Promise<FileRecord | null> {
   const row = await db().getFirstAsync<FileRecordRow>(
-    'SELECT id, fileName, fileSize, createdAt, updatedAt, fileType, localId FROM files WHERE id = ?',
+    'SELECT id, fileName, fileSize, createdAt, updatedAt, fileType, localId, contentHash FROM files WHERE id = ?',
     id
   )
   if (!row) {
@@ -234,17 +229,6 @@ export async function readFileRecord(id: string): Promise<FileRecord | null> {
   }
   const objects = await readLocalObjectsForFile(id)
   return transformRow(row, objects)
-}
-
-export async function readFileRecordBySourceId(
-  localId: string
-): Promise<FileRecord | null> {
-  const row = await db().getFirstAsync<FileRecordRow>(
-    'SELECT id, fileName, fileSize, createdAt, updatedAt, fileType, localId FROM files WHERE localId = ?',
-    localId
-  )
-  if (!row) return null
-  return transformRow(row)
 }
 
 export async function updateFileRecord(
@@ -288,6 +272,7 @@ export function transformRow(
     updatedAt: row.updatedAt,
     fileType: row.fileType,
     localId: row.localId,
+    contentHash: row.contentHash,
     objects: objectsMap,
   }
 }

--- a/src/stores/library.ts
+++ b/src/stores/library.ts
@@ -64,7 +64,7 @@ async function readOrderedFileRecords(
   }
 
   const rows = await db().getAllAsync<FileRecordRow>(
-    `SELECT id, fileName, fileSize, createdAt, updatedAt, fileType, localId
+    `SELECT id, fileName, fileSize, createdAt, updatedAt, fileType, localId, contentHash
      FROM files
      ${where}
      ORDER BY ${orderExpr}${pageClause}`,


### PR DESCRIPTION
- Adds a contentHash column to the files table.
- The contentHash is a unique identifier for each file. It is unique across devices, so it can be used to track whether incoming files from any source have already been imported.
- Content hash format:
    - Images: Pixel-hash in canonical sRGB RGBA8 to ignore EXIF/metadata differences.
    - Other file types: Raw byte SHA-256 for exact file identity.