### PR TITLE
fix: adding missing fields to file db queries

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,6 +1,7 @@
 import * as SQLite from 'expo-sqlite'
 import { runMigrations } from './migrations'
 import { logger } from '../lib/logger'
+import { Mutex } from '../lib/mutex'
 
 export let database: SQLite.SQLiteDatabase
 const dbName = 'app.db'
@@ -33,4 +34,17 @@ export async function resetDb() {
 
 export function db() {
   return database
+}
+
+const txMutex = new Mutex()
+
+/** Run operations in a transaction and serialize all database transactions across the app. */
+export async function withTransactionLock<T>(fn: () => Promise<T>): Promise<T> {
+  return txMutex.runExclusive(async () => {
+    let out!: T
+    await db().withTransactionAsync(async () => {
+      out = await fn()
+    })
+    return out
+  })
 }

--- a/src/lib/mutex.ts
+++ b/src/lib/mutex.ts
@@ -1,0 +1,24 @@
+export class Mutex {
+  private tail: Promise<void> = Promise.resolve()
+
+  /** Acquire the mutex; returns a release function to be called when done. */
+  async acquire(): Promise<() => void> {
+    const previous = this.tail
+    let release!: () => void
+    this.tail = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    await previous
+    return release
+  }
+
+  /** Run a function exclusively under the mutex. */
+  async runExclusive<T>(fn: () => Promise<T>): Promise<T> {
+    const release = await this.acquire()
+    try {
+      return await fn()
+    } finally {
+      release()
+    }
+  }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,1 +1,12 @@
 export type MaybeError<T> = [T, null] | [null, Error]
+
+/**
+ * Define a list of keys for a record type, enforcing that all keys are present.
+ * @example
+ * const keys = keysOf<FileMetadata>()(['name', 'type', 'size', 'hash', 'createdAt', 'updatedAt', 'thumbForHash', 'thumbSize'])
+ */
+export function keysOf<T>() {
+  return <K extends readonly (keyof T)[]>(
+    keys: K & Record<Exclude<keyof T, K[number]>, never>
+  ) => keys
+}

--- a/src/stores/files.ts
+++ b/src/stores/files.ts
@@ -4,13 +4,14 @@ import {
 } from '../encoding/localObject'
 import { upsertLocalObject, readLocalObjectsForFile } from './localObjects'
 import { logger } from '../lib/logger'
-import { db } from '../db'
+import { db, withTransactionLock } from '../db'
 import useSWR from 'swr'
 import { createGetterAndSWRHook } from '../lib/selectors'
 import { LocalObjectRow } from '../encoding/localObject'
 import { getIndexerURL } from './settings'
 import { librarySwr } from './library'
 import { removeEmptyValues } from '../lib/object'
+import { keysOf } from '../lib/types'
 
 /** Valid thumbnail sizes in pixels. */
 export type ThumbSize = 64 | 512
@@ -30,6 +31,17 @@ export type FileMetadata = {
   updatedAt: number
 }
 
+export const fileMetadataKeys = keysOf<FileMetadata>()([
+  'name',
+  'type',
+  'size',
+  'hash',
+  'createdAt',
+  'updatedAt',
+  'thumbForHash',
+  'thumbSize',
+])
+
 /** Fields that are stored only in the local database. */
 export type FileLocalMetadata = {
   id: string
@@ -37,7 +49,18 @@ export type FileLocalMetadata = {
   addedAt: number
 }
 
+export const fileLocalMetadataKeys = keysOf<FileLocalMetadata>()([
+  'id',
+  'localId',
+  'addedAt',
+])
+
 export type FileRecordRow = FileMetadata & FileLocalMetadata
+
+export const fileRecordRowKeys = keysOf<FileRecordRow>()([
+  ...fileMetadataKeys,
+  ...fileLocalMetadataKeys,
+])
 
 export type FileRecord = FileRecordRow & {
   objects: Record<string, LocalObject>
@@ -82,7 +105,7 @@ export async function createFileRecord(
 export async function createManyFileRecords(
   files: FileRecord[]
 ): Promise<void> {
-  await db().withTransactionAsync(async () => {
+  await withTransactionLock(async () => {
     for (const fr of files) {
       await createFileRecord(fr, false)
     }
@@ -183,7 +206,7 @@ export async function readAllFileRecords(opts: {
         objectUpdatedAt: number
       }
   >(
-    `SELECT f.id, f.name, f.size, f.createdAt, f.updatedAt, f.type, f.localId, f.hash,
+    `SELECT f.id, f.name, f.size, f.createdAt, f.updatedAt, f.type, f.localId, f.hash, f.addedAt, f.thumbForHash, f.thumbSize,
             o.fileId as fileId, o.indexerURL as indexerURL, o.id as objectId, o.slabs as slabs,
             o.encryptedMasterKey as encryptedMasterKey, o.encryptedMetadata as encryptedMetadata,
             o.signature as signature, o.createdAt as objectCreatedAt, o.updatedAt as objectUpdatedAt
@@ -292,14 +315,14 @@ export async function updateFileRecord(
   const params: (string | number | null)[] = []
   const updatableFields = [
     'name',
+    'type',
     'size',
+    'hash',
     'createdAt',
     'updatedAt',
-    'type',
-    'localId',
-    'hash',
     'thumbForHash',
     'thumbSize',
+    'localId',
   ]
   for (const field of updatableFields) {
     const nonEmptyUpdate = removeEmptyValues(update)
@@ -323,7 +346,7 @@ export async function updateFileRecord(
 export async function updateManyFileRecords(
   updates: Partial<FileRecordRow> & { id: string }[]
 ): Promise<void> {
-  await db().withTransactionAsync(async () => {
+  await withTransactionLock(async () => {
     for (const update of updates) {
       await updateFileRecord(update, false)
     }
@@ -348,7 +371,7 @@ export async function deleteFileRecordAndThumbnails(id: string): Promise<void> {
   const original = await readFileRecord(id)
   if (!original) return
   const hash = original.hash
-  await db().withTransactionAsync(async () => {
+  await withTransactionLock(async () => {
     await db().runAsync('DELETE FROM files WHERE thumbForHash = ?', hash)
     await db().runAsync('DELETE FROM files WHERE id = ?', id)
   })
@@ -365,7 +388,7 @@ export async function createFileRecordWithLocalObject(
   localObject: LocalObject
 ): Promise<void> {
   try {
-    await db().withTransactionAsync(async () => {
+    await withTransactionLock(async () => {
       await createFileRecord(fileRecord, false)
       await upsertLocalObject(localObject, false)
     })
@@ -382,7 +405,7 @@ export async function updateFileRecordWithLocalObject(
   localObject: LocalObject
 ): Promise<void> {
   try {
-    await db().withTransactionAsync(async () => {
+    await withTransactionLock(async () => {
       await updateFileRecord(fileRecord, false)
       await upsertLocalObject(localObject, false)
     })

--- a/src/stores/thumbnails.ts
+++ b/src/stores/thumbnails.ts
@@ -6,6 +6,7 @@ import {
   ThumbSizes,
   transformRow,
 } from './files'
+import { readLocalObjectsForFile } from './localObjects'
 import { buildSWRHelpers } from '../lib/swr'
 
 export const thumbnailSwr = buildSWRHelpers('thumbnails')
@@ -22,6 +23,21 @@ export async function readThumbnailsByHash(
     hash
   )
   return rows.map((row) => transformRow(row))
+}
+
+export async function readThumbnailRecordByThumbForHashAndSize(
+  thumbForHash: string,
+  size: ThumbSize
+): Promise<FileRecord | null> {
+  const row = await db().getFirstAsync<FileRecordRow>(
+    `SELECT id, name, size, createdAt, updatedAt, type, localId, hash, addedAt, thumbForHash, thumbSize
+     FROM files WHERE thumbForHash = ? AND thumbSize = ?`,
+    thumbForHash,
+    size
+  )
+  if (!row) return null
+  const objects = await readLocalObjectsForFile(row.id)
+  return transformRow(row, objects)
 }
 
 /** Read all existing thumbnail sizes for a given original hash. */
@@ -63,7 +79,9 @@ export async function readBestThumbnailByHash(
     hash,
     requiredSize
   )
-  return row ? transformRow(row) : null
+  if (!row) return null
+  const objects = await readLocalObjectsForFile(row.id)
+  return transformRow(row, objects)
 }
 
 /** Check if a thumbnail exists for an original hash and exact size. */


### PR DESCRIPTION
- This PR fixes some small files db related issues.
- Adds objects to thumbnail retrieval methods, without the object the gallery items were not aware the thumbnail could be downloaded.
- Adds a mutex and helper for running database transactions. I was seeing some database transaction conflict errors.
- Adds a `keysOf`​ helper for creating an array of exact keys for an object type. This is useful in other code where we want to iterate through all row keys.