### PR TITLE
fix: make thumbnails unique

### DIFF
--- a/src/db/migrations/0002_add_thumbnail_columns.ts
+++ b/src/db/migrations/0002_add_thumbnail_columns.ts
@@ -29,7 +29,7 @@ async function up(db: SQLite.SQLiteDatabase): Promise<void> {
 
     // Create an index to efficiently select thumbnails for an original and size bucket.
     await db.execAsync(
-      `CREATE INDEX IF NOT EXISTS idx_files_thumbForHash_thumbSize ON files(thumbForHash, thumbSize)`
+      `CREATE UNIQUE INDEX IF NOT EXISTS idx_files_thumbForHash_thumbSize ON files(thumbForHash, thumbSize)`
     )
   } catch (e) {
     logger.log('[db] error running migration 0002_add_thumbnail_columns', e)

--- a/src/encoding/fileMetadata.ts
+++ b/src/encoding/fileMetadata.ts
@@ -38,7 +38,7 @@ export function decodeFileMetadata(buffer?: ArrayBuffer): FileMetadata {
 }
 
 /// Checks for complete metadata, most importantly the presence of the hash.
-export function hasCompleteMetadata(metadata: FileMetadata): boolean {
+export function hasCompleteFileMetadata(metadata: FileMetadata): boolean {
   return (
     !!metadata.hash &&
     !!metadata.type &&
@@ -46,5 +46,14 @@ export function hasCompleteMetadata(metadata: FileMetadata): boolean {
     !!metadata.size &&
     !!metadata.updatedAt &&
     !!metadata.createdAt
+  )
+}
+
+/// Checks for complete thumbnail metadata.
+export function hasCompleteThumbnailMetadata(metadata: FileMetadata): boolean {
+  return (
+    hasCompleteFileMetadata(metadata) &&
+    !!metadata.thumbForHash &&
+    !!metadata.thumbSize
   )
 }

--- a/src/managers/syncDownEvents.ts
+++ b/src/managers/syncDownEvents.ts
@@ -3,16 +3,18 @@ import { SYNC_EVENTS_INTERVAL } from '../config'
 import { getIsConnected, getSdk } from '../stores/sdk'
 import { getAutoSyncDownEvents, getIndexerURL } from '../stores/settings'
 import {
-  readFileRecord,
   readFileRecordByObjectId,
   deleteFileRecord,
   createFileRecordWithLocalObject,
   updateFileRecordWithLocalObject,
   readFileRecordByContentHash,
+  FileRecord,
+  FileMetadata,
 } from '../stores/files'
 import {
   decodeFileMetadata,
-  hasCompleteMetadata,
+  hasCompleteFileMetadata,
+  hasCompleteThumbnailMetadata,
 } from '../encoding/fileMetadata'
 import {
   ObjectEvent,
@@ -30,6 +32,7 @@ import {
 } from '../stores/fileCache'
 import { uniqueId } from '../lib/uniqueId'
 import { cancelUpload } from '../stores/uploads'
+import { readThumbnailRecordByThumbForHashAndSize } from '../stores/thumbnails'
 
 const batchSize = 100
 
@@ -154,14 +157,52 @@ async function handleUpdateEvent(
 ): Promise<void> {
   const indexerURL = await getIndexerURL()
   const metadata = decodeFileMetadata(object.metadata())
-  logger.log(`[syncDownEvents] updating file objectId=${object.id()}`)
-  if (!hasCompleteMetadata(metadata)) {
-    logger.log(`[syncDownEvents] incomplete metadata, skipping update`)
+  if (hasCompleteThumbnailMetadata(metadata)) {
+    const existingThumbnail = await readThumbnailRecordByThumbForHashAndSize(
+      metadata.thumbForHash!,
+      metadata.thumbSize!
+    )
+    await handleFileRecord(
+      'thumbnail',
+      existingThumbnail,
+      indexerURL,
+      object,
+      metadata,
+      counts
+    )
     return
   }
-  const existingFile = await readFileRecordByContentHash(metadata.hash)
+  if (hasCompleteFileMetadata(metadata)) {
+    const existingFile = await readFileRecordByContentHash(metadata.hash)
+    await handleFileRecord(
+      'file',
+      existingFile,
+      indexerURL,
+      object,
+      metadata,
+      counts
+    )
+    return
+  }
+  logger.log(`[syncDownEvents] incomplete metadata, skipping update`)
+}
 
+async function handleFileRecord(
+  type: 'file' | 'thumbnail',
+  existingFile: FileRecord | null,
+  indexerURL: string,
+  object: PinnedObjectInterface,
+  metadata: FileMetadata,
+  counts: Counts
+) {
   if (existingFile) {
+    if (type === 'file') {
+      logger.log(`[syncDownEvents] updating file hash=${existingFile.hash}`)
+    } else {
+      logger.log(
+        `[syncDownEvents] updating thumbnail thumbForHash=${existingFile.thumbForHash}`
+      )
+    }
     const localObject = await pinnedObjectToLocalObject(
       existingFile.id,
       indexerURL,
@@ -170,7 +211,7 @@ async function handleUpdateEvent(
     await updateFileRecordWithLocalObject(
       {
         ...existingFile,
-        ...metadata,
+        ...(metadata.updatedAt >= existingFile.updatedAt ? metadata : {}),
       },
       localObject
     )
@@ -178,6 +219,13 @@ async function handleUpdateEvent(
     cancelUpload(existingFile.id)
     counts.existing++
   } else {
+    if (type === 'file') {
+      logger.log(`[syncDownEvents] creating file hash=${metadata.hash}`)
+    } else {
+      logger.log(
+        `[syncDownEvents] creating thumbnail thumbForHash=${metadata.thumbForHash}`
+      )
+    }
     const fileId = uniqueId()
     const localObject = await pinnedObjectToLocalObject(
       fileId,

--- a/src/managers/thumbnailer/index.ts
+++ b/src/managers/thumbnailer/index.ts
@@ -308,11 +308,6 @@ export async function runThumbnailer(): Promise<ThumbnailerResult> {
         break
       }
 
-      logger.log('[thumbnailer] candidates', {
-        count: batch.length,
-        ids: batch.map((c) => c.id).slice(0, 10),
-      })
-
       for (const c of batch) {
         if (producedCount >= MAX_THUMBS_PER_TICK) break
         processedThisRun.add(c.id)

--- a/src/screens/ImportFileScreen.tsx
+++ b/src/screens/ImportFileScreen.tsx
@@ -26,7 +26,7 @@ import { FileDetailsImport } from '../components/FileDetailsImport'
 import { logger } from '../lib/logger'
 import {
   decodeFileMetadata,
-  hasCompleteMetadata,
+  hasCompleteFileMetadata,
   transformFileMetadata,
 } from '../encoding/fileMetadata'
 import { getIndexerURL } from '../stores/settings'
@@ -86,7 +86,7 @@ export function ImportFileScreen({ route }: Props) {
         return
       }
       logger.log('[ImportFileScreen] handleAddToDatabase', sharedFile.id)
-      if (!hasCompleteMetadata(sharedFile)) {
+      if (!hasCompleteFileMetadata(sharedFile)) {
         toast.show('Shared file must have complete metadata')
         return
       }


### PR DESCRIPTION
- Adds UNIQUE to the thumbnail index going out in the next release.
- Refactors the sync down events code to have clear checks and code paths for regular files and thumbnails.
- The Thumbnail code checks if a thumbnail already exists on the new thumb index. This is useful for the edge-case where two devices generate the same thumbnails and then later sync, this now resolves to a single database record.