### PR TITLE
feat: add slab map to file details

### DIFF
--- a/src/components/FileDetails/FileMap.tsx
+++ b/src/components/FileDetails/FileMap.tsx
@@ -1,34 +1,71 @@
-import { StyleSheet, Platform } from 'react-native'
-import MapView from 'react-native-maps'
+import React, { useMemo } from 'react'
+import { StyleSheet, View } from 'react-native'
+import useSWR from 'swr'
+import { AddressProtocol, Host } from 'react-native-sia'
+import { DEFAULT_INDEXER_URL } from '../../config'
+import { type FileRecord } from '../../stores/files'
+import { useHosts } from '../../stores/hosts'
+import { useSdk } from '../../stores/sdk'
+import Map from '../Map/Map'
+import { MapMarker } from '../Map/MapMarker'
+import { determineBestRegion } from '../Map/mapHelpers'
+import { SWROverlay } from '../SWROverlay'
 
-export function FileMap() {
+export function FileMap({ file }: { file: FileRecord }) {
+  const sdk = useSdk()
+  const hosts = useHosts()
+
+  const firstSlabID = useMemo(() => {
+    const slabs = file.objects[DEFAULT_INDEXER_URL]?.slabs ?? []
+    return slabs[0]?.id
+  }, [file])
+
+  const slab = useSWR(
+    sdk && firstSlabID ? ['sdk/slab', firstSlabID] : null,
+    () => sdk?.slab(firstSlabID!)
+  )
+
+  const matchingHosts: Host[] = useMemo(() => {
+    if (!hosts.data || !slab.data) return []
+    const keys = new Set(
+      (slab.data.sectors ?? []).map((sec: any) => sec.hostKey)
+    )
+    return hosts.data.filter((h) => keys.has(h.publicKey))
+  }, [hosts.data, slab.data])
+
+  const region = useMemo(() => {
+    if (matchingHosts.length === 0) return undefined
+    return determineBestRegion(matchingHosts)
+  }, [matchingHosts])
+
   return (
-    <MapView
-      style={styles.map}
-      mapType={Platform.OS === 'ios' ? 'mutedStandard' : 'standard'}
-      showsCompass={false}
-      showsScale={false}
-      showsIndoors={false}
-      showsTraffic={false}
-      zoomEnabled={false}
-      rotateEnabled={false}
-      pitchEnabled={false}
-      scrollEnabled={false}
-      toolbarEnabled={false}
-    >
-      {/* {file.slabs?.map((s) => (
-        <Marker
-          key={s.id}
-          coordinate={{ latitude: s.latitude, longitude: s.longitude }}
-        />
-      ))} */}
-    </MapView>
+    <View style={styles.container}>
+      <SWROverlay
+        response={hosts}
+        errorMessage="Failed to load hosts"
+        noDataMessage="No hosts available"
+      >
+        <Map region={region}>
+          {matchingHosts.map((h) => (
+            <MapMarker
+              size={10}
+              key={h.publicKey}
+              coordinate={{ latitude: h.latitude, longitude: h.longitude }}
+              title={
+                hosts.data
+                  ? h.addresses.find(
+                      (a) => a.protocol === AddressProtocol.SiaMux
+                    )?.address ?? h.publicKey
+                  : h.publicKey
+              }
+            />
+          ))}
+        </Map>
+      </SWROverlay>
+    </View>
   )
 }
 
 const styles = StyleSheet.create({
-  map: {
-    width: '100%',
-    height: 220,
-  },
+  container: { flex: 1 },
 })

--- a/src/components/FileDetails/index.tsx
+++ b/src/components/FileDetails/index.tsx
@@ -4,6 +4,7 @@ import { colors, palette } from '../../styles/colors'
 import { type FileRecord } from '../../stores/files'
 import { useFileStatus } from '../../lib/file'
 import { FileMeta } from './FileMeta'
+import { FileMap } from './FileMap'
 
 export function FileDetails({
   file,
@@ -18,7 +19,10 @@ export function FileDetails({
     <View style={styles.container}>
       <ScrollView contentContainerStyle={styles.scrollContent}>
         {header}
-        <View style={styles.metaWrap}>
+        <View style={styles.mapContainer}>
+          <FileMap file={file} />
+        </View>
+        <View style={styles.metaContainer}>
           <FileMeta file={file} status={status} />
         </View>
       </ScrollView>
@@ -29,6 +33,6 @@ export function FileDetails({
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: palette.gray[950] },
   scrollContent: { paddingBottom: 96 },
-  viewerWrap: {},
-  metaWrap: { marginTop: 16, backgroundColor: colors.bgElevated },
+  metaContainer: { marginTop: 16, backgroundColor: colors.bgElevated },
+  mapContainer: { height: '100%' },
 })


### PR DESCRIPTION
Closes [#94](https://github.com/SiaFoundation/sia-mobile/issues/94)

![Screenshot 2025-10-23 at 9.32.11 AM.png](https://app.graphite.dev/user-attachments/assets/27c0b258-8fe8-4d74-ab38-f4dc62114fc4.png)

~~This puts all slabs on the map because that seemed easy and is fully expressive of what's happening behind the scenes with a client's data.~~

After consultation with the team, this now uses only the hosts for the first slab.