### PR TITLE
fix: save custom recovery phrase

### DIFF
--- a/src/screens/RecoveryPhraseScreen.tsx
+++ b/src/screens/RecoveryPhraseScreen.tsx
@@ -58,6 +58,7 @@ export default function RecoveryPhraseScreen() {
 
       try {
         validateRecoveryPhrase(normalizedManualPhrase)
+        setRecoveryPhrase(normalizedManualPhrase)
         return { isValid: true, error: null }
       } catch (e) {
         if (__DEV__) logger.log('Recovery phrase validation failed:', e)


### PR DESCRIPTION
- The custom recovery phrase flow was not saving the validated phrase. This fixes that, although it may be better to refactor the submit flow out.