### PR TITLE
refactor: update share scheme and url format

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Sia Storage",
     "slug": "siastorage",
-    "scheme": "siamobile",
+    "scheme": "sia",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -27,22 +27,18 @@ export function Root() {
     }
   }, [])
 
-  useLinkedURL((incomingUrl) => {
+  useLinkedURL((shareUrl) => {
     try {
-      const url = new URL(incomingUrl)
-      const path = url.pathname.replace(/^\//, '')
-      const host = url.host
-      if (host === 'new-file' || path === 'new-file') {
-        const shareUrl = url.searchParams.get('shareUrl') ?? undefined
-        if (shareUrl && navigationRef.isReady()) {
-          navigationRef.navigate('ImportTab', {
-            screen: 'ImportFile',
-            params: { shareUrl },
-          })
-        }
-      }
-    } catch (_) {
+      new URL(shareUrl)
+    } catch (error) {
       // Ignore invalid URLs.
+      return
+    }
+    if (shareUrl && navigationRef.isReady()) {
+      navigationRef.navigate('ImportTab', {
+        screen: 'ImportFile',
+        params: { shareUrl },
+      })
     }
   })
 

--- a/src/components/FileDetails/FileMeta.tsx
+++ b/src/components/FileDetails/FileMeta.tsx
@@ -61,6 +61,16 @@ export function FileMeta({
           )}
           {showAdvanced.data && (
             <LabeledValueRow
+              label="Content Hash"
+              value={file.contentHash ?? '-'}
+              isMonospace
+              ellipsizeMode="middle"
+              canCopy={!!file.contentHash}
+              showDividerTop
+            />
+          )}
+          {showAdvanced.data && (
+            <LabeledValueRow
               label="File URI"
               value={status.fileUri ?? 'Not available'}
               isMonospace
@@ -77,6 +87,11 @@ export function FileMeta({
           <LabeledValueRow
             label="Created"
             value={new Date(file.createdAt).toLocaleString()}
+            showDividerTop
+          />
+          <LabeledValueRow
+            label="Updated"
+            value={new Date(file.updatedAt).toLocaleString()}
             showDividerTop
           />
           <LabeledValueRow

--- a/src/hooks/useShareAction.tsx
+++ b/src/hooks/useShareAction.tsx
@@ -6,6 +6,7 @@ import { getOneSealedObject, getPinnedObject, useFileStatus } from '../lib/file'
 import { useFileDetails } from '../stores/files'
 import Share from 'react-native-share'
 import { logger } from '../lib/logger'
+import { generateSiaShareUrl } from '../lib/shareUrl'
 
 export function useShareAction({ fileId }: { fileId: string }) {
   const toast = useToast()
@@ -22,8 +23,7 @@ export function useShareAction({ fileId }: { fileId: string }) {
     const pinnedObject = await getPinnedObject(sealedObject)
     const expiresAt = new Date()
     expiresAt.setDate(expiresAt.getDate() + 1)
-    const shareUrl = sdk.shareObject(pinnedObject, expiresAt)
-    return `siamobile://new-file?shareUrl=${encodeURIComponent(shareUrl)}`
+    return generateSiaShareUrl(sdk, pinnedObject, expiresAt)
   }, [file, sdk])
 
   const handleShareURL = useCallback(async () => {

--- a/src/lib/authApp.ts
+++ b/src/lib/authApp.ts
@@ -4,8 +4,8 @@ import { palette } from '../styles/colors'
 
 export default async function authApp(url: string) {
   if (await InAppBrowser.isAvailable()) {
-    const sub = Linking.addEventListener('url', ({ url: recievedURL }) => {
-      if (recievedURL.includes('siamobile://')) {
+    const sub = Linking.addEventListener('url', ({ url: receivedURL }) => {
+      if (receivedURL.includes('sia://')) {
         InAppBrowser.close()
         sub.remove()
       }

--- a/src/lib/shareUrl.ts
+++ b/src/lib/shareUrl.ts
@@ -1,0 +1,18 @@
+import { PinnedObjectInterface, Sdk } from 'react-native-sia'
+
+export function generateSiaShareUrl(
+  sdk: Sdk,
+  pinnedObject: PinnedObjectInterface,
+  expiresAt: Date
+) {
+  const shareUrl = sdk.shareObject(pinnedObject, expiresAt)
+  return shareUrl.replace(/https?:\/\//, 'sia://')
+}
+
+export function convertSiaShareUrlToHttp(shareUrl?: string) {
+  if (!shareUrl) return null
+  if (shareUrl.startsWith('sia://')) {
+    return shareUrl.replace('sia://', 'https://')
+  }
+  return shareUrl
+}

--- a/src/screens/ImportFileScreen.tsx
+++ b/src/screens/ImportFileScreen.tsx
@@ -32,15 +32,16 @@ import { FileDetailScreenHeader } from '../components/FileDetailScreenHeader'
 import { colors } from '../styles/colors'
 import { pinnedObjectToLocalObject } from '../lib/localObjects'
 import { upsertLocalObject } from '../stores/localObjects'
+import { convertSiaShareUrlToHttp } from '../lib/shareUrl'
 
 type Props = NativeStackScreenProps<ImportStackParamList, 'ImportFile'>
 
 export function ImportFileScreen({ route }: Props) {
   const navigation = useNavigation<NavigationProp<RootTabParamList>>()
   const toast = useToast()
-  const shareUrl = route.params?.shareUrl
+  const shareUrl = convertSiaShareUrlToHttp(route.params?.shareUrl)
   const sdk = useSdk()
-  const id = useMemo(() => uniqueId(), [])
+  const id = useMemo(() => uniqueId(), [shareUrl])
   const sharedObject = useSWR(
     sdk ? ['sharedObject', shareUrl] : null,
     async () => {

--- a/src/stores/sdk.ts
+++ b/src/stores/sdk.ts
@@ -102,7 +102,7 @@ export async function tryToConnectAndSet(newIndexerURL: string) {
         name: 'Test',
         description: 'Test',
         serviceUrl: 'https://sia.storage',
-        callbackUrl: 'siamobile://callback',
+        callbackUrl: 'sia://callback',
         logoUrl: 'https://sia.storage/logo.png',
       })
 


### PR DESCRIPTION
- Update the app to use the discussed share URL scheme and format:
    - Before: `siamobile://new-file?shareUrl=${encodeURIComponent(shareUrl)}`
After: `sia://app.sia.storage/objects/e1d9cc1e251...de1736/shared?sv=1761751357&sc=CMDomP...`
- Adds two additional metadata fields to the screen.