### PR TITLE
feat: setting to reset sync down cursor

### DIFF
--- a/src/components/SettingsAdvancedSync.tsx
+++ b/src/components/SettingsAdvancedSync.tsx
@@ -1,13 +1,15 @@
-import { Switch } from 'react-native'
+import { Switch, Alert } from 'react-native'
 import { InfoCard } from './InfoCard'
 import { LabeledValueRow } from './LabeledValueRow'
 import { RowGroup } from './Group'
+import { Button } from './Button'
 import {
   toggleAutoScanUploads,
   toggleAutoSyncDownEvents,
   useAutoScanUploads,
   useAutoSyncDownEvents,
 } from '../stores/settings'
+import { resetSyncDownCursor } from '../managers/syncDownEvents'
 
 export function SettingsAdvancedSync() {
   const autoScan = useAutoScanUploads()
@@ -34,6 +36,32 @@ export function SettingsAdvancedSync() {
               value={autoSync.data ?? false}
               onValueChange={toggleAutoSyncDownEvents}
             />
+          }
+        />
+        <LabeledValueRow
+          label="Reset sync cursor"
+          labelWidth={250}
+          value={
+            <Button
+              variant="secondary"
+              style={{ paddingVertical: 8, paddingHorizontal: 16 }}
+              onPress={() => {
+                Alert.alert(
+                  'Reset Sync Cursor',
+                  'This will reset the sync cursor and cause the app to resync all events from the beginning. Continue?',
+                  [
+                    { text: 'Cancel', style: 'cancel' },
+                    {
+                      text: 'Reset',
+                      style: 'destructive',
+                      onPress: () => resetSyncDownCursor(),
+                    },
+                  ]
+                )
+              }}
+            >
+              Reset
+            </Button>
           }
         />
       </InfoCard>


### PR DESCRIPTION
- Adds a developer setting to reset the sync cursor which will resync all indexer events from the very beginning.