### PR TITLE
feat: reset data on db error button

### DIFF
--- a/src/components/LibraryLocalResetButton.tsx
+++ b/src/components/LibraryLocalResetButton.tsx
@@ -1,0 +1,38 @@
+import { Button } from './Button'
+import { Alert } from 'react-native'
+import { resetData } from '../stores/app'
+import { librarySwr } from '../stores/library'
+
+/**
+ * Button to reset the database and resync from the indexer.
+ * This button should almost never be shown to the user, only
+ * when there is a database query issue which should only
+ * be on test and dev builds.
+ */
+export function LibraryLocalResetButton() {
+  return (
+    <Button
+      variant="danger"
+      style={{ width: '100%', marginTop: 12 }}
+      onPress={() => {
+        Alert.alert(
+          'Reset Data',
+          'This will reset your library and resync from the indexer. This cannot be undone and you will lose any files that have not been uploaded. Continue?',
+          [
+            { text: 'Cancel', style: 'cancel' },
+            {
+              text: 'Reset',
+              style: 'destructive',
+              onPress: async () => {
+                await resetData()
+                librarySwr.triggerChange()
+              },
+            },
+          ]
+        )
+      }}
+    >
+      Reset library
+    </Button>
+  )
+}

--- a/src/screens/LibraryScreen.tsx
+++ b/src/screens/LibraryScreen.tsx
@@ -16,6 +16,7 @@ import { LibraryControlBar } from '../components/LibraryControlBar'
 import { type NativeStackScreenProps } from '@react-navigation/native-stack'
 import { IconButton } from '../components/IconButton'
 import { SettingsIcon } from 'lucide-react-native'
+import { LibraryLocalResetButton } from '../components/LibraryLocalResetButton'
 
 type Props = NativeStackScreenProps<MainStackParamList, 'LibraryHome'>
 
@@ -123,6 +124,7 @@ export function LibraryScreen({ route, navigation }: Props) {
                 ? files.error.message
                 : 'No files matching the selected filters.'}
             </Text>
+            {files.error ? <LibraryLocalResetButton /> : null}
           </View>
         )
       ) : (

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -62,18 +62,27 @@ export async function onboardIndexer(indexerURL: string): Promise<ConnectResult>
   return tryToConnectAndSet(indexerURL)
 }
 
-export function shutdownApp() {
+function cancelAllTransfers() {
   cancelAllUploads()
   cancelAllDownloads()
 }
 
-export async function resetApp() {
+export function shutdownApp() {
+  cancelAllTransfers()
+}
+
+export async function resetData() {
   await deleteAllFileRecords()
   await resetDb()
+  await resetSyncDownCursor()
+  cancelAllTransfers()
+}
+
+export async function resetApp() {
+  await resetData()
   await setRecoveryPhrase('')
   await setHasOnboarded(false)
   await resetSdk()
-  await resetSyncDownCursor()
   await resetPhotosNewCursor()
   await resetPhotosArchiveCursor()
 }


### PR DESCRIPTION
- This adds a reset library button to the library screen that shows if there is an error. There is only ever an error if the database query returns an error. In production this should never show, but during development if schema is out of sync this is a convenient way of seeing that and quickly reseting things.

![Screenshot 2025-11-03 at 1.41.56 PM.png](https://app.graphite.dev/user-attachments/assets/d5242322-bfb3-40c4-9a62-458c9a33d5f6.png)![Screenshot 2025-11-03 at 1.41.47 PM.png](https://app.graphite.dev/user-attachments/assets/555067f2-bd3b-45c5-9969-ed4043675a61.png)

