### PR TITLE
refactor: remove ScreenHeader topOffset negative paddding to align with settings gear icon

### DIFF
--- a/src/components/ScreenHeader.tsx
+++ b/src/components/ScreenHeader.tsx
@@ -18,7 +18,7 @@ export function ScreenHeader({
   zIndex = 10,
 }: Props) {
   const insets = useSafeAreaInsets()
-  const topOffset = Platform.OS === 'ios' && Platform.isPad ? 8 : -4
+  const topOffset = Platform.OS === 'ios' && Platform.isPad ? 8 : 0
   const paddingHorizontal = Platform.OS === 'ios' && Platform.isPad ? 18 : 16
   return (
     <View


### PR DESCRIPTION
[Screen Recording 2025-11-05 at 11.57.51 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/3aafdf09-9ff6-4b67-bcf5-34f574b8b0a0.mov" />](https://app.graphite.com/user-attachments/video/3aafdf09-9ff6-4b67-bcf5-34f574b8b0a0.mov)

