### PR TITLE
feat: display media library permissions

### DIFF
--- a/src/components/SettingsAdvancedSync.tsx
+++ b/src/components/SettingsAdvancedSync.tsx
@@ -17,8 +17,8 @@ export function SettingsAdvancedSync() {
     <RowGroup title="Advanced Sync">
       <InfoCard>
         <LabeledValueRow
-          label="Automatically upload files to network"
-          labelWidth={300}
+          label="Upload files to network"
+          labelWidth={250}
           value={
             <Switch
               value={autoScan.data ?? false}
@@ -27,8 +27,8 @@ export function SettingsAdvancedSync() {
           }
         />
         <LabeledValueRow
-          label="Automatically sync with your other devices"
-          labelWidth={300}
+          label="Sync with other devices"
+          labelWidth={250}
           value={
             <Switch
               value={autoSync.data ?? false}

--- a/src/components/SettingsSyncPhotos.tsx
+++ b/src/components/SettingsSyncPhotos.tsx
@@ -1,4 +1,4 @@
-import { Switch } from 'react-native'
+import { Linking, StyleSheet, Switch } from 'react-native'
 import { InfoCard } from './InfoCard'
 import { LabeledValueRow } from './LabeledValueRow'
 import { Button } from './Button'
@@ -11,20 +11,40 @@ import {
   usePhotosArchiveCursor,
   restartPhotosArchiveCursor,
 } from '../managers/syncPhotosArchive'
+import { useMediaLibraryPermissions } from '../lib/mediaLibraryPermissions'
+import { Text } from 'react-native'
+import { colors } from '../styles/colors'
 
 export function SettingsSyncPhotos() {
   const autoSyncNew = useAutoSyncNewPhotos()
   const photosArchiveCursor = usePhotosArchiveCursor()
   const photosArchiveInProgress = (photosArchiveCursor.data ?? 0) > 0
+  const { isSomeAccess, accessLabel, color } = useMediaLibraryPermissions()
+
+  const isDisabled = !isSomeAccess
 
   return (
-    <RowGroup title="Photos">
+    <RowGroup
+      title="Photos"
+      indicator={
+        <Text
+          accessibilityRole="link"
+          onPress={() => {
+            Linking.openSettings().catch(() => {})
+          }}
+          style={[styles.link, { color }]}
+        >
+          {accessLabel}
+        </Text>
+      }
+    >
       <InfoCard>
         <LabeledValueRow
-          label="Automatically import new photos"
-          labelWidth={300}
+          label="Import new photos"
+          labelWidth={250}
           value={
             <Switch
+              disabled={isDisabled}
               value={autoSyncNew.data ?? false}
               onValueChange={toggleAutoSyncNewPhotos}
             />
@@ -33,7 +53,7 @@ export function SettingsSyncPhotos() {
       </InfoCard>
       <Button
         style={{ marginTop: 10 }}
-        disabled={photosArchiveInProgress}
+        disabled={photosArchiveInProgress || isDisabled}
         onPress={() => {
           void restartPhotosArchiveCursor()
         }}
@@ -43,3 +63,9 @@ export function SettingsSyncPhotos() {
     </RowGroup>
   )
 }
+
+const styles = StyleSheet.create({
+  link: {
+    color: colors.accentPrimary,
+  },
+})

--- a/src/lib/mediaLibraryPermissions.ts
+++ b/src/lib/mediaLibraryPermissions.ts
@@ -1,0 +1,77 @@
+import * as MediaLibrary from 'expo-media-library'
+import { Linking, Platform } from 'react-native'
+import { useCallback, useMemo } from 'react'
+import { useFocusEffect } from '@react-navigation/native'
+import useSWR from 'swr'
+import { palette } from '../styles/colors'
+
+export async function ensureMediaLibraryPermission(): Promise<boolean> {
+  const res = await MediaLibrary.requestPermissionsAsync()
+  return res.granted === true
+}
+
+export function useMediaLibraryPermissions() {
+  const perms = useSWR(['mediaLibrary', 'permissions'], () =>
+    MediaLibrary.getPermissionsAsync()
+  )
+
+  useFocusEffect(
+    useCallback(() => {
+      void perms.mutate()
+    }, [perms.mutate])
+  )
+
+  const photosAccess: 'all' | 'limited' | 'none' | 'unknown' = useMemo(() => {
+    const p = perms.data
+    if (!p) return 'unknown'
+    if (Platform.OS === 'ios') {
+      const ap = p.accessPrivileges as 'all' | 'limited' | 'none' | undefined
+      if (ap) return ap
+      return p.granted ? 'all' : 'none'
+    }
+    return p.granted ? 'all' : 'none'
+  }, [perms.data])
+
+  const isFullAccess = photosAccess === 'all'
+  const isSomeAccess = photosAccess === 'limited' || photosAccess === 'all'
+  const accessLabel =
+    photosAccess === 'all'
+      ? 'Full access'
+      : photosAccess === 'limited'
+      ? 'Access limited (selected photos)'
+      : photosAccess === 'none'
+      ? 'No access'
+      : 'Unknown access'
+  const color =
+    photosAccess === 'all'
+      ? palette.blue[400]
+      : photosAccess === 'limited'
+      ? palette.yellow[400]
+      : photosAccess === 'none'
+      ? palette.red[500]
+      : palette.gray[500]
+
+  const manageAccess = useCallback(async () => {
+    // Open app settings to adjust photo access for this app.
+    // Try the URL scheme first on iOS, then generic openSettings as a fallback.
+    if (Platform.OS === 'ios') {
+      try {
+        await Linking.openURL('app-settings:')
+        return
+      } catch {}
+    }
+    try {
+      await Linking.openSettings()
+      return
+    } catch {}
+  }, [])
+
+  return {
+    photosAccess,
+    isFullAccess,
+    isSomeAccess,
+    accessLabel,
+    color,
+    manageAccess,
+  }
+}

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -1,7 +1,0 @@
-import * as MediaLibrary from 'expo-media-library'
-import { logger } from './logger'
-
-export async function ensurePhotosPermission(): Promise<boolean> {
-  const res = await MediaLibrary.requestPermissionsAsync()
-  return res.granted === true
-}

--- a/src/managers/syncNewPhotos.test.ts
+++ b/src/managers/syncNewPhotos.test.ts
@@ -1,7 +1,7 @@
 import { SYNC_NEW_PHOTOS_INTERVAL } from '../config'
 import { initSyncNewPhotos } from './syncNewPhotos'
 import * as MediaLibrary from 'expo-media-library'
-import { ensurePhotosPermission } from '../lib/permissions'
+import { ensureMediaLibraryPermission } from '../lib/mediaLibraryPermissions'
 import { processAssets } from '../lib/processAssets'
 
 jest.useFakeTimers()
@@ -11,8 +11,8 @@ jest.mock('expo-media-library', () => ({
   SortBy: { creationTime: 'creationTime' },
   MediaType: { photo: 'photo', video: 'video' },
 }))
-jest.mock('../lib/permissions', () => ({
-  ensurePhotosPermission: jest.fn(),
+jest.mock('../lib/mediaLibraryPermissions', () => ({
+  ensureMediaLibraryPermission: jest.fn(),
 }))
 jest.mock('../lib/processAssets', () => ({
   processAssets: jest.fn(),
@@ -65,11 +65,13 @@ describe('syncNewPhotos', () => {
   })
 
   it('iterates forward adding all new files', async () => {
-    const ensurePhotosPermissionMock = jest.mocked(ensurePhotosPermission)
+    const ensureMediaLibraryPermissionMock = jest.mocked(
+      ensureMediaLibraryPermission
+    )
     const getAssetsAsyncMock = jest.mocked(MediaLibrary.getAssetsAsync)
     const processAssetsMock = jest.mocked(processAssets)
 
-    ensurePhotosPermissionMock.mockResolvedValue(true)
+    ensureMediaLibraryPermissionMock.mockResolvedValue(true)
     getAssetsAsyncMock
       .mockResolvedValueOnce(
         page([asset('a1', '1.jpg', 1000), asset('a2', '2.jpg', 2000)])

--- a/src/managers/syncNewPhotos.ts
+++ b/src/managers/syncNewPhotos.ts
@@ -12,12 +12,12 @@ import {
   setSecureStoreBoolean,
   setSecureStoreNumber,
 } from '../stores/secureStore'
-import { ensurePhotosPermission } from '../lib/permissions'
+import { ensureMediaLibraryPermission } from '../lib/mediaLibraryPermissions'
 
 const PAGE_SIZE = 200
 
 async function workForward(): Promise<void> {
-  if (!(await ensurePhotosPermission())) return
+  if (!(await ensureMediaLibraryPermission())) return
   const cursor = await getPhotosNewCursor()
 
   try {

--- a/src/managers/syncPhotosArchive.test.ts
+++ b/src/managers/syncPhotosArchive.test.ts
@@ -1,6 +1,6 @@
 import { SYNC_PHOTOS_ARCHIVE_INTERVAL } from '../config'
 import * as MediaLibrary from 'expo-media-library'
-import { ensurePhotosPermission } from '../lib/permissions'
+import { ensureMediaLibraryPermission } from '../lib/mediaLibraryPermissions'
 import { processAssets } from '../lib/processAssets'
 import {
   initSyncPhotosArchive,
@@ -17,9 +17,9 @@ jest.mock('expo-media-library', () => ({
   SortBy: { creationTime: 'creationTime' },
   MediaType: { photo: 'photo', video: 'video' },
 }))
-jest.mock('../lib/permissions', () => ({
+jest.mock('../lib/mediaLibraryPermissions', () => ({
   __esModule: true,
-  ensurePhotosPermission: jest.fn(),
+  ensureMediaLibraryPermission: jest.fn(),
 }))
 jest.mock('../lib/processAssets', () => ({
   __esModule: true,
@@ -69,11 +69,13 @@ describe('syncPhotosArchive', () => {
   })
 
   it('iterates backward adding files until exhausting the archive', async () => {
-    const ensurePhotosPermissionMock = jest.mocked(ensurePhotosPermission)
+    const ensureMediaLibraryPermissionMock = jest.mocked(
+      ensureMediaLibraryPermission
+    )
     const getAssetsAsyncMock = jest.mocked(MediaLibrary.getAssetsAsync)
     const processAssetsMock = jest.mocked(processAssets)
 
-    ensurePhotosPermissionMock.mockResolvedValue(true)
+    ensureMediaLibraryPermissionMock.mockResolvedValue(true)
 
     getAssetsAsyncMock.mockImplementation(
       async (

--- a/src/managers/syncPhotosArchive.ts
+++ b/src/managers/syncPhotosArchive.ts
@@ -10,12 +10,12 @@ import {
 } from '../stores/secureStore'
 import { createServiceInterval } from '../lib/serviceInterval'
 import { SYNC_PHOTOS_ARCHIVE_INTERVAL } from '../config'
-import { ensurePhotosPermission } from '../lib/permissions'
+import { ensureMediaLibraryPermission } from '../lib/mediaLibraryPermissions'
 
 const PAGE_SIZE = 200
 
 export async function workBackward(): Promise<void> {
-  if (!(await ensurePhotosPermission())) return
+  if (!(await ensureMediaLibraryPermission())) return
   const cursor = await getPhotosArchiveCursor()
 
   try {


### PR DESCRIPTION
- The Photos Sync setting now shows the current state of the media library permissions, tapping the indicator opens the platforms setting screen where the permission level can be changed.

![Screenshot 2025-11-03 at 2.36.59 PM.png](https://app.graphite.dev/user-attachments/assets/391dc2e9-0129-496a-b73b-929ef74e717e.png)![Screenshot 2025-11-03 at 2.36.48 PM.png](https://app.graphite.dev/user-attachments/assets/752eda25-43cd-4753-ac3f-601544f43831.png)![Screenshot 2025-11-03 at 2.26.44 PM.png](https://app.graphite.dev/user-attachments/assets/2c4c3f43-6ac0-43b9-84fb-396378b363f3.png)

