### PR TITLE
fix: stream local id uploads from copy

### DIFF
--- a/src/managers/uploadToNetwork.ts
+++ b/src/managers/uploadToNetwork.ts
@@ -1,5 +1,10 @@
 import { Sdk, encodedSize } from 'react-native-sia'
 import { File } from 'expo-file-system'
+import {
+  getCacheTmpUploadFileForId,
+  getLocalUri,
+  removeCacheTmpUploadFileForId,
+} from '../stores/fileCache'
 import { updateUploadProgress } from '../stores/uploads'
 import { encodeFileMetadata } from '../encoding/fileMetadata'
 import { logger } from '../lib/logger'
@@ -26,8 +31,24 @@ export async function uploadToNetwork(params: {
     return
   }
 
-  const f = new File(fileUri)
-  const stream = f.stream()
+  let stream: ReadableStream<Uint8Array<ArrayBuffer>>
+  if (file.localId) {
+    logger.log(
+      'uploadToNetwork',
+      'file is a localId asset, streaming from tmp file...'
+    )
+    const localUri = await getLocalUri(file.localId)
+    if (!localUri) {
+      throw new Error('Local URI not found')
+    }
+    const source = new File(localUri)
+    const tmp = await getCacheTmpUploadFileForId(file)
+    source.copy(tmp)
+    stream = tmp.stream()
+  } else {
+    logger.log('uploadToNetwork', 'file is in app cache, streaming directly...')
+    stream = new File(fileUri).stream()
+  }
 
   const totalEncodedSize = encodedSize(
     BigInt(fileSize),
@@ -109,4 +130,7 @@ export async function uploadToNetwork(params: {
   await upsertLocalObject(localObject)
 
   signal.removeEventListener('abort', onAbort)
+  if (file.localId) {
+    await removeCacheTmpUploadFileForId(file)
+  }
 }

--- a/src/stores/fileCache.ts
+++ b/src/stores/fileCache.ts
@@ -22,6 +22,23 @@ export async function ensureCacheDir(): Promise<void> {
   }
 }
 
+export async function getCacheTmpUploadFileForId(
+  file: FileCopyInfo
+): Promise<File> {
+  await removeCacheTmpUploadFileForId(file)
+  return new File(CACHE_DIR, `${file.id}.upload.tmp`)
+}
+
+export async function removeCacheTmpUploadFileForId(
+  file: FileCopyInfo
+): Promise<void> {
+  const tmp = new File(CACHE_DIR, `${file.id}.upload.tmp`)
+  try {
+    const exists = tmp.info().exists
+    if (exists) tmp.delete()
+  } catch {}
+}
+
 async function getCacheFileForId(file: FileCopyInfo): Promise<File> {
   return new File(CACHE_DIR, `${file.id}${extFromMime(file.type)}`)
 }


### PR DESCRIPTION
- iOS does not allow streaming a PHAsset directly.
- To work around this, if we are uploading from a Photos asset (local ID), we copy the file before creating the stream.