### PR TITLE
fix: content hash tests and mocks

### DIFF
--- a/jest.setup.cjs
+++ b/jest.setup.cjs
@@ -30,15 +30,17 @@ jest.mock('react-native-quick-crypto', () => {
 const rnfsStat = jest.fn()
 const rnfsRead = jest.fn()
 const rnfsReadFile = jest.fn()
+const rnfsHash = jest.fn()
 jest.mock('react-native-fs', () => ({
   __esModule: true,
   default: {
     stat: rnfsStat,
     read: rnfsRead,
     readFile: rnfsReadFile,
+    hash: rnfsHash,
   },
 }))
-global.__rnfs = { rnfsStat, rnfsRead, rnfsReadFile }
+global.__rnfs = { rnfsStat, rnfsRead, rnfsReadFile, rnfsHash }
 
 // In-memory SecureStore for tests.
 jest.mock('./src/stores/secureStore', () => {

--- a/src/lib/__snapshots__/contentHash.test.ts.snap
+++ b/src/lib/__snapshots__/contentHash.test.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`calculateContentHash falls back to whole-file read when stat/read fail 1`] = `"sha256|f2e2c6db1745cc40df646dc40c385487c36e4ceb3f1d5c8d6ad1f7620af1ebae"`;
+exports[`calculateContentHash falls back to QuickCrypto when RNFS.hash fails 1`] = `"sha256|c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2"`;
 
-exports[`calculateContentHash hashes via streaming 1`] = `"sha256|c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2"`;
+exports[`calculateContentHash handles binary data with null bytes via fallback 1`] = `"sha256|7f07808cb0745837d54ca4174b39ceed57db3bddc520b1402ed0c14ccc2cce76"`;
+
+exports[`calculateContentHash handles empty files via fallback 1`] = `"sha256|e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"`;

--- a/src/lib/contentHash.test.ts
+++ b/src/lib/contentHash.test.ts
@@ -4,6 +4,7 @@ type RNFSMocks = {
   rnfsStat: jest.Mock
   rnfsRead: jest.Mock
   rnfsReadFile: jest.Mock
+  rnfsHash: jest.Mock
 }
 
 function getMocks(): { rnfs: RNFSMocks } {
@@ -16,17 +17,24 @@ beforeEach(() => {
   rnfs.rnfsStat.mockReset()
   rnfs.rnfsRead.mockReset()
   rnfs.rnfsReadFile.mockReset()
+  rnfs.rnfsHash.mockReset()
 })
 
 describe('calculateContentHash', () => {
-  it('hashes via streaming', async () => {
-    // Arrange non-image path: force decode to null and stream bytes.
+  it('uses RNFS.hash when available', async () => {
     const { rnfs } = getMocks()
+    const expectedHash =
+      'c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2'
+    rnfs.rnfsHash.mockResolvedValueOnce(expectedHash)
+
+    const res = await calculateContentHash('file:///test.txt')
+    expect(res).toBe(`sha256|${expectedHash}`)
+  })
+
+  it('falls back to QuickCrypto when RNFS.hash fails', async () => {
+    const { rnfs } = getMocks()
+    rnfs.rnfsHash.mockRejectedValueOnce(new Error('hash not supported'))
     rnfs.rnfsReadFile.mockResolvedValueOnce(
-      Buffer.from('not-an-image').toString('base64')
-    )
-    rnfs.rnfsStat.mockResolvedValueOnce({ size: 6 })
-    rnfs.rnfsRead.mockResolvedValueOnce(
       Buffer.from('foobar').toString('base64')
     )
 
@@ -34,18 +42,32 @@ describe('calculateContentHash', () => {
     expect(res).toMatchSnapshot()
   })
 
-  it('falls back to whole-file read when stat/read fail', async () => {
+  it('handles empty files via fallback', async () => {
     const { rnfs } = getMocks()
-    rnfs.rnfsReadFile.mockResolvedValueOnce(
-      Buffer.from('not-an-image').toString('base64')
-    )
-    rnfs.rnfsStat.mockRejectedValueOnce(new Error('no stat'))
-    rnfs.rnfsRead.mockRejectedValueOnce(new Error('no read'))
-    rnfs.rnfsReadFile.mockResolvedValueOnce(
-      Buffer.from('abcdef').toString('base64')
-    )
+    rnfs.rnfsHash.mockRejectedValueOnce(new Error('hash not supported'))
+    rnfs.rnfsReadFile.mockResolvedValueOnce('') // Empty base64
 
-    const res = await calculateContentHash('content://weird')
+    const res = await calculateContentHash('file:///empty.txt')
     expect(res).toMatchSnapshot()
+  })
+
+  it('handles binary data with null bytes via fallback', async () => {
+    const { rnfs } = getMocks()
+    rnfs.rnfsHash.mockRejectedValueOnce(new Error('hash not supported'))
+    const binaryData = Buffer.from([0x00, 0x01, 0xff, 0xfe, 0x00, 0x42])
+    rnfs.rnfsReadFile.mockResolvedValueOnce(binaryData.toString('base64'))
+
+    const res = await calculateContentHash('file:///binary.bin')
+    expect(res).toMatchSnapshot()
+  })
+
+  it('returns null for empty URI', async () => {
+    const res = await calculateContentHash('')
+    expect(res).toBeNull()
+  })
+
+  it('returns null for null URI', async () => {
+    const res = await calculateContentHash(null as unknown as string)
+    expect(res).toBeNull()
   })
 })

--- a/src/lib/contentHash.ts
+++ b/src/lib/contentHash.ts
@@ -18,18 +18,24 @@ export async function calculateContentHash(
   return `sha256|${hex}`
 }
 
-/** SHA-256 via RNFS.hash. Falls back to manual hashing when needed */
+/** SHA-256. Try streamed native RNFS.hash first, otherwise fallback to QuickCrypto. */
 async function sha256File(uri: string): Promise<string> {
   try {
-    return await RNFS.hash(uri, 'sha256')
+    return await rnfsHash(uri)
   } catch {
-    // Fallback for URIs where stat/ranged read is unsupported (some content:// cases):
-    // Read entire file. Prefer avoiding this for very large files but ensures correctness.
-    const b64 = await RNFS.readFile(uri, 'base64')
-    const h = QuickCrypto.createHash('sha256')
-    h.update(sliceBuffer(Buffer.from(b64, 'base64')))
-    return h.digest('hex')
+    return await quickcryptoHash(uri)
   }
+}
+
+export async function rnfsHash(uri: string): Promise<string> {
+  return RNFS.hash(uri, 'sha256')
+}
+
+export async function quickcryptoHash(uri: string): Promise<string> {
+  const b64 = await RNFS.readFile(uri, 'base64')
+  const h = QuickCrypto.createHash('sha256')
+  h.update(sliceBuffer(Buffer.from(b64, 'base64')))
+  return h.digest('hex')
 }
 
 // Extract the exact ArrayBuffer slice to avoid extra capacity bytes.


### PR DESCRIPTION
- Updates jest setup with rnfs hash mocks.
- Refine unit tests.
- Add explicit methods for each hasher for use in e2e PR.