### PR TITLE
refactor: restructure asset processing

### DIFF
--- a/src/db/migrations/0002_add_file_local_id.ts
+++ b/src/db/migrations/0002_add_file_local_id.ts
@@ -20,7 +20,7 @@ async function up(db: SQLite.SQLiteDatabase): Promise<void> {
     if (!hasCol) {
       await db.execAsync(`ALTER TABLE files ADD COLUMN localId TEXT`)
       await db.execAsync(
-        `CREATE UNIQUE INDEX IF NOT EXISTS idx_files_localId ON files(localId)`
+        `CREATE INDEX IF NOT EXISTS idx_files_localId ON files(localId)`
       )
     }
   } catch (e) {

--- a/src/db/migrations/0003_add_file_content_hash.ts
+++ b/src/db/migrations/0003_add_file_content_hash.ts
@@ -18,7 +18,7 @@ async function up(db: SQLite.SQLiteDatabase): Promise<void> {
     if (!hasContentHash) {
       await db.execAsync(`ALTER TABLE files ADD COLUMN contentHash TEXT`)
       await db.execAsync(
-        `CREATE UNIQUE INDEX IF NOT EXISTS idx_files_contentHash ON files(contentHash)`
+        `CREATE INDEX IF NOT EXISTS idx_files_contentHash ON files(contentHash)`
       )
     }
   } catch (e) {

--- a/src/encoding/fileMetadata.ts
+++ b/src/encoding/fileMetadata.ts
@@ -1,41 +1,45 @@
 import { logger } from '../lib/logger'
+import { FileRecordRow } from '../stores/files'
 
-export type FileMetadata = {
-  id: string
-  name: string
-  fileType: string
+type LegacyFileMetadata = {
+  name?: string
   size?: number
-  updatedAt: number
-  createdAt: number
-  localId: string | null
-  contentHash: string | null
+}
+
+export type FileMetadata = FileRecordRow & LegacyFileMetadata
+
+export function transformFileMetadata(
+  metadata: FileRecordRow & LegacyFileMetadata
+): FileRecordRow {
+  const now = new Date().getTime()
+  return {
+    id: metadata.id,
+    fileName: metadata.fileName ?? metadata.name ?? '',
+    fileType: metadata.fileType,
+    fileSize: metadata.fileSize ?? metadata.size ?? 0,
+    updatedAt: metadata.updatedAt ?? now,
+    createdAt: metadata.createdAt ?? now,
+    localId: metadata.localId,
+    contentHash: metadata.contentHash,
+  }
 }
 
 export function encodeFileMetadata(
-  params: Required<FileMetadata>
+  params: Required<FileRecordRow> & LegacyFileMetadata
 ): ArrayBuffer {
-  return new TextEncoder().encode(
-    JSON.stringify({
-      id: params.id,
-      name: params.name,
-      fileType: params.fileType,
-      size: params.size,
-      updatedAt: params.updatedAt,
-      createdAt: params.createdAt,
-      localId: params.localId,
-      contentHash: params.contentHash,
-    })
-  ).buffer as ArrayBuffer
+  return new TextEncoder().encode(JSON.stringify(transformFileMetadata(params)))
+    .buffer as ArrayBuffer
 }
 
-export function decodeFileMetadata(buffer?: ArrayBuffer): FileMetadata {
+export function decodeFileMetadata(buffer?: ArrayBuffer): FileRecordRow {
   try {
-    return JSON.parse(new TextDecoder().decode(buffer)) as FileMetadata
+    return transformFileMetadata(JSON.parse(new TextDecoder().decode(buffer)))
   } catch (e) {
     logger.log('Error converting file metadata from buffer', e)
     return {
       id: '',
-      name: '',
+      fileName: '',
+      fileSize: 0,
       fileType: '',
       updatedAt: 0,
       createdAt: 0,

--- a/src/hooks/useCameraCapture.ts
+++ b/src/hooks/useCameraCapture.ts
@@ -1,19 +1,18 @@
 import * as ImagePicker from 'react-native-image-picker'
 import { useCallback, useRef } from 'react'
-import { mimeFromAssetUri } from '../lib/fileTypes'
-import { uniqueId } from '../lib/uniqueId'
 import { logger } from '../lib/logger'
 import { useToast } from '../lib/toastContext'
-import { type PickerAsset } from './useImagePicker'
+import { FileRecord } from '../stores/files'
 import { useUploader } from '../managers/uploader'
+import { processAssets } from '../lib/processAssets'
 
 export function useCameraCapture() {
   const toast = useToast()
   const isCapturingRef = useRef<boolean>(false)
-  return useCallback(async () => {
+  return useCallback(async (): Promise<FileRecord[]> => {
     if (isCapturingRef.current) {
       logger.log('[cameraCapture] already capturing, ignoring new request.')
-      return [] as PickerAsset[]
+      return []
     }
     isCapturingRef.current = true
     try {
@@ -26,36 +25,39 @@ export function useCameraCapture() {
 
       if (result.didCancel) {
         logger.log('[cameraCapture] capture canceled.')
-        return [] as PickerAsset[]
+        return []
       }
       if (result.errorCode) {
         logger.log(
           `[cameraCapture] error: ${result.errorMessage ?? result.errorCode}`
         )
-        return [] as PickerAsset[]
+        return []
       }
 
       const first = (result.assets ?? [])[0]
       if (!first || !first.uri) {
         toast.show('No media captured.')
-        return [] as PickerAsset[]
+        return []
       }
 
-      const asset: PickerAsset = {
-        id: uniqueId(),
-        uri: first.uri,
-        fileType: mimeFromAssetUri(first),
-        createdAt: Date.now(),
-        fileSize: first.fileSize ?? 0,
-        fileName:
-          first.fileName ??
-          (first.type?.startsWith('video') ? 'camera-video' : 'camera-photo'),
+      const { files, warnings } = await processAssets(
+        result.assets?.map((a) => ({
+          id: a.id,
+          fileName: a.fileName,
+          fileSize: a.fileSize,
+          fileType: a.type,
+          sourceUri: a.uri,
+          timestamp: a.timestamp,
+        }))
+      )
+      if (warnings.length > 0) {
+        warnings.forEach((warning) => toast.show(warning))
       }
 
-      return [asset]
+      return files
     } catch (e) {
       logger.log('[cameraCapture] error', e)
-      return [] as PickerAsset[]
+      return []
     } finally {
       isCapturingRef.current = false
     }
@@ -66,9 +68,9 @@ export function useCameraCaptureAndUpload() {
   const capture = useCameraCapture()
   const uploader = useUploader()
   return useCallback(async () => {
-    const assets = await capture()
-    if (assets && assets.length > 0) {
-      await uploader(assets)
+    const files = await capture()
+    if (files && files.length > 0) {
+      await uploader(files)
     }
   }, [capture, uploader])
 }

--- a/src/hooks/useDocumentPicker.ts
+++ b/src/hooks/useDocumentPicker.ts
@@ -1,16 +1,15 @@
 import * as DocumentPicker from 'expo-document-picker'
 import { useCallback, useRef } from 'react'
-import { type PickerAsset } from './useImagePicker'
-import { uniqueId } from '../lib/uniqueId'
 import { logger } from '../lib/logger'
-import { mimeFromAssetUri } from '../lib/fileTypes'
 import { useToast } from '../lib/toastContext'
 import { useUploader } from '../managers/uploader'
+import { processAssets } from '../lib/processAssets'
+import { FileRecord } from '../stores/files'
 
 export function useDocumentPicker() {
   const toast = useToast()
   const isPickingRef = useRef<boolean>(false)
-  return useCallback(async (): Promise<PickerAsset[]> => {
+  return useCallback(async (): Promise<FileRecord[]> => {
     if (isPickingRef.current) {
       logger.log('[documentPicker] already picking, ignoring new request.')
       return []
@@ -24,43 +23,26 @@ export function useDocumentPicker() {
         copyToCacheDirectory: true,
       })
 
-      logger.log('[documentPicker] result', result)
-
       if (result.canceled) {
         logger.log('[documentPicker] selection canceled.')
         return []
       }
 
-      const assetsWithRequiredFields = (result.assets ?? []).filter(
-        (a) => a.uri && a.name && a.size
+      const { files, warnings } = await processAssets(
+        result.assets?.map((a) => ({
+          id: undefined,
+          fileName: a.name,
+          fileSize: a.size,
+          fileType: a.mimeType,
+          timestamp: new Date(a.lastModified).toISOString(),
+          sourceUri: a.uri,
+        }))
       )
-
-      if (assetsWithRequiredFields.length !== result.assets?.length) {
-        toast.show(
-          `Assets without required fields: ${
-            result.assets?.length
-              ? result.assets.length - assetsWithRequiredFields.length
-              : 0
-          }`
-        )
+      if (warnings.length > 0) {
+        warnings.forEach((warning) => toast.show(warning))
       }
 
-      const assets: PickerAsset[] = assetsWithRequiredFields.map((a) => ({
-        id: uniqueId(),
-        fileName: a.name,
-        fileSize: a.size ?? 0,
-        createdAt: Date.now(),
-        fileType: a.mimeType ?? mimeFromAssetUri(a),
-        // Documents do not have any local ID.
-        localId: null,
-      }))
-
-      if (assets.length === 0) {
-        logger.log('[documentPicker] no files selected.')
-        return []
-      }
-
-      return assets
+      return files
     } catch (e) {
       logger.log('[documentPicker] error', e)
       return []
@@ -74,9 +56,9 @@ export function useDocumentPickerAndUpload() {
   const pickAssets = useDocumentPicker()
   const uploader = useUploader()
   return useCallback(async () => {
-    const assets = await pickAssets()
-    if (assets.length > 0) {
-      await uploader(assets)
+    const files = await pickAssets()
+    if (files.length > 0) {
+      await uploader(files)
     }
   }, [pickAssets, uploader])
 }

--- a/src/hooks/useImagePicker.ts
+++ b/src/hooks/useImagePicker.ts
@@ -1,24 +1,15 @@
 import * as ImagePicker from 'react-native-image-picker'
 import { useCallback, useRef } from 'react'
-import { uniqueId } from '../lib/uniqueId'
 import { logger } from '../lib/logger'
 import { useToast } from '../lib/toastContext'
 import { useUploader } from '../managers/uploader'
-import { mimeFromAssetUri } from '../lib/fileTypes'
-
-export type PickerAsset = {
-  id: string
-  uri: string
-  fileName: string
-  fileSize: number
-  createdAt: number
-  fileType: string
-}
+import { processAssets } from '../lib/processAssets'
+import { FileRecord } from '../stores/files'
 
 export function useImagePicker() {
   const toast = useToast()
   const isPickingRef = useRef<boolean>(false)
-  return useCallback(async (): Promise<PickerAsset[]> => {
+  return useCallback(async (): Promise<FileRecord[]> => {
     if (isPickingRef.current) {
       logger.log('[imagePicker] already picking, ignoring new request.')
       return []
@@ -43,34 +34,20 @@ export function useImagePicker() {
         return []
       }
 
-      const assetsWithRequiredFields = (result.assets ?? []).filter(
-        (a) => a.uri && a.id && a.fileName && a.fileSize
+      const { files, warnings } = await processAssets(
+        result.assets?.map((a) => ({
+          id: a.id,
+          fileName: a.fileName,
+          fileSize: a.fileSize,
+          fileType: a.type,
+          timestamp: a.timestamp,
+          sourceUri: a.uri,
+        }))
       )
-
-      if (assetsWithRequiredFields.length !== result.assets?.length) {
-        toast.show(
-          `Assets without required fields: ${
-            result.assets?.length
-              ? result.assets.length - assetsWithRequiredFields.length
-              : 0
-          }`
-        )
+      if (warnings.length > 0) {
+        warnings.forEach((warning) => toast.show(warning))
       }
-      const assets: PickerAsset[] = assetsWithRequiredFields.map((a) => ({
-        id: uniqueId(),
-        uri: a.uri as string,
-        fileType: mimeFromAssetUri(a),
-        createdAt: Date.now(),
-        fileSize: a.fileSize!,
-        fileName: a.fileName!,
-      }))
-
-      if (assets.length === 0) {
-        logger.log('[imagePicker] no media selected.')
-        return []
-      }
-
-      return assets
+      return files
     } catch (e) {
       logger.log('[imagePicker] error', e)
       return []
@@ -84,9 +61,9 @@ export function useImagePickerAndUpload() {
   const pickAssets = useImagePicker()
   const uploader = useUploader()
   return useCallback(async () => {
-    const assets = await pickAssets()
-    if (assets.length > 0) {
-      await uploader(assets)
+    const files = await pickAssets()
+    if (files.length > 0) {
+      await uploader(files)
     }
   }, [pickAssets, uploader])
 }

--- a/src/lib/file.ts
+++ b/src/lib/file.ts
@@ -83,7 +83,7 @@ export function useFileStatus(file?: {
   const downloadState = useDownloadState(file?.id || '')
   const fileUri = useFileUri(file)
   return useSWR(
-    [file?.id, file?.localId || '', file?.objects || '', fileUri.data || ''],
+    [file?.id, 'status'],
     () =>
       computeFileStatus({
         file: file ?? { objects: null },
@@ -91,7 +91,10 @@ export function useFileStatus(file?: {
         downloadState,
         fileUri: fileUri.data ?? null,
         errorText: uploadState?.error || downloadState?.error || null,
-      })
+      }),
+    {
+      refreshInterval: 5_000,
+    }
   )
 }
 

--- a/src/lib/object.ts
+++ b/src/lib/object.ts
@@ -1,0 +1,26 @@
+type KeysWithNullish<T> = {
+  [K in keyof T]-?: null extends T[K] ? K : undefined extends T[K] ? K : never
+}[keyof T]
+
+type KeysWithoutNullish<T> = Exclude<keyof T, KeysWithNullish<T>>
+
+type Cleaned<T> = {
+  [K in KeysWithoutNullish<T>]: T[K]
+} & {
+  [K in KeysWithNullish<T>]?: Exclude<T[K], null | undefined>
+}
+
+/**
+ * Removes all null and undefined values from an object.
+ * @param obj - The object to clean.
+ * @returns The cleaned object.
+ */
+export function removeEmptyValues<T extends Record<string, unknown>>(
+  obj: T
+): Cleaned<T> {
+  return Object.fromEntries(
+    Object.entries(obj).filter(
+      ([_, value]) => value !== null && value !== undefined
+    )
+  ) as Cleaned<T>
+}

--- a/src/lib/processAssets.test.ts
+++ b/src/lib/processAssets.test.ts
@@ -1,0 +1,174 @@
+import { processAssets } from './processAssets'
+import { calculateContentHash } from './contentHash'
+import {
+  createFileRecord,
+  readAllFileRecords,
+  readFileRecord,
+  type FileRecord,
+} from '../stores/files'
+import { initializeDB, resetDb } from '../db'
+import { copyFileToCache } from '../stores/fileCache'
+
+// Deterministic ids.
+jest.mock('./uniqueId', () => {
+  let c = 0
+  return { uniqueId: () => `uid-${++c}` }
+})
+
+jest.mock('./contentHash', () => ({
+  calculateContentHash: jest.fn(
+    async (uri: string) => `sha256|BYTESv1|hash:${uri}`
+  ),
+}))
+jest.mock('../stores/fileCache', () => ({
+  getLocalUri: jest.fn(async (localId: string | null) =>
+    localId ? `file://${localId}` : null
+  ),
+  copyFileToCache: jest.fn(async () => 'file://cache/mock'),
+}))
+jest.mock('expo-file-system', () => ({
+  File: jest.fn((uri: string) => ({ uri })),
+}))
+
+beforeAll(async () => {
+  await initializeDB()
+})
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+afterEach(async () => {
+  await resetDb()
+})
+
+describe('processAssets', () => {
+  it('creates a new record when no duplicates exist', async () => {
+    const assets = [
+      {
+        id: '1',
+        fileName: 'a.jpg',
+        fileSize: 100,
+        sourceUri: 'file://1',
+        fileType: 'image/jpeg',
+        timestamp: '2021-01-01',
+      },
+    ]
+
+    const { files } = await processAssets(assets)
+
+    expect(files).toHaveLength(1)
+    const rows = await readAllFileRecords({ order: 'ASC' })
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      id: 'uid-1',
+      fileName: 'a.jpg',
+      fileSize: 100,
+    })
+    expect(copyFileToCache).not.toHaveBeenCalled()
+  })
+
+  it('updates existing by localId and does not create new records', async () => {
+    await createFileRecord(
+      {
+        id: 'existing-1',
+        fileName: 'old.jpg',
+        fileSize: 5,
+        createdAt: 1,
+        updatedAt: 1,
+        fileType: 'image/jpeg',
+        localId: '1',
+        contentHash: null,
+      } as FileRecord,
+      false
+    )
+
+    const assets = [
+      {
+        id: '1',
+        fileName: 'new.jpg',
+        fileSize: 200,
+        sourceUri: 'file://1',
+        fileType: 'image/jpeg',
+        timestamp: '2021-01-01',
+      },
+    ]
+    const { files, updatedFiles } = await processAssets(assets)
+
+    expect(updatedFiles).toHaveLength(1)
+    expect(files).toHaveLength(0)
+    // Should not hash when localId duplicate is detected.
+    expect(calculateContentHash).not.toHaveBeenCalled()
+    const updated = await readFileRecord('existing-1')
+    expect(updated).toMatchObject({
+      id: 'existing-1',
+      fileName: 'new.jpg',
+      fileSize: 200,
+    })
+    expect(copyFileToCache).not.toHaveBeenCalled()
+  })
+
+  it('updates existing by contentHash and does not create new records', async () => {
+    await createFileRecord(
+      {
+        id: 'existing-hash',
+        fileName: 'old-h.jpg',
+        fileSize: 10,
+        createdAt: 1,
+        updatedAt: 1,
+        fileType: 'image/jpeg',
+        localId: null,
+        contentHash: 'sha256|BYTESv1|hash:file://2',
+      } as FileRecord,
+      false
+    )
+
+    const assets = [
+      {
+        id: '2',
+        fileName: 'new-h.jpg',
+        fileSize: 300,
+        sourceUri: 'file://2',
+        fileType: 'image/jpeg',
+        timestamp: '2021-01-01',
+      },
+    ]
+    const { files, updatedFiles } = await processAssets(assets)
+
+    expect(updatedFiles).toHaveLength(1)
+    expect(files).toHaveLength(0)
+    const updated = await readFileRecord('existing-hash')
+    expect(updated).toMatchObject({
+      id: 'existing-hash',
+      fileName: 'new-h.jpg',
+      fileSize: 300,
+    })
+    expect(copyFileToCache).not.toHaveBeenCalled()
+  })
+
+  it('copies sourceUri to cache when asset lacks id', async () => {
+    const copyFileToCacheMock = jest.mocked(copyFileToCache)
+
+    const assets = [
+      {
+        id: undefined,
+        fileName: 'no-id.jpg',
+        fileSize: 123,
+        sourceUri: 'file:///tmp/no-id.jpg',
+        fileType: 'image/jpeg',
+        timestamp: '2021-01-01',
+      },
+    ]
+
+    const { files } = await processAssets(assets)
+
+    expect(files).toHaveLength(1)
+    expect(copyFileToCache).toHaveBeenCalledTimes(1)
+    const call = copyFileToCacheMock.mock.calls[0]
+    expect(call[0]).toMatchObject({ id: files[0].id, fileType: 'image/jpeg' })
+    expect(call[1]).toBeDefined()
+    expect(call[1].uri).toBe('file:///tmp/no-id.jpg')
+
+    const rows = await readAllFileRecords({ order: 'ASC' })
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ fileName: 'no-id.jpg', fileSize: 123 })
+  })
+})

--- a/src/lib/processAssets.ts
+++ b/src/lib/processAssets.ts
@@ -1,0 +1,151 @@
+import { uniqueId } from './uniqueId'
+import { logger } from './logger'
+import {
+  createManyFileRecords,
+  FileRecord,
+  readFileRecordsByContentHashes,
+  readFileRecordsByLocalIds,
+  updateManyFileRecords,
+} from '../stores/files'
+import { mimeFromAssetUri } from './fileTypes'
+import { calculateContentHash } from './contentHash'
+import { copyFileToCache, getLocalUri } from '../stores/fileCache'
+import { removeEmptyValues } from './object'
+import { File } from 'expo-file-system'
+
+type Asset = {
+  id: string | undefined
+  sourceUri: string | undefined
+  fileSize: number | undefined
+  fileType: string | undefined
+  fileName: string | undefined
+  timestamp: string | undefined
+}
+
+type IncomingFileRecord = FileRecord & {
+  sourceUri?: string
+  status: 'foundByLocalId' | 'foundByContentHash' | 'new'
+}
+
+/**
+ * processAssets imports a list of assets from any source.
+ * This function will:
+ * - Check for duplicates by localId and contentHash.
+ * - Create new file records for the assets.
+ * - Copy files without a local ID to the app's file cache.
+ * - Update the metadata of any existing files.
+ * - Return the resulting files and warnings.
+ * @param assets - The assets to process.
+ * @param defaultFileName - The default file name to use for assets that do not have a file name.
+ * @returns The resulting files and warnings.
+ * @throws If the assets cannot be processed.
+ */
+export async function processAssets(
+  assets: Asset[] | undefined,
+  defaultFileName: string = 'file'
+) {
+  const incomingFiles: IncomingFileRecord[] = (assets ?? []).map((a) => {
+    if (a.id) {
+      return {
+        id: uniqueId(),
+        localId: a.id ?? null,
+        fileName: a.fileName ?? defaultFileName,
+        fileSize: a.fileSize ?? null,
+        createdAt: new Date(a.timestamp ?? Date.now()).getTime(),
+        updatedAt: new Date(a.timestamp ?? Date.now()).getTime(),
+        fileType: a.fileType ?? mimeFromAssetUri(a),
+        objects: {},
+        contentHash: null,
+        status: 'new',
+      }
+    }
+    // If the asset does not have an id, pass a sourceUri so we can copy the
+    // file to the app's file cache.
+    return {
+      id: uniqueId(),
+      localId: null,
+      sourceUri: a.sourceUri,
+      fileName: a.fileName ?? defaultFileName,
+      fileSize: a.fileSize ?? null,
+      createdAt: new Date(a.timestamp ?? Date.now()).getTime(),
+      updatedAt: new Date(a.timestamp ?? Date.now()).getTime(),
+      fileType: a.fileType ?? mimeFromAssetUri(a),
+      objects: {},
+      contentHash: null,
+      status: 'new',
+    }
+  })
+
+  // Update the status of the files that are found by localId.
+  // This is quick but will only detect duplicates from the same device.
+  const existingLocalIds = await readFileRecordsByLocalIds(
+    incomingFiles.filter((a) => a.localId !== null).map((a) => a.localId!)
+  )
+  for (const f of existingLocalIds) {
+    const validFile = incomingFiles.find((v) => v.localId === f.localId)
+    if (validFile) {
+      validFile.id = f.id
+      validFile.status = 'foundByLocalId'
+    }
+  }
+
+  // Add content hashes to files that are still new.
+  await Promise.all(
+    incomingFiles
+      .filter((f) => f.status === 'new')
+      .map(async (f) => {
+        const fileUri = await getLocalUri(f.localId)
+        if (!fileUri) return f
+        const contentHash = await calculateContentHash(fileUri)
+        f.contentHash = contentHash
+      })
+  )
+
+  // Check for duplicates by content hash.
+  const existingContentHashes = await readFileRecordsByContentHashes(
+    incomingFiles
+      .filter((f) => f.status === 'new' && f.contentHash !== null)
+      .map((f) => f.contentHash!)
+  )
+
+  // Update the status of the files that are found by content hash.
+  for (const f of existingContentHashes) {
+    const validFile = incomingFiles.find((v) => v.contentHash === f.contentHash)
+    if (validFile) {
+      validFile.id = f.id
+      validFile.status = 'foundByContentHash'
+    }
+  }
+
+  const newFiles = incomingFiles.filter((f) => f.status === 'new')
+  const existingFiles = incomingFiles.filter((f) => f.status !== 'new')
+
+  // Non media library assets do not have a localId so we need to copy the
+  // file to the app cache.
+  const nonMediaAssets = newFiles.filter((a) => !!a.sourceUri)
+  logger.log(
+    `[processAssets] copying ${nonMediaAssets.length} non media assets to cache`
+  )
+  for (const f of nonMediaAssets) {
+    await copyFileToCache(f, new File(f.sourceUri!))
+  }
+
+  const warnings: string[] = []
+  const existingFilesByLocalIdCount = existingLocalIds.length
+  const existingFilesByContentHashCount = existingContentHashes.length
+  logger.log(
+    `[processAssets] result: picked=${incomingFiles.length}, new=${newFiles.length}, existingFilesByLocalId=${existingFilesByLocalIdCount}, existingFilesByContentHash=${existingFilesByContentHashCount}`
+  )
+  if (existingFilesByLocalIdCount > 0 || existingFilesByContentHashCount > 0) {
+    warnings.push('Some files were duplicates and were not included.')
+  }
+
+  await updateManyFileRecords(existingFiles.map((f) => removeEmptyValues(f)))
+  await createManyFileRecords(newFiles)
+
+  return {
+    files: newFiles,
+    updatedFiles: existingFiles,
+    warnings,
+  }
+}

--- a/src/managers/syncDownEvents.ts
+++ b/src/managers/syncDownEvents.ts
@@ -67,7 +67,15 @@ async function syncDownEvents(): Promise<void> {
 
       const events = await sdk.objects(cursor, batchSize)
 
-      logger.log(`[syncDownEvents] batch size=${events.length}`)
+      // If the batch size is 1, we are probably synced and repeatedly polling the last event.
+      if (events.length === 1) {
+        logger.log(
+          `[syncDownEvents] batch size=${events.length}, no new events found`
+        )
+      } else {
+        logger.log(`[syncDownEvents] batch size=${events.length}`)
+      }
+
       await processBatch(events, counts)
 
       // Update the cursor to the last event in the batch.
@@ -159,13 +167,13 @@ async function handleUpdateEvent(
   } else {
     await createFileRecord({
       id: fileId,
-      fileName: metadata.name ?? null,
-      fileSize: metadata.size ?? null,
+      fileName: metadata.fileName,
+      fileSize: metadata.fileSize,
       createdAt: object.createdAt().getTime(),
       updatedAt: object.updatedAt().getTime(),
-      fileType: metadata.fileType ?? null,
-      localId: metadata.localId ?? null,
-      contentHash: metadata.contentHash ?? null,
+      fileType: metadata.fileType,
+      localId: metadata.localId,
+      contentHash: metadata.contentHash,
     })
     const localObject = await pinnedObjectToLocalObject(
       fileId,
@@ -214,4 +222,9 @@ async function getSyncDownCursor(): Promise<ObjectsCursor | undefined> {
 
 export async function setSyncDownCursor(value: ObjectsCursor | undefined) {
   await setSecureStoreJSON('syncDownCursor', value, objectsCursorCodec)
+}
+
+export async function resetSyncDownCursor() {
+  logger.log('[syncDownEvents] resetting sync down cursor')
+  await setSyncDownCursor(undefined)
 }

--- a/src/managers/uploadToIndexer.ts
+++ b/src/managers/uploadToIndexer.ts
@@ -10,16 +10,10 @@ import {
 } from '../config'
 import { upsertLocalObject } from '../stores/localObjects'
 import { pinnedObjectToLocalObject } from '../lib/localObjects'
+import { FileRecordRow } from '../stores/files'
 
 export async function uploadToIndexer(params: {
-  file: {
-    id: string
-    fileName: string | null
-    fileType: string | null
-    fileSize: number | null
-    updatedAt: number
-    createdAt: number
-  }
+  file: FileRecordRow
   sdk: Sdk
   indexerURL: string
   data: ArrayBuffer
@@ -36,12 +30,8 @@ export async function uploadToIndexer(params: {
     dataShards: UPLOAD_DATA_SHARDS,
     parityShards: UPLOAD_PARITY_SHARDS,
     metadata: encodeFileMetadata({
-      id: file.id,
-      name: file.fileName ?? '',
-      fileType: file.fileType ?? '',
-      updatedAt: file.updatedAt ?? new Date().getTime(),
-      createdAt: file.createdAt ?? new Date().getTime(),
-      size: data.byteLength,
+      ...file,
+      fileSize: data.byteLength,
     }),
     progressCallback: {
       progress: (uploaded, encodedSize) => {

--- a/src/managers/uploader.ts
+++ b/src/managers/uploader.ts
@@ -4,79 +4,44 @@ import * as FileSystem from 'expo-file-system'
 import { useCallback } from 'react'
 import { useSdk, getSdk } from '../stores/sdk'
 import { getIndexerURL } from '../stores/settings'
-import {
-  createManyFileRecords,
-  FileRecord,
-  readFileRecord,
-} from '../stores/files'
+import { FileRecord, readFileRecord } from '../stores/files'
 import { logger } from '../lib/logger'
-import { PickerAsset } from '../hooks/useImagePicker'
 import { runUploadWithSlot } from '../stores/uploads'
-import { calculateContentHash } from '../lib/contentHash'
 
 export function useUploader() {
   const sdk = useSdk()
   return useCallback(
-    async (assets: PickerAsset[]) => {
+    async (files: FileRecord[]) => {
       if (!sdk) {
         logger.log('[uploader] sdk not initialized')
         return
       }
       try {
-        const fileRecords: FileRecord[] = []
-        for (const asset of assets) {
-          logger.log(
-            '[uploader] creating file record for asset',
-            asset.id,
-            asset.fileName,
-            asset.fileType
-          )
-          const contentHash = await calculateContentHash(asset.uri)
-          fileRecords.push({
-            id: asset.id,
-            fileName: asset.fileName,
-            fileSize: asset.fileSize,
-            updatedAt: asset.createdAt,
-            createdAt: asset.createdAt,
-            fileType: asset.fileType,
-            localId: asset.localId,
-            contentHash: contentHash,
-            objects: {},
-          })
-        }
-        await createManyFileRecords(fileRecords)
         await Promise.all(
-          assets.map(async (asset: PickerAsset, index: number) => {
+          files.map(async (file: FileRecord, index: number) => {
             logger.log(
-              `[uploader] processing media ${index + 1}/$${assets.length}...`
+              `[uploader] processing media ${index + 1}/$${files.length}...`
             )
-            const fileUri = await getLocalUri(asset.localId)
+            const fileUri = await getLocalUri(file.localId)
             if (!fileUri) {
-              logger.log(`[uploader] file not found ${asset.id}`)
+              logger.log(`[uploader] file uri not found ${file.id}`)
               return
             }
-            logger.log(`[uploader] cached file ${asset.id} -> ${fileUri}`)
+            logger.log(`[uploader] cached file ${file.id} -> ${fileUri}`)
             runUploadWithSlot({
-              id: asset.id,
+              id: file.id,
               task: async (signal) => {
                 const indexerURL = await getIndexerURL()
-                logger.log(`[uploader] uploading ${asset.id} to hosts...`)
+                logger.log(`[uploader] uploading ${file.id} to hosts...`)
                 const fileBytes = await new FileSystem.File(fileUri).bytes()
                 await uploadToIndexer({
-                  file: {
-                    id: asset.id,
-                    fileName: asset.fileName,
-                    fileType: asset.fileType,
-                    fileSize: asset.fileSize,
-                    updatedAt: asset.createdAt,
-                    createdAt: asset.createdAt,
-                  },
+                  file,
                   indexerURL,
                   sdk,
                   data: fileBytes.buffer as ArrayBuffer,
                   signal,
                 })
-                logger.log(`[uploader] upload complete ${asset.id}`)
+                logger.log(`[uploader] upload complete ${file.id}`)
               },
             })
           })
@@ -110,14 +75,7 @@ export function useReuploadFile() {
           logger.log(`[uploader] uploading ${fileId}...`)
           const fileBytes = await new FileSystem.File(fileUri).bytes()
           await uploadToIndexer({
-            file: {
-              id: fileId,
-              fileName: file.fileName,
-              fileType: file.fileType,
-              fileSize: file.fileSize,
-              updatedAt: file.updatedAt,
-              createdAt: file.createdAt,
-            },
+            file,
             indexerURL,
             sdk,
             data: fileBytes.buffer,
@@ -143,14 +101,7 @@ export async function queueUploadForFileId(fileId: string): Promise<void> {
     task: async (signal) => {
       const fileBytes = await new FileSystem.File(fileUri).bytes()
       await uploadToIndexer({
-        file: {
-          id: fileId,
-          fileName: file.fileName,
-          fileType: file.fileType,
-          fileSize: file.fileSize,
-          updatedAt: file.updatedAt,
-          createdAt: file.createdAt,
-        },
+        file,
         indexerURL,
         sdk,
         data: fileBytes.buffer,

--- a/src/screens/ImportFileScreen.tsx
+++ b/src/screens/ImportFileScreen.tsx
@@ -20,7 +20,11 @@ import { createFileRecord } from '../stores/files'
 import { uniqueId } from '../lib/uniqueId'
 import { FileDetailsImport } from '../components/FileDetailsImport'
 import { logger } from '../lib/logger'
-import { decodeFileMetadata } from '../encoding/fileMetadata'
+import {
+  decodeFileMetadata,
+  FileMetadata,
+  transformFileMetadata,
+} from '../encoding/fileMetadata'
 import { getIndexerURL } from '../stores/settings'
 import { BottomActionButton } from '../components/BottomActionButton'
 import { PlusIcon } from 'lucide-react-native'
@@ -55,13 +59,17 @@ export function ImportFileScreen({ route }: Props) {
       try {
         if (!sharedObject.data) return null
         const metadata = decodeFileMetadata(sharedObject.data.metadata())
-        return {
+        const file: FileMetadata = transformFileMetadata({
           id,
-          size: Number(sharedObject.data.size()),
-          fileSize: metadata.size ?? 0,
-          fileType: metadata.fileType ?? '',
-          fileName: metadata.name ?? '',
-        }
+          fileSize: Number(sharedObject.data.size()),
+          fileType: metadata.fileType,
+          fileName: metadata.fileName,
+          contentHash: metadata.contentHash,
+          localId: metadata.localId,
+          createdAt: metadata.createdAt,
+          updatedAt: metadata.updatedAt,
+        })
+        return file
       } catch (e) {
         logger.log('Error getting shared file', e)
         return null
@@ -78,11 +86,7 @@ export function ImportFileScreen({ route }: Props) {
       indexerURL,
       pinnedObject
     )
-    await createFileRecord({
-      ...sharedFile.data,
-      createdAt: new Date().getTime(),
-      updatedAt: new Date().getTime(),
-    })
+    await createFileRecord(sharedFile.data)
     await upsertLocalObject(localObject)
     toast.show('File added')
     navigation.navigate('MainTab', {

--- a/src/screens/LibraryScreen.tsx
+++ b/src/screens/LibraryScreen.tsx
@@ -119,7 +119,9 @@ export function LibraryScreen({ route, navigation }: Props) {
             />
             <Text style={styles.emptyTitle}>No files found</Text>
             <Text style={styles.emptyText}>
-              No files matching the selected filters.
+              {files.error
+                ? files.error.message
+                : 'No files matching the selected filters.'}
             </Text>
           </View>
         )

--- a/src/stores/fileCache.ts
+++ b/src/stores/fileCache.ts
@@ -143,7 +143,7 @@ export function useFileUri(file?: {
   fileType: string | null
   localId?: string | null
 }) {
-  return useSWR([...getKey(file?.id), file?.localId], () => {
+  return useSWR([...getKey(file?.id), 'uri', file?.localId || ''], () => {
     return file ? getFileUri(file) : null
   })
 }

--- a/src/stores/files.ts
+++ b/src/stores/files.ts
@@ -61,7 +61,9 @@ export async function createManyFileRecords(
       await createFileRecord(fr, false)
     }
   })
-  await librarySwr.triggerChange()
+  if (files.length > 0) {
+    await librarySwr.triggerChange()
+  }
 }
 
 function buildFileRecordsQuery(
@@ -204,14 +206,24 @@ export async function readFileRecordByObjectId(
   return transformRow(row, objects)
 }
 
-export async function readFileRecordsByLocalIds(
-  localIds: string[]
-): Promise<FileRecord[]> {
+export async function readFileRecordsByLocalIds(localIds: string[]) {
   const rows = await db().getAllAsync<FileRecordRow>(
     `SELECT id, fileName, fileSize, createdAt, updatedAt, fileType, localId, contentHash FROM files WHERE localId IN (${localIds
       .map((_) => `?`)
       .join(',')})`,
     ...localIds
+  )
+  return rows.map((row) => transformRow(row)) as (FileRecord & {
+    localId: string
+  })[]
+}
+
+export async function readFileRecordsByContentHashes(contentHashes: string[]) {
+  const rows = await db().getAllAsync<FileRecordRow>(
+    `SELECT id, fileName, fileSize, createdAt, updatedAt, fileType, localId, contentHash FROM files WHERE contentHash IN (${contentHashes
+      .map((_) => `?`)
+      .join(',')})`,
+    ...contentHashes
   )
   return rows.map((row) => transformRow(row)) as (FileRecord & {
     contentHash: string
@@ -232,19 +244,50 @@ export async function readFileRecord(id: string): Promise<FileRecord | null> {
 }
 
 export async function updateFileRecord(
-  fileRecord: Omit<FileRecord, 'objects'>
+  update: Partial<FileRecordRow> & { id: string },
+  triggerUpdate: boolean = true
 ): Promise<void> {
-  const { id, fileName, fileSize, createdAt, updatedAt, fileType } = fileRecord
-  await db().runAsync(
-    'UPDATE files SET fileName = ?, fileSize = ?, createdAt = ?, updatedAt = ?, fileType = ? WHERE id = ?',
-    fileName,
-    fileSize,
-    createdAt,
-    updatedAt,
-    fileType,
-    id
-  )
-  await librarySwr.triggerChange()
+  const { id } = update
+  const sets: string[] = []
+  const params: (string | number | null)[] = []
+  const updatableFields = [
+    'fileName',
+    'fileSize',
+    'createdAt',
+    'updatedAt',
+    'fileType',
+    'localId',
+    'contentHash',
+  ]
+  for (const field of updatableFields) {
+    if (field in update) {
+      sets.push(`${field} = ?`)
+      params.push(update[field as keyof typeof update] ?? null)
+    }
+  }
+
+  if (sets.length === 0) {
+    return
+  }
+
+  const sql = `UPDATE files SET ${sets.join(', ')} WHERE id = ?`
+  await db().runAsync(sql, ...params, id)
+  if (triggerUpdate) {
+    await librarySwr.triggerChange()
+  }
+}
+
+export async function updateManyFileRecords(
+  updates: Partial<FileRecordRow> & { id: string }[]
+): Promise<void> {
+  await db().withTransactionAsync(async () => {
+    for (const update of updates) {
+      await updateFileRecord(update, false)
+    }
+  })
+  if (updates.length > 0) {
+    await librarySwr.triggerChange()
+  }
 }
 
 export async function deleteFileRecord(id: string): Promise<void> {


### PR DESCRIPTION
This PR adds `processAssets`​ and refactors all file pickers and import flows to use this new method. It does the following:

- Checks for duplicates by localId and contentHash.
- Creates new file records for the assets.
- Updates the metadata of any existing files.
- Copies any non media assets to the app file cache.
- Return the resulting files and any warnings.

PR also removes uniqueness from the two files column migrations. Deduplication should be eventually consistent so we can always sync all object events to the database.