### PR TITLE
fix: memoize library items on file id

### DIFF
--- a/src/components/FileGallery.tsx
+++ b/src/components/FileGallery.tsx
@@ -7,15 +7,10 @@ import { FileGalleryItem } from './FileGalleryItem'
 
 type Props = {
   onPressItem: (item: FileRecord) => void
-  setItemRef?: (id: string, ref: any) => void
   numColumns?: number
 }
 
-export function FileGallery({
-  onPressItem,
-  setItemRef,
-  numColumns = 3,
-}: Props) {
+export function FileGallery({ onPressItem, numColumns = 3 }: Props) {
   const { data: files, size, setSize, isValidating, hasMore } = useFileList()
   const { isLoadingMore, handleEndReached } = useFlatListControls({
     data: files,
@@ -37,11 +32,7 @@ export function FileGallery({
       automaticallyAdjustsScrollIndicatorInsets={false}
       contentContainerStyle={styles.galleryContent}
       renderItem={({ item }) => (
-        <FileGalleryItem
-          file={item}
-          onPressItem={onPressItem}
-          setItemRef={setItemRef}
-        />
+        <FileGalleryItem file={item} onPressItem={onPressItem} />
       )}
       onEndReachedThreshold={0.95}
       onEndReached={handleEndReached}

--- a/src/components/FileGalleryItem.tsx
+++ b/src/components/FileGalleryItem.tsx
@@ -11,18 +11,13 @@ import { UploadStatusIcon } from './UploadStatusIcon'
 type Props = {
   file: FileRecord
   onPressItem: (item: FileRecord) => void
-  setItemRef?: (id: string, ref: any) => void
 }
 
-function FileGalleryItemComponent({ file, onPressItem, setItemRef }: Props) {
+function FileGalleryItemComponent({ file, onPressItem }: Props) {
   const toast = useToast()
   const status = useFileStatus(file)
   return (
-    <View
-      collapsable={false}
-      ref={(node) => setItemRef?.(file.id, node)}
-      style={styles.thumbCell}
-    >
+    <View collapsable={false} style={styles.thumbCell}>
       <Pressable
         accessibilityRole="button"
         onPress={() => onPressItem(file)}
@@ -45,9 +40,9 @@ function FileGalleryItemComponent({ file, onPressItem, setItemRef }: Props) {
 
 export const FileGalleryItem = memo(FileGalleryItemComponent, (prev, next) => {
   return (
-    prev.file === next.file &&
-    prev.onPressItem === next.onPressItem &&
-    prev.setItemRef === next.setItemRef
+    prev.file.id === next.file.id &&
+    prev.file.updatedAt === next.file.updatedAt &&
+    prev.onPressItem === next.onPressItem
   )
 })
 

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -7,10 +7,9 @@ import { useFlatListControls } from '../hooks/useFlatListControls'
 
 type Props = {
   onPressItem: (item: FileRecord) => void
-  setItemRef?: (id: string, ref: any) => void
 }
 
-export function FileList({ onPressItem, setItemRef }: Props) {
+export function FileList({ onPressItem }: Props) {
   const { data: files, size, setSize, isValidating, hasMore } = useFileList()
   const { isLoadingMore, handleEndReached } = useFlatListControls({
     data: files,
@@ -35,11 +34,7 @@ export function FileList({ onPressItem, setItemRef }: Props) {
         paddingBottom: 130,
       }}
       renderItem={({ item }) => (
-        <FileListItem
-          file={item}
-          onPressItem={onPressItem}
-          setItemRef={setItemRef}
-        />
+        <FileListItem file={item} onPressItem={onPressItem} />
       )}
       onEndReachedThreshold={0.9}
       onEndReached={handleEndReached}

--- a/src/components/FileListItem.tsx
+++ b/src/components/FileListItem.tsx
@@ -11,15 +11,13 @@ import { memo } from 'react'
 type Props = {
   file: FileRecord
   onPressItem: (item: FileRecord) => void
-  setItemRef?: (id: string, ref: any) => void
 }
 
-function FileListItemComponent({ file, onPressItem, setItemRef }: Props) {
+function FileListItemComponent({ file, onPressItem }: Props) {
   const status = useFileStatus(file)
   return (
     <Pressable
       collapsable={false}
-      ref={(node) => setItemRef?.(file.id, node)}
       style={styles.container}
       onPress={() => onPressItem(file)}
     >
@@ -56,9 +54,9 @@ function FileListItemComponent({ file, onPressItem, setItemRef }: Props) {
 
 export const FileListItem = memo(FileListItemComponent, (prev, next) => {
   return (
-    prev.file === next.file &&
-    prev.onPressItem === next.onPressItem &&
-    prev.setItemRef === next.setItemRef
+    prev.file.id === next.file.id &&
+    prev.file.updatedAt === next.file.updatedAt &&
+    prev.onPressItem === next.onPressItem
   )
 })
 

--- a/src/screens/LibraryScreen.tsx
+++ b/src/screens/LibraryScreen.tsx
@@ -10,7 +10,6 @@ import { useFileList, useLibrary, type Category } from '../stores/library'
 import { FileList } from '../components/FileList'
 import { AddFileActionSheet } from '../components/AddFileActionSheet'
 import LibraryStatusSheet from '../components/LibraryStatusSheet'
-import { useState } from 'react'
 import { useLibraryViewMode } from '../stores/settings'
 import { LibraryControlBar } from '../components/LibraryControlBar'
 import { type NativeStackScreenProps } from '@react-navigation/native-stack'
@@ -22,7 +21,6 @@ import { LibraryAppStatusIcon } from '../components/LibraryAppStatusIcon'
 type Props = NativeStackScreenProps<MainStackParamList, 'LibraryHome'>
 
 export function LibraryScreen({ route, navigation }: Props) {
-  const [statusSheetVisible, setStatusSheetVisible] = useState<boolean>(false)
   const viewMode = useLibraryViewMode()
   const { selectedCategories, searchQuery } = useLibrary()
   const files = useFileList()


### PR DESCRIPTION
- Updates the memo for gallery and list items to be on `id`​ rather then entire object reference which may change. The goal is to improve the flatlist performance with a large library.
- Removes some unused props.