### PR TITLE
feat: sync photos library

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -25,3 +25,7 @@ export const SCANNER_ADD_TO_QUEUE_FACTOR = 2
 export const SCANNER_INTERVAL = 5_000 // 5 seconds
 // Sync events interval.
 export const SYNC_EVENTS_INTERVAL = 10_000 // 10 seconds
+// Sync new photos interval.
+export const SYNC_NEW_PHOTOS_INTERVAL = 30_000 // 30 seconds
+// Sync archive photos interval.
+export const SYNC_PHOTOS_ARCHIVE_INTERVAL = 5_000 // 5 seconds

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -1,0 +1,7 @@
+import * as MediaLibrary from 'expo-media-library'
+import { logger } from './logger'
+
+export async function ensurePhotosPermission(): Promise<boolean> {
+  const res = await MediaLibrary.requestPermissionsAsync()
+  return res.granted === true
+}

--- a/src/managers/syncNewPhotos.test.ts
+++ b/src/managers/syncNewPhotos.test.ts
@@ -1,0 +1,111 @@
+import { SYNC_NEW_PHOTOS_INTERVAL } from '../config'
+import { initSyncNewPhotos } from './syncNewPhotos'
+import * as MediaLibrary from 'expo-media-library'
+import { ensurePhotosPermission } from '../lib/permissions'
+import { processAssets } from '../lib/processAssets'
+
+jest.useFakeTimers()
+
+jest.mock('expo-media-library', () => ({
+  getAssetsAsync: jest.fn(),
+  SortBy: { creationTime: 'creationTime' },
+  MediaType: { photo: 'photo', video: 'video' },
+}))
+jest.mock('../lib/permissions', () => ({
+  ensurePhotosPermission: jest.fn(),
+}))
+jest.mock('../lib/processAssets', () => ({
+  processAssets: jest.fn(),
+}))
+jest.mock('../stores/library', () => ({
+  librarySwr: {
+    triggerChange: jest.fn(),
+    addChangeCallback: jest.fn(),
+    getKey: jest.fn((k: string) => [k]),
+  },
+}))
+
+async function runTick() {
+  await jest.advanceTimersByTimeAsync(SYNC_NEW_PHOTOS_INTERVAL)
+}
+
+function getTime(t: number | Date | undefined): number {
+  if (!t) return 0
+  return typeof t === 'number' ? t : t.getTime()
+}
+
+function asset(id: string, name: string, time: number): MediaLibrary.Asset {
+  return {
+    id,
+    filename: name,
+    uri: `file://${id}`,
+    mediaType: MediaLibrary.MediaType.photo,
+    creationTime: time,
+    modificationTime: time,
+    width: 1,
+    height: 1,
+    duration: 0,
+  }
+}
+
+function page(
+  a: MediaLibrary.Asset[]
+): MediaLibrary.PagedInfo<MediaLibrary.Asset> {
+  return {
+    assets: a,
+    endCursor: '',
+    hasNextPage: false,
+    totalCount: a.length,
+  }
+}
+
+describe('syncNewPhotos', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('iterates forward adding all new files', async () => {
+    const ensurePhotosPermissionMock = jest.mocked(ensurePhotosPermission)
+    const getAssetsAsyncMock = jest.mocked(MediaLibrary.getAssetsAsync)
+    const processAssetsMock = jest.mocked(processAssets)
+
+    ensurePhotosPermissionMock.mockResolvedValue(true)
+    getAssetsAsyncMock
+      .mockResolvedValueOnce(
+        page([asset('a1', '1.jpg', 1000), asset('a2', '2.jpg', 2000)])
+      )
+      .mockResolvedValueOnce(page([asset('a3', '3.jpg', 2500)]))
+      .mockResolvedValueOnce(page([]))
+      .mockResolvedValueOnce(page([asset('a4', '4.jpg', 3000)]))
+
+    initSyncNewPhotos()
+    await runTick()
+    await runTick()
+    await runTick()
+    await runTick()
+
+    const opts0 = getAssetsAsyncMock.mock.calls[0][0]
+    const opts1 = getAssetsAsyncMock.mock.calls[1][0]
+    const opts2 = getAssetsAsyncMock.mock.calls[2][0]
+    const opts3 = getAssetsAsyncMock.mock.calls[3][0]
+    // createdAfter is set to current time on first init.
+    expect(getTime(opts0?.createdAfter)).toBeGreaterThan(0)
+    // First tick had two assets, two process calls.
+    expect(getTime(opts1?.createdAfter)).toBe(2000)
+    // Third tick had no assets, no further processing.
+    expect(getTime(opts2?.createdAfter)).toBe(2500)
+    // Fourth tick had one asset, one process call.
+    expect(getTime(opts3?.createdAfter)).toBe(2500)
+    expect(processAssetsMock).toHaveBeenCalledTimes(3)
+    expect(processAssetsMock).toHaveBeenNthCalledWith(1, [
+      expect.objectContaining({ id: 'a1', fileName: '1.jpg' }),
+      expect.objectContaining({ id: 'a2', fileName: '2.jpg' }),
+    ])
+    expect(processAssetsMock).toHaveBeenNthCalledWith(2, [
+      expect.objectContaining({ id: 'a3', fileName: '3.jpg' }),
+    ])
+    expect(processAssetsMock).toHaveBeenNthCalledWith(3, [
+      expect.objectContaining({ id: 'a4', fileName: '4.jpg' }),
+    ])
+  })
+})

--- a/src/managers/syncNewPhotos.ts
+++ b/src/managers/syncNewPhotos.ts
@@ -1,0 +1,95 @@
+import * as MediaLibrary from 'expo-media-library'
+import { logger } from '../lib/logger'
+import { createServiceInterval } from '../lib/serviceInterval'
+import { getKey, triggerChange } from '../stores/settings'
+import { processAssets } from '../lib/processAssets'
+import { librarySwr } from '../stores/library'
+import { SYNC_NEW_PHOTOS_INTERVAL } from '../config'
+import { createGetterAndSWRHook } from '../lib/selectors'
+import {
+  getSecureStoreBoolean,
+  getSecureStoreNumber,
+  setSecureStoreBoolean,
+  setSecureStoreNumber,
+} from '../stores/secureStore'
+import { ensurePhotosPermission } from '../lib/permissions'
+
+const PAGE_SIZE = 200
+
+async function workForward(): Promise<void> {
+  if (!(await ensurePhotosPermission())) return
+  const cursor = await getPhotosNewCursor()
+
+  try {
+    const page = await MediaLibrary.getAssetsAsync({
+      first: PAGE_SIZE,
+      createdAfter: new Date(cursor),
+      // Ascending order.
+      sortBy: [[MediaLibrary.SortBy.creationTime, true]],
+      mediaType: [MediaLibrary.MediaType.photo, MediaLibrary.MediaType.video],
+    })
+    if (page.assets.length === 0) {
+      logger.log('[syncNewPhotos] no new photos found')
+      return
+    }
+    logger.log('[syncNewPhotos] batch size', page.assets.length)
+    await setPhotosNewCursor(
+      page.assets[page.assets.length - 1].creationTime ?? 0
+    )
+    const { files } = await processAssets(
+      page.assets.map((asset) => ({
+        id: asset.id,
+        sourceUri: undefined,
+        fileName: asset.filename,
+        fileType: undefined,
+        fileSize: undefined,
+        timestamp: new Date(asset.creationTime).toISOString(),
+      }))
+    )
+    if (files.length > 0) await librarySwr.triggerChange()
+  } catch (e) {
+    logger.log('[syncNewPhotos] batch error', e)
+  }
+}
+
+export const initSyncNewPhotos = createServiceInterval({
+  name: 'syncNewPhotos',
+  worker: workForward,
+  getState: () => getAutoSyncNewPhotos(),
+  interval: SYNC_NEW_PHOTOS_INTERVAL,
+})
+
+// Photos sync - new photos forward cursor and toggle.
+
+export const [getAutoSyncNewPhotos, useAutoSyncNewPhotos] =
+  createGetterAndSWRHook(getKey('autoSyncNewPhotos'), () =>
+    getSecureStoreBoolean('autoSyncNewPhotos', true)
+  )
+
+export async function setAutoSyncNewPhotos(value: boolean) {
+  await setSecureStoreBoolean('autoSyncNewPhotos', value)
+  triggerChange('autoSyncNewPhotos')
+}
+
+export async function toggleAutoSyncNewPhotos() {
+  const current = await getAutoSyncNewPhotos()
+  const next = !current
+  await setAutoSyncNewPhotos(next)
+}
+
+const defaultValue = new Date().getTime()
+
+export const [getPhotosNewCursor, usePhotosNewCursor] = createGetterAndSWRHook(
+  getKey('photosNewCursor'),
+  () => getSecureStoreNumber('photosNewCursor', defaultValue)
+)
+
+export async function setPhotosNewCursor(value: number) {
+  await setSecureStoreNumber('photosNewCursor', value)
+  triggerChange('photosNewCursor')
+}
+
+export async function resetPhotosNewCursor() {
+  logger.log('[syncNewPhotos] resetting photos new sync cursor')
+  await setPhotosNewCursor(defaultValue)
+}

--- a/src/managers/syncPhotosArchive.test.ts
+++ b/src/managers/syncPhotosArchive.test.ts
@@ -1,0 +1,124 @@
+import { SYNC_PHOTOS_ARCHIVE_INTERVAL } from '../config'
+import * as MediaLibrary from 'expo-media-library'
+import { ensurePhotosPermission } from '../lib/permissions'
+import { processAssets } from '../lib/processAssets'
+import {
+  initSyncPhotosArchive,
+  getPhotosArchiveCursor,
+  restartPhotosArchiveCursor,
+} from './syncPhotosArchive'
+
+jest.useFakeTimers()
+
+// Mocks
+jest.mock('expo-media-library', () => ({
+  __esModule: true,
+  getAssetsAsync: jest.fn(),
+  SortBy: { creationTime: 'creationTime' },
+  MediaType: { photo: 'photo', video: 'video' },
+}))
+jest.mock('../lib/permissions', () => ({
+  __esModule: true,
+  ensurePhotosPermission: jest.fn(),
+}))
+jest.mock('../lib/processAssets', () => ({
+  __esModule: true,
+  processAssets: jest.fn(),
+}))
+jest.mock('../stores/library', () => ({
+  __esModule: true,
+  librarySwr: {
+    triggerChange: jest.fn(),
+    addChangeCallback: jest.fn(),
+    getKey: jest.fn((k: string) => [k]),
+  },
+}))
+
+async function runTick() {
+  await jest.advanceTimersByTimeAsync(SYNC_PHOTOS_ARCHIVE_INTERVAL)
+}
+
+function asset(id: string, name: string, time: number): MediaLibrary.Asset {
+  return {
+    id,
+    filename: name,
+    uri: `file://${id}`,
+    mediaType: MediaLibrary.MediaType.photo,
+    creationTime: time,
+    modificationTime: time,
+    width: 1,
+    height: 1,
+    duration: 0,
+  }
+}
+
+function page(
+  a: MediaLibrary.Asset[]
+): MediaLibrary.PagedInfo<MediaLibrary.Asset> {
+  return {
+    assets: a,
+    endCursor: '',
+    hasNextPage: false,
+    totalCount: a.length,
+  }
+}
+
+describe('syncPhotosArchive', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('iterates backward adding files until exhausting the archive', async () => {
+    const ensurePhotosPermissionMock = jest.mocked(ensurePhotosPermission)
+    const getAssetsAsyncMock = jest.mocked(MediaLibrary.getAssetsAsync)
+    const processAssetsMock = jest.mocked(processAssets)
+
+    ensurePhotosPermissionMock.mockResolvedValue(true)
+
+    getAssetsAsyncMock.mockImplementation(
+      async (
+        opts?: MediaLibrary.AssetsOptions
+      ): Promise<MediaLibrary.PagedInfo<MediaLibrary.Asset>> => {
+        const t = opts?.createdBefore
+          ? new Date(opts.createdBefore).getTime()
+          : Number.MAX_SAFE_INTEGER
+        if (t >= 1_000_000)
+          return page([
+            asset('b1', 'one.jpg', 10_000),
+            asset('b2', 'two.jpg', 5_000),
+          ])
+        if (t === 5_000) return page([asset('b3', 'three.jpg', 1_000)])
+        return page([])
+      }
+    )
+
+    processAssetsMock
+      .mockResolvedValueOnce({ files: [], updatedFiles: [], warnings: [] })
+      .mockResolvedValueOnce({ files: [], updatedFiles: [], warnings: [] })
+
+    // Seed initial cursor so service is enabled.
+    await restartPhotosArchiveCursor()
+
+    initSyncPhotosArchive()
+
+    // Tick 1: createdBefore 1_000_000 -> returns [10_000, 5_000], cursor -> 5_000
+    await runTick()
+    expect(processAssetsMock).toHaveBeenNthCalledWith(1, [
+      expect.objectContaining({ id: 'b1', fileName: 'one.jpg' }),
+      expect.objectContaining({ id: 'b2', fileName: 'two.jpg' }),
+    ])
+    expect(await getPhotosArchiveCursor()).toBe(5_000)
+
+    // Tick 2: createdBefore 5_000 -> returns [1_000], cursor -> 1_000
+    await runTick()
+    expect(processAssetsMock).toHaveBeenNthCalledWith(2, [
+      expect.objectContaining({ id: 'b3', fileName: 'three.jpg' }),
+    ])
+    expect(await getPhotosArchiveCursor()).toBe(1_000)
+
+    // Tick 3: createdBefore 1_000 -> returns [], cursor should reset to 0 and stop
+    await runTick()
+    expect(await getPhotosArchiveCursor()).toBe(0)
+    expect(processAssetsMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/managers/syncPhotosArchive.ts
+++ b/src/managers/syncPhotosArchive.ts
@@ -1,0 +1,81 @@
+import * as MediaLibrary from 'expo-media-library'
+import { logger } from '../lib/logger'
+import { getKey, triggerChange } from '../stores/settings'
+import { processAssets } from '../lib/processAssets'
+import { librarySwr } from '../stores/library'
+import { createGetterAndSWRHook } from '../lib/selectors'
+import {
+  getSecureStoreNumber,
+  setSecureStoreNumber,
+} from '../stores/secureStore'
+import { createServiceInterval } from '../lib/serviceInterval'
+import { SYNC_PHOTOS_ARCHIVE_INTERVAL } from '../config'
+import { ensurePhotosPermission } from '../lib/permissions'
+
+const PAGE_SIZE = 200
+
+export async function workBackward(): Promise<void> {
+  if (!(await ensurePhotosPermission())) return
+  const cursor = await getPhotosArchiveCursor()
+
+  try {
+    const page = await MediaLibrary.getAssetsAsync({
+      first: PAGE_SIZE,
+      createdBefore: new Date(cursor),
+      // Descending order.
+      sortBy: [[MediaLibrary.SortBy.creationTime, false]],
+      mediaType: [MediaLibrary.MediaType.photo, MediaLibrary.MediaType.video],
+    })
+    if (page.assets.length === 0) {
+      logger.log('[syncPhotosArchive] archive is fully synced')
+      await setPhotosArchiveCursor(0)
+      return
+    }
+    logger.log('[syncPhotosArchive] batch size', page.assets.length)
+    await setPhotosArchiveCursor(
+      page.assets[page.assets.length - 1].creationTime ?? 0
+    )
+    const { files } = await processAssets(
+      page.assets.map((asset) => ({
+        id: asset.id,
+        sourceUri: undefined,
+        fileName: asset.filename,
+        fileType: undefined,
+        fileSize: undefined,
+        timestamp: new Date(asset.creationTime).toISOString(),
+      }))
+    )
+    if (files.length > 0) await librarySwr.triggerChange()
+  } catch (e) {
+    logger.log('[syncPhotosArchive] batch error', e)
+  }
+}
+
+export const initSyncPhotosArchive = createServiceInterval({
+  name: 'syncPhotosArchive',
+  worker: workBackward,
+  getState: async () => (await getPhotosArchiveCursor()) > 0,
+  interval: SYNC_PHOTOS_ARCHIVE_INTERVAL,
+})
+
+const defaultValue = 0
+
+export const [getPhotosArchiveCursor, usePhotosArchiveCursor] =
+  createGetterAndSWRHook(getKey('photosArchiveCursor'), () =>
+    getSecureStoreNumber('photosArchiveCursor', defaultValue)
+  )
+
+export async function setPhotosArchiveCursor(value: number) {
+  await setSecureStoreNumber('photosArchiveCursor', value)
+  triggerChange('photosArchiveCursor')
+}
+
+export async function restartPhotosArchiveCursor() {
+  logger.log('[syncPhotosArchive] restarting photos archive sync cursor')
+  await setPhotosArchiveCursor(Date.now())
+}
+
+export async function resetPhotosArchiveCursor() {
+  logger.log('[syncPhotosArchive] disabling photos archive sync cursor')
+  await setPhotosArchiveCursor(defaultValue)
+}

--- a/src/screens/SettingsSyncScreen.tsx
+++ b/src/screens/SettingsSyncScreen.tsx
@@ -8,18 +8,26 @@ import { cancelAllDownloads, useDownloadCounts } from '../stores/downloads'
 import { Button } from '../components/Button'
 import { RowGroup } from '../components/Group'
 import { InputRow } from '../components/InputRow'
-import {
-  toggleAutoScanUploads,
-  toggleAutoSyncDownEvents,
-  useAutoScanUploads,
-  useAutoSyncDownEvents,
-} from '../stores/settings'
 import { useInputValue } from '../hooks/useInputValue'
 import { SettingsLayout } from '../components/SettingsLayout'
 import { colors } from '../styles/colors'
 import { useSettingsHeader } from '../hooks/useSettingsHeader'
 import { setMaxUploads, useMaxUploads } from '../managers/uploadsPool'
 import { setMaxDownloads, useMaxDownloads } from '../managers/downloadsPool'
+import {
+  toggleAutoScanUploads,
+  toggleAutoSyncDownEvents,
+  useAutoScanUploads,
+  useAutoSyncDownEvents,
+} from '../stores/settings'
+import {
+  toggleAutoSyncNewPhotos,
+  useAutoSyncNewPhotos,
+} from '../managers/syncNewPhotos'
+import {
+  usePhotosArchiveCursor,
+  restartPhotosArchiveCursor,
+} from '../managers/syncPhotosArchive'
 
 type Props = NativeStackScreenProps<SettingsStackParamList, 'Sync'>
 
@@ -31,6 +39,9 @@ export function SettingsSyncScreen(_props: Props) {
   const maxUploads = useMaxUploads()
   const maxDownloads = useMaxDownloads()
   const autoSync = useAutoSyncDownEvents()
+  const autoSyncNew = useAutoSyncNewPhotos()
+  const photosArchiveCursor = usePhotosArchiveCursor()
+  const photosArchiveInProgress = (photosArchiveCursor.data ?? 0) > 0
 
   const maxUploadsInputProps = useInputValue({
     value: String(maxUploads.data),
@@ -53,8 +64,8 @@ export function SettingsSyncScreen(_props: Props) {
       <RowGroup title="Sync">
         <InfoCard>
           <LabeledValueRow
-            label="Auto upload unsynced files"
-            labelWidth={200}
+            label="Automatically upload files to network"
+            labelWidth={300}
             value={
               <Switch
                 value={autoScan.data ?? false}
@@ -63,8 +74,8 @@ export function SettingsSyncScreen(_props: Props) {
             }
           />
           <LabeledValueRow
-            label="Auto sync with other devices"
-            labelWidth={200}
+            label="Automatically sync with your other devices"
+            labelWidth={300}
             value={
               <Switch
                 value={autoSync.data ?? false}
@@ -73,6 +84,31 @@ export function SettingsSyncScreen(_props: Props) {
             }
           />
         </InfoCard>
+      </RowGroup>
+      <RowGroup title="Photos">
+        <InfoCard>
+          <LabeledValueRow
+            label="Automatically import new photos"
+            labelWidth={300}
+            value={
+              <Switch
+                value={autoSyncNew.data ?? false}
+                onValueChange={toggleAutoSyncNewPhotos}
+              />
+            }
+          />
+        </InfoCard>
+        <Button
+          style={{ marginTop: 10 }}
+          disabled={photosArchiveInProgress}
+          onPress={() => {
+            void restartPhotosArchiveCursor()
+          }}
+        >
+          {photosArchiveInProgress
+            ? 'Sync in progress'
+            : 'Import photos library'}
+        </Button>
       </RowGroup>
       <RowGroup title="Uploads">
         <InfoCard>
@@ -86,13 +122,11 @@ export function SettingsSyncScreen(_props: Props) {
             label="Queued"
             value={String(uploadCounts.totalQueued)}
             canCopy={false}
-            showDividerTop
           />
           <LabeledValueRow
             label="Active"
             value={String(uploadCounts.totalActive)}
             canCopy={false}
-            showDividerTop
           />
         </InfoCard>
         <Button
@@ -118,13 +152,11 @@ export function SettingsSyncScreen(_props: Props) {
             label="Queued"
             value={String(downloadCounts.totalQueued)}
             canCopy={false}
-            showDividerTop
           />
           <LabeledValueRow
             label="Active"
             value={String(downloadCounts.totalActive)}
             canCopy={false}
-            showDividerTop
           />
         </InfoCard>
         <Button

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -11,8 +11,16 @@ import { ensureCacheDir } from './fileCache'
 import { resetDb } from '../db'
 import {
   initSyncDownEvents,
-  setSyncDownCursor,
+  resetSyncDownCursor,
 } from '../managers/syncDownEvents'
+import {
+  initSyncNewPhotos,
+  resetPhotosNewCursor,
+} from '../managers/syncNewPhotos'
+import {
+  initSyncPhotosArchive,
+  resetPhotosArchiveCursor,
+} from '../managers/syncPhotosArchive'
 
 export type AppState = {
   isInitializing: boolean
@@ -38,6 +46,8 @@ export async function initApp() {
   await SplashScreen.hideAsync()
   initUploadScanner()
   initSyncDownEvents()
+  initSyncNewPhotos()
+  initSyncPhotosArchive()
 }
 
 export async function onboardIndexer(indexerURL: string) {
@@ -61,7 +71,9 @@ export async function resetApp() {
   await setRecoveryPhrase('')
   await setHasOnboarded(false)
   await resetSdk()
-  await setSyncDownCursor(undefined)
+  await resetSyncDownCursor()
+  await resetPhotosNewCursor()
+  await resetPhotosArchiveCursor()
 }
 
 // selectors

--- a/src/stores/secureStore.ts
+++ b/src/stores/secureStore.ts
@@ -9,7 +9,7 @@ export async function setSecureStoreBoolean(key: string, value: boolean) {
   return SecureStore.setItemAsync(key, value ? 'true' : 'false')
 }
 
-export async function getSecureStoreBoolean(key: string, fallback = false) {
+export async function getSecureStoreBoolean(key: string, initialValue = false) {
   try {
     const found = await SecureStore.getItemAsync(key)
     if (typeof found === 'string') {
@@ -19,9 +19,10 @@ export async function getSecureStoreBoolean(key: string, fallback = false) {
         return false
       }
     }
-    return fallback
+    setSecureStoreBoolean(key, initialValue)
+    return initialValue
   } catch {
-    return fallback
+    return initialValue
   }
 }
 
@@ -35,16 +36,19 @@ export async function setSecureStoreNumber(key: string, value: number) {
   return SecureStore.setItemAsync(key, str)
 }
 
-export async function getSecureStoreNumber(key: string, fallback = 0) {
+export async function getSecureStoreNumber(key: string, initialValue = 0) {
   try {
     const found = await SecureStore.getItemAsync(key)
     if (typeof found === 'string' && found.trim().length > 0) {
       const n = Number(found)
-      return Number.isFinite(n) ? n : fallback
+      if (Number.isFinite(n)) {
+        return n
+      }
+      setSecureStoreNumber(key, initialValue)
     }
-    return fallback
+    return initialValue
   } catch {
-    return fallback
+    return initialValue
   }
 }
 
@@ -62,13 +66,17 @@ export async function setSecureStoreString<T extends string>(
 
 export async function getSecureStoreString<T extends string>(
   key: string,
-  fallback: T
+  initialValue: T
 ): Promise<T> {
   try {
     const found = await SecureStore.getItemAsync(key)
-    return (found as T | null) || fallback
+    if (typeof found === 'string' && found.trim().length > 0) {
+      return found as T
+    }
+    setSecureStoreString(key, initialValue)
+    return initialValue
   } catch {
-    return fallback
+    return initialValue
   }
 }
 
@@ -102,16 +110,17 @@ export async function setSecureStoreJSON<TStorage, TDomain>(
 export async function getSecureStoreJSON<TStorage, TDomain>(
   key: string,
   codec: JsonCodec<TStorage, TDomain>,
-  fallback?: TDomain
+  initialValue?: TDomain
 ): Promise<TDomain | undefined> {
   try {
     const found = await SecureStore.getItemAsync(key)
     if (typeof found !== 'string' || found.trim().length === 0) {
-      return fallback
+      setSecureStoreJSON(key, initialValue, codec)
+      return initialValue
     }
     const parsed = JSON.parse(found) as TStorage
     return codec.decode(parsed)
   } catch {
-    return fallback
+    return initialValue
   }
 }


### PR DESCRIPTION
- This PR adds two services for keeping the Photos library synced with Sia Storage.
- syncNewPhotos: this service continuously syncs any new photos added to the users Photos library.
- syncPhotosArchive: this service incrementally syncs the user's entire photos archive by slowly churning through batches in reverse chronological order. The service is user initiated and when it reaches the end is shuts off until the user initiates it again.
- Also updates secureStore to set the fallback/initial values so that when passing a default like a time, it is saved and the same value is returned on subsequent calls.

![Screenshot 2025-10-26 at 9.46.37 PM.png](https://app.graphite.dev/user-attachments/assets/2a9240fe-db85-4158-beb4-1bdd5aae4a77.png)