### PR TITLE
refactor: finalize field names

### DIFF
--- a/src/components/FileActionsSheet.tsx
+++ b/src/components/FileActionsSheet.tsx
@@ -61,7 +61,7 @@ export function FileActionsSheet({
       toast.show('Failed to remove cache')
       closeSheet()
     }
-  }, [file?.id, file?.fileType, toast])
+  }, [file?.id, file?.type, toast])
 
   const reupload = useReuploadFile()
   const handleReupload = useCallback(async () => {

--- a/src/components/FileDetails/FileMeta.tsx
+++ b/src/components/FileDetails/FileMeta.tsx
@@ -22,13 +22,13 @@ export function FileMeta({
 }) {
   const showAdvanced = useShowAdvanced()
   const fileSize = useMemo(() => {
-    return humanSize(file.fileSize)
-  }, [file.fileSize])
+    return humanSize(file.size)
+  }, [file.size])
 
   const fileNameInputProps = useInputValue({
-    value: file.fileName ?? '',
+    value: file.name ?? '',
     save: (value) => {
-      updateFileRecord({ ...file, fileName: value })
+      updateFileRecord({ ...file, name: value })
     },
   })
   const pinnedObjects = usePinnedObjects(file)
@@ -62,10 +62,10 @@ export function FileMeta({
           {showAdvanced.data && (
             <LabeledValueRow
               label="Content Hash"
-              value={file.contentHash ?? '-'}
+              value={file.hash ?? '-'}
               isMonospace
               ellipsizeMode="middle"
-              canCopy={!!file.contentHash}
+              canCopy={!!file.hash}
               showDividerTop
             />
           )}
@@ -96,7 +96,7 @@ export function FileMeta({
           />
           <LabeledValueRow
             label="Type"
-            value={file.fileType ?? '—'}
+            value={file.type ?? '—'}
             showDividerTop
           />
         </InfoCard>

--- a/src/components/FileDetailsImport/FileMetaImport.tsx
+++ b/src/components/FileDetailsImport/FileMetaImport.tsx
@@ -6,30 +6,26 @@ import { InfoCard } from '../InfoCard'
 import { LabeledValueRow } from '../LabeledValueRow'
 import { RowGroup } from '../Group'
 import { useShowAdvanced } from '../../stores/settings'
+import { FileRecord } from '../../stores/files'
 
 export function FileMetaImport({
   file,
   status,
 }: {
-  file: {
-    id: string
-    fileName: string | null
-    fileSize: number | null
-    fileType: string | null
-  }
+  file: FileRecord
   status: FileStatus
 }) {
   const humanSize = useMemo(() => {
-    if (file.fileSize == null) return null
+    if (file.size == null) return null
     const units = ['B', 'KB', 'MB', 'GB']
-    let s = file.fileSize
+    let s = file.size
     let u = 0
     while (s >= 1024 && u < units.length - 1) {
       s /= 1024
       u += 1
     }
     return `${s.toFixed(1)} ${units[u]}`
-  }, [file.fileSize])
+  }, [file.size])
 
   const showAdvanced = useShowAdvanced()
 
@@ -40,7 +36,7 @@ export function FileMetaImport({
           <LabeledValueRow label="Size" value={humanSize ?? '—'} />
           <LabeledValueRow
             label="Type"
-            value={file.fileType ?? '—'}
+            value={file.type ?? '—'}
             showDividerTop
           />
           {showAdvanced.data && status.fileUri && (

--- a/src/components/FileListItem.tsx
+++ b/src/components/FileListItem.tsx
@@ -29,7 +29,7 @@ function FileListItemComponent({ file, onPressItem, setItemRef }: Props) {
       <View style={styles.infoContainer}>
         <View style={styles.fileDetails}>
           <Text style={styles.fileName} numberOfLines={1} ellipsizeMode="tail">
-            {file.fileName}
+            {file.name}
           </Text>
           <View style={styles.fileMetaData}>
             {status.data ? (
@@ -44,9 +44,9 @@ function FileListItemComponent({ file, onPressItem, setItemRef }: Props) {
                 <DotIcon size={16} color="grey" />
               </>
             ) : null}
-            <Text style={styles.fileText}>{humanSize(file.fileSize)}</Text>
+            <Text style={styles.fileText}>{humanSize(file.size)}</Text>
             <DotIcon size={16} color="grey" />
-            <Text style={styles.fileText}>{file.fileType}</Text>
+            <Text style={styles.fileText}>{file.type}</Text>
           </View>
         </View>
       </View>

--- a/src/components/FileThumbnail.tsx
+++ b/src/components/FileThumbnail.tsx
@@ -36,7 +36,7 @@ export function FileThumbnail({
     )
   }
 
-  if (file.fileType?.includes('image')) {
+  if (file.type?.includes('image')) {
     if (status.data?.fileUri) {
       return (
         <Image
@@ -51,7 +51,7 @@ export function FileThumbnail({
       </View>
     )
   }
-  if (file.fileType?.includes('pdf')) {
+  if (file.type?.includes('pdf')) {
     if (status.data?.fileUri) {
       return (
         <Image
@@ -66,21 +66,21 @@ export function FileThumbnail({
       </View>
     )
   }
-  if (file.fileType?.includes('video')) {
+  if (file.type?.includes('video')) {
     return (
       <View style={styles.thumbnailImage}>
         <FileVideoIcon size={iconSize} color={iconColor} />
       </View>
     )
   }
-  if (file.fileType?.includes('application/pdf')) {
+  if (file.type?.includes('application/pdf')) {
     return (
       <View style={styles.thumbnailImage}>
         <FileTextIcon size={iconSize} color={iconColor} />
       </View>
     )
   }
-  if (file.fileType?.includes('audio')) {
+  if (file.type?.includes('audio')) {
     return (
       <View style={styles.thumbnailImage}>
         <FileAudioIcon size={iconSize} color={iconColor} />
@@ -88,9 +88,9 @@ export function FileThumbnail({
     )
   }
   if (
-    file.fileType?.includes('text/plain') ||
-    file.fileType?.includes('text/markdown') ||
-    file.fileName?.toLowerCase().includes('.md')
+    file.type?.includes('text/plain') ||
+    file.type?.includes('text/markdown') ||
+    file.name?.toLowerCase().includes('.md')
   ) {
     return (
       <View style={styles.thumbnailImage}>
@@ -99,8 +99,8 @@ export function FileThumbnail({
     )
   }
   if (
-    file.fileType?.includes('application/json') ||
-    file.fileName?.toLowerCase().includes('.json')
+    file.type?.includes('application/json') ||
+    file.name?.toLowerCase().includes('.json')
   ) {
     return (
       <View style={styles.thumbnailImage}>

--- a/src/components/FileViewer/index.tsx
+++ b/src/components/FileViewer/index.tsx
@@ -25,7 +25,7 @@ export function FileViewer({
   fullscreen?: boolean
   customDownloader?: () => void
 }) {
-  const { fileType, fileName } = file
+  const { type, name } = file
   const status = useFileStatus(file)
   const { fileUri, isDownloaded, isDownloading } = status.data ?? {}
   const fileDownload = useDownload(file)
@@ -37,10 +37,7 @@ export function FileViewer({
     else fileDownload()
   }, [isDownloading, customDownloader, fileDownload])
 
-  const lowerCasedFileName = useMemo(
-    () => fileName?.toLowerCase() ?? '',
-    [fileName]
-  )
+  const lowerCasedFileName = useMemo(() => name?.toLowerCase() ?? '', [name])
 
   const DownloadPanel = useMemo(() => {
     return (
@@ -71,7 +68,7 @@ export function FileViewer({
   const MediaDisplayElement = useMemo(() => {
     if (!isDownloaded || !fileUri) return DownloadPanel
 
-    if (fileType?.includes('image')) {
+    if (type?.includes('image')) {
       return (
         <ImageViewer
           uri={fileUri}
@@ -79,7 +76,7 @@ export function FileViewer({
         />
       )
     }
-    if (fileType?.includes('video')) {
+    if (type?.includes('video')) {
       return (
         <VideoPlayer
           source={fileUri}
@@ -87,47 +84,36 @@ export function FileViewer({
         />
       )
     }
-    if (fileType?.includes('audio')) {
+    if (type?.includes('audio')) {
       return (
         <AudioPlayer
           source={fileUri}
-          filename={fileName}
+          filename={name}
           style={fullscreen ? styles.mediaWithPadding : styles.media}
         />
       )
     }
-    if (fileType?.includes('pdf') || lowerCasedFileName.endsWith('.pdf')) {
+    if (type?.includes('pdf') || lowerCasedFileName.endsWith('.pdf')) {
       return <PDFViewer source={fileUri} style={styles.media} />
     }
     if (
-      fileType?.includes('application/json') ||
+      type?.includes('application/json') ||
       lowerCasedFileName.endsWith('.json')
     ) {
       return (
-        <JSONViewer
-          uri={fileUri}
-          fileSize={file.fileSize}
-          style={styles.media}
-        />
+        <JSONViewer uri={fileUri} fileSize={file.size} style={styles.media} />
       )
     }
     if (
-      fileType?.includes('text/markdown') ||
+      type?.includes('text/markdown') ||
       lowerCasedFileName.endsWith('.md') ||
       lowerCasedFileName.endsWith('.markdown')
     ) {
       return <MarkdownViewer uri={fileUri} style={styles.media} />
     }
-    if (
-      fileType?.includes('text/plain') ||
-      lowerCasedFileName.endsWith('.txt')
-    ) {
+    if (type?.includes('text/plain') || lowerCasedFileName.endsWith('.txt')) {
       return (
-        <TextViewer
-          uri={fileUri}
-          fileSize={file.fileSize}
-          style={styles.media}
-        />
+        <TextViewer uri={fileUri} fileSize={file.size} style={styles.media} />
       )
     }
 
@@ -145,11 +131,11 @@ export function FileViewer({
   }, [
     fileUri,
     isDownloaded,
-    fileType,
+    type,
     lowerCasedFileName,
     fullscreen,
-    fileName,
-    file.fileSize,
+    name,
+    file.size,
     DownloadPanel,
   ])
 

--- a/src/encoding/fileMetadata.ts
+++ b/src/encoding/fileMetadata.ts
@@ -3,12 +3,12 @@ import { FileMetadata } from '../stores/files'
 
 export function transformFileMetadata(metadata: FileMetadata): FileMetadata {
   return {
-    fileName: metadata.fileName,
-    fileType: metadata.fileType,
-    fileSize: metadata.fileSize,
+    name: metadata.name,
+    type: metadata.type,
+    size: metadata.size,
     updatedAt: metadata.updatedAt,
     createdAt: metadata.createdAt,
-    contentHash: metadata.contentHash,
+    hash: metadata.hash,
   }
 }
 
@@ -23,23 +23,23 @@ export function decodeFileMetadata(buffer?: ArrayBuffer): FileMetadata {
   } catch (e) {
     logger.log('Error converting file metadata from buffer', e)
     return {
-      fileName: '',
-      fileSize: 0,
-      fileType: '',
+      name: '',
+      size: 0,
+      type: '',
       updatedAt: 0,
       createdAt: 0,
-      contentHash: '',
+      hash: '',
     }
   }
 }
 
-/// Checks for complete metadata, most importantly the presence of the contentHash.
+/// Checks for complete metadata, most importantly the presence of the hash.
 export function hasCompleteMetadata(metadata: FileMetadata): boolean {
   return (
-    !!metadata.contentHash &&
-    !!metadata.fileType &&
-    !!metadata.fileName &&
-    !!metadata.fileSize &&
+    !!metadata.hash &&
+    !!metadata.type &&
+    !!metadata.name &&
+    !!metadata.size &&
     !!metadata.updatedAt &&
     !!metadata.createdAt
   )

--- a/src/hooks/useAutoDownload.ts
+++ b/src/hooks/useAutoDownload.ts
@@ -10,9 +10,9 @@ import { FileRecord } from '../stores/files'
  * its an image or PDF, or its less than 4 MB.
  */
 export function thumbnailShouldAutoDownload(file: FileRecord): boolean {
-  const isImage = file.fileType?.startsWith('image') ?? false
-  const isPdf = (file.fileType ?? '').includes('pdf')
-  const sizeOk = (file.fileSize ?? Infinity) <= 4 * 1000 * 1000 // 4 MB
+  const isImage = file.type?.startsWith('image') ?? false
+  const isPdf = (file.type ?? '').includes('pdf')
+  const sizeOk = (file.size ?? Infinity) <= 4 * 1000 * 1000 // 4 MB
   return isImage || isPdf || sizeOk
 }
 
@@ -21,9 +21,9 @@ export function thumbnailShouldAutoDownload(file: FileRecord): boolean {
  * its an image, PDF, or its less than 10 MB.
  */
 export function detailsShouldAutoDownload(file: FileRecord): boolean {
-  const isImage = file.fileType?.startsWith('image') ?? false
-  const isPdf = (file.fileType ?? '').includes('pdf')
-  const sizeOk = (file.fileSize ?? Infinity) <= 10 * 1000 * 1000 // 10 MB
+  const isImage = file.type?.startsWith('image') ?? false
+  const isPdf = (file.type ?? '').includes('pdf')
+  const sizeOk = (file.size ?? Infinity) <= 10 * 1000 * 1000 // 10 MB
   return isImage || isPdf || sizeOk
 }
 

--- a/src/hooks/useCameraCapture.ts
+++ b/src/hooks/useCameraCapture.ts
@@ -43,9 +43,9 @@ export function useCameraCapture() {
       const { files, warnings } = await processAssets(
         result.assets?.map((a) => ({
           id: a.id,
-          fileName: a.fileName,
-          fileSize: a.fileSize,
-          fileType: a.type,
+          name: a.fileName,
+          size: a.fileSize,
+          type: a.type,
           sourceUri: a.uri,
           timestamp: a.timestamp,
         }))

--- a/src/hooks/useDocumentPicker.ts
+++ b/src/hooks/useDocumentPicker.ts
@@ -31,9 +31,9 @@ export function useDocumentPicker() {
       const { files, warnings } = await processAssets(
         result.assets?.map((a) => ({
           id: undefined,
-          fileName: a.name,
-          fileSize: a.size,
-          fileType: a.mimeType,
+          name: a.name,
+          size: a.size,
+          type: a.mimeType,
           timestamp: new Date(a.lastModified).toISOString(),
           sourceUri: a.uri,
         }))

--- a/src/hooks/useImagePicker.ts
+++ b/src/hooks/useImagePicker.ts
@@ -37,9 +37,9 @@ export function useImagePicker() {
       const { files, warnings } = await processAssets(
         result.assets?.map((a) => ({
           id: a.id,
-          fileName: a.fileName,
-          fileSize: a.fileSize,
-          fileType: a.type,
+          name: a.fileName,
+          size: a.fileSize,
+          type: a.type,
           timestamp: a.timestamp,
           sourceUri: a.uri,
         }))

--- a/src/hooks/useShareAction.tsx
+++ b/src/hooks/useShareAction.tsx
@@ -37,15 +37,15 @@ export function useShareAction({ fileId }: { fileId: string }) {
 
   const handleShareFile = useCallback(async () => {
     if (!file) return
-    if (!file.fileType) return
+    if (!file.type) return
     if (!status.data?.fileUri) return
 
     try {
       await Share.open({
         url: status.data.fileUri,
-        type: file.fileType,
-        filename: file.fileName ?? undefined,
-        subject: `Sia Storage - ${file.fileType}`,
+        type: file.type,
+        filename: file.name ?? undefined,
+        subject: `Sia Storage - ${file.type}`,
       })
     } catch (e) {
       if (typeof e === 'string' && !e.includes('User did not share')) {

--- a/src/lib/file.ts
+++ b/src/lib/file.ts
@@ -94,13 +94,13 @@ export function useFileStatus(
 export function getFileTypeName(
   file: FileRecord
 ): 'photo' | 'video' | 'audio' | 'document' | 'other' {
-  return file.fileType?.startsWith('image')
+  return file.type?.startsWith('image')
     ? 'photo'
-    : file.fileType?.startsWith('video')
+    : file.type?.startsWith('video')
     ? 'video'
-    : file.fileType?.startsWith('audio')
+    : file.type?.startsWith('audio')
     ? 'audio'
-    : file.fileType?.startsWith('application')
+    : file.type?.startsWith('application')
     ? 'document'
     : 'other'
 }

--- a/src/lib/processAssets.test.ts
+++ b/src/lib/processAssets.test.ts
@@ -57,10 +57,10 @@ describe('processAssets', () => {
     const assets = [
       {
         id: '1',
-        fileName: 'a.jpg',
-        fileSize: 100,
+        name: 'a.jpg',
+        size: 100,
         sourceUri: 'file://1',
-        fileType: 'image/jpeg',
+        type: 'image/jpeg',
         timestamp: '2021-01-01',
       },
     ]
@@ -72,8 +72,8 @@ describe('processAssets', () => {
     expect(rows).toHaveLength(1)
     expect(rows[0]).toMatchObject({
       id: 'uid-1',
-      fileName: 'a.jpg',
-      fileSize: 100,
+      name: 'a.jpg',
+      size: 100,
     })
     expect(copyFileToCache).not.toHaveBeenCalled()
   })
@@ -82,13 +82,13 @@ describe('processAssets', () => {
     await createFileRecord(
       {
         id: 'existing-1',
-        fileName: 'old.jpg',
-        fileSize: 5,
+        name: 'old.jpg',
+        size: 5,
         createdAt: 1,
         updatedAt: 1,
-        fileType: 'image/jpeg',
+        type: 'image/jpeg',
         localId: '1',
-        contentHash: '',
+        hash: '',
       },
       false
     )
@@ -96,10 +96,10 @@ describe('processAssets', () => {
     const assets = [
       {
         id: '1',
-        fileName: 'new.jpg',
-        fileSize: 200,
+        name: 'new.jpg',
+        size: 200,
         sourceUri: 'file://1',
-        fileType: 'image/jpeg',
+        type: 'image/jpeg',
         timestamp: '2021-01-01',
       },
     ]
@@ -112,22 +112,22 @@ describe('processAssets', () => {
     const updated = await readFileRecord('existing-1')
     expect(updated).toMatchObject({
       id: 'existing-1',
-      fileName: 'new.jpg',
-      fileSize: 200,
+      name: 'new.jpg',
+      size: 200,
     })
     expect(copyFileToCache).not.toHaveBeenCalled()
   })
 
-  it('updates existing by contentHash and does not create new records', async () => {
+  it('updates existing by hash and does not create new records', async () => {
     await createFileRecord(
       {
         id: 'existing-hash',
-        fileName: 'old-h.jpg',
-        fileSize: 10,
+        name: 'old-h.jpg',
+        size: 10,
         createdAt: 1,
         updatedAt: 1,
-        fileType: 'image/jpeg',
-        contentHash: 'sha256|BYTESv1|hash:file://2',
+        type: 'image/jpeg',
+        hash: 'sha256|BYTESv1|hash:file://2',
         localId: null,
       },
       false
@@ -136,10 +136,10 @@ describe('processAssets', () => {
     const assets = [
       {
         id: '2',
-        fileName: 'new-h.jpg',
-        fileSize: 300,
+        name: 'new-h.jpg',
+        size: 300,
         sourceUri: 'file://2',
-        fileType: 'image/jpeg',
+        type: 'image/jpeg',
         timestamp: '2021-01-01',
       },
     ]
@@ -150,8 +150,8 @@ describe('processAssets', () => {
     const updated = await readFileRecord('existing-hash')
     expect(updated).toMatchObject({
       id: 'existing-hash',
-      fileName: 'new-h.jpg',
-      fileSize: 300,
+      name: 'new-h.jpg',
+      size: 300,
     })
     expect(copyFileToCache).not.toHaveBeenCalled()
   })
@@ -162,10 +162,10 @@ describe('processAssets', () => {
     const assets = [
       {
         id: undefined,
-        fileName: 'no-id.jpg',
-        fileSize: 123,
+        name: 'no-id.jpg',
+        size: 123,
         sourceUri: 'file:///tmp/no-id.jpg',
-        fileType: 'image/jpeg',
+        type: 'image/jpeg',
         timestamp: '2021-01-01',
       },
     ]
@@ -175,28 +175,28 @@ describe('processAssets', () => {
     expect(files).toHaveLength(1)
     expect(copyFileToCache).toHaveBeenCalledTimes(1)
     const call = copyFileToCacheMock.mock.calls[0]
-    expect(call[0]).toMatchObject({ id: files[0].id, fileType: 'image/jpeg' })
+    expect(call[0]).toMatchObject({ id: files[0].id, type: 'image/jpeg' })
     expect(call[1]).toBeDefined()
     expect(call[1].uri).toBe('file:///tmp/no-id.jpg')
 
     const rows = await readAllFileRecords({ order: 'ASC' })
     expect(rows).toHaveLength(1)
-    expect(rows[0]).toMatchObject({ fileName: 'no-id.jpg', fileSize: 123 })
+    expect(rows[0]).toMatchObject({ name: 'no-id.jpg', size: 123 })
   })
 
   it('adds file size to new files', async () => {
     const assets = [
       {
         id: undefined,
-        fileName: 'no-id.jpg',
-        fileSize: undefined,
+        name: 'no-id.jpg',
+        size: undefined,
         sourceUri: 'file:///tmp/no-id.jpg',
-        fileType: 'image/jpeg',
+        type: 'image/jpeg',
         timestamp: '2021-01-01',
       },
     ]
     const { files } = await processAssets(assets)
     expect(files).toHaveLength(1)
-    expect(files[0].fileSize).toBe(333)
+    expect(files[0].size).toBe(333)
   })
 })

--- a/src/lib/processAssets.ts
+++ b/src/lib/processAssets.ts
@@ -15,21 +15,21 @@ import { File } from 'expo-file-system'
 type Asset = {
   id: string | undefined
   sourceUri: string | undefined
-  fileSize: number | undefined
-  fileType: string | undefined
-  fileName: string | undefined
+  size: number | undefined
+  type: string | undefined
+  name: string | undefined
   timestamp: string | undefined
 }
 
 type CandidateFileRecord = {
   id: string
   localId: string | null
-  fileName: string
+  name: string
   createdAt: number
   updatedAt: number
-  fileType: string
-  contentHash: string | null
-  fileSize: number | null
+  type: string
+  hash: string | null
+  size: number | null
   sourceUri: string | null
   status: 'existing' | 'new' | 'incomplete'
   statusDetails:
@@ -44,7 +44,7 @@ type CandidateFileRecord = {
 /**
  * processAssets imports a list of assets from any source.
  * This function will:
- * - Check for duplicates by localId and contentHash.
+ * - Check for duplicates by localId and hash.
  * - Copy files without a local ID to the app's file cache.
  * - Add content hashes to files that are new.
  * - Create new file records for the assets.
@@ -65,12 +65,12 @@ export async function processAssets(
     // If the asset does not have an id, pass a sourceUri so we can copy the
     // file to the app's file cache.
     sourceUri: a.id ? null : a.sourceUri ?? null,
-    fileName: a.fileName ?? defaultFileName,
-    fileSize: a.fileSize ?? null,
+    name: a.name ?? defaultFileName,
+    size: a.size ?? null,
     createdAt: new Date(a.timestamp ?? Date.now()).getTime(),
     updatedAt: new Date(a.timestamp ?? Date.now()).getTime(),
-    fileType: a.fileType ?? mimeFromAssetUri(a),
-    contentHash: null,
+    type: a.type ?? mimeFromAssetUri(a),
+    hash: null,
     status: 'new',
     statusDetails: null,
   }))
@@ -112,17 +112,17 @@ export async function processAssets(
           f.statusDetails = 'noFileUri'
           return
         }
-        if (!f.fileSize) {
+        if (!f.size) {
           // Try again to get the file size.
-          f.fileSize = getFileSize(fileUri)
-          if (!f.fileSize) {
+          f.size = getFileSize(fileUri)
+          if (!f.size) {
             f.status = 'incomplete'
             f.statusDetails = 'noFileSize'
             return
           }
         }
-        f.contentHash = await calculateContentHash(fileUri)
-        if (!f.contentHash) {
+        f.hash = await calculateContentHash(fileUri)
+        if (!f.hash) {
           f.status = 'incomplete'
           f.statusDetails = 'noContentHash'
           return
@@ -133,15 +133,13 @@ export async function processAssets(
   // Check for duplicates by content hash.
   const existingContentHashes = await readFileRecordsByContentHashes(
     candidateFiles
-      .filter((f) => f.status === 'new' && f.contentHash !== null)
-      .map((f) => f.contentHash!)
+      .filter((f) => f.status === 'new' && f.hash !== null)
+      .map((f) => f.hash!)
   )
 
   // Update the status of the files that are found by content hash.
   for (const f of existingContentHashes) {
-    const validFile = candidateFiles.find(
-      (v) => v.contentHash === f.contentHash
-    )
+    const validFile = candidateFiles.find((v) => v.hash === f.hash)
     if (validFile) {
       validFile.id = f.id
       validFile.status = 'existing'
@@ -151,19 +149,17 @@ export async function processAssets(
 
   // Assert that the files are new and have a content hash.
   const newFiles: FileRecord[] = candidateFiles
-    .filter(
-      (f) => f.status === 'new' && f.contentHash !== null && f.fileSize !== null
-    )
+    .filter((f) => f.status === 'new' && f.hash !== null && f.size !== null)
     .map((f) => ({
       id: f.id,
       localId: f.localId,
-      fileName: f.fileName,
+      name: f.name,
       createdAt: f.createdAt,
       updatedAt: f.updatedAt,
       addedAt: Date.now(),
-      fileType: f.fileType,
-      fileSize: f.fileSize!,
-      contentHash: f.contentHash!,
+      type: f.type,
+      size: f.size!,
+      hash: f.hash!,
       objects: {},
     }))
   const incompleteFiles = candidateFiles.filter(

--- a/src/managers/syncDownEvents.ts
+++ b/src/managers/syncDownEvents.ts
@@ -158,7 +158,7 @@ async function handleUpdateEvent(
     logger.log(`[syncDownEvents] incomplete metadata, skipping update`)
     return
   }
-  const existingFile = await readFileRecordByContentHash(metadata.contentHash)
+  const existingFile = await readFileRecordByContentHash(metadata.hash)
 
   if (existingFile) {
     const localObject = await pinnedObjectToLocalObject(
@@ -185,13 +185,14 @@ async function handleUpdateEvent(
     await createFileRecordWithLocalObject(
       {
         id: fileId,
-        fileName: metadata.fileName,
-        fileSize: metadata.fileSize,
+        name: metadata.name,
+        size: metadata.size,
         createdAt: metadata.createdAt,
         updatedAt: metadata.updatedAt,
-        fileType: metadata.fileType,
-        contentHash: metadata.contentHash,
+        type: metadata.type,
+        hash: metadata.hash,
         localId: null,
+        addedAt: Date.now(),
       },
       localObject
     )

--- a/src/managers/syncNewPhotos.test.ts
+++ b/src/managers/syncNewPhotos.test.ts
@@ -98,14 +98,14 @@ describe('syncNewPhotos', () => {
     expect(getTime(opts3?.createdAfter)).toBe(2500)
     expect(processAssetsMock).toHaveBeenCalledTimes(3)
     expect(processAssetsMock).toHaveBeenNthCalledWith(1, [
-      expect.objectContaining({ id: 'a1', fileName: '1.jpg' }),
-      expect.objectContaining({ id: 'a2', fileName: '2.jpg' }),
+      expect.objectContaining({ id: 'a1', name: '1.jpg' }),
+      expect.objectContaining({ id: 'a2', name: '2.jpg' }),
     ])
     expect(processAssetsMock).toHaveBeenNthCalledWith(2, [
-      expect.objectContaining({ id: 'a3', fileName: '3.jpg' }),
+      expect.objectContaining({ id: 'a3', name: '3.jpg' }),
     ])
     expect(processAssetsMock).toHaveBeenNthCalledWith(3, [
-      expect.objectContaining({ id: 'a4', fileName: '4.jpg' }),
+      expect.objectContaining({ id: 'a4', name: '4.jpg' }),
     ])
   })
 })

--- a/src/managers/syncNewPhotos.ts
+++ b/src/managers/syncNewPhotos.ts
@@ -40,9 +40,9 @@ async function workForward(): Promise<void> {
       page.assets.map((asset) => ({
         id: asset.id,
         sourceUri: undefined,
-        fileName: asset.filename,
-        fileType: undefined,
-        fileSize: undefined,
+        name: asset.filename,
+        type: undefined,
+        size: undefined,
         timestamp: new Date(asset.creationTime).toISOString(),
       }))
     )

--- a/src/managers/syncPhotosArchive.test.ts
+++ b/src/managers/syncPhotosArchive.test.ts
@@ -104,15 +104,15 @@ describe('syncPhotosArchive', () => {
     // Tick 1: createdBefore 1_000_000 -> returns [10_000, 5_000], cursor -> 5_000
     await runTick()
     expect(processAssetsMock).toHaveBeenNthCalledWith(1, [
-      expect.objectContaining({ id: 'b1', fileName: 'one.jpg' }),
-      expect.objectContaining({ id: 'b2', fileName: 'two.jpg' }),
+      expect.objectContaining({ id: 'b1', name: 'one.jpg' }),
+      expect.objectContaining({ id: 'b2', name: 'two.jpg' }),
     ])
     expect(await getPhotosArchiveCursor()).toBe(5_000)
 
     // Tick 2: createdBefore 5_000 -> returns [1_000], cursor -> 1_000
     await runTick()
     expect(processAssetsMock).toHaveBeenNthCalledWith(2, [
-      expect.objectContaining({ id: 'b3', fileName: 'three.jpg' }),
+      expect.objectContaining({ id: 'b3', name: 'three.jpg' }),
     ])
     expect(await getPhotosArchiveCursor()).toBe(1_000)
 

--- a/src/managers/syncPhotosArchive.ts
+++ b/src/managers/syncPhotosArchive.ts
@@ -39,9 +39,9 @@ export async function workBackward(): Promise<void> {
       page.assets.map((asset) => ({
         id: asset.id,
         sourceUri: undefined,
-        fileName: asset.filename,
-        fileType: undefined,
-        fileSize: undefined,
+        name: asset.filename,
+        type: undefined,
+        size: undefined,
         timestamp: new Date(asset.creationTime).toISOString(),
       }))
     )

--- a/src/managers/uploadToIndexer.ts
+++ b/src/managers/uploadToIndexer.ts
@@ -37,7 +37,7 @@ export async function uploadToIndexer(params: {
     parityShards: UPLOAD_PARITY_SHARDS,
     metadata: encodeFileMetadata({
       ...file,
-      fileSize: data.byteLength,
+      size: data.byteLength,
     }),
     progressCallback: {
       progress: (uploaded) => {

--- a/src/screens/FileDetailScreen.tsx
+++ b/src/screens/FileDetailScreen.tsx
@@ -23,7 +23,7 @@ export function FileDetailScreen({ route, navigation }: Props) {
           file={file}
           header={
             <FileDetailScreenHeader
-              title={file?.fileName ?? 'View'}
+              title={file?.name ?? 'View'}
               navigation={navigation}
             />
           }
@@ -34,7 +34,7 @@ export function FileDetailScreen({ route, navigation }: Props) {
             file={file}
             header={
               <FileDetailScreenHeader
-                title={file?.fileName ?? 'Details'}
+                title={file?.name ?? 'Details'}
                 navigation={navigation}
               />
             }

--- a/src/screens/ImportFileScreen.tsx
+++ b/src/screens/ImportFileScreen.tsx
@@ -62,10 +62,10 @@ export function ImportFileScreen({ route }: Props) {
         const metadata = decodeFileMetadata(sharedObject.data.metadata())
         const file: FileMetadata = transformFileMetadata({
           id,
-          fileSize: Number(sharedObject.data.size()),
-          fileType: metadata.fileType,
-          fileName: metadata.fileName,
-          contentHash: metadata.contentHash,
+          size: Number(sharedObject.data.size()),
+          type: metadata.type,
+          name: metadata.name,
+          hash: metadata.hash,
           localId: metadata.localId,
           createdAt: metadata.createdAt,
           updatedAt: metadata.updatedAt,

--- a/src/stores/fileCache.ts
+++ b/src/stores/fileCache.ts
@@ -11,7 +11,7 @@ const CACHE_DIR = new Directory(Paths.cache, 'files-cache')
 
 type FileCopyInfo = {
   id: string
-  fileType: string
+  type: string
   localId: string | null
 }
 
@@ -23,7 +23,7 @@ export async function ensureCacheDir(): Promise<void> {
 }
 
 async function getCacheFileForId(file: FileCopyInfo): Promise<File> {
-  return new File(CACHE_DIR, `${file.id}${extFromMime(file.fileType)}`)
+  return new File(CACHE_DIR, `${file.id}${extFromMime(file.type)}`)
 }
 
 async function getCacheTmpFileForId(file: FileCopyInfo): Promise<File> {

--- a/src/stores/files.ts
+++ b/src/stores/files.ts
@@ -14,18 +14,19 @@ import { removeEmptyValues } from '../lib/object'
 
 /** Fields that are stored in both the local database and the indexer metadata. */
 export type FileMetadata = {
-  fileName: string
+  name: string
+  type: string
+  size: number
+  hash: string
   createdAt: number
   updatedAt: number
-  fileType: string
-  fileSize: number
-  contentHash: string
 }
 
 /** Fields that are stored only in the local database. */
 export type FileLocalMetadata = {
   id: string
   localId: string | null
+  addedAt: number
 }
 
 export type FileRecordRow = FileMetadata & FileLocalMetadata
@@ -38,26 +39,19 @@ export async function createFileRecord(
   fileRecord: Omit<FileRecord, 'objects'>,
   triggerUpdate: boolean = true
 ): Promise<void> {
-  const {
-    id,
-    fileName,
-    fileSize,
-    createdAt,
-    updatedAt,
-    fileType,
-    localId,
-    contentHash,
-  } = fileRecord
+  const { id, name, size, createdAt, updatedAt, type, localId, hash, addedAt } =
+    fileRecord
   await db().runAsync(
-    'INSERT INTO files (id, fileName, fileSize, createdAt, updatedAt, fileType, localId, contentHash) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+    'INSERT INTO files (id, name, size, createdAt, updatedAt, type, localId, hash, addedAt) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
     id,
-    fileName,
-    fileSize,
+    name,
+    size,
     createdAt,
     updatedAt,
-    fileType,
+    type,
     localId,
-    contentHash
+    hash,
+    addedAt
   )
   if (triggerUpdate) {
     await librarySwr.triggerChange()
@@ -168,7 +162,7 @@ export async function readAllFileRecords(opts: {
         objectUpdatedAt: number
       }
   >(
-    `SELECT f.id, f.fileName, f.fileSize, f.createdAt, f.updatedAt, f.fileType, f.localId, f.contentHash,
+    `SELECT f.id, f.name, f.size, f.createdAt, f.updatedAt, f.type, f.localId, f.hash,
             o.fileId as fileId, o.indexerURL as indexerURL, o.id as objectId, o.slabs as slabs,
             o.encryptedMasterKey as encryptedMasterKey, o.encryptedMetadata as encryptedMetadata,
             o.signature as signature, o.createdAt as objectCreatedAt, o.updatedAt as objectUpdatedAt
@@ -209,7 +203,7 @@ export async function readFileRecordByObjectId(
   objectId: string
 ): Promise<FileRecord | null> {
   const row = await db().getFirstAsync<FileRecordRow>(
-    `SELECT id, fileName, fileSize, createdAt, updatedAt, fileType, localId, contentHash FROM files WHERE id IN (SELECT fileId FROM objects WHERE id = ?) LIMIT 1`,
+    `SELECT id, name, size, createdAt, updatedAt, type, localId, hash FROM files WHERE id IN (SELECT fileId FROM objects WHERE id = ?) LIMIT 1`,
     objectId
   )
   if (!row) return null
@@ -219,7 +213,7 @@ export async function readFileRecordByObjectId(
 
 export async function readFileRecordsByLocalIds(localIds: string[]) {
   const rows = await db().getAllAsync<FileRecordRow>(
-    `SELECT id, fileName, fileSize, createdAt, updatedAt, fileType, localId, contentHash FROM files WHERE localId IN (${localIds
+    `SELECT id, name, size, createdAt, updatedAt, type, localId, hash FROM files WHERE localId IN (${localIds
       .map((_) => `?`)
       .join(',')})`,
     ...localIds
@@ -231,23 +225,23 @@ export async function readFileRecordsByLocalIds(localIds: string[]) {
 
 export async function readFileRecordsByContentHashes(contentHashes: string[]) {
   const rows = await db().getAllAsync<FileRecordRow>(
-    `SELECT id, fileName, fileSize, createdAt, updatedAt, fileType, localId, contentHash FROM files WHERE contentHash IN (${contentHashes
+    `SELECT id, name, size, createdAt, updatedAt, type, localId, hash FROM files WHERE hash IN (${contentHashes
       .map((_) => `?`)
       .join(',')})`,
     ...contentHashes
   )
   return rows.map((row) => transformRow(row)) as (FileRecord & {
-    contentHash: string
+    hash: string
   })[]
 }
 
-export async function readFileRecordByContentHash(contentHash: string) {
+export async function readFileRecordByContentHash(hash: string) {
   const row = await db().getFirstAsync<FileRecordRow>(
-    'SELECT id, fileName, fileSize, createdAt, updatedAt, fileType, localId, contentHash FROM files WHERE contentHash = ?',
-    contentHash
+    'SELECT id, name, size, createdAt, updatedAt, type, localId, hash FROM files WHERE hash = ?',
+    hash
   )
   if (!row) {
-    logger.log('[db] file not found by contentHash', contentHash)
+    logger.log('[db] file not found by hash', hash)
     return null
   }
   const objects = await readLocalObjectsForFile(row.id)
@@ -256,7 +250,7 @@ export async function readFileRecordByContentHash(contentHash: string) {
 
 export async function readFileRecord(id: string): Promise<FileRecord | null> {
   const row = await db().getFirstAsync<FileRecordRow>(
-    'SELECT id, fileName, fileSize, createdAt, updatedAt, fileType, localId, contentHash FROM files WHERE id = ?',
+    'SELECT id, name, size, createdAt, updatedAt, type, localId, hash FROM files WHERE id = ?',
     id
   )
   if (!row) {
@@ -276,13 +270,13 @@ export async function updateFileRecord(
   const sets: string[] = []
   const params: (string | number | null)[] = []
   const updatableFields = [
-    'fileName',
-    'fileSize',
+    'name',
+    'size',
     'createdAt',
     'updatedAt',
-    'fileType',
+    'type',
     'localId',
-    'contentHash',
+    'hash',
   ]
   for (const field of updatableFields) {
     const nonEmptyUpdate = removeEmptyValues(update)
@@ -374,13 +368,14 @@ export function transformRow(
   }
   return {
     id: row.id,
-    fileName: row.fileName,
-    fileSize: row.fileSize,
+    name: row.name,
+    size: row.size,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
-    fileType: row.fileType,
+    addedAt: row.addedAt,
+    type: row.type,
     localId: row.localId,
-    contentHash: row.contentHash,
+    hash: row.hash,
     objects: objectsMap,
   }
 }

--- a/src/stores/library.ts
+++ b/src/stores/library.ts
@@ -43,11 +43,11 @@ async function readOrderedFileRecords(
   const whereParts: string[] = []
   const params: (string | number | null)[] = []
   if (hasCategories) {
-    whereParts.push(prefixes.map(() => 'fileType LIKE ?').join(' OR '))
+    whereParts.push(prefixes.map(() => 'type LIKE ?').join(' OR '))
     params.push(...prefixes.map((p) => `${p}%`))
   }
   if (hasQuery) {
-    whereParts.push('fileName LIKE ? COLLATE NOCASE ESCAPE "\\"')
+    whereParts.push('name LIKE ? COLLATE NOCASE ESCAPE "\\"')
     const escaped = (query ?? '').replace(/[%_\\]/g, (m) => `\\${m}`)
     params.push(`%${escaped}%`)
   }
@@ -55,7 +55,7 @@ async function readOrderedFileRecords(
 
   const orderExpr =
     sortBy === 'NAME'
-      ? `(fileName IS NULL) ASC, fileName COLLATE NOCASE ${dir}, id ${dir}`
+      ? `(name IS NULL) ASC, name COLLATE NOCASE ${dir}, id ${dir}`
       : `createdAt ${dir}, id ${dir}`
 
   let pageClause = ''
@@ -64,7 +64,7 @@ async function readOrderedFileRecords(
   }
 
   const rows = await db().getAllAsync<FileRecordRow>(
-    `SELECT id, fileName, fileSize, createdAt, updatedAt, fileType, localId, contentHash
+    `SELECT id, name, size, createdAt, updatedAt, type, localId, hash
      FROM files
      ${where}
      ORDER BY ${orderExpr}${pageClause}`,


### PR DESCRIPTION
- Cleans up field names before we fully commit to them. File prefix was redundant, this should also save some space.

```
fileName => name
fileSize => size
fileType => type
contentHash => hash
```