### PR TITLE
fix: hide advanced sync settings

### DIFF
--- a/src/components/SettingsAdvancedAccount.tsx
+++ b/src/components/SettingsAdvancedAccount.tsx
@@ -1,0 +1,16 @@
+import { RowGroup } from './Group'
+import { InfoCard } from './InfoCard'
+import { LabeledValueRow } from './LabeledValueRow'
+import { useAccount } from '../hooks/useAccount'
+
+export function SettingsAdvancedAccount() {
+  const account = useAccount()
+
+  return account.data ? (
+    <RowGroup title="Account">
+      <InfoCard>
+        <LabeledValueRow label="Account Key" value={account.data.accountKey} />
+      </InfoCard>
+    </RowGroup>
+  ) : null
+}

--- a/src/components/SettingsAdvancedDangerZone.tsx
+++ b/src/components/SettingsAdvancedDangerZone.tsx
@@ -1,0 +1,31 @@
+import { View, Alert } from 'react-native'
+import { resetApp } from '../stores/app'
+import { GroupTitle } from './Group'
+import { Button } from './Button'
+
+export function SettingsAdvancedDangerZone() {
+  return (
+    <View>
+      <GroupTitle title="Danger Zone" />
+      <Button
+        variant="danger"
+        onPress={() => {
+          Alert.alert(
+            'Reset Application',
+            'This will delete all local metadata. This cannot be undone.',
+            [
+              { text: 'Cancel', style: 'cancel' },
+              {
+                text: 'Permanently reset',
+                style: 'destructive',
+                onPress: () => resetApp(),
+              },
+            ]
+          )
+        }}
+      >
+        Reset application
+      </Button>
+    </View>
+  )
+}

--- a/src/components/SettingsAdvancedInfo.tsx
+++ b/src/components/SettingsAdvancedInfo.tsx
@@ -1,0 +1,26 @@
+import { Switch } from 'react-native'
+import { setShowAdvanced, useShowAdvanced } from '../stores/settings'
+import { RowGroup } from './Group'
+import { InfoCard } from './InfoCard'
+import { LabeledValueRow } from './LabeledValueRow'
+
+export function SettingsAdvancedInfo() {
+  const showAdvanced = useShowAdvanced()
+
+  return (
+    <RowGroup title="Developers">
+      <InfoCard>
+        <LabeledValueRow
+          label="Show advanced information"
+          labelWidth={200}
+          value={
+            <Switch
+              value={showAdvanced.data}
+              onValueChange={(val) => setShowAdvanced(val)}
+            />
+          }
+        />
+      </InfoCard>
+    </RowGroup>
+  )
+}

--- a/src/components/SettingsAdvancedSync.tsx
+++ b/src/components/SettingsAdvancedSync.tsx
@@ -1,0 +1,42 @@
+import { Switch } from 'react-native'
+import { InfoCard } from './InfoCard'
+import { LabeledValueRow } from './LabeledValueRow'
+import { RowGroup } from './Group'
+import {
+  toggleAutoScanUploads,
+  toggleAutoSyncDownEvents,
+  useAutoScanUploads,
+  useAutoSyncDownEvents,
+} from '../stores/settings'
+
+export function SettingsAdvancedSync() {
+  const autoScan = useAutoScanUploads()
+  const autoSync = useAutoSyncDownEvents()
+
+  return (
+    <RowGroup title="Advanced Sync">
+      <InfoCard>
+        <LabeledValueRow
+          label="Automatically upload files to network"
+          labelWidth={300}
+          value={
+            <Switch
+              value={autoScan.data ?? false}
+              onValueChange={toggleAutoScanUploads}
+            />
+          }
+        />
+        <LabeledValueRow
+          label="Automatically sync with your other devices"
+          labelWidth={300}
+          value={
+            <Switch
+              value={autoSync.data ?? false}
+              onValueChange={toggleAutoSyncDownEvents}
+            />
+          }
+        />
+      </InfoCard>
+    </RowGroup>
+  )
+}

--- a/src/components/SettingsAdvancedTransfers.tsx
+++ b/src/components/SettingsAdvancedTransfers.tsx
@@ -1,0 +1,96 @@
+import { InfoCard } from './InfoCard'
+import { LabeledValueRow } from './LabeledValueRow'
+import { cancelAllUploads, useUploadCounts } from '../stores/uploads'
+import { cancelAllDownloads, useDownloadCounts } from '../stores/downloads'
+import { Button } from './Button'
+import { RowGroup } from './Group'
+import { InputRow } from './InputRow'
+import { useInputValue } from '../hooks/useInputValue'
+import { setMaxUploads, useMaxUploads } from '../managers/uploadsPool'
+import { setMaxDownloads, useMaxDownloads } from '../managers/downloadsPool'
+
+export function SettingsAdvancedTransfers() {
+  const uploadCounts = useUploadCounts()
+  const downloadCounts = useDownloadCounts()
+  const maxUploads = useMaxUploads()
+  const maxDownloads = useMaxDownloads()
+
+  const maxUploadsInputProps = useInputValue({
+    value: String(maxUploads.data),
+    save: (text) => {
+      const n = Number(text.replace(/[^0-9]/g, ''))
+      if (Number.isFinite(n) && n > 0) setMaxUploads(n)
+    },
+  })
+
+  const maxDownloadsInputProps = useInputValue({
+    value: String(maxDownloads.data),
+    save: (text) => {
+      const n = Number(text.replace(/[^0-9]/g, ''))
+      if (Number.isFinite(n) && n > 0) setMaxDownloads(n)
+    },
+  })
+
+  return (
+    <>
+      <RowGroup title="Uploads">
+        <InfoCard>
+          <InputRow
+            label="Max concurrent uploads"
+            labelWidth={200}
+            keyboardType="number-pad"
+            {...maxUploadsInputProps}
+          />
+          <LabeledValueRow
+            label="Queued"
+            value={String(uploadCounts.totalQueued)}
+            canCopy={false}
+          />
+          <LabeledValueRow
+            label="Active"
+            value={String(uploadCounts.totalActive)}
+            canCopy={false}
+          />
+        </InfoCard>
+        <Button
+          style={{ marginTop: 10 }}
+          disabled={uploadCounts.total === 0}
+          onPress={() => {
+            cancelAllUploads()
+          }}
+        >
+          Cancel uploads
+        </Button>
+      </RowGroup>
+      <RowGroup title="Downloads">
+        <InfoCard>
+          <InputRow
+            label="Max concurrent downloads"
+            labelWidth={200}
+            keyboardType="number-pad"
+            {...maxDownloadsInputProps}
+          />
+          <LabeledValueRow
+            label="Queued"
+            value={String(downloadCounts.totalQueued)}
+            canCopy={false}
+          />
+          <LabeledValueRow
+            label="Active"
+            value={String(downloadCounts.totalActive)}
+            canCopy={false}
+          />
+        </InfoCard>
+        <Button
+          style={{ marginTop: 10 }}
+          disabled={downloadCounts.total === 0}
+          onPress={() => {
+            cancelAllDownloads()
+          }}
+        >
+          Cancel downloads
+        </Button>
+      </RowGroup>
+    </>
+  )
+}

--- a/src/components/SettingsSyncPhotos.tsx
+++ b/src/components/SettingsSyncPhotos.tsx
@@ -1,0 +1,45 @@
+import { Switch } from 'react-native'
+import { InfoCard } from './InfoCard'
+import { LabeledValueRow } from './LabeledValueRow'
+import { Button } from './Button'
+import { RowGroup } from './Group'
+import {
+  toggleAutoSyncNewPhotos,
+  useAutoSyncNewPhotos,
+} from '../managers/syncNewPhotos'
+import {
+  usePhotosArchiveCursor,
+  restartPhotosArchiveCursor,
+} from '../managers/syncPhotosArchive'
+
+export function SettingsSyncPhotos() {
+  const autoSyncNew = useAutoSyncNewPhotos()
+  const photosArchiveCursor = usePhotosArchiveCursor()
+  const photosArchiveInProgress = (photosArchiveCursor.data ?? 0) > 0
+
+  return (
+    <RowGroup title="Photos">
+      <InfoCard>
+        <LabeledValueRow
+          label="Automatically import new photos"
+          labelWidth={300}
+          value={
+            <Switch
+              value={autoSyncNew.data ?? false}
+              onValueChange={toggleAutoSyncNewPhotos}
+            />
+          }
+        />
+      </InfoCard>
+      <Button
+        style={{ marginTop: 10 }}
+        disabled={photosArchiveInProgress}
+        onPress={() => {
+          void restartPhotosArchiveCursor()
+        }}
+      >
+        {photosArchiveInProgress ? 'Sync in progress' : 'Import photos library'}
+      </Button>
+    </RowGroup>
+  )
+}

--- a/src/screens/SettingsAdvancedScreen.tsx
+++ b/src/screens/SettingsAdvancedScreen.tsx
@@ -1,74 +1,24 @@
-import { View, StyleSheet, Switch, Alert } from 'react-native'
-import { colors, palette } from '../styles/colors'
+import { StyleSheet } from 'react-native'
 import { type NativeStackScreenProps } from '@react-navigation/native-stack'
 import { type SettingsStackParamList } from '../stacks/types'
-import { setShowAdvanced, useShowAdvanced } from '../stores/settings'
-import { resetApp } from '../stores/app'
-import { GroupTitle, RowGroup } from '../components/Group'
-import { InfoCard } from '../components/InfoCard'
-import { Button } from '../components/Button'
-import { LabeledValueRow } from '../components/LabeledValueRow'
 import { SettingsRecoveryPhrase } from '../components/SettingsRecoveryPhrase'
 import { SettingsLayout } from '../components/SettingsLayout'
 import { useSettingsHeader } from '../hooks/useSettingsHeader'
-import { useAccount } from '../hooks/useAccount'
+import { SettingsAdvancedAccount } from '../components/SettingsAdvancedAccount'
+import { SettingsAdvancedDangerZone } from '../components/SettingsAdvancedDangerZone'
+import { SettingsAdvancedInfo } from '../components/SettingsAdvancedInfo'
 
 type Props = NativeStackScreenProps<SettingsStackParamList, 'Advanced'>
 
 export function SettingsAdvancedScreen(_props: Props) {
-  const showAdvanced = useShowAdvanced()
-  const account = useAccount()
   useSettingsHeader()
 
   return (
     <SettingsLayout style={styles.container}>
-      {account.data ? (
-        <RowGroup title="Account">
-          <InfoCard>
-            <LabeledValueRow
-              label="Account Key"
-              value={account.data.accountKey}
-            />
-          </InfoCard>
-        </RowGroup>
-      ) : null}
+      <SettingsAdvancedAccount />
       <SettingsRecoveryPhrase />
-      <RowGroup title="Developers">
-        <InfoCard>
-          <LabeledValueRow
-            label="Show advanced information"
-            labelWidth={200}
-            value={
-              <Switch
-                value={showAdvanced.data}
-                onValueChange={(val) => setShowAdvanced(val)}
-              />
-            }
-          />
-        </InfoCard>
-      </RowGroup>
-      <View>
-        <GroupTitle title="Danger Zone" />
-        <Button
-          variant="danger"
-          onPress={() => {
-            Alert.alert(
-              'Reset Application',
-              'This will delete all local metadata. This cannot be undone.',
-              [
-                { text: 'Cancel', style: 'cancel' },
-                {
-                  text: 'Permanently reset',
-                  style: 'destructive',
-                  onPress: () => resetApp(),
-                },
-              ]
-            )
-          }}
-        >
-          Reset application
-        </Button>
-      </View>
+      <SettingsAdvancedInfo />
+      <SettingsAdvancedDangerZone />
     </SettingsLayout>
   )
 }
@@ -80,24 +30,4 @@ const styles = StyleSheet.create({
     paddingBottom: 24,
     gap: 24,
   },
-  rowItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: 14,
-    paddingVertical: 12,
-  },
-  rowLabel: {
-    color: colors.textTitleDark,
-  },
-  dangerRow: {
-    paddingHorizontal: 16,
-    paddingVertical: 14,
-    backgroundColor: colors.bgPanel,
-    borderTopColor: colors.borderSubtle,
-    borderTopWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: colors.borderSubtle,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-  },
-  dangerText: { color: palette.red[500], fontSize: 16, fontWeight: '600' },
 })

--- a/src/screens/SettingsSyncScreen.tsx
+++ b/src/screens/SettingsSyncScreen.tsx
@@ -1,174 +1,28 @@
-import { StyleSheet, Switch } from 'react-native'
+import { StyleSheet } from 'react-native'
 import { type NativeStackScreenProps } from '@react-navigation/native-stack'
 import { type SettingsStackParamList } from '../stacks/types'
-import { InfoCard } from '../components/InfoCard'
-import { LabeledValueRow } from '../components/LabeledValueRow'
-import { cancelAllUploads, useUploadCounts } from '../stores/uploads'
-import { cancelAllDownloads, useDownloadCounts } from '../stores/downloads'
-import { Button } from '../components/Button'
-import { RowGroup } from '../components/Group'
-import { InputRow } from '../components/InputRow'
-import { useInputValue } from '../hooks/useInputValue'
 import { SettingsLayout } from '../components/SettingsLayout'
-import { colors } from '../styles/colors'
 import { useSettingsHeader } from '../hooks/useSettingsHeader'
-import { setMaxUploads, useMaxUploads } from '../managers/uploadsPool'
-import { setMaxDownloads, useMaxDownloads } from '../managers/downloadsPool'
-import {
-  toggleAutoScanUploads,
-  toggleAutoSyncDownEvents,
-  useAutoScanUploads,
-  useAutoSyncDownEvents,
-} from '../stores/settings'
-import {
-  toggleAutoSyncNewPhotos,
-  useAutoSyncNewPhotos,
-} from '../managers/syncNewPhotos'
-import {
-  usePhotosArchiveCursor,
-  restartPhotosArchiveCursor,
-} from '../managers/syncPhotosArchive'
+import { SettingsSyncPhotos } from '../components/SettingsSyncPhotos'
+import { SettingsAdvancedSync } from '../components/SettingsAdvancedSync'
+import { SettingsAdvancedTransfers } from '../components/SettingsAdvancedTransfers'
+import { useShowAdvanced } from '../stores/settings'
 
 type Props = NativeStackScreenProps<SettingsStackParamList, 'Sync'>
 
 export function SettingsSyncScreen(_props: Props) {
   useSettingsHeader()
-  const uploadCounts = useUploadCounts()
-  const downloadCounts = useDownloadCounts()
-  const autoScan = useAutoScanUploads()
-  const maxUploads = useMaxUploads()
-  const maxDownloads = useMaxDownloads()
-  const autoSync = useAutoSyncDownEvents()
-  const autoSyncNew = useAutoSyncNewPhotos()
-  const photosArchiveCursor = usePhotosArchiveCursor()
-  const photosArchiveInProgress = (photosArchiveCursor.data ?? 0) > 0
-
-  const maxUploadsInputProps = useInputValue({
-    value: String(maxUploads.data),
-    save: (text) => {
-      const n = Number(text.replace(/[^0-9]/g, ''))
-      if (Number.isFinite(n) && n > 0) setMaxUploads(n)
-    },
-  })
-
-  const maxDownloadsInputProps = useInputValue({
-    value: String(maxDownloads.data),
-    save: (text) => {
-      const n = Number(text.replace(/[^0-9]/g, ''))
-      if (Number.isFinite(n) && n > 0) setMaxDownloads(n)
-    },
-  })
+  const showAdvanced = useShowAdvanced()
 
   return (
     <SettingsLayout style={styles.container}>
-      <RowGroup title="Sync">
-        <InfoCard>
-          <LabeledValueRow
-            label="Automatically upload files to network"
-            labelWidth={300}
-            value={
-              <Switch
-                value={autoScan.data ?? false}
-                onValueChange={toggleAutoScanUploads}
-              />
-            }
-          />
-          <LabeledValueRow
-            label="Automatically sync with your other devices"
-            labelWidth={300}
-            value={
-              <Switch
-                value={autoSync.data ?? false}
-                onValueChange={toggleAutoSyncDownEvents}
-              />
-            }
-          />
-        </InfoCard>
-      </RowGroup>
-      <RowGroup title="Photos">
-        <InfoCard>
-          <LabeledValueRow
-            label="Automatically import new photos"
-            labelWidth={300}
-            value={
-              <Switch
-                value={autoSyncNew.data ?? false}
-                onValueChange={toggleAutoSyncNewPhotos}
-              />
-            }
-          />
-        </InfoCard>
-        <Button
-          style={{ marginTop: 10 }}
-          disabled={photosArchiveInProgress}
-          onPress={() => {
-            void restartPhotosArchiveCursor()
-          }}
-        >
-          {photosArchiveInProgress
-            ? 'Sync in progress'
-            : 'Import photos library'}
-        </Button>
-      </RowGroup>
-      <RowGroup title="Uploads">
-        <InfoCard>
-          <InputRow
-            label="Max concurrent uploads"
-            labelWidth={200}
-            keyboardType="number-pad"
-            {...maxUploadsInputProps}
-          />
-          <LabeledValueRow
-            label="Queued"
-            value={String(uploadCounts.totalQueued)}
-            canCopy={false}
-          />
-          <LabeledValueRow
-            label="Active"
-            value={String(uploadCounts.totalActive)}
-            canCopy={false}
-          />
-        </InfoCard>
-        <Button
-          style={{ marginTop: 10 }}
-          disabled={uploadCounts.total === 0}
-          onPress={() => {
-            cancelAllUploads()
-          }}
-        >
-          Cancel uploads
-        </Button>
-      </RowGroup>
-
-      <RowGroup title="Downloads">
-        <InfoCard>
-          <InputRow
-            label="Max concurrent downloads"
-            labelWidth={200}
-            keyboardType="number-pad"
-            {...maxDownloadsInputProps}
-          />
-          <LabeledValueRow
-            label="Queued"
-            value={String(downloadCounts.totalQueued)}
-            canCopy={false}
-          />
-          <LabeledValueRow
-            label="Active"
-            value={String(downloadCounts.totalActive)}
-            canCopy={false}
-          />
-        </InfoCard>
-        <Button
-          style={{ marginTop: 10 }}
-          disabled={downloadCounts.total === 0}
-          onPress={() => {
-            cancelAllDownloads()
-          }}
-        >
-          Cancel downloads
-        </Button>
-      </RowGroup>
+      <SettingsSyncPhotos />
+      {showAdvanced.data ? (
+        <>
+          <SettingsAdvancedSync />
+          <SettingsAdvancedTransfers />
+        </>
+      ) : null}
     </SettingsLayout>
   )
 }
@@ -179,15 +33,5 @@ const styles = StyleSheet.create({
     paddingTop: 24,
     paddingBottom: 24,
     gap: 24,
-  },
-  rowItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: 14,
-    paddingVertical: 12,
-  },
-  rowLabel: {
-    color: colors.textTitleDark,
   },
 })


### PR DESCRIPTION
- The upload and sync device / events list settings are now hidden behind the advanced developer information toggle. 
- Also moves some of the settings blocks into their own components so they are contained and easier to move around.

![Screenshot 2025-10-27 at 12.24.54 PM.png](https://app.graphite.dev/user-attachments/assets/aa76f298-0d9d-4781-9066-fd850780174a.png)

![Screenshot 2025-10-27 at 12.22.19 PM.png](https://app.graphite.dev/user-attachments/assets/3e9614dc-9e23-4d95-b71c-c40e1acd3ac4.png)![Screenshot 2025-10-27 at 12.21.13 PM.png](https://app.graphite.dev/user-attachments/assets/4ea0d855-0d46-40e2-bb2a-f5f131e24ae0.png)

