### PR TITLE
feat: thumbnail support

### DIFF
--- a/src/components/FileDetailScreenHeader.tsx
+++ b/src/components/FileDetailScreenHeader.tsx
@@ -10,7 +10,7 @@ import { useFileStatus } from '../lib/file'
 import { UploadStatusIcon } from './UploadStatusIcon'
 
 type Props = {
-  file: FileRecord
+  file?: FileRecord
   title: string
   navigation: NavigationProp<Record<string, object | undefined>>
   icon?: 'back' | 'close'

--- a/src/components/FileDetails/FileMeta.tsx
+++ b/src/components/FileDetails/FileMeta.tsx
@@ -12,6 +12,9 @@ import { useShowAdvanced } from '../../stores/settings'
 import { InputRow } from '../InputRow'
 import { useInputValue } from '../../hooks/useInputValue'
 import { usePinnedObjects } from '../../hooks/usePinnedObjects'
+import useSWR from 'swr'
+import { readThumbnailsByHash, thumbnailSwr } from '../../stores/thumbnails'
+import { getFileUri } from '../../stores/fileCache'
 
 export function FileMeta({
   file,
@@ -32,6 +35,18 @@ export function FileMeta({
     },
   })
   const pinnedObjects = usePinnedObjects(file)
+  const thumbnails = useSWR(
+    showAdvanced.data ? thumbnailSwr.getKey(`${file.hash}/all`) : null,
+    async () => {
+      const records = await readThumbnailsByHash(file.hash)
+      return Promise.all(
+        records.map(async (thumb) => ({
+          record: thumb,
+          uri: await getFileUri(thumb),
+        }))
+      )
+    }
+  )
   return (
     <View style={styles.container}>
       <RowGroup title="Details">
@@ -103,6 +118,33 @@ export function FileMeta({
       </RowGroup>
       {showAdvanced.data && (
         <>
+          {thumbnails.data?.length ? (
+            <RowGroup title="Thumbnails">
+              <InfoCard>
+                {thumbnails.data.map(({ record, uri }, index) => {
+                  const thumbSizeLabel = record.thumbSize
+                    ? `${record.thumbSize}px`
+                    : 'Unknown'
+                  const label = `Thumbnail ${thumbSizeLabel} URI`
+                  const value = uri ?? 'Not cached'
+                  return (
+                    <LabeledValueRow
+                      key={record.id}
+                      labelWidth={200}
+                      label={label}
+                      value={value}
+                      isMonospace
+                      align="left"
+                      ellipsizeMode="middle"
+                      numberOfLines={1}
+                      showDividerTop={index > 0}
+                      canCopy={!!uri}
+                    />
+                  )
+                })}
+              </InfoCard>
+            </RowGroup>
+          ) : null}
           {pinnedObjects.data && pinnedObjects.data.length > 1 && (
             <View style={styles.section}>
               <Text style={styles.sectionTitle}>Pinned Objects</Text>

--- a/src/components/FileGalleryItem.tsx
+++ b/src/components/FileGalleryItem.tsx
@@ -27,7 +27,7 @@ function FileGalleryItemComponent({ file, onPressItem }: Props) {
           toast.show('Copied item id')
         }}
       >
-        <FileThumbnail file={file} iconSize={24} />
+        <FileThumbnail file={file} iconSize={24} thumbSize={512} />
         {status.data ? (
           <View style={{ position: 'absolute', bottom: 8, right: 8 }}>
             <UploadStatusIcon status={status.data} size={10} />

--- a/src/components/FileListItem.tsx
+++ b/src/components/FileListItem.tsx
@@ -22,7 +22,7 @@ function FileListItemComponent({ file, onPressItem }: Props) {
       onPress={() => onPressItem(file)}
     >
       <View style={styles.thumbnailContainer}>
-        <FileThumbnail file={file} />
+        <FileThumbnail file={file} thumbSize={64} />
       </View>
       <View style={styles.infoContainer}>
         <View style={styles.fileDetails}>

--- a/src/components/FileThumbnail.tsx
+++ b/src/components/FileThumbnail.tsx
@@ -1,5 +1,5 @@
 import { Image, StyleSheet, View } from 'react-native'
-import { FileRecord } from '../stores/files'
+import { FileRecord, type ThumbSize } from '../stores/files'
 import { useFileStatus } from '../lib/file'
 import {
   FileAudioIcon,
@@ -8,25 +8,25 @@ import {
   FileTextIcon,
   FileVideoIcon,
   ImageIcon,
+  PlayIcon,
 } from 'lucide-react-native'
 import { palette } from '../styles/colors'
-import {
-  thumbnailShouldAutoDownload,
-  useAutoDownload,
-} from '../hooks/useAutoDownload'
 import { CenteredProgress } from './CenteredProgress'
+import { useBestThumbnailUri } from '../hooks/useBestThumbnail'
 
 export function FileThumbnail({
   file,
+  thumbSize,
   iconSize = 16,
   iconColor = palette.gray[200],
 }: {
   file: FileRecord
+  thumbSize: ThumbSize
   iconSize?: number
   iconColor?: string
 }) {
   const status = useFileStatus(file)
-  useAutoDownload(file, thumbnailShouldAutoDownload)
+  const bestThumb = useBestThumbnailUri(file, thumbSize)
 
   if (status.data?.isDownloading) {
     return (
@@ -37,13 +37,9 @@ export function FileThumbnail({
   }
 
   if (file.type?.includes('image')) {
-    if (status.data?.fileUri) {
-      return (
-        <Image
-          source={{ uri: status.data?.fileUri }}
-          style={styles.thumbnailImage}
-        />
-      )
+    const thumbUri = bestThumb.data
+    if (thumbUri) {
+      return <Image source={{ uri: thumbUri }} style={styles.thumbnailImage} />
     }
     return (
       <View style={styles.thumbnailImage}>
@@ -52,6 +48,10 @@ export function FileThumbnail({
     )
   }
   if (file.type?.includes('pdf')) {
+    const thumbUri = bestThumb.data
+    if (thumbUri) {
+      return <Image source={{ uri: thumbUri }} style={styles.thumbnailImage} />
+    }
     if (status.data?.fileUri) {
       return (
         <Image
@@ -67,9 +67,16 @@ export function FileThumbnail({
     )
   }
   if (file.type?.includes('video')) {
+    const thumbUri = bestThumb.data
     return (
       <View style={styles.thumbnailImage}>
-        <FileVideoIcon size={iconSize} color={iconColor} />
+        {thumbUri ? (
+          <Image
+            source={{ uri: thumbUri }}
+            style={[{ position: 'absolute' }, styles.thumbnailImage]}
+          />
+        ) : null}
+        <PlayIcon size={iconSize} color={iconColor} />
       </View>
     )
   }

--- a/src/db/migrations/0002_add_thumbnail_columns.ts
+++ b/src/db/migrations/0002_add_thumbnail_columns.ts
@@ -1,0 +1,43 @@
+import * as SQLite from 'expo-sqlite'
+import { type Migration } from './types'
+import { logger } from '../../lib/logger'
+
+async function columnExists(
+  db: SQLite.SQLiteDatabase,
+  table: string,
+  column: string
+): Promise<boolean> {
+  const cols = await db.getAllAsync<{ name: string }>(
+    `PRAGMA table_info('${table}')`
+  )
+  return cols.some((c) => c.name === column)
+}
+
+// Add thumb-related columns to files: thumbForHash, thumbSize, width, height.
+async function up(db: SQLite.SQLiteDatabase): Promise<void> {
+  try {
+    const table = 'files'
+    const needsThumbForHash = !(await columnExists(db, table, 'thumbForHash'))
+    const needsThumbSize = !(await columnExists(db, table, 'thumbSize'))
+
+    if (needsThumbForHash) {
+      await db.execAsync(`ALTER TABLE ${table} ADD COLUMN thumbForHash TEXT`)
+    }
+    if (needsThumbSize) {
+      await db.execAsync(`ALTER TABLE ${table} ADD COLUMN thumbSize INTEGER`)
+    }
+
+    // Create an index to efficiently select thumbnails for an original and size bucket.
+    await db.execAsync(
+      `CREATE INDEX IF NOT EXISTS idx_files_thumbForHash_thumbSize ON files(thumbForHash, thumbSize)`
+    )
+  } catch (e) {
+    logger.log('[db] error running migration 0002_add_thumbnail_columns', e)
+    throw e
+  }
+}
+
+export const migration_0002_add_thumbnail_columns: Migration = {
+  id: '0002_add_thumbnail_columns',
+  up,
+}

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -20,8 +20,12 @@ import * as SQLite from 'expo-sqlite'
 import { logger } from '../../lib/logger'
 import { type Migration } from './types'
 import { migration_0001_init_schema } from './0001_init_schema'
+import { migration_0002_add_thumbnail_columns } from './0002_add_thumbnail_columns'
 
-const migrations: Migration[] = [migration_0001_init_schema]
+const migrations: Migration[] = [
+  migration_0001_init_schema,
+  migration_0002_add_thumbnail_columns,
+]
 
 export async function runMigrations(db: SQLite.SQLiteDatabase): Promise<void> {
   logger.log('[db] checking migrations...')

--- a/src/encoding/fileMetadata.ts
+++ b/src/encoding/fileMetadata.ts
@@ -9,6 +9,8 @@ export function transformFileMetadata(metadata: FileMetadata): FileMetadata {
     updatedAt: metadata.updatedAt,
     createdAt: metadata.createdAt,
     hash: metadata.hash,
+    thumbForHash: metadata.thumbForHash,
+    thumbSize: metadata.thumbSize,
   }
 }
 
@@ -29,6 +31,8 @@ export function decodeFileMetadata(buffer?: ArrayBuffer): FileMetadata {
       updatedAt: 0,
       createdAt: 0,
       hash: '',
+      thumbForHash: undefined,
+      thumbSize: undefined,
     }
   }
 }

--- a/src/hooks/useAutoDownload.ts
+++ b/src/hooks/useAutoDownload.ts
@@ -6,17 +6,6 @@ import { useDownload, useDownloadFromShareURL } from '../managers/downloader'
 import { FileRecord } from '../stores/files'
 
 /**
- * When a file is rendered in a thumbnail view, auto download it if:
- * its an image or PDF, or its less than 4 MB.
- */
-export function thumbnailShouldAutoDownload(file: FileRecord): boolean {
-  const isImage = file.type?.startsWith('image') ?? false
-  const isPdf = (file.type ?? '').includes('pdf')
-  const sizeOk = (file.size ?? Infinity) <= 4 * 1000 * 1000 // 4 MB
-  return isImage || isPdf || sizeOk
-}
-
-/**
  * When a file is rendered in a detail view, auto download it if:
  * its an image, PDF, or its less than 10 MB.
  */
@@ -27,6 +16,10 @@ export function detailsShouldAutoDownload(file: FileRecord): boolean {
   return isImage || isPdf || sizeOk
 }
 
+/**
+ * useAutoDownload automatically downloads a file if it is not already downloaded.
+ * This is used in the main file viewer with detailsShouldAutoDownload.
+ */
 export function useAutoDownload(
   file: FileRecord,
   shouldDownload: (file: FileRecord) => boolean

--- a/src/hooks/useBestThumbnail.ts
+++ b/src/hooks/useBestThumbnail.ts
@@ -1,0 +1,59 @@
+import useSWR from 'swr'
+import { useIsInitializing } from '../stores/app'
+import { useIsConnected } from '../stores/sdk'
+import { useFileStatus } from '../lib/file'
+import { useDownload } from '../managers/downloader'
+import { useEffect } from 'react'
+import { readBestThumbnailByHash, thumbnailSwr } from '../stores/thumbnails'
+import { FileRecord, ThumbSize } from '../stores/files'
+import { getFileUri } from '../stores/fileCache'
+
+/**
+ * useBestThumbnailUri returns the local URI of the best available thumbnail for a file.
+ *
+ * Behavior:
+ * - Only considers thumbnails with thumbSize <= requested size.
+ * - Picks the largest thumbSize that does not exceed the requested size.
+ * - Returns null if no qualifying thumbnail exists.
+ * - If a best thumbnail exists on the network but is not cached locally,
+ *   this hook will auto-download it.
+ */
+export function useBestThumbnailUri(
+  file?: FileRecord,
+  thumbSize: ThumbSize = 512
+) {
+  // Fetch the best thumbnail record.
+  const thumbRecord = useSWR(
+    file ? thumbnailSwr.getKey(`${file.hash}/${thumbSize}/record`) : null,
+    () => (file ? readBestThumbnailByHash(file.hash, thumbSize) : null)
+  )
+
+  // Auto-download the chosen thumbnail.
+  const isInitializing = useIsInitializing()
+  const isConnected = useIsConnected()
+  const status = useFileStatus(thumbRecord.data ?? undefined)
+  const download = useDownload(thumbRecord.data)
+  useEffect(() => {
+    if (isInitializing) return
+    if (!isConnected) return
+    if (!thumbRecord.data) return
+    if (!status.data?.isUploaded) return
+    if (status.data?.isDownloaded) return
+    if (status.data?.isDownloading) return
+    download()
+  }, [isInitializing, isConnected, thumbRecord.data, status.data])
+
+  // Get the URI for the thumbnail.
+  const response = useSWR(
+    file ? thumbnailSwr.getKey(`${file.hash}/${thumbSize}/uri`) : null,
+    async () => {
+      if (!thumbRecord.data) return null
+      return await getFileUri(thumbRecord.data)
+    }
+  )
+  // Update when status changes so the thumbnail is re-rendered when the uri becomes available.
+  useEffect(() => {
+    response.mutate()
+  }, [status.data])
+  return response
+}

--- a/src/managers/downloader.ts
+++ b/src/managers/downloader.ts
@@ -81,6 +81,7 @@ export function useDownloadFromShareURL() {
           const localMetadata: FileLocalMetadata = {
             id,
             localId: null,
+            addedAt: Date.now(),
           }
           const file: FileRecord = {
             ...metadata,

--- a/src/managers/syncDownEvents.ts
+++ b/src/managers/syncDownEvents.ts
@@ -170,7 +170,7 @@ async function handleUpdateEvent(
     await updateFileRecordWithLocalObject(
       {
         ...existingFile,
-        ...decodeFileMetadata(object.metadata()),
+        ...metadata,
       },
       localObject
     )
@@ -187,12 +187,7 @@ async function handleUpdateEvent(
     await createFileRecordWithLocalObject(
       {
         id: fileId,
-        name: metadata.name,
-        size: metadata.size,
-        createdAt: metadata.createdAt,
-        updatedAt: metadata.updatedAt,
-        type: metadata.type,
-        hash: metadata.hash,
+        ...metadata,
         localId: null,
         addedAt: Date.now(),
       },

--- a/src/screens/ImportFileScreen.tsx
+++ b/src/screens/ImportFileScreen.tsx
@@ -61,12 +61,8 @@ export function ImportFileScreen({ route }: Props) {
     if (!sharedObject.data) return null
     const metadata = decodeFileMetadata(sharedObject.data.metadata())
     const fileMetadata: FileMetadata = transformFileMetadata({
+      ...metadata,
       size: Number(sharedObject.data.size()),
-      type: metadata.type,
-      name: metadata.name,
-      hash: metadata.hash,
-      createdAt: metadata.createdAt,
-      updatedAt: metadata.updatedAt,
     })
     const localMetadata: FileLocalMetadata = {
       id,

--- a/src/screens/LibraryScreen.tsx
+++ b/src/screens/LibraryScreen.tsx
@@ -5,8 +5,13 @@ import { Gradient } from '../components/Gradient'
 import { ScreenHeader } from '../components/ScreenHeader'
 import { FileGallery } from '../components/FileGallery'
 import { type MainStackParamList } from '../stacks/types'
-import { type FileRecord, useFileCount } from '../stores/files'
-import { useFileList, useLibrary, type Category } from '../stores/library'
+import { type FileRecord } from '../stores/files'
+import {
+  useFileList,
+  useLibrary,
+  type Category,
+  useLibraryCount,
+} from '../stores/library'
 import { FileList } from '../components/FileList'
 import { AddFileActionSheet } from '../components/AddFileActionSheet'
 import LibraryStatusSheet from '../components/LibraryStatusSheet'
@@ -24,7 +29,7 @@ export function LibraryScreen({ route, navigation }: Props) {
   const viewMode = useLibraryViewMode()
   const { selectedCategories, searchQuery } = useLibrary()
   const files = useFileList()
-  const fileCount = useFileCount()
+  const fileCount = useLibraryCount()
   const handleOpenDetail = useCallback(
     (file: FileRecord) => {
       navigation.navigate('FileDetail', { id: file.id })

--- a/src/stores/files.ts
+++ b/src/stores/files.ts
@@ -12,12 +12,20 @@ import { getIndexerURL } from './settings'
 import { librarySwr } from './library'
 import { removeEmptyValues } from '../lib/object'
 
+/** Valid thumbnail sizes in pixels. */
+export type ThumbSize = 64 | 512
+export const ThumbSizes: ThumbSize[] = [64, 512]
+
 /** Fields that are stored in both the local database and the indexer metadata. */
 export type FileMetadata = {
   name: string
   type: string
   size: number
   hash: string
+  // Hash of the original file content this thumbnail is for.
+  thumbForHash?: string
+  // Size of the thumbnail in pixels.
+  thumbSize?: ThumbSize
   createdAt: number
   updatedAt: number
 }
@@ -39,10 +47,7 @@ export async function createFileRecord(
   fileRecord: Omit<FileRecord, 'objects'>,
   triggerUpdate: boolean = true
 ): Promise<void> {
-  const { id, name, size, createdAt, updatedAt, type, localId, hash, addedAt } =
-    fileRecord
-  await db().runAsync(
-    'INSERT INTO files (id, name, size, createdAt, updatedAt, type, localId, hash, addedAt) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+  const {
     id,
     name,
     size,
@@ -51,7 +56,23 @@ export async function createFileRecord(
     type,
     localId,
     hash,
-    addedAt
+    addedAt,
+    thumbForHash,
+    thumbSize,
+  } = fileRecord
+  await db().runAsync(
+    'INSERT INTO files (id, name, size, createdAt, updatedAt, type, localId, hash, addedAt, thumbForHash, thumbSize) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+    id,
+    name,
+    size,
+    createdAt,
+    updatedAt,
+    type,
+    localId,
+    hash,
+    addedAt,
+    thumbForHash ?? null,
+    thumbSize ?? null
   )
   if (triggerUpdate) {
     await librarySwr.triggerChange()
@@ -250,7 +271,7 @@ export async function readFileRecordByContentHash(hash: string) {
 
 export async function readFileRecord(id: string): Promise<FileRecord | null> {
   const row = await db().getFirstAsync<FileRecordRow>(
-    'SELECT id, name, size, createdAt, updatedAt, type, localId, hash FROM files WHERE id = ?',
+    'SELECT id, name, size, createdAt, updatedAt, type, localId, hash, addedAt, thumbForHash, thumbSize FROM files WHERE id = ?',
     id
   )
   if (!row) {
@@ -277,6 +298,8 @@ export async function updateFileRecord(
     'type',
     'localId',
     'hash',
+    'thumbForHash',
+    'thumbSize',
   ]
   for (const field of updatableFields) {
     const nonEmptyUpdate = removeEmptyValues(update)
@@ -318,6 +341,18 @@ export async function deleteFileRecord(
   if (triggerUpdate) {
     await librarySwr.triggerChange()
   }
+}
+
+/** Delete an original file and all its associated thumbnails. */
+export async function deleteFileRecordAndThumbnails(id: string): Promise<void> {
+  const original = await readFileRecord(id)
+  if (!original) return
+  const hash = original.hash
+  await db().withTransactionAsync(async () => {
+    await db().runAsync('DELETE FROM files WHERE thumbForHash = ?', hash)
+    await db().runAsync('DELETE FROM files WHERE id = ?', id)
+  })
+  await librarySwr.triggerChange()
 }
 
 export async function deleteAllFileRecords(): Promise<void> {
@@ -376,18 +411,10 @@ export function transformRow(
     type: row.type,
     localId: row.localId,
     hash: row.hash,
+    thumbForHash: row.thumbForHash ?? undefined,
+    thumbSize: row.thumbSize ?? undefined,
     objects: objectsMap,
   }
-}
-
-export function useFileCount() {
-  return useSWR(librarySwr.getKey('count'), () =>
-    readAllFileRecordsCount({
-      limit: undefined,
-      after: undefined,
-      order: 'ASC',
-    })
-  )
 }
 
 export function useFileCountAll() {

--- a/src/stores/library.ts
+++ b/src/stores/library.ts
@@ -4,6 +4,7 @@ import useSWRInfinite from 'swr/infinite'
 import { FileRecord, FileRecordRow, transformRow } from './files'
 import { readLocalObjectsForFiles } from './localObjects'
 import { buildSWRHelpers } from '../lib/swr'
+import useSWR from 'swr'
 
 export const librarySwr = buildSWRHelpers('library')
 
@@ -42,6 +43,8 @@ async function readOrderedFileRecords(
 
   const whereParts: string[] = []
   const params: (string | number | null)[] = []
+  // Exclude thumbnails from library lists.
+  whereParts.push('thumbForHash IS NULL')
   if (hasCategories) {
     whereParts.push(prefixes.map(() => 'type LIKE ?').join(' OR '))
     params.push(...prefixes.map((p) => `${p}%`))
@@ -127,6 +130,16 @@ export function useFileList() {
     data: flat,
     hasMore,
   }
+}
+
+// Count of library files excluding thumbnails.
+export function useLibraryCount() {
+  return useSWR(librarySwr.getKey('countWithoutThumbs'), async () => {
+    const row = await db().getFirstAsync<{ count: number }>(
+      `SELECT COUNT(*) as count FROM files WHERE thumbForHash IS NULL`
+    )
+    return row?.count ?? 0
+  })
 }
 
 // File View Store

--- a/src/stores/thumbnails.ts
+++ b/src/stores/thumbnails.ts
@@ -1,0 +1,80 @@
+import { db } from '../db'
+import {
+  FileRecord,
+  FileRecordRow,
+  ThumbSize,
+  ThumbSizes,
+  transformRow,
+} from './files'
+import { buildSWRHelpers } from '../lib/swr'
+
+export const thumbnailSwr = buildSWRHelpers('thumbnails')
+
+/** Read all thumbnails associated with an original file content hash. */
+export async function readThumbnailsByHash(
+  hash: string
+): Promise<FileRecord[]> {
+  const rows = await db().getAllAsync<FileRecordRow>(
+    `SELECT id, name, size, createdAt, updatedAt, type, localId, hash, addedAt, thumbForHash, thumbSize
+     FROM files
+     WHERE thumbForHash = ?
+     ORDER BY COALESCE(thumbSize, 0) ASC, id ASC`,
+    hash
+  )
+  return rows.map((row) => transformRow(row))
+}
+
+/** Read all existing thumbnail sizes for a given original hash. */
+export async function readThumbnailSizesForHash(
+  hash: string
+): Promise<ThumbSize[]> {
+  const rows = await db().getAllAsync<{ thumbSize: number | null }>(
+    `SELECT thumbSize FROM files WHERE thumbForHash = ?`,
+    hash
+  )
+  return rows
+    .map((r) => (typeof r.thumbSize === 'number' ? r.thumbSize : null))
+    .filter(
+      (n): n is ThumbSize => n !== null && ThumbSizes.includes(n as ThumbSize)
+    )
+    .sort((a, b) => a - b)
+}
+
+/**
+ * Read the best thumbnail for a given original file hash and required thumb size.
+ *
+ * Selection rule:
+ * - Only consider thumbnails whose thumbSize is less than or equal to the required size.
+ * - Prefer the largest available thumbSize that does not exceed the required size.
+ * - Return null if no thumbnails are at or below the required size.
+ */
+export async function readBestThumbnailByHash(
+  hash: string,
+  requiredSize: ThumbSize
+): Promise<FileRecord | null> {
+  const row = await db().getFirstAsync<FileRecordRow>(
+    `SELECT id, name, size, createdAt, updatedAt, type, localId, hash, addedAt, thumbForHash, thumbSize
+     FROM files
+     WHERE thumbForHash = ? AND COALESCE(thumbSize, 0) <= ?
+     ORDER BY 
+       COALESCE(thumbSize, 0) DESC,
+       id ASC
+     LIMIT 1`,
+    hash,
+    requiredSize
+  )
+  return row ? transformRow(row) : null
+}
+
+/** Check if a thumbnail exists for an original hash and exact size. */
+export async function thumbnailExistsForHashAndSize(
+  hash: string,
+  size: ThumbSize
+): Promise<boolean> {
+  const row = await db().getFirstAsync<{ id: string }>(
+    `SELECT id FROM files WHERE thumbForHash = ? AND thumbSize = ? LIMIT 1`,
+    hash,
+    size
+  )
+  return !!row
+}


### PR DESCRIPTION
- Adds support for image and video thumbnails. Starting with 64px and 512px. Thumbnails are files/objects under the hood but they have a `thumbForHash`​ field which specifies what files they are a thumb for.
- Adds the local sqlite database schema, as well as the pinned object schema for these fields.
- Swaps out original images in the gallery and file list for thumbnails.
    - This should really improve the rendering performance when interacting with a large library.
- Continues to break out files table queries into a few contexts:
    - `src/stores/files.ts`​ generic files queries for storage and used by sync.
    - `src/stores/library.ts`​ files queries for what the user sees in their library.
    - `src/stores/thumbnails.ts` files queries for thumbnails.