### PR TITLE
test: content hash e2e tests

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -7,16 +7,19 @@ export function Button({
   onPress,
   children,
   variant = 'primary',
+  accessibilityLabel,
 }: {
   style?: StyleProp<ViewStyle>
   disabled?: boolean
   onPress: () => void
   children: React.ReactNode
   variant?: 'primary' | 'secondary' | 'danger'
+  accessibilityLabel?: string
 }) {
   return (
     <Pressable
       accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
       style={[
         styles.primaryButton,
         variant === 'danger' && styles.dangerButton,

--- a/src/components/SettingsAdvancedInfo.tsx
+++ b/src/components/SettingsAdvancedInfo.tsx
@@ -1,10 +1,15 @@
-import { Switch } from 'react-native'
+import { Switch, View, Text, Pressable, StyleSheet } from 'react-native'
 import { setShowAdvanced, useShowAdvanced } from '../stores/settings'
 import { RowGroup } from './Group'
 import { InfoCard } from './InfoCard'
 import { LabeledValueRow } from './LabeledValueRow'
+import { type NativeStackScreenProps } from '@react-navigation/native-stack'
+import { type SettingsStackParamList } from '../stacks/types'
+import { colors, palette } from '../styles/colors'
 
-export function SettingsAdvancedInfo() {
+type Props = NativeStackScreenProps<SettingsStackParamList, 'Advanced'>
+
+export function SettingsAdvancedInfo({ navigation }: Props) {
   const showAdvanced = useShowAdvanced()
 
   return (
@@ -20,7 +25,41 @@ export function SettingsAdvancedInfo() {
             />
           }
         />
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Debug"
+          onPress={() => navigation.navigate('Debug')}
+          style={styles.debugButton}
+        >
+          <View style={styles.rowItem}>
+            <Text style={styles.rowLabel}>Debug</Text>
+            <Text style={styles.rowChevron}>›</Text>
+          </View>
+        </Pressable>
       </InfoCard>
     </RowGroup>
   )
 }
+
+const styles = StyleSheet.create({
+  debugButton: {
+    marginTop: 12,
+  },
+  rowItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    backgroundColor: colors.bgPanel,
+    borderRadius: 10,
+  },
+  rowLabel: {
+    flex: 1,
+    color: palette.gray[100],
+    fontSize: 16,
+  },
+  rowChevron: {
+    color: palette.gray[300],
+    fontSize: 18,
+  },
+})

--- a/src/components/SettingsDebugHash.tsx
+++ b/src/components/SettingsDebugHash.tsx
@@ -1,0 +1,462 @@
+import { StyleSheet, Text, View, ActivityIndicator } from 'react-native'
+import { useState } from 'react'
+import RNFS from 'react-native-fs'
+import { Buffer } from 'buffer'
+import { colors, palette } from '../styles/colors'
+import { RowGroup, GroupTitle } from './Group'
+import { InfoCard } from './InfoCard'
+import { Button } from './Button'
+import { rnfsHash, quickcryptoHash } from '../lib/contentHash'
+
+/**
+ * Hash testing component for debugging and E2E testing.
+ *
+ * This component provides a UI for testing native hashing implementations
+ * (RNFS.hash() and QuickCrypto) on real devices. This is essential because:
+ * - Unit tests cannot test native RNFS.hash() implementation (it's mocked)
+ * - E2E tests can verify that native hashing works correctly on actual devices
+ * - Allows comparison between RNFS.hash() and QuickCrypto fallback methods
+ *
+ * Test cases:
+ * 1. Small file (30 characters): Tests basic hashing correctness
+ * 2. Large file (10MB): Tests performance and streaming behavior
+ */
+type HashResult = {
+  hash: string | null
+  error?: string
+  durationMs?: number
+}
+
+type TestState = 'idle' | 'running' | 'complete'
+
+type TestCase = {
+  dataDescription: string
+  rnfs: { state: TestState; result: HashResult | null }
+  quickCrypto: { state: TestState; result: HashResult | null }
+}
+
+function HashResultView({
+  state,
+  result,
+  label,
+}: {
+  state: TestState
+  result: HashResult | null
+  label: string
+}) {
+  const formatDuration = (ms?: number) => {
+    if (ms === undefined) return ''
+    if (ms < 1000) return `${ms}ms`
+    return `${(ms / 1000).toFixed(2)}s`
+  }
+
+  return (
+    <View style={styles.resultColumn}>
+      <View style={styles.resultHeader}>
+        <Text style={styles.resultLabel}>{label}</Text>
+        {state === 'running' && (
+          <ActivityIndicator size="small" color={palette.blue[400]} />
+        )}
+      </View>
+      {result?.hash ? (
+        <>
+          <Text
+            style={styles.hashText}
+            numberOfLines={1}
+            ellipsizeMode="middle"
+          >
+            {result.hash}
+          </Text>
+          <View style={styles.resultMeta}>
+            <Text style={styles.successText}>✓</Text>
+            <Text style={styles.durationText}>
+              {formatDuration(result.durationMs)}
+            </Text>
+          </View>
+        </>
+      ) : result?.error ? (
+        <>
+          <Text style={styles.errorText} numberOfLines={2}>
+            {result.error}
+          </Text>
+          <View style={styles.resultMeta}>
+            <Text style={styles.failureText}>✗</Text>
+            <Text style={styles.durationText}>
+              {formatDuration(result.durationMs)}
+            </Text>
+          </View>
+        </>
+      ) : state === 'running' ? (
+        <Text style={styles.pendingText}>Calculating...</Text>
+      ) : (
+        <Text style={styles.pendingText}>—</Text>
+      )}
+    </View>
+  )
+}
+
+function TestCaseRow({ testCase }: { testCase: TestCase }) {
+  const hashesMatch =
+    testCase.rnfs.result?.hash &&
+    testCase.quickCrypto.result?.hash &&
+    testCase.rnfs.result.hash === testCase.quickCrypto.result.hash
+
+  return (
+    <View style={styles.testCaseRow}>
+      <Text
+        style={styles.dataDescription}
+        numberOfLines={1}
+        ellipsizeMode="tail"
+      >
+        {testCase.dataDescription}
+      </Text>
+      <View style={styles.resultsRow}>
+        <HashResultView
+          state={testCase.rnfs.state}
+          result={testCase.rnfs.result}
+          label="RNFS"
+        />
+        <View style={styles.separator} />
+        <HashResultView
+          state={testCase.quickCrypto.state}
+          result={testCase.quickCrypto.result}
+          label="QuickCrypto"
+        />
+      </View>
+      {testCase.rnfs.result?.hash && testCase.quickCrypto.result?.hash && (
+        <Text
+          style={[
+            styles.matchText,
+            hashesMatch ? styles.matchSuccess : styles.matchFailure,
+          ]}
+        >
+          {hashesMatch ? '✓ Match' : '✗ Mismatch'}
+        </Text>
+      )}
+    </View>
+  )
+}
+
+export function SettingsDebugHash() {
+  const [smallRnfsState, setSmallRnfsState] = useState<TestState>('idle')
+  const [smallQuickCryptoState, setSmallQuickCryptoState] =
+    useState<TestState>('idle')
+  const [largeRnfsState, setLargeRnfsState] = useState<TestState>('idle')
+  const [largeQuickCryptoState, setLargeQuickCryptoState] =
+    useState<TestState>('idle')
+
+  const [smallRnfsResult, setSmallRnfsResult] = useState<HashResult | null>(
+    null
+  )
+  const [smallQuickCryptoResult, setSmallQuickCryptoResult] =
+    useState<HashResult | null>(null)
+  const [largeRnfsResult, setLargeRnfsResult] = useState<HashResult | null>(
+    null
+  )
+  const [largeQuickCryptoResult, setLargeQuickCryptoResult] =
+    useState<HashResult | null>(null)
+
+  const handleRunSmallTest = async () => {
+    setSmallRnfsState('running')
+    setSmallQuickCryptoState('running')
+    setSmallRnfsResult(null)
+    setSmallQuickCryptoResult(null)
+
+    let testFile: string | null = null
+    let testDir: string | null = null
+
+    try {
+      testDir = `${RNFS.DocumentDirectoryPath}/hash-test`
+      await RNFS.mkdir(testDir)
+      testFile = `${testDir}/test.bin`
+      // 30 bytes of zeros
+      const testContent = Buffer.alloc(30, 0)
+      await RNFS.writeFile(testFile, testContent.toString('base64'), 'base64')
+
+      // Run both in parallel, updating state independently as each completes
+      const rnfsPromise = (async () => {
+        const start = Date.now()
+        try {
+          const hash = await rnfsHash(testFile!)
+          setSmallRnfsResult({ hash, durationMs: Date.now() - start })
+        } catch (error) {
+          setSmallRnfsResult({
+            hash: null,
+            error: error instanceof Error ? error.message : String(error),
+            durationMs: Date.now() - start,
+          })
+        } finally {
+          setSmallRnfsState('complete')
+        }
+      })()
+
+      const quickCryptoPromise = (async () => {
+        const start = Date.now()
+        try {
+          const hash = await quickcryptoHash(testFile!)
+          setSmallQuickCryptoResult({ hash, durationMs: Date.now() - start })
+        } catch (error) {
+          setSmallQuickCryptoResult({
+            hash: null,
+            error: error instanceof Error ? error.message : String(error),
+            durationMs: Date.now() - start,
+          })
+        } finally {
+          setSmallQuickCryptoState('complete')
+        }
+      })()
+
+      // Wait for both to complete before cleanup
+      await Promise.allSettled([rnfsPromise, quickCryptoPromise])
+    } catch (error) {
+      setSmallRnfsResult({
+        hash: null,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      setSmallQuickCryptoResult({
+        hash: null,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      setSmallRnfsState('complete')
+      setSmallQuickCryptoState('complete')
+    } finally {
+      try {
+        if (testFile) await RNFS.unlink(testFile)
+        if (testDir) await RNFS.unlink(testDir)
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  }
+
+  const handleRunLargeTest = async () => {
+    setLargeRnfsState('running')
+    setLargeQuickCryptoState('running')
+    setLargeRnfsResult(null)
+    setLargeQuickCryptoResult(null)
+
+    let largeFile: string | null = null
+    let testDir: string | null = null
+    const testStartTime = Date.now()
+
+    try {
+      testDir = `${RNFS.DocumentDirectoryPath}/hash-test`
+      await RNFS.mkdir(testDir)
+      largeFile = `${testDir}/large.bin`
+      const largeFileSizeBytes = 10 * 1024 * 1024 // 10MB
+      // 10MB of zeros
+      const largeContent = Buffer.alloc(largeFileSizeBytes, 0)
+      await RNFS.writeFile(largeFile, largeContent.toString('base64'), 'base64')
+
+      // Run both in parallel, updating state independently as each completes
+      const rnfsPromise = (async () => {
+        const hashStart = Date.now()
+        try {
+          const hash = await rnfsHash(largeFile!)
+          setLargeRnfsResult({ hash, durationMs: Date.now() - hashStart })
+        } catch (error) {
+          setLargeRnfsResult({
+            hash: null,
+            error: error instanceof Error ? error.message : String(error),
+            durationMs: Date.now() - hashStart,
+          })
+        } finally {
+          setLargeRnfsState('complete')
+        }
+      })()
+
+      const quickCryptoPromise = (async () => {
+        const hashStart = Date.now()
+        try {
+          const hash = await quickcryptoHash(largeFile!)
+          setLargeQuickCryptoResult({
+            hash,
+            durationMs: Date.now() - hashStart,
+          })
+        } catch (error) {
+          setLargeQuickCryptoResult({
+            hash: null,
+            error: error instanceof Error ? error.message : String(error),
+            durationMs: Date.now() - hashStart,
+          })
+        } finally {
+          setLargeQuickCryptoState('complete')
+        }
+      })()
+
+      // Wait for both to complete before cleanup
+      await Promise.allSettled([rnfsPromise, quickCryptoPromise])
+    } catch (error) {
+      setLargeRnfsResult({
+        hash: null,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      setLargeQuickCryptoResult({
+        hash: null,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      setLargeRnfsState('complete')
+      setLargeQuickCryptoState('complete')
+    } finally {
+      try {
+        if (largeFile) await RNFS.unlink(largeFile)
+        if (testDir) await RNFS.unlink(testDir)
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  }
+
+  const smallTestCase: TestCase = {
+    dataDescription: '30 bytes of 0s',
+    rnfs: { state: smallRnfsState, result: smallRnfsResult },
+    quickCrypto: {
+      state: smallQuickCryptoState,
+      result: smallQuickCryptoResult,
+    },
+  }
+
+  const largeTestCase: TestCase = {
+    dataDescription: '10 MB of 0s',
+    rnfs: { state: largeRnfsState, result: largeRnfsResult },
+    quickCrypto: {
+      state: largeQuickCryptoState,
+      result: largeQuickCryptoResult,
+    },
+  }
+
+  const isSmallRunning =
+    smallRnfsState === 'running' || smallQuickCryptoState === 'running'
+  const isLargeRunning =
+    largeRnfsState === 'running' || largeQuickCryptoState === 'running'
+
+  return (
+    <View style={styles.container}>
+      <GroupTitle title="Sha256 Hash Testing" />
+      <InfoCard>
+        <Button
+          onPress={handleRunSmallTest}
+          disabled={isSmallRunning}
+          variant="secondary"
+        >
+          {isSmallRunning ? 'Running...' : 'Test Small File'}
+        </Button>
+        <View style={styles.resultsContainer}>
+          <TestCaseRow testCase={smallTestCase} />
+        </View>
+      </InfoCard>
+      <InfoCard>
+        <Button
+          onPress={handleRunLargeTest}
+          disabled={isLargeRunning}
+          variant="secondary"
+        >
+          {isLargeRunning ? 'Running...' : 'Test Large File'}
+        </Button>
+        <View style={styles.resultsContainer}>
+          <TestCaseRow testCase={largeTestCase} />
+        </View>
+      </InfoCard>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 12,
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  button: {
+    flex: 1,
+  },
+  resultsContainer: {
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: colors.bgElevated,
+  },
+  testCaseRow: {
+    backgroundColor: colors.bgPanel,
+    borderRadius: 10,
+    padding: 12,
+    marginBottom: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.bgElevated,
+  },
+  dataDescription: {
+    color: palette.gray[300],
+    fontSize: 12,
+    marginBottom: 10,
+  },
+  resultsRow: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  resultColumn: {
+    flex: 1,
+  },
+  resultHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginBottom: 6,
+  },
+  resultLabel: {
+    color: palette.gray[100],
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  hashText: {
+    color: palette.gray[200],
+    fontSize: 11,
+    fontFamily: 'monospace',
+    marginBottom: 4,
+  },
+  resultMeta: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginTop: 2,
+  },
+  successText: {
+    color: palette.green[500],
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  failureText: {
+    color: palette.red[500],
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  durationText: {
+    color: palette.gray[400],
+    fontSize: 11,
+  },
+  errorText: {
+    color: palette.red[500],
+    fontSize: 11,
+    marginBottom: 4,
+  },
+  pendingText: {
+    color: palette.gray[400],
+    fontSize: 11,
+    fontStyle: 'italic',
+  },
+  separator: {
+    width: StyleSheet.hairlineWidth,
+    backgroundColor: colors.bgElevated,
+  },
+  matchText: {
+    fontSize: 12,
+    fontWeight: '600',
+    textAlign: 'center',
+    marginTop: 8,
+  },
+  matchSuccess: {
+    color: palette.green[500],
+  },
+  matchFailure: {
+    color: palette.red[500],
+  },
+})

--- a/src/lib/contentHash.ts
+++ b/src/lib/contentHash.ts
@@ -19,7 +19,7 @@ export async function calculateContentHash(
 }
 
 /** SHA-256. Try streamed native RNFS.hash first, otherwise fallback to QuickCrypto. */
-async function sha256File(uri: string): Promise<string> {
+export async function sha256File(uri: string): Promise<string> {
   try {
     return await rnfsHash(uri)
   } catch {

--- a/src/lib/toastContext.tsx
+++ b/src/lib/toastContext.tsx
@@ -88,7 +88,9 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
           ]}
         >
           <View style={styles.toastCard}>
-            <Text style={styles.toastText}>{message}</Text>
+            <Text style={styles.toastText} accessibilityLabel={message}>
+              {message}
+            </Text>
           </View>
         </Animated.View>
       ) : null}

--- a/src/screens/LibraryScreen.tsx
+++ b/src/screens/LibraryScreen.tsx
@@ -84,6 +84,7 @@ export function LibraryScreen({ route, navigation }: Props) {
           <IconButton
             onPress={() => navigation.navigate('SettingsTab' as never)}
             style={[styles.headerIcon, { paddingHorizontal: 4 }]}
+            accessibilityLabel="Settings"
           >
             <SettingsIcon color={palette.gray[50]} />
           </IconButton>

--- a/src/screens/SettingsAdvancedScreen.tsx
+++ b/src/screens/SettingsAdvancedScreen.tsx
@@ -10,14 +10,14 @@ import { SettingsAdvancedInfo } from '../components/SettingsAdvancedInfo'
 
 type Props = NativeStackScreenProps<SettingsStackParamList, 'Advanced'>
 
-export function SettingsAdvancedScreen(_props: Props) {
+export function SettingsAdvancedScreen(props: Props) {
   useSettingsHeader()
 
   return (
     <SettingsLayout style={styles.container}>
       <SettingsAdvancedAccount />
       <SettingsRecoveryPhrase />
-      <SettingsAdvancedInfo />
+      <SettingsAdvancedInfo {...props} />
       <SettingsAdvancedDangerZone />
     </SettingsLayout>
   )

--- a/src/screens/SettingsDebugScreen.tsx
+++ b/src/screens/SettingsDebugScreen.tsx
@@ -1,0 +1,26 @@
+import { StyleSheet } from 'react-native'
+import { type NativeStackScreenProps } from '@react-navigation/native-stack'
+import { type SettingsStackParamList } from '../stacks/types'
+import { SettingsLayout } from '../components/SettingsLayout'
+import { useSettingsHeader } from '../hooks/useSettingsHeader'
+import { SettingsDebugHash } from '../components/SettingsDebugHash'
+
+type Props = NativeStackScreenProps<SettingsStackParamList, 'Debug'>
+
+export function SettingsDebugScreen(_props: Props) {
+  useSettingsHeader()
+
+  return (
+    <SettingsLayout style={styles.container}>
+      <SettingsDebugHash />
+    </SettingsLayout>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 16,
+    paddingTop: 24,
+    paddingBottom: 24,
+  },
+})

--- a/src/screens/SettingsHomeScreen.tsx
+++ b/src/screens/SettingsHomeScreen.tsx
@@ -38,13 +38,21 @@ export function SettingsHomeScreen({ navigation }: Props) {
           <Text style={styles.rowChevron}>›</Text>
         </View>
       </Pressable>
-      <Pressable onPress={() => navigation.navigate('Advanced')}>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Advanced"
+        onPress={() => navigation.navigate('Advanced')}
+      >
         <View style={styles.rowItem}>
           <Text style={styles.rowLabel}>Advanced</Text>
           <Text style={styles.rowChevron}>›</Text>
         </View>
       </Pressable>
-      <Pressable onPress={() => navigation.navigate('Logs')}>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Logs"
+        onPress={() => navigation.navigate('Logs')}
+      >
         <View style={styles.rowItem}>
           <Text style={styles.rowLabel}>Logs</Text>
           <Text style={styles.rowChevron}>›</Text>

--- a/src/stacks/SettingsStack.tsx
+++ b/src/stacks/SettingsStack.tsx
@@ -8,6 +8,7 @@ import { SettingsSyncScreen } from '../screens/SettingsSyncScreen'
 import { type SettingsStackParamList } from './types'
 import { SettingsAdvancedScreen } from '../screens/SettingsAdvancedScreen'
 import { SettingsLogsScreen } from '../screens/SettingsLogsScreen'
+import { SettingsDebugScreen } from '../screens/SettingsDebugScreen'
 import { StyleSheet } from 'react-native'
 import { palette } from '../styles/colors'
 
@@ -56,6 +57,11 @@ export function SettingsStack() {
         name="Advanced"
         component={SettingsAdvancedScreen}
         options={{ title: 'Advanced' }}
+      />
+      <Stack.Screen
+        name="Debug"
+        component={SettingsDebugScreen}
+        options={{ title: 'Debug' }}
       />
     </Stack.Navigator>
   )

--- a/src/stacks/types.ts
+++ b/src/stacks/types.ts
@@ -13,6 +13,7 @@ export type SettingsStackParamList = {
   Sync: undefined
   Logs: undefined
   Advanced: undefined
+  Debug: undefined
 }
 
 export type AuthStackParamList = {

--- a/test/e2e/hash_test.yml
+++ b/test/e2e/hash_test.yml
@@ -1,0 +1,68 @@
+appId: sia.storage
+---
+- launchApp
+
+# Wait for app to load - should be on Library screen
+- extendedWaitUntil:
+    visible: 'Library'
+    timeout: 10000
+
+# Tap Settings icon in header to navigate to Settings
+- tapOn: 'Settings'
+
+# Wait for Settings screen to load
+- assertVisible: 'Settings'
+
+# Navigate to Advanced - may need to scroll
+- scrollUntilVisible:
+    element:
+      text: 'Advanced'
+    direction: DOWN
+    timeout: 5000
+- assertVisible: 'Advanced'
+- tapOn: 'Advanced'
+
+# Wait for Advanced screen to load
+- assertVisible: 'Show advanced information'
+
+# Navigate to Debug screen
+- scrollUntilVisible:
+    element:
+      text: 'Debug'
+    direction: DOWN
+    timeout: 5000
+- assertVisible: 'Debug'
+- tapOn: 'Debug'
+
+# Wait for Debug screen to load
+- assertVisible: 'Sha256 Hash Testing'
+
+# Run small file hash test
+- assertVisible: 'Test Small File'
+- tapOn: 'Test Small File'
+
+# Wait for small test to complete (button text changes back)
+- extendedWaitUntil:
+    visible: 'Test Small File'
+    timeout: 15000
+
+# Verify small file test results
+- assertVisible: '30 bytes of 0s'
+- assertVisible: 'RNFS'
+- assertVisible: 'QuickCrypto'
+- assertVisible: '✓ Match'
+
+# Run large file hash test
+- assertVisible: 'Test Large File'
+- tapOn: 'Test Large File'
+
+# Wait for large test to complete (button text changes back)
+- extendedWaitUntil:
+    visible: 'Test Large File'
+    timeout: 30000
+
+# Verify large file test results
+- assertVisible: '10 MB of 0s'
+- assertVisible:
+    text: '✓ Match'
+    index: 1


### PR DESCRIPTION
- Adds maestro e2e test to compare RNFS hash and QuickCrypto fallback result in the same hash.
    - The only way to actually test RNFS hash is running on a device.
    - `maestro test test/e2e/hash_test.yml`​
- Adds accessibility labels to handful of components for the automation.
- Adds a developer debug area in settings where we can put developer debug and testing controls. 

[e2e.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/ca4da190-b113-43a5-b8f0-2b9b9903fd72.mp4" />](https://app.graphite.com/user-attachments/video/ca4da190-b113-43a5-b8f0-2b9b9903fd72.mp4)

