### PR TITLE
fix: sync archive faster progress

### DIFF
--- a/src/lib/serviceInterval.ts
+++ b/src/lib/serviceInterval.ts
@@ -15,7 +15,7 @@ export function createServiceInterval({
   interval,
 }: {
   name: string
-  worker: () => void | Promise<void>
+  worker: () => void | number | Promise<void | number>
   getState: () => Promise<boolean>
   interval: number
 }): () => void {
@@ -44,19 +44,22 @@ export function createServiceInterval({
 
       if (!enabled) {
         // Service disabled: skip work but still schedule the next check.
-        scheduleNextRun()
+        scheduleNextRun(interval)
         return
       }
 
+      let nextInterval = interval
       try {
-        await Promise.resolve(worker())
+        const customInterval = await Promise.resolve(worker())
+        if (typeof customInterval === 'number') {
+          nextInterval = customInterval
+        }
       } finally {
-        // Always schedule the next run, even if the worker throws.
-        scheduleNextRun()
+        scheduleNextRun(nextInterval)
       }
     }
 
-    function scheduleNextRun() {
+    function scheduleNextRun(interval: number) {
       // Only schedule if this init remains the latest.
       const current = schedulerStateMap.get(name)
       if (!current || current.token !== token) return
@@ -64,7 +67,7 @@ export function createServiceInterval({
       schedulerStateMap.set(name, { token, timeoutId })
     }
 
-    scheduleNextRun()
+    scheduleNextRun(interval)
   }
 
   return init

--- a/src/managers/syncPhotosArchive.test.ts
+++ b/src/managers/syncPhotosArchive.test.ts
@@ -97,7 +97,54 @@ describe('syncPhotosArchive', () => {
     )
 
     processAssetsMock
-      .mockResolvedValueOnce({ files: [], updatedFiles: [], warnings: [] })
+      .mockResolvedValueOnce({
+        files: [
+          {
+            id: 'b1',
+            name: 'one.jpg',
+            type: 'image/jpeg',
+            size: 100,
+            hash: 'hash1',
+            createdAt: 10_000,
+            updatedAt: 10_000,
+            localId: 'b1',
+            addedAt: 10_000,
+            objects: {},
+          },
+          {
+            id: 'b2',
+            name: 'two.jpg',
+            type: 'image/jpeg',
+            size: 100,
+            hash: 'hash2',
+            createdAt: 5_000,
+            updatedAt: 5_000,
+            localId: 'b2',
+            addedAt: 10_000,
+            objects: {},
+          },
+        ],
+        updatedFiles: [],
+        warnings: [],
+      })
+      .mockResolvedValueOnce({
+        files: [
+          {
+            id: 'b3',
+            name: 'three.jpg',
+            type: 'image/jpeg',
+            size: 100,
+            hash: 'hash3',
+            createdAt: 1_000,
+            updatedAt: 1_000,
+            localId: 'b3',
+            addedAt: 10_000,
+            objects: {},
+          },
+        ],
+        updatedFiles: [],
+        warnings: [],
+      })
       .mockResolvedValueOnce({ files: [], updatedFiles: [], warnings: [] })
 
     // Seed initial cursor so service is enabled.
@@ -113,14 +160,14 @@ describe('syncPhotosArchive', () => {
     ])
     expect(await getPhotosArchiveCursor()).toBe(4_999)
 
-    // Tick 2: createdBefore 5_000 -> returns [1_000], cursor -> 1_000
+    // Tick 2: createdBefore 4_999 -> returns [1_000], cursor -> 999
     await runTick()
     expect(processAssetsMock).toHaveBeenNthCalledWith(2, [
       expect.objectContaining({ id: 'b3', name: 'three.jpg' }),
     ])
     expect(await getPhotosArchiveCursor()).toBe(999)
 
-    // Tick 3: createdBefore 1_000 -> returns [], cursor should reset to 0 and stop
+    // Tick 3: createdBefore 1_000 -> returns [], cursor -> 0
     await runTick()
     expect(await getPhotosArchiveCursor()).toBe(0)
     expect(processAssetsMock).toHaveBeenCalledTimes(2)

--- a/src/managers/syncPhotosArchive.ts
+++ b/src/managers/syncPhotosArchive.ts
@@ -16,7 +16,7 @@ import { ensureMediaLibraryPermission } from '../lib/mediaLibraryPermissions'
 
 const PAGE_SIZE = 1
 
-export async function workBackward(): Promise<void> {
+export async function workBackward() {
   if (!(await ensureMediaLibraryPermission())) return
   const cursor = await getPhotosArchiveCursor()
 
@@ -50,7 +50,12 @@ export async function workBackward(): Promise<void> {
         timestamp: new Date(asset.creationTime).toISOString(),
       }))
     )
-    if (files.length > 0) await librarySwr.triggerChange()
+    if (files.length > 0) {
+      await librarySwr.triggerChange()
+    } else {
+      // Nothing was found so immediately start next interval.
+      return 0
+    }
   } catch (e) {
     logger.log('[syncPhotosArchive] batch error', e)
   }


### PR DESCRIPTION
- Adds support to createServiceInterval for returning a custom next interval delay. This allows the business logic to decide the next delay.
- When re-running Photos archive sync it will churn through many photos it has already seen, we can return 0 to schedule the next run immediately instead of the normal delay between processing cycles.