### PR TITLE
fix: strict metadata for shared file imports

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -13,6 +13,7 @@ import * as SplashScreen from 'expo-splash-screen'
 import useLinkedURL from './hooks/useLinkedURL'
 import { useReconnectIndexer } from './hooks/useReconnectIndexer'
 import { RootTabs } from './stacks/RootTabs'
+import { uniqueId } from './lib/uniqueId'
 
 SplashScreen.preventAutoHideAsync()
 
@@ -37,7 +38,7 @@ export function Root() {
     if (shareUrl && navigationRef.isReady()) {
       navigationRef.navigate('ImportTab', {
         screen: 'ImportFile',
-        params: { shareUrl },
+        params: { shareUrl, id: uniqueId() },
       })
     }
   })

--- a/src/components/FileDetailsImport/FileMetaImport.tsx
+++ b/src/components/FileDetailsImport/FileMetaImport.tsx
@@ -33,6 +33,7 @@ export function FileMetaImport({
     <View style={styles.container}>
       <RowGroup title="Details">
         <InfoCard>
+          {showAdvanced.data && <LabeledValueRow label="ID" value={file.id} />}
           <LabeledValueRow label="Size" value={humanSize ?? '—'} />
           <LabeledValueRow
             label="Type"

--- a/src/components/FileDetailsImport/index.tsx
+++ b/src/components/FileDetailsImport/index.tsx
@@ -17,7 +17,7 @@ export function FileDetailsImport({
   file: FileRecord
   shareUrl: string
 }) {
-  const status = useFileStatus(file)
+  const status = useFileStatus(file, true)
   const handleDownload = useDownloadFromShareURL()
 
   // If the file is less than 4 MB, go ahead and download it to the user
@@ -38,6 +38,7 @@ export function FileDetailsImport({
         <View style={{ height: 500 }}>
           <FileViewer
             file={file}
+            isShared
             fullscreen={false}
             customDownloader={() => {
               handleDownload(file.id, shareUrl)

--- a/src/components/FileViewer/index.tsx
+++ b/src/components/FileViewer/index.tsx
@@ -16,17 +16,19 @@ import { FileRecord } from '../../stores/files'
 
 export function FileViewer({
   file,
+  isShared,
   header,
   fullscreen = true,
   customDownloader,
 }: {
   file: FileRecord
+  isShared?: boolean
   header?: React.ReactNode
   fullscreen?: boolean
   customDownloader?: () => void
 }) {
   const { type, name } = file
-  const status = useFileStatus(file)
+  const status = useFileStatus(file, isShared)
   const { fileUri, isDownloaded, isDownloading } = status.data ?? {}
   const fileDownload = useDownload(file)
   const fileDownloadState = useDownloadState(file.id)

--- a/src/hooks/useAutoDownload.ts
+++ b/src/hooks/useAutoDownload.ts
@@ -57,7 +57,7 @@ export function useAutoDownloadFromShareURL(
   const isInitializing = useIsInitializing()
   const isConnected = useIsConnected()
   const download = useDownloadFromShareURL()
-  const status = useFileStatus(file)
+  const status = useFileStatus(file, true)
   useEffect(() => {
     if (isInitializing) return
     if (!isConnected) return
@@ -68,5 +68,5 @@ export function useAutoDownloadFromShareURL(
     if (status.data.isDownloading) return
     if (!shouldDownload(file)) return
     download(file.id, shareUrl)
-  }, [isInitializing, isConnected, status.data])
+  }, [file.id, shareUrl, isInitializing, isConnected, status.data])
 }

--- a/src/lib/file.ts
+++ b/src/lib/file.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useEffect } from 'react'
 import { type UploadState } from '../stores/uploads'
 import { type DownloadState } from '../stores/downloads'
 import { FileRecord } from '../stores/files'
@@ -36,12 +36,14 @@ export type FileStatus = {
 
 function computeFileStatus({
   file,
+  isShared,
   uploadState,
   downloadState,
   fileUri,
   errorText,
 }: {
   file?: FileRecord
+  isShared?: boolean
   uploadState: UploadState | undefined
   downloadState: DownloadState | undefined
   fileUri: string | null
@@ -57,7 +59,7 @@ function computeFileStatus({
     isDownloading,
     isUploadQueued: uploadState?.status === 'queued',
     isDownloadQueued: downloadState?.status === 'queued',
-    isUploaded: hasSealedObject,
+    isUploaded: hasSealedObject || !!isShared,
     isDownloaded: !!fileUri,
     isErrored:
       uploadState?.status === 'error' || downloadState?.status === 'error',
@@ -70,25 +72,27 @@ function computeFileStatus({
 }
 
 export function useFileStatus(
-  file?: FileRecord
+  file?: FileRecord,
+  isShared?: boolean
 ): SWRResponse<FileStatus, Error> {
   const uploadState = useUploadState(file?.id || '')
   const downloadState = useDownloadState(file?.id || '')
   const fileUri = useFileUri(file)
-  return useSWR(
-    [file?.id, 'status'],
-    () =>
-      computeFileStatus({
-        file,
-        uploadState,
-        downloadState,
-        fileUri: fileUri.data ?? null,
-        errorText: uploadState?.error || downloadState?.error || null,
-      }),
-    {
-      refreshInterval: 5_000,
-    }
+  const response = useSWR(fileUri.isLoading ? null : [file?.id, 'status'], () =>
+    computeFileStatus({
+      file,
+      isShared,
+      uploadState,
+      downloadState,
+      fileUri: fileUri.data ?? null,
+      errorText: uploadState?.error || downloadState?.error || null,
+    })
   )
+  // Immediately update when there are changes to data or transfer progress.
+  useEffect(() => {
+    response.mutate()
+  }, [file, uploadState, downloadState, fileUri.data])
+  return response
 }
 
 export function getFileTypeName(

--- a/src/screens/ImportFileScreen.tsx
+++ b/src/screens/ImportFileScreen.tsx
@@ -1,6 +1,6 @@
 import { type NativeStackScreenProps } from '@react-navigation/native-stack'
 import { useNavigation, type NavigationProp } from '@react-navigation/native'
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import useSWR from 'swr'
 import {
   ActivityIndicator,
@@ -8,7 +8,6 @@ import {
   StyleSheet,
   Text,
   View,
-  Platform,
 } from 'react-native'
 import {
   type ImportStackParamList,
@@ -16,13 +15,18 @@ import {
 } from '../stacks/types'
 import { useToast } from '../lib/toastContext'
 import { useSdk } from '../stores/sdk'
-import { createFileRecord } from '../stores/files'
-import { uniqueId } from '../lib/uniqueId'
+import {
+  createFileRecordWithLocalObject,
+  FileLocalMetadata,
+  FileMetadata,
+  FileRecord,
+  readFileRecordByContentHash,
+} from '../stores/files'
 import { FileDetailsImport } from '../components/FileDetailsImport'
 import { logger } from '../lib/logger'
 import {
   decodeFileMetadata,
-  FileMetadata,
+  hasCompleteMetadata,
   transformFileMetadata,
 } from '../encoding/fileMetadata'
 import { getIndexerURL } from '../stores/settings'
@@ -31,7 +35,6 @@ import { PlusIcon } from 'lucide-react-native'
 import { FileDetailScreenHeader } from '../components/FileDetailScreenHeader'
 import { colors } from '../styles/colors'
 import { pinnedObjectToLocalObject } from '../lib/localObjects'
-import { upsertLocalObject } from '../stores/localObjects'
 import { convertSiaShareUrlToHttp } from '../lib/shareUrl'
 
 type Props = NativeStackScreenProps<ImportStackParamList, 'ImportFile'>
@@ -39,11 +42,11 @@ type Props = NativeStackScreenProps<ImportStackParamList, 'ImportFile'>
 export function ImportFileScreen({ route }: Props) {
   const navigation = useNavigation<NavigationProp<RootTabParamList>>()
   const toast = useToast()
-  const shareUrl = convertSiaShareUrlToHttp(route.params?.shareUrl)
+  const id = route.params.id
+  const shareUrl = convertSiaShareUrlToHttp(route.params.shareUrl)
   const sdk = useSdk()
-  const id = useMemo(() => uniqueId(), [shareUrl])
   const sharedObject = useSWR(
-    sdk ? ['sharedObject', shareUrl] : null,
+    sdk ? ['sharedObject', shareUrl, id] : null,
     async () => {
       try {
         if (!sdk || !shareUrl) return null
@@ -54,47 +57,68 @@ export function ImportFileScreen({ route }: Props) {
       }
     }
   )
-  const sharedFile = useSWR(
-    sharedObject.data ? ['sharedFile', shareUrl] : null,
-    async () => {
-      try {
-        if (!sharedObject.data) return null
-        const metadata = decodeFileMetadata(sharedObject.data.metadata())
-        const file: FileMetadata = transformFileMetadata({
-          id,
-          size: Number(sharedObject.data.size()),
-          type: metadata.type,
-          name: metadata.name,
-          hash: metadata.hash,
-          localId: metadata.localId,
-          createdAt: metadata.createdAt,
-          updatedAt: metadata.updatedAt,
-        })
-        return file
-      } catch (e) {
-        logger.log('Error getting shared file', e)
-        return null
-      }
-    }
-  )
-
-  const handleAddToDatabase = useCallback(async () => {
-    if (!sharedObject.data || !sdk || !sharedFile.data) return
-    const indexerURL = await getIndexerURL()
-    const pinnedObject = await sdk.pinShared(sharedObject.data)
-    const localObject = await pinnedObjectToLocalObject(
-      sharedFile.data.id,
-      indexerURL,
-      pinnedObject
-    )
-    await createFileRecord(sharedFile.data)
-    await upsertLocalObject(localObject)
-    toast.show('File added')
-    navigation.navigate('MainTab', {
-      screen: 'FileDetail',
-      params: { id: sharedFile.data.id },
+  const sharedFile = useMemo(() => {
+    if (!sharedObject.data) return null
+    const metadata = decodeFileMetadata(sharedObject.data.metadata())
+    const fileMetadata: FileMetadata = transformFileMetadata({
+      size: Number(sharedObject.data.size()),
+      type: metadata.type,
+      name: metadata.name,
+      hash: metadata.hash,
+      createdAt: metadata.createdAt,
+      updatedAt: metadata.updatedAt,
     })
-  }, [sharedFile.data, sdk, toast, navigation])
+    const localMetadata: FileLocalMetadata = {
+      id,
+      localId: null,
+      addedAt: Date.now(),
+    }
+    const file: FileRecord = {
+      ...fileMetadata,
+      ...localMetadata,
+      objects: {},
+    }
+    return file
+  }, [sharedObject.data, id])
+
+  const [isAddingToDatabase, setIsAddingToDatabase] = useState(false)
+  const handleAddToDatabase = useCallback(async () => {
+    setIsAddingToDatabase(true)
+    try {
+      if (!sharedObject.data || !sdk || !sharedFile) {
+        toast.show('Error adding file to library')
+        return
+      }
+      logger.log('[ImportFileScreen] handleAddToDatabase', sharedFile.id)
+      if (!hasCompleteMetadata(sharedFile)) {
+        toast.show('Shared file must have complete metadata')
+        return
+      }
+      const existingFile = await readFileRecordByContentHash(sharedFile.hash)
+      if (existingFile) {
+        toast.show('File already exists in library')
+        return
+      }
+      const indexerURL = await getIndexerURL()
+      const pinnedObject = await sdk.pinShared(sharedObject.data)
+      const localObject = await pinnedObjectToLocalObject(
+        sharedFile.id,
+        indexerURL,
+        pinnedObject
+      )
+      await createFileRecordWithLocalObject(sharedFile, localObject)
+      toast.show('File added')
+      navigation.navigate('MainTab', {
+        screen: 'FileDetail',
+        params: { id: sharedFile.id },
+      })
+    } catch (e) {
+      logger.log('[ImportFileScreen] Error adding file to library', e)
+      toast.show('Error adding file to library')
+    } finally {
+      setIsAddingToDatabase(false)
+    }
+  }, [sharedFile, sdk, toast, navigation])
 
   return (
     <View style={styles.container}>
@@ -104,23 +128,24 @@ export function ImportFileScreen({ route }: Props) {
         icon="close"
       />
       <ScrollView contentContainerStyle={styles.content}>
-        {sharedFile.isValidating ? (
+        {sharedObject.isLoading ? (
           <View style={styles.center}>
             <ActivityIndicator color={colors.accentPrimary} />
             <Text style={styles.loadingText}>Loading…</Text>
           </View>
-        ) : sharedFile.error ? (
-          <Text style={styles.errorText}>{sharedFile.error.message}</Text>
+        ) : sharedObject.error ? (
+          <Text style={styles.errorText}>{sharedObject.error.message}</Text>
         ) : (
           <>
-            {shareUrl && sharedFile.data && (
-              <FileDetailsImport file={sharedFile.data} shareUrl={shareUrl} />
+            {shareUrl && sharedFile && (
+              <FileDetailsImport file={sharedFile} shareUrl={shareUrl} />
             )}
           </>
         )}
       </ScrollView>
       <BottomActionButton
-        label="Add to library"
+        label={isAddingToDatabase ? 'Adding to library...' : 'Add to library'}
+        disabled={isAddingToDatabase}
         icon={<PlusIcon color="white" size={22} />}
         onPress={handleAddToDatabase}
       />
@@ -134,15 +159,6 @@ const styles = StyleSheet.create({
     backgroundColor: colors.bgCanvas,
   },
   content: { padding: 0 },
-  footer: { padding: 16 },
-  title: {
-    color: colors.textTitleDark,
-    fontWeight: '700',
-    fontSize: 18,
-    marginBottom: 12,
-  },
-  linkRow: { marginBottom: 12 },
-  link: { color: colors.accentPrimary },
   center: {
     alignItems: 'center',
     justifyContent: 'center',
@@ -150,17 +166,4 @@ const styles = StyleSheet.create({
   },
   loadingText: { color: colors.textSecondary, marginTop: 8 },
   errorText: { color: colors.textDanger },
-  card: {
-    maxHeight: 200,
-    backgroundColor: colors.bgSurface,
-    borderRadius: 12,
-    borderColor: colors.borderMutedLight,
-    borderWidth: StyleSheet.hairlineWidth,
-    padding: 12,
-  },
-  mono: {
-    color: colors.textTitleDark,
-    fontFamily: Platform.select({ ios: 'Menlo', android: 'monospace' }),
-    fontSize: 12,
-  },
 })

--- a/src/stacks/types.ts
+++ b/src/stacks/types.ts
@@ -20,7 +20,7 @@ export type AuthStackParamList = {
 }
 
 export type ImportStackParamList = {
-  ImportFile: { shareUrl?: string }
+  ImportFile: { shareUrl: string; id: string }
 }
 
 export type RootTabParamList = {


### PR DESCRIPTION
- The import file screen now checks for complete metadata and content hash before importing a file. If the content hash already exists in the database the user now gets a notification.
- Also adds a loading state to provide user feedback and show import of shared file is in progress.
- File ID is now generated when navigating to screen. This fixes a bug where the ID was being re-used between different imports.

![Screenshot 2025-10-30 at 5.31.44 PM.png](https://app.graphite.dev/user-attachments/assets/bbf18516-7af6-4fba-9959-0c292233700b.png)

