### PR TITLE
feat: app status sheet

### DIFF
--- a/src/components/LibraryAppStatusIcon.tsx
+++ b/src/components/LibraryAppStatusIcon.tsx
@@ -1,0 +1,44 @@
+import { View, Text, StyleSheet, Pressable } from 'react-native'
+import { overlay, palette } from '../styles/colors'
+import { useAppStatus } from '../hooks/useAppStatus'
+import { openSheet } from '../stores/sheets'
+
+export function LibraryAppStatusIcon() {
+  const appStatus = useAppStatus()
+  return (
+    appStatus.visible && (
+      <View style={styles.statusPillContainer}>
+        <Pressable
+          accessibilityRole="button"
+          onPress={() => openSheet('libraryStatus')}
+          style={styles.statusPill}
+        >
+          {appStatus.icon}
+          {appStatus.hint ? (
+            <Text style={styles.statusPillText}>{appStatus.hint}</Text>
+          ) : null}
+        </Pressable>
+      </View>
+    )
+  )
+}
+
+const styles = StyleSheet.create({
+  statusPillContainer: {
+    position: 'relative',
+  },
+  statusPill: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    gap: 4,
+    flexDirection: 'row',
+    borderRadius: 18,
+    overflow: 'hidden',
+    backgroundColor: overlay.pill,
+  },
+  statusPillText: {
+    color: palette.gray[50],
+    fontSize: 10,
+    fontWeight: '600',
+  },
+})

--- a/src/components/LibraryStatusSheet.tsx
+++ b/src/components/LibraryStatusSheet.tsx
@@ -1,0 +1,144 @@
+import { View, Text, StyleSheet } from 'react-native'
+import ActionSheet from './ActionSheet'
+import { InfoCard } from './InfoCard'
+import { RowGroup } from './Group'
+import { LabeledValueRow } from './LabeledValueRow'
+import { palette } from '../styles/colors'
+import { useIsConnected } from '../stores/sdk'
+import { useIsOnline } from '../hooks/useIsOnline'
+import { useUploadScannerStatus } from '../managers/uploadScanner'
+import { closeSheet, useSheetOpen } from '../stores/sheets'
+
+export function LibraryStatusSheet() {
+  const isConnected = useIsConnected()
+  const isOnline = useIsOnline()
+  const uploadsProgress = useUploadScannerStatus()
+
+  const uploadedCount = Math.max(
+    0,
+    (uploadsProgress.total ?? 0) - (uploadsProgress.remaining ?? 0)
+  )
+
+  const isOpen = useSheetOpen('libraryStatus')
+
+  return (
+    <ActionSheet
+      visible={isOpen}
+      onRequestClose={() => closeSheet()}
+      contentStyle={styles.sheetContent}
+    >
+      <View style={styles.sheetInnerDark}>
+        <View style={styles.sheetHeaderRow}>
+          <Text style={styles.sheetTitle}>App status</Text>
+        </View>
+
+        <RowGroup title="Connections" style={styles.groupSpacing}>
+          <InfoCard>
+            <LabeledValueRow
+              label="Internet"
+              align="right"
+              value={
+                <View style={styles.valueRight}>
+                  <View style={{ flex: 1 }} />
+                  <Text style={styles.valueText}>
+                    {typeof isOnline.data === 'boolean'
+                      ? isOnline.data
+                        ? 'Online'
+                        : 'Offline'
+                      : '—'}
+                  </Text>
+                  <View
+                    style={isOnline.data ? styles.dotOnline : styles.dotOffline}
+                  />
+                </View>
+              }
+              canCopy={false}
+            />
+            <LabeledValueRow
+              label="Indexer"
+              value={
+                <View style={styles.valueRight}>
+                  <View style={{ flex: 1 }} />
+                  <Text style={styles.valueText}>
+                    {isConnected ? 'Connected' : 'Disconnected'}
+                  </Text>
+                  <View
+                    style={isConnected ? styles.dotOnline : styles.dotOffline}
+                  />
+                </View>
+              }
+              showDividerTop
+              canCopy={false}
+            />
+          </InfoCard>
+        </RowGroup>
+
+        <RowGroup
+          title="Uploads"
+          style={styles.groupSpacing}
+          indicator={
+            <Text style={styles.groupIndicator}>
+              {uploadsProgress.percentComplete}
+            </Text>
+          }
+        >
+          <InfoCard>
+            <LabeledValueRow
+              label="Uploaded"
+              value={`${uploadedCount} / ${uploadsProgress.total}`}
+              canCopy={false}
+            />
+          </InfoCard>
+        </RowGroup>
+      </View>
+    </ActionSheet>
+  )
+}
+
+const styles = StyleSheet.create({
+  sheetContent: {
+    paddingTop: 16,
+    paddingBottom: 48,
+    paddingHorizontal: 12,
+    backgroundColor: palette.gray[950],
+  },
+  sheetInnerDark: {
+    gap: 14,
+  },
+  sheetHeaderRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 10,
+  },
+  sheetTitle: {
+    color: palette.gray[50],
+    fontSize: 20,
+    fontWeight: '900',
+    letterSpacing: 0.2,
+  },
+  groupSpacing: { marginTop: 8 },
+  groupIndicator: { color: palette.gray[300], fontSize: 12, fontWeight: '700' },
+  valueRight: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    justifyContent: 'flex-end',
+    flex: 1,
+  },
+  valueText: { color: palette.gray[100] },
+  dotOnline: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: palette.green[500],
+  },
+  dotOffline: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: palette.red[500],
+  },
+})
+
+export default LibraryStatusSheet

--- a/src/hooks/useAppStatus.tsx
+++ b/src/hooks/useAppStatus.tsx
@@ -1,5 +1,11 @@
 import React from 'react'
-import { TriangleAlertIcon, UploadCloudIcon } from 'lucide-react-native'
+import {
+  CheckCheckIcon,
+  CheckIcon,
+  CircleCheckIcon,
+  TriangleAlertIcon,
+  UploadCloudIcon,
+} from 'lucide-react-native'
 import { palette } from '../styles/colors'
 import { useIsConnected } from '../stores/sdk'
 import { useIsInitializing } from '../stores/app'
@@ -9,7 +15,6 @@ import { useIsOnline } from './useIsOnline'
 
 export type AppStatus = {
   visible: boolean
-  message: string
   icon: React.ReactElement | null
   hint?: string
   level: 'info' | 'warning'
@@ -23,13 +28,12 @@ export function useAppStatus(): AppStatus {
   const isOnline = useIsOnline()
 
   if (!hasOnboarded || isInitializing) {
-    return { visible: false, message: '', icon: null, level: 'info' }
+    return { visible: false, icon: null, level: 'info' }
   }
 
   if (typeof isOnline.data === 'boolean' && !isOnline.data) {
     return {
       visible: true,
-      message: 'No internet connection',
       icon: <TriangleAlertIcon size={14} color={palette.yellow[400]} />,
       level: 'warning',
     }
@@ -38,7 +42,6 @@ export function useAppStatus(): AppStatus {
   if (!isConnected) {
     return {
       visible: true,
-      message: 'Indexer not connected',
       icon: <TriangleAlertIcon size={14} color={palette.yellow[400]} />,
       level: 'warning',
     }
@@ -47,12 +50,15 @@ export function useAppStatus(): AppStatus {
   if (uploadsProgress.show) {
     return {
       visible: true,
-      message: 'Uploading files to network',
       icon: <UploadCloudIcon size={14} color={palette.gray[50]} />,
       hint: `${uploadsProgress.percentComplete}`,
       level: 'info',
     }
   }
 
-  return { visible: false, message: '', icon: null, level: 'info' }
+  return {
+    visible: true,
+    icon: <CircleCheckIcon size={14} color={palette.green[500]} />,
+    level: 'info',
+  }
 }

--- a/src/managers/uploadScanner.ts
+++ b/src/managers/uploadScanner.ts
@@ -69,10 +69,9 @@ export function useUploadScannerStatus(): {
   const activeProgress = activeUploads
     .map((u) => u.progress)
     .reduce((a, b) => a + b, 0)
-  const percentComplete =
-    localOnlyCount && totalCount
-      ? (activeProgress + uploadedCount) / totalCount
-      : 0
+  const percentComplete = totalCount
+    ? (activeProgress + uploadedCount) / totalCount
+    : 0
 
   return {
     show: isEnabled && !!localOnlyCount,

--- a/src/screens/LibraryScreen.tsx
+++ b/src/screens/LibraryScreen.tsx
@@ -8,24 +8,25 @@ import { type MainStackParamList } from '../stacks/types'
 import { type FileRecord, useFileCount } from '../stores/files'
 import { useFileList, useLibrary, type Category } from '../stores/library'
 import { FileList } from '../components/FileList'
-import { useAppStatus } from '../hooks/useAppStatus'
 import { AddFileActionSheet } from '../components/AddFileActionSheet'
-import { ExpandableBadge } from '../components/ExpandableBadge'
+import LibraryStatusSheet from '../components/LibraryStatusSheet'
+import { useState } from 'react'
 import { useLibraryViewMode } from '../stores/settings'
 import { LibraryControlBar } from '../components/LibraryControlBar'
 import { type NativeStackScreenProps } from '@react-navigation/native-stack'
 import { IconButton } from '../components/IconButton'
 import { SettingsIcon } from 'lucide-react-native'
 import { LibraryLocalResetButton } from '../components/LibraryLocalResetButton'
+import { LibraryAppStatusIcon } from '../components/LibraryAppStatusIcon'
 
 type Props = NativeStackScreenProps<MainStackParamList, 'LibraryHome'>
 
 export function LibraryScreen({ route, navigation }: Props) {
+  const [statusSheetVisible, setStatusSheetVisible] = useState<boolean>(false)
   const viewMode = useLibraryViewMode()
   const { selectedCategories, searchQuery } = useLibrary()
   const files = useFileList()
   const fileCount = useFileCount()
-  const appStatus = useAppStatus()
   const handleOpenDetail = useCallback(
     (file: FileRecord) => {
       navigation.navigate('FileDetail', { id: file.id })
@@ -79,20 +80,7 @@ export function LibraryScreen({ route, navigation }: Props) {
           </Text>
         </View>
         <View style={styles.buttonRow}>
-          {appStatus.visible && (
-            <View style={styles.statusPillContainer}>
-              <ExpandableBadge
-                label={appStatus.message}
-                hint={appStatus.hint}
-                size={12}
-                interactive={true}
-                backgroundColor={overlay.pill}
-                borderColor={overlay.pill}
-              >
-                {appStatus.icon}
-              </ExpandableBadge>
-            </View>
-          )}
+          <LibraryAppStatusIcon />
           <IconButton
             onPress={() => navigation.navigate('SettingsTab' as never)}
             style={[styles.headerIcon, { paddingHorizontal: 4 }]}
@@ -141,6 +129,7 @@ export function LibraryScreen({ route, navigation }: Props) {
         </View>
       )}
       <AddFileActionSheet />
+      <LibraryStatusSheet />
       <LibraryControlBar navigation={navigation} route={route} />
     </View>
   )
@@ -178,37 +167,6 @@ const styles = StyleSheet.create({
     marginTop: 4,
   },
   headerIcon: { paddingVertical: 6, paddingHorizontal: 8 },
-  blurPillWrap: {
-    position: 'relative',
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    overflow: 'hidden',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  blurShade: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: overlay.pill,
-  },
-  statusPillContainer: {
-    position: 'relative',
-  },
-  statusPill: {
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    gap: 4,
-    flexDirection: 'row',
-    borderRadius: 18,
-    overflow: 'hidden',
-    backgroundColor: overlay.pill,
-  },
-  statusPillText: {
-    color: palette.gray[50],
-    fontSize: 10,
-    fontWeight: '600',
-  },
-
   emptyImage: { width: 140, height: 140 },
   emptyWrap: {
     flex: 1,


### PR DESCRIPTION
- Tapping the app status icon now opens a sheet that contains all the info reported across different statuses.

![Screenshot 2025-11-04 at 4.54.56 PM.png](https://app.graphite.dev/user-attachments/assets/adbfd4c9-fe33-43da-8053-ad8f6dfecb33.png)

