### PR TITLE
fix: default sync new photos to false

### DIFF
--- a/src/components/SettingsSyncPhotos.tsx
+++ b/src/components/SettingsSyncPhotos.tsx
@@ -51,7 +51,6 @@ export function SettingsSyncPhotos() {
           labelWidth={250}
           value={
             <Switch
-              disabled={isPhotosAccessDisabled}
               value={autoSyncNew.data ?? false}
               onValueChange={toggleAutoSyncNewPhotos}
             />
@@ -64,7 +63,6 @@ export function SettingsSyncPhotos() {
           labelWidth={250}
           value={
             <Switch
-              disabled={isPhotosAccessDisabled}
               value={autoSyncPhotosArchive.data ?? false}
               onValueChange={toggleAutoSyncPhotosArchive}
             />

--- a/src/lib/mediaLibraryPermissions.ts
+++ b/src/lib/mediaLibraryPermissions.ts
@@ -40,7 +40,7 @@ export function useMediaLibraryPermissions() {
       : photosAccess === 'limited'
       ? 'Access limited (selected photos)'
       : photosAccess === 'none'
-      ? 'No access'
+      ? 'No access, tap to grant access'
       : 'Unknown access'
   const color =
     photosAccess === 'all'

--- a/src/managers/syncNewPhotos.ts
+++ b/src/managers/syncNewPhotos.ts
@@ -66,12 +66,15 @@ export const initSyncNewPhotos = createServiceInterval({
 
 export const [getAutoSyncNewPhotos, useAutoSyncNewPhotos] =
   createGetterAndSWRHook(getKey('autoSyncNewPhotos'), () =>
-    getSecureStoreBoolean('autoSyncNewPhotos', true)
+    getSecureStoreBoolean('autoSyncNewPhotos', false)
   )
 
 export async function setAutoSyncNewPhotos(value: boolean) {
   await setSecureStoreBoolean('autoSyncNewPhotos', value)
   triggerChange('autoSyncNewPhotos')
+  if (value) {
+    ensureMediaLibraryPermission()
+  }
 }
 
 export async function toggleAutoSyncNewPhotos() {

--- a/src/managers/syncPhotosArchive.ts
+++ b/src/managers/syncPhotosArchive.ts
@@ -73,6 +73,9 @@ export const [getAutoSyncPhotosArchive, useAutoSyncPhotosArchive] =
 export async function setAutoSyncPhotosArchive(value: boolean) {
   await setSecureStoreBoolean('autoSyncPhotosArchive', value)
   triggerChange('autoSyncPhotosArchive')
+  if (value) {
+    ensureMediaLibraryPermission()
+  }
 }
 
 export async function toggleAutoSyncPhotosArchive() {


### PR DESCRIPTION
- Default this to false. This way there are no permissions requests until the user enables a photos sync feature.
- Request access when a sync feature is toggled to enabled.
- We will instead add a PR that explicitly asks the user to enable this and provide permissions in the onboarding flow.