### PR TITLE
fix: cancel any uploads for synced objects

### DIFF
--- a/src/managers/syncDownEvents.ts
+++ b/src/managers/syncDownEvents.ts
@@ -29,6 +29,7 @@ import {
   removeTmpFileFromCache,
 } from '../stores/fileCache'
 import { uniqueId } from '../lib/uniqueId'
+import { cancelUpload } from '../stores/uploads'
 
 const batchSize = 100
 
@@ -173,7 +174,8 @@ async function handleUpdateEvent(
       },
       localObject
     )
-    // TODO: cancel any upload for this file.
+    // Cancel any inflight upload for this file since we now have a pinned object.
+    cancelUpload(existingFile.id)
     counts.existing++
   } else {
     const fileId = uniqueId()

--- a/src/stores/uploads.ts
+++ b/src/stores/uploads.ts
@@ -74,6 +74,15 @@ export function cancelAllUploads() {
   useUploadsStore.setState({ uploads: {} })
 }
 
+export function cancelUpload(id: string) {
+  const current = getState().uploads
+  const rec = current[id]
+  if (!rec) return
+  logger.log('aborting upload', id)
+  rec.controller?.abort()
+  removeUpload(id)
+}
+
 export type UploadCounts = {
   total: number
   totalActive: number


### PR DESCRIPTION
- Cancel any active uploads if a file pinned object is synced down, since this means its already on the network.