### PR TITLE
fix: ability to add videos

### DIFF
--- a/src/stores/fileCache.ts
+++ b/src/stores/fileCache.ts
@@ -118,10 +118,21 @@ export async function getLocalUri(
     const asset = await MediaLibrary.getAssetInfoAsync(localId, {
       shouldDownloadFromNetwork: true,
     })
-    return asset.localUri ?? null
+    return normalizeFsUri(asset.localUri)
   } catch (e) {
     return null
   }
+}
+
+/**
+ * Normalize the URI for a file. Remove the hash index if it exists.
+ * This is necessary because the MediaLibrary.getAssetInfoAsync() sometimes
+ * returns a URI with a hash index that is not valid for the File system API.
+ */
+function normalizeFsUri(uri: string | null | undefined): string | null {
+  if (!uri) return null
+  const hashIndex = uri.indexOf('#')
+  return hashIndex >= 0 ? uri.slice(0, hashIndex) : uri
 }
 
 /**


### PR DESCRIPTION
- MediaLibrary.getAssetInfoAsync sometimes returns URIs with a hash, the URI with a hash throws an error when its passed into the File system API. This PR normalizes URIs.