### PR TITLE
feat: add archive sync controls

### DIFF
--- a/src/components/SettingsSyncPhotos.tsx
+++ b/src/components/SettingsSyncPhotos.tsx
@@ -10,6 +10,8 @@ import {
 import {
   usePhotosArchiveCursor,
   restartPhotosArchiveCursor,
+  useAutoSyncPhotosArchive,
+  toggleAutoSyncPhotosArchive,
 } from '../managers/syncPhotosArchive'
 import { useMediaLibraryPermissions } from '../lib/mediaLibraryPermissions'
 import { Text } from 'react-native'
@@ -17,11 +19,16 @@ import { colors } from '../styles/colors'
 
 export function SettingsSyncPhotos() {
   const autoSyncNew = useAutoSyncNewPhotos()
+  const autoSyncPhotosArchive = useAutoSyncPhotosArchive()
   const photosArchiveCursor = usePhotosArchiveCursor()
-  const photosArchiveInProgress = (photosArchiveCursor.data ?? 0) > 0
+  const cursorValue = photosArchiveCursor.data ?? 0
+  const photosArchiveInProgress = cursorValue > 0
   const { isSomeAccess, accessLabel, color } = useMediaLibraryPermissions()
 
-  const isDisabled = !isSomeAccess
+  const isPhotosAccessDisabled = !isSomeAccess
+  const archiveDateLabel = formatArchiveCursor(cursorValue)
+  const syncPhotosArchiveControlsDisabled =
+    isPhotosAccessDisabled || !autoSyncPhotosArchive.data
 
   return (
     <RowGroup
@@ -44,21 +51,54 @@ export function SettingsSyncPhotos() {
           labelWidth={250}
           value={
             <Switch
-              disabled={isDisabled}
+              disabled={isPhotosAccessDisabled}
               value={autoSyncNew.data ?? false}
               onValueChange={toggleAutoSyncNewPhotos}
             />
           }
         />
       </InfoCard>
+      <InfoCard style={{ marginTop: 10 }}>
+        <LabeledValueRow
+          label="Import archive"
+          labelWidth={250}
+          value={
+            <Switch
+              disabled={isPhotosAccessDisabled}
+              value={autoSyncPhotosArchive.data ?? false}
+              onValueChange={toggleAutoSyncPhotosArchive}
+            />
+          }
+        />
+      </InfoCard>
+      {photosArchiveCursor.data && photosArchiveCursor.data > 0
+        ? archiveDateLabel && (
+            <Text
+              style={[
+                styles.info,
+                syncPhotosArchiveControlsDisabled
+                  ? styles.infoDisabled
+                  : undefined,
+              ]}
+            >{`Currently synced back to: ${archiveDateLabel} ${
+              !autoSyncPhotosArchive.data
+                ? '(paused)'
+                : photosArchiveInProgress
+                ? '(in progress)'
+                : ''
+            }`}</Text>
+          )
+        : null}
       <Button
         style={{ marginTop: 10 }}
-        disabled={photosArchiveInProgress || isDisabled}
+        disabled={syncPhotosArchiveControlsDisabled}
         onPress={() => {
           void restartPhotosArchiveCursor()
         }}
       >
-        {photosArchiveInProgress ? 'Sync in progress' : 'Import photos library'}
+        {photosArchiveCursor.data && photosArchiveCursor.data > 0
+          ? 'Restart archive sync'
+          : 'Start archive sync'}
       </Button>
     </RowGroup>
   )
@@ -68,4 +108,28 @@ const styles = StyleSheet.create({
   link: {
     color: colors.accentPrimary,
   },
+  info: {
+    color: colors.textSecondary,
+    marginTop: 10,
+  },
+  infoDisabled: {
+    color: colors.textMuted,
+  },
 })
+
+function formatArchiveCursor(value: number): string | null {
+  // Always show a date; if value is not set or <= 0, use current time.
+  const ts = Number.isFinite(value) && value > 0 ? value : Date.now()
+  if (!Number.isFinite(ts)) return null
+  const d = new Date(ts)
+  if (Number.isNaN(d.getTime())) return null
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    }).format(d)
+  } catch {
+    return d.toDateString()
+  }
+}

--- a/src/managers/syncNewPhotos.ts
+++ b/src/managers/syncNewPhotos.ts
@@ -35,9 +35,10 @@ async function workForward(): Promise<void> {
       return
     }
     logger.log('[syncNewPhotos] batch size', page.assets.length)
-    await setPhotosNewCursor(
-      page.assets[page.assets.length - 1].creationTime ?? 0
-    )
+    const lastAssetCreationTime =
+      page.assets[page.assets.length - 1].creationTime
+    const nextTimestamp = lastAssetCreationTime ? lastAssetCreationTime + 1 : 0
+    await setPhotosNewCursor(nextTimestamp)
     const { files } = await processAssets(
       page.assets.map((asset) => ({
         id: asset.id,

--- a/src/managers/syncPhotosArchive.ts
+++ b/src/managers/syncPhotosArchive.ts
@@ -7,12 +7,14 @@ import { createGetterAndSWRHook } from '../lib/selectors'
 import {
   getSecureStoreNumber,
   setSecureStoreNumber,
+  getSecureStoreBoolean,
+  setSecureStoreBoolean,
 } from '../stores/secureStore'
 import { createServiceInterval } from '../lib/serviceInterval'
 import { SYNC_PHOTOS_ARCHIVE_INTERVAL } from '../config'
 import { ensureMediaLibraryPermission } from '../lib/mediaLibraryPermissions'
 
-const PAGE_SIZE = 200
+const PAGE_SIZE = 1
 
 export async function workBackward(): Promise<void> {
   if (!(await ensureMediaLibraryPermission())) return
@@ -34,9 +36,10 @@ export async function workBackward(): Promise<void> {
       return
     }
     logger.log('[syncPhotosArchive] batch size', page.assets.length)
-    await setPhotosArchiveCursor(
+    const lastAssetCreationTime =
       page.assets[page.assets.length - 1].creationTime ?? 0
-    )
+    const nextTimestamp = lastAssetCreationTime ? lastAssetCreationTime - 1 : 0
+    await setPhotosArchiveCursor(nextTimestamp)
     const { files } = await processAssets(
       page.assets.map((asset) => ({
         id: asset.id,
@@ -56,11 +59,27 @@ export async function workBackward(): Promise<void> {
 export const initSyncPhotosArchive = createServiceInterval({
   name: 'syncPhotosArchive',
   worker: workBackward,
-  getState: async () => (await getPhotosArchiveCursor()) > 0,
+  getState: async () => getAutoSyncPhotosArchive(),
   interval: SYNC_PHOTOS_ARCHIVE_INTERVAL,
 })
 
 const defaultValue = 0
+
+export const [getAutoSyncPhotosArchive, useAutoSyncPhotosArchive] =
+  createGetterAndSWRHook(getKey('autoSyncPhotosArchive'), () =>
+    getSecureStoreBoolean('autoSyncPhotosArchive', false)
+  )
+
+export async function setAutoSyncPhotosArchive(value: boolean) {
+  await setSecureStoreBoolean('autoSyncPhotosArchive', value)
+  triggerChange('autoSyncPhotosArchive')
+}
+
+export async function toggleAutoSyncPhotosArchive() {
+  const current = await getAutoSyncPhotosArchive()
+  const next = !current
+  await setAutoSyncPhotosArchive(next)
+}
 
 export const [getPhotosArchiveCursor, usePhotosArchiveCursor] =
   createGetterAndSWRHook(getKey('photosArchiveCursor'), () =>


### PR DESCRIPTION
- Add some visibility into the state of the archive sync.
- Also adds ability to pause/disable, restart.
- Photo sync cursors do not move forward and get stuck if the pages has 1 result. This PR also adds 1 ms to the timestamp to ensure it does not include the same item again.

![Screenshot 2025-11-05 at 9.06.40 AM.png](https://app.graphite.com/user-attachments/assets/d80261aa-0673-4ff9-a619-7d4180dc301c.png)