### PR TITLE
fix: custom phrase close keyboard

### DIFF
--- a/src/screens/RecoveryPhraseScreen.tsx
+++ b/src/screens/RecoveryPhraseScreen.tsx
@@ -180,6 +180,8 @@ export default function RecoveryPhraseScreen() {
                   autoCapitalize="none"
                   autoCorrect={false}
                   textAlignVertical="center"
+                  submitBehavior="blurAndSubmit"
+                  returnKeyType="done"
                 />
               </View>
 


### PR DESCRIPTION
- There was no way to close the keyboard from the multiline recovery phrase input. This swaps newline Return key with a Done that submits and closes the keyboard.