### PR TITLE
test: update sync photos tests

### DIFF
--- a/jest.setup.cjs
+++ b/jest.setup.cjs
@@ -85,3 +85,26 @@ jest.mock('./src/stores/secureStore', () => {
     }),
   }
 })
+
+// These warnings are produced when Jest loads Expo modules without native bindings.
+// In the test environment we intentionally replace those bindings with mocks, so
+// the messages are expected noise and safe to ignore.
+const suppressedWarnings = [
+  'EXNativeModulesProxy',
+  'ExpoModulesCoreJSLogger',
+  'ExponentConstants',
+  'ExpoUpdates',
+  'ExpoGo',
+  '_reactNative.TurboModuleRegistry.get is not a function',
+]
+const originalConsoleWarn = console.warn
+console.warn = (...args) => {
+  const [message] = args
+  if (
+    typeof message === 'string' &&
+    suppressedWarnings.some((pattern) => message.includes(pattern))
+  ) {
+    return
+  }
+  originalConsoleWarn(...args)
+}

--- a/src/managers/syncNewPhotos.test.ts
+++ b/src/managers/syncNewPhotos.test.ts
@@ -1,5 +1,5 @@
 import { SYNC_NEW_PHOTOS_INTERVAL } from '../config'
-import { initSyncNewPhotos } from './syncNewPhotos'
+import { initSyncNewPhotos, setAutoSyncNewPhotos } from './syncNewPhotos'
 import * as MediaLibrary from 'expo-media-library'
 import { ensureMediaLibraryPermission } from '../lib/mediaLibraryPermissions'
 import { processAssets } from '../lib/processAssets'
@@ -72,6 +72,7 @@ describe('syncNewPhotos', () => {
     const processAssetsMock = jest.mocked(processAssets)
 
     ensureMediaLibraryPermissionMock.mockResolvedValue(true)
+    await setAutoSyncNewPhotos(true)
     getAssetsAsyncMock
       .mockResolvedValueOnce(
         page([asset('a1', '1.jpg', 1000), asset('a2', '2.jpg', 2000)])
@@ -93,11 +94,11 @@ describe('syncNewPhotos', () => {
     // createdAfter is set to current time on first init.
     expect(getTime(opts0?.createdAfter)).toBeGreaterThan(0)
     // First tick had two assets, two process calls.
-    expect(getTime(opts1?.createdAfter)).toBe(2000)
+    expect(getTime(opts1?.createdAfter)).toBe(2001)
     // Third tick had no assets, no further processing.
-    expect(getTime(opts2?.createdAfter)).toBe(2500)
+    expect(getTime(opts2?.createdAfter)).toBe(2501)
     // Fourth tick had one asset, one process call.
-    expect(getTime(opts3?.createdAfter)).toBe(2500)
+    expect(getTime(opts3?.createdAfter)).toBe(2501)
     expect(processAssetsMock).toHaveBeenCalledTimes(3)
     expect(processAssetsMock).toHaveBeenNthCalledWith(1, [
       expect.objectContaining({ id: 'a1', name: '1.jpg' }),

--- a/src/managers/syncPhotosArchive.test.ts
+++ b/src/managers/syncPhotosArchive.test.ts
@@ -6,6 +6,7 @@ import {
   initSyncPhotosArchive,
   getPhotosArchiveCursor,
   restartPhotosArchiveCursor,
+  setAutoSyncPhotosArchive,
 } from './syncPhotosArchive'
 
 jest.useFakeTimers()
@@ -76,6 +77,7 @@ describe('syncPhotosArchive', () => {
     const processAssetsMock = jest.mocked(processAssets)
 
     ensureMediaLibraryPermissionMock.mockResolvedValue(true)
+    await setAutoSyncPhotosArchive(true)
 
     getAssetsAsyncMock.mockImplementation(
       async (
@@ -89,7 +91,7 @@ describe('syncPhotosArchive', () => {
             asset('b1', 'one.jpg', 10_000),
             asset('b2', 'two.jpg', 5_000),
           ])
-        if (t === 5_000) return page([asset('b3', 'three.jpg', 1_000)])
+        if (t >= 4_999) return page([asset('b3', 'three.jpg', 1_000)])
         return page([])
       }
     )
@@ -109,14 +111,14 @@ describe('syncPhotosArchive', () => {
       expect.objectContaining({ id: 'b1', name: 'one.jpg' }),
       expect.objectContaining({ id: 'b2', name: 'two.jpg' }),
     ])
-    expect(await getPhotosArchiveCursor()).toBe(5_000)
+    expect(await getPhotosArchiveCursor()).toBe(4_999)
 
     // Tick 2: createdBefore 5_000 -> returns [1_000], cursor -> 1_000
     await runTick()
     expect(processAssetsMock).toHaveBeenNthCalledWith(2, [
       expect.objectContaining({ id: 'b3', name: 'three.jpg' }),
     ])
-    expect(await getPhotosArchiveCursor()).toBe(1_000)
+    expect(await getPhotosArchiveCursor()).toBe(999)
 
     // Tick 3: createdBefore 1_000 -> returns [], cursor should reset to 0 and stop
     await runTick()


### PR DESCRIPTION
- Updates photo sync unit tests to pass with recent change which bumps the cursors forward by an extra millisecond.
    - I will add these the unit tests to the CI in subsequent PR so we don't miss them again.
- Adds some jest config to silence warnings for mocked expo modules.