### PR TITLE
fix: archive cursor

### DIFF
--- a/src/managers/syncNewPhotos.ts
+++ b/src/managers/syncNewPhotos.ts
@@ -35,9 +35,10 @@ async function workForward(): Promise<void> {
       return
     }
     logger.log('[syncNewPhotos] batch size', page.assets.length)
-    await setPhotosNewCursor(
-      page.assets[page.assets.length - 1].creationTime ?? 0
-    )
+    const lastAssetCreationTime =
+      page.assets[page.assets.length - 1].creationTime
+    const nextTimestamp = lastAssetCreationTime ? lastAssetCreationTime + 1 : 0
+    await setPhotosNewCursor(nextTimestamp)
     const { files } = await processAssets(
       page.assets.map((asset) => ({
         id: asset.id,

--- a/src/managers/syncPhotosArchive.ts
+++ b/src/managers/syncPhotosArchive.ts
@@ -37,9 +37,10 @@ export async function workBackward(): Promise<void> {
       return
     }
     logger.log('[syncPhotosArchive] batch size', page.assets.length)
-    await setPhotosArchiveCursor(
+    const lastAssetCreationTime =
       page.assets[page.assets.length - 1].creationTime ?? 0
-    )
+    const nextTimestamp = lastAssetCreationTime ? lastAssetCreationTime - 1 : 0
+    await setPhotosArchiveCursor(nextTimestamp)
     const { files } = await processAssets(
       page.assets.map((asset) => ({
         id: asset.id,


### PR DESCRIPTION
- These cursors do not move forward and get stuck if the pages has 1 result. This adds 1 ms to the timestamp to ensure it does not include the same item again.