### PR TITLE
fix: remove custom image hashing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,6 @@
         "@react-navigation/bottom-tabs": "^7.4.7",
         "@react-navigation/native": "^7.1.17",
         "@react-navigation/native-stack": "^7.3.26",
-        "@shopify/react-native-skia": "2.2.12",
         "expo": "54.0.20",
         "expo-audio": "^1.0.13",
         "expo-clipboard": "8.0.2",
@@ -67,7 +66,6 @@
   },
   "trustedDependencies": [
     "better-sqlite3",
-    "@shopify/react-native-skia",
   ],
   "packages": {
     "@0no-co/graphql.web": ["@0no-co/graphql.web@1.2.0", "", { "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0" }, "optionalPeers": ["graphql"] }, "sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw=="],
@@ -414,8 +412,6 @@
 
     "@react-navigation/routers": ["@react-navigation/routers@7.5.1", "", { "dependencies": { "nanoid": "^3.3.11" } }, "sha512-pxipMW/iEBSUrjxz2cDD7fNwkqR4xoi0E/PcfTQGCcdJwLoaxzab5kSadBLj1MTJyT0YRrOXL9umHpXtp+Dv4w=="],
 
-    "@shopify/react-native-skia": ["@shopify/react-native-skia@2.2.12", "", { "dependencies": { "canvaskit-wasm": "0.40.0", "react-reconciler": "0.31.0" }, "peerDependencies": { "react": ">=19.0", "react-native": ">=0.78", "react-native-reanimated": ">=3.19.1" }, "optionalPeers": ["react-native", "react-native-reanimated"], "bin": { "setup-skia-web": "scripts/setup-canvaskit.js" } }, "sha512-P5wZSMPTp00hM0do+awNFtb5aPh5hSpodMGwy7NaxK90AV+SmUu7wZe6NGevzQIwgFa89Epn6xK3j4jKWdQi+A=="],
-
     "@sinclair/typebox": ["@sinclair/typebox@0.27.8", "", {}, "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="],
 
     "@sinonjs/commons": ["@sinonjs/commons@3.0.1", "", { "dependencies": { "type-detect": "4.0.8" } }, "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ=="],
@@ -507,8 +503,6 @@
     "@webassemblyjs/wasm-parser": ["@webassemblyjs/wasm-parser@1.14.1", "", { "dependencies": { "@webassemblyjs/ast": "1.14.1", "@webassemblyjs/helper-api-error": "1.13.2", "@webassemblyjs/helper-wasm-bytecode": "1.13.2", "@webassemblyjs/ieee754": "1.13.2", "@webassemblyjs/leb128": "1.13.2", "@webassemblyjs/utf8": "1.13.2" } }, "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ=="],
 
     "@webassemblyjs/wast-printer": ["@webassemblyjs/wast-printer@1.14.1", "", { "dependencies": { "@webassemblyjs/ast": "1.14.1", "@xtuc/long": "4.2.2" } }, "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw=="],
-
-    "@webgpu/types": ["@webgpu/types@0.1.21", "", {}, "sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow=="],
 
     "@xmldom/xmldom": ["@xmldom/xmldom@0.8.11", "", {}, "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw=="],
 
@@ -641,8 +635,6 @@
     "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001751", "", {}, "sha512-A0QJhug0Ly64Ii3eIqHu5X51ebln3k4yTUkY1j8drqpWHVreg/VLijN48cZ1bYPiqOQuqpkIKnzr/Ul8V+p6Cw=="],
-
-    "canvaskit-wasm": ["canvaskit-wasm@0.40.0", "", { "dependencies": { "@webgpu/types": "0.1.21" } }, "sha512-Od2o+ZmoEw9PBdN/yCGvzfu0WVqlufBPEWNG452wY7E9aT8RBE+ChpZF526doOlg7zumO4iCS+RAeht4P0Gbpw=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -1440,8 +1432,6 @@
 
     "react-native-worklets": ["react-native-worklets@0.5.1", "", { "dependencies": { "@babel/plugin-transform-arrow-functions": "^7.0.0-0", "@babel/plugin-transform-class-properties": "^7.0.0-0", "@babel/plugin-transform-classes": "^7.0.0-0", "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0", "@babel/plugin-transform-optional-chaining": "^7.0.0-0", "@babel/plugin-transform-shorthand-properties": "^7.0.0-0", "@babel/plugin-transform-template-literals": "^7.0.0-0", "@babel/plugin-transform-unicode-regex": "^7.0.0-0", "@babel/preset-typescript": "^7.16.7", "convert-source-map": "^2.0.0", "semver": "7.7.2" }, "peerDependencies": { "@babel/core": "^7.0.0-0", "react": "*", "react-native": "*" } }, "sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w=="],
 
-    "react-reconciler": ["react-reconciler@0.31.0", "", { "dependencies": { "scheduler": "^0.25.0" }, "peerDependencies": { "react": "^19.0.0" } }, "sha512-7Ob7Z+URmesIsIVRjnLoDGwBEG/tVitidU0nMsqX/eeJaLY89RISO/10ERe0MqmzuKUUB1rmY+h1itMbUHg9BQ=="],
-
     "react-refresh": ["react-refresh@0.14.2", "", {}, "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA=="],
 
     "react-server-dom-webpack": ["react-server-dom-webpack@19.0.0", "", { "dependencies": { "acorn-loose": "^8.3.0", "neo-async": "^2.6.1", "webpack-sources": "^3.2.0" }, "peerDependencies": { "react": "^19.0.0", "react-dom": "^19.0.0", "webpack": "^5.59.0" } }, "sha512-hLug9KEXLc8vnU9lDNe2b2rKKDaqrp5gNiES4uyu2Up3FZfZJZmdwLFXlWzdA9gTB/6/cWduSB2K1Lfag2pSvw=="],
@@ -2011,8 +2001,6 @@
     "react-native-reanimated/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "react-native-worklets/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
-
-    "react-reconciler/scheduler": ["scheduler@0.25.0", "", {}, "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA=="],
 
     "react-test-renderer/react-is": ["react-is@19.2.0", "", {}, "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA=="],
 

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -6,7 +6,7 @@ module.exports = {
     '<rootDir>/jest.setup.cjs',
   ],
   transformIgnorePatterns: [
-    'node_modules/(?!(react-native|@react-native|@shopify/react-native-skia|react-native-fs|react-native-quick-crypto|expo|@expo|expo-.*|expo-sqlite|expo-modules-core)/)',
+    'node_modules/(?!(react-native|@react-native|react-native-fs|react-native-quick-crypto|expo|@expo|expo-.*|expo-sqlite|expo-modules-core)/)',
   ],
   moduleNameMapper: {},
 }

--- a/jest.setup.cjs
+++ b/jest.setup.cjs
@@ -40,16 +40,6 @@ jest.mock('react-native-fs', () => ({
 }))
 global.__rnfs = { rnfsStat, rnfsRead, rnfsReadFile }
 
-const makeImageFromEncoded = jest.fn()
-jest.mock('@shopify/react-native-skia', () => ({
-  __esModule: true,
-  Skia: {
-    Data: { fromBase64: () => ({}) },
-    Image: { MakeImageFromEncoded: makeImageFromEncoded },
-  },
-}))
-global.__skia = { makeImageFromEncoded }
-
 // In-memory SecureStore for tests.
 jest.mock('./src/stores/secureStore', () => {
   const numStore = new Map()

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@react-navigation/bottom-tabs": "^7.4.7",
     "@react-navigation/native": "^7.1.17",
     "@react-navigation/native-stack": "^7.3.26",
-    "@shopify/react-native-skia": "2.2.12",
     "expo": "54.0.20",
     "expo-audio": "^1.0.13",
     "expo-clipboard": "8.0.2",
@@ -74,7 +73,6 @@
   },
   "private": true,
   "trustedDependencies": [
-    "@shopify/react-native-skia",
     "better-sqlite3"
   ]
 }

--- a/src/lib/__snapshots__/contentHash.test.ts.snap
+++ b/src/lib/__snapshots__/contentHash.test.ts.snap
@@ -1,7 +1,5 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`calculateContentHash falls back to whole-file read when stat/read fail 1`] = `"sha256|BYTESv1|bef57ec7f53a6d40beb640a780a639c83bc29ac8a9816f1fc6c5c6dcd93c4721"`;
+exports[`calculateContentHash falls back to whole-file read when stat/read fail 1`] = `"sha256|f2e2c6db1745cc40df646dc40c385487c36e4ceb3f1d5c8d6ad1f7620af1ebae"`;
 
-exports[`calculateContentHash hashes images via IMGv1-RGBA scheme with canonical pixels 1`] = `"sha256|IMGv1-RGBA|8d48680f2defa6ce83cef6bfc64dbdf8b2f5a510274989cc741f4676e8d24bb0"`;
-
-exports[`calculateContentHash hashes non-images via BYTESv1 scheme using streaming 1`] = `"sha256|BYTESv1|c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2"`;
+exports[`calculateContentHash hashes via streaming 1`] = `"sha256|c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2"`;

--- a/src/lib/contentHash.test.ts
+++ b/src/lib/contentHash.test.ts
@@ -5,47 +5,26 @@ type RNFSMocks = {
   rnfsRead: jest.Mock
   rnfsReadFile: jest.Mock
 }
-type SkiaMocks = { makeImageFromEncoded: jest.Mock }
 
-function getMocks(): { rnfs: RNFSMocks; skia: SkiaMocks } {
+function getMocks(): { rnfs: RNFSMocks } {
   const rnfs = (global as unknown as { __rnfs: RNFSMocks }).__rnfs
-  const skia = (global as unknown as { __skia: SkiaMocks }).__skia
-  return { rnfs, skia }
+  return { rnfs }
 }
 
 beforeEach(() => {
-  const { rnfs, skia } = getMocks()
+  const { rnfs } = getMocks()
   rnfs.rnfsStat.mockReset()
   rnfs.rnfsRead.mockReset()
   rnfs.rnfsReadFile.mockReset()
-  skia.makeImageFromEncoded.mockReset()
 })
 
 describe('calculateContentHash', () => {
-  it('hashes images via IMGv1-RGBA scheme with canonical pixels', async () => {
-    // Arrange image decode path.
-    const { rnfs, skia } = getMocks()
-    rnfs.rnfsReadFile.mockResolvedValueOnce(
-      Buffer.from('fake-image').toString('base64')
-    )
-    skia.makeImageFromEncoded.mockReturnValueOnce({
-      width: () => 2,
-      height: () => 1,
-      // Two pixels (RGBA per pixel): [255,0,0,255] [0,255,0,255]
-      readPixels: () => new Uint8Array([255, 0, 0, 255, 0, 255, 0, 255]),
-    })
-
-    const res = await calculateContentHash('file:///test.heic')
-    expect(res).toMatchSnapshot()
-  })
-
-  it('hashes non-images via BYTESv1 scheme using streaming', async () => {
+  it('hashes via streaming', async () => {
     // Arrange non-image path: force decode to null and stream bytes.
-    const { rnfs, skia } = getMocks()
+    const { rnfs } = getMocks()
     rnfs.rnfsReadFile.mockResolvedValueOnce(
       Buffer.from('not-an-image').toString('base64')
     )
-    skia.makeImageFromEncoded.mockReturnValueOnce(null)
     rnfs.rnfsStat.mockResolvedValueOnce({ size: 6 })
     rnfs.rnfsRead.mockResolvedValueOnce(
       Buffer.from('foobar').toString('base64')
@@ -56,11 +35,10 @@ describe('calculateContentHash', () => {
   })
 
   it('falls back to whole-file read when stat/read fail', async () => {
-    const { rnfs, skia } = getMocks()
+    const { rnfs } = getMocks()
     rnfs.rnfsReadFile.mockResolvedValueOnce(
       Buffer.from('not-an-image').toString('base64')
     )
-    skia.makeImageFromEncoded.mockReturnValueOnce(null)
     rnfs.rnfsStat.mockRejectedValueOnce(new Error('no stat'))
     rnfs.rnfsRead.mockRejectedValueOnce(new Error('no read'))
     rnfs.rnfsReadFile.mockResolvedValueOnce(

--- a/src/lib/contentHash.ts
+++ b/src/lib/contentHash.ts
@@ -1,16 +1,12 @@
 import RNFS from 'react-native-fs'
 import QuickCrypto from 'react-native-quick-crypto'
-import { Skia, SkImage } from '@shopify/react-native-skia'
 import { Buffer } from 'buffer'
 
-export type HashResult =
-  | `sha256|IMGv1-RGBA|${string}`
-  | `sha256|BYTESv1|${string}`
+export type HashResult = `sha256|${string}`
 
 /**
  * Calculate a content hash for a file.
- * - Images: Pixel-hash in canonical sRGB RGBA8 to ignore EXIF/metadata differences.
- * - Others (video, audio, documents): Raw byte SHA-256 for exact file identity.
+ * - Raw byte SHA-256 for exact file identity.
  */
 export async function calculateContentHash(
   uri: string
@@ -18,65 +14,11 @@ export async function calculateContentHash(
   if (!uri || uri === '') {
     return null
   }
-  const img = await tryDecodeImage(uri)
-  if (img) {
-    const hex = await hashImagePixels(img)
-    return `sha256|IMGv1-RGBA|${hex}`
-  }
   const hex = await sha256File(uri)
-  return `sha256|BYTESv1|${hex}`
+  return `sha256|${hex}`
 }
 
-/** Try to decode with Skia. If decode fails, return null. */
-async function tryDecodeImage(uri: string): Promise<SkImage | null> {
-  try {
-    // Skia decode requires the full encoded image bytes.
-    const b64 = await RNFS.readFile(uri, 'base64')
-    const data = Skia.Data.fromBase64(b64)
-    const img = Skia.Image.MakeImageFromEncoded(data)
-    return img ?? null
-  } catch {
-    return null
-  }
-}
-
-/**
- * Canonical pixel hash for images.
- * - Decoded to sRGB RGBA8 by Skia, normalizing EXIF orientation and color space.
- * - Prelude encodes a stable header: tag + width + height + pixel format.
- * - Hash is SHA-256 over prelude || raw RGBA pixel data.
- */
-async function hashImagePixels(img: SkImage): Promise<string> {
-  const width = img.width()
-  const height = img.height()
-
-  // Read pixel data. Skia returns Uint8Array (RGBA8) or Float32Array (rare HDR paths).
-  const pixelData = img.readPixels()
-  if (!pixelData) throw new Error('readPixels failed')
-
-  // If Float32Array, reinterpret to bytes in native order.
-  const pixels =
-    pixelData instanceof Uint8Array
-      ? pixelData
-      : new Uint8Array(pixelData.buffer)
-
-  // Build stable prelude: "IMG1" + width/height (u32 LE) + tag "RGBA".
-  const prelude = new Uint8Array(4 + 4 + 4 + 4)
-  prelude.set([0x49, 0x4d, 0x47, 0x31], 0) // "IMG1".
-  new DataView(prelude.buffer).setUint32(4, width, true)
-  new DataView(prelude.buffer).setUint32(8, height, true)
-  prelude.set([0x52, 0x47, 0x42, 0x41], 12) // "RGBA".
-
-  const h = QuickCrypto.createHash('sha256')
-  const preludeBuf = Buffer.from(prelude)
-  h.update(sliceBuffer(preludeBuf))
-
-  const pixelsBuf = Buffer.from(pixels)
-  h.update(sliceBuffer(pixelsBuf))
-  return h.digest('hex')
-}
-
-/** Streamed SHA-256 for non-images and big files. */
+/** Streamed SHA-256. */
 async function sha256File(uri: string): Promise<string> {
   const h = QuickCrypto.createHash('sha256')
   const chunkSize = 1 * 1024 * 1024 // 1MB


### PR DESCRIPTION
- Remove the custom image hashing that normalized metadata in favor of consistent sha256 across all files.
- Instead just request originals and full metadata from the platform at all import points - ideally that gives us stable/consistent enough file and meta data.
- The custom hash would not have helped in cases where the platform transcodes anyway.