### PR TITLE
feat: sync up metadata changes

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -29,3 +29,7 @@ export const SYNC_NEW_PHOTOS_INTERVAL = 30_000 // 30 seconds
 export const SYNC_PHOTOS_ARCHIVE_INTERVAL = 5_000 // 5 seconds
 // Thumbnail interval.
 export const THUMBNAIL_INTERVAL = 5_000 // 5 seconds
+// Sync up metadata interval.
+export const SYNC_UP_METADATA_INTERVAL = 10_000 // 10 seconds
+// Sync up metadata batch size.
+export const SYNC_UP_METADATA_BATCH_SIZE = 500 // 500 files

--- a/src/db/migrations/0003_add_updated_at_index.ts
+++ b/src/db/migrations/0003_add_updated_at_index.ts
@@ -1,0 +1,21 @@
+import * as SQLite from 'expo-sqlite'
+import { type Migration } from './types'
+import { logger } from '../../lib/logger'
+
+// Adds an index on the updatedAt column to the files table.
+// This is used to efficiently query files that have been updated since a given time.
+async function up(db: SQLite.SQLiteDatabase): Promise<void> {
+  try {
+    await db.execAsync(
+      `CREATE INDEX IF NOT EXISTS idx_files_updatedAt_id ON files(updatedAt, id);`
+    )
+  } catch (e) {
+    logger.log('[db] error running migration 0003_add_updated_at_index', e)
+    throw e
+  }
+}
+
+export const migration_0003_add_updated_at_index: Migration = {
+  id: '0003_add_updated_at_index',
+  up,
+}

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -21,10 +21,12 @@ import { logger } from '../../lib/logger'
 import { type Migration } from './types'
 import { migration_0001_init_schema } from './0001_init_schema'
 import { migration_0002_add_thumbnail_columns } from './0002_add_thumbnail_columns'
+import { migration_0003_add_updated_at_index } from './0003_add_updated_at_index'
 
 const migrations: Migration[] = [
   migration_0001_init_schema,
   migration_0002_add_thumbnail_columns,
+  migration_0003_add_updated_at_index,
 ]
 
 export async function runMigrations(db: SQLite.SQLiteDatabase): Promise<void> {

--- a/src/managers/syncUpMetadata.test.ts
+++ b/src/managers/syncUpMetadata.test.ts
@@ -1,0 +1,324 @@
+import {
+  getSyncUpCursor,
+  setSyncUpCursor,
+  runSyncUpMetadata,
+} from './syncUpMetadata'
+import { initializeDB, resetDb } from '../db'
+import {
+  createFileRecordWithLocalObject,
+  type FileRecord,
+} from '../stores/files'
+import { type LocalObject } from '../encoding/localObject'
+
+jest.mock('../stores/sdk', () => ({
+  getIsConnected: jest.fn(),
+  getPinnedObject: jest.fn(),
+  updateMetadata: jest.fn(),
+}))
+
+jest.mock('../stores/settings', () => ({
+  getIndexerURL: jest.fn(),
+}))
+
+jest.mock('../encoding/fileMetadata', () => ({
+  decodeFileMetadata: jest.fn(),
+  encodeFileMetadata: jest.fn(),
+}))
+
+function makeLocalObject(params: {
+  fileId: string
+  objectId: string
+  indexerURL: string
+  createdAt: number
+  updatedAt: number
+}): LocalObject {
+  return {
+    id: params.objectId,
+    fileId: params.fileId,
+    indexerURL: params.indexerURL,
+    slabs: [],
+    encryptedMasterKey: new Uint8Array([1]).buffer,
+    encryptedMetadata: new Uint8Array([2]).buffer,
+    signature: new Uint8Array([3]).buffer,
+    createdAt: new Date(params.createdAt),
+    updatedAt: new Date(params.updatedAt),
+  }
+}
+
+describe('syncUpMetadata', () => {
+  const sdk = require('../stores/sdk') as jest.Mocked<any>
+  const settings = require('../stores/settings') as jest.Mocked<any>
+  const meta = require('../encoding/fileMetadata') as jest.Mocked<any>
+  const INDEXER_URL = 'indexer-url'
+  const NOW_BASE = 400
+
+  beforeEach(async () => {
+    await initializeDB()
+    jest.clearAllMocks()
+    settings.getIndexerURL.mockResolvedValue(INDEXER_URL)
+    await setSyncUpCursor(undefined)
+    sdk.getIsConnected.mockReturnValue(true)
+  })
+
+  afterEach(async () => {
+    await resetDb()
+  })
+
+  test('updates files where local is newer, skips files where remote is newer', async () => {
+    sdk.getIsConnected.mockReturnValue(true)
+
+    // File A: local updatedAt=200, remote updatedAt=150 -> LOCAL NEWER -> should UPDATE
+    const localA: Omit<FileRecord, 'objects'> = {
+      id: 'file-a',
+      name: 'a.jpg',
+      type: 'image/jpeg',
+      size: 100,
+      hash: 'hash-a',
+      createdAt: 100,
+      updatedAt: 200, // local newer
+      localId: null,
+      addedAt: 100,
+      thumbForHash: undefined,
+      thumbSize: undefined,
+    }
+    await createFileRecordWithLocalObject(
+      localA,
+      makeLocalObject({
+        fileId: localA.id,
+        objectId: 'obj-a',
+        indexerURL: INDEXER_URL,
+        createdAt: 100,
+        updatedAt: 200,
+      })
+    )
+
+    // File B: local updatedAt=100, remote updatedAt=200 -> REMOTE NEWER -> should SKIP
+    const localB: Omit<FileRecord, 'objects'> = {
+      id: 'file-b',
+      name: 'b.jpg',
+      type: 'image/jpeg',
+      size: 200,
+      hash: 'hash-b',
+      createdAt: 110,
+      updatedAt: 100, // local older
+      localId: null,
+      addedAt: 110,
+      thumbForHash: undefined,
+      thumbSize: undefined,
+    }
+    await createFileRecordWithLocalObject(
+      localB,
+      makeLocalObject({
+        fileId: localB.id,
+        objectId: 'obj-b',
+        indexerURL: INDEXER_URL,
+        createdAt: 110,
+        updatedAt: 100,
+      })
+    )
+
+    sdk.getPinnedObject.mockImplementation(async (_objectId: string) => {
+      return { metadata: () => new ArrayBuffer(0) }
+    })
+
+    const remoteA = {
+      name: 'a.jpg',
+      type: 'image/jpeg',
+      size: 100,
+      hash: 'hash-a',
+      createdAt: 100,
+      updatedAt: 150, // remote older -> local should win
+      thumbForHash: undefined,
+      thumbSize: undefined,
+    }
+    const remoteB = {
+      name: 'b.jpg',
+      type: 'image/jpeg',
+      size: 200,
+      hash: 'hash-b',
+      createdAt: 110,
+      updatedAt: 200, // remote newer -> remote should win, skip update
+      thumbForHash: undefined,
+      thumbSize: undefined,
+    }
+    meta.decodeFileMetadata
+      .mockReturnValueOnce(remoteA)
+      .mockReturnValueOnce(remoteB)
+
+    await runSyncUpMetadata(5)
+
+    // Only file A should be updated, file B should be skipped.
+    expect(sdk.updateMetadata).toHaveBeenCalledTimes(1)
+    expect(meta.encodeFileMetadata).toHaveBeenCalledTimes(1)
+    expect(meta.encodeFileMetadata).toHaveBeenCalledWith(
+      expect.objectContaining(localA)
+    )
+  })
+
+  test('early exit when disconnected', async () => {
+    sdk.getIsConnected.mockReturnValue(false)
+    await runSyncUpMetadata(5)
+    expect(true).toBe(true)
+  })
+
+  test('cursor reset when no items', async () => {
+    sdk.getIsConnected.mockReturnValue(true)
+    await runSyncUpMetadata(5)
+    const cur = await getSyncUpCursor()
+    expect(cur).toBeUndefined()
+  })
+
+  test('advances cursor when full batch processed', async () => {
+    const batchSize = 5
+    for (let i = 0; i < batchSize; i++) {
+      const file: Omit<FileRecord, 'objects'> = {
+        id: `file-${i}`,
+        name: `name-${i}`,
+        type: 'image/jpeg',
+        size: 100 + i,
+        hash: `hash-${i}`,
+        createdAt: NOW_BASE + i,
+        updatedAt: NOW_BASE + i,
+        localId: null,
+        addedAt: NOW_BASE + i,
+        thumbForHash: undefined,
+        thumbSize: undefined,
+      }
+      await createFileRecordWithLocalObject(
+        file,
+        makeLocalObject({
+          fileId: file.id,
+          objectId: `obj-${i}`,
+          indexerURL: INDEXER_URL,
+          createdAt: NOW_BASE + i,
+          updatedAt: NOW_BASE + i,
+        })
+      )
+    }
+
+    await runSyncUpMetadata(batchSize)
+
+    const cur = await getSyncUpCursor()
+    expect(cur).toEqual({
+      updatedAt: NOW_BASE + (batchSize - 1),
+      id: `file-${batchSize - 1}`,
+    })
+  })
+
+  test('advances cursor past partial batch', async () => {
+    const batchSize = 5
+    const count = 3
+    for (let i = 0; i < count; i++) {
+      const file: Omit<FileRecord, 'objects'> = {
+        id: `file-${i}`,
+        name: `name-${i}`,
+        type: 'image/jpeg',
+        size: 100 + i,
+        hash: `hash-${i}`,
+        createdAt: NOW_BASE + i,
+        updatedAt: NOW_BASE + i,
+        localId: null,
+        addedAt: NOW_BASE + i,
+        thumbForHash: undefined,
+        thumbSize: undefined,
+      }
+      await createFileRecordWithLocalObject(
+        file,
+        makeLocalObject({
+          fileId: file.id,
+          objectId: `obj-${i}`,
+          indexerURL: INDEXER_URL,
+          createdAt: NOW_BASE + i,
+          updatedAt: NOW_BASE + i,
+        })
+      )
+    }
+
+    await runSyncUpMetadata(batchSize)
+
+    const cur = await getSyncUpCursor()
+    expect(cur).toEqual({
+      updatedAt: NOW_BASE + count,
+      id: `file-${count - 1}`,
+    })
+  })
+  test('skips files at or before cursor updatedAt', async () => {
+    sdk.getIsConnected.mockReturnValue(true)
+    const batchSize = 10
+
+    const records: Omit<FileRecord, 'objects'>[] = [
+      {
+        id: 'file-0',
+        name: 'name-0',
+        type: 'image/jpeg',
+        size: 101,
+        hash: 'hash-0',
+        createdAt: NOW_BASE,
+        updatedAt: NOW_BASE,
+        localId: null,
+        addedAt: NOW_BASE,
+        thumbForHash: undefined,
+        thumbSize: undefined,
+      },
+      {
+        id: 'file-1',
+        name: 'name-1',
+        type: 'image/jpeg',
+        size: 102,
+        hash: 'hash-1',
+        createdAt: NOW_BASE + 1,
+        updatedAt: NOW_BASE + 1,
+        localId: null,
+        addedAt: NOW_BASE + 1,
+        thumbForHash: undefined,
+        thumbSize: undefined,
+      },
+      {
+        id: 'file-2',
+        name: 'name-2',
+        type: 'image/jpeg',
+        size: 103,
+        hash: 'hash-2',
+        createdAt: NOW_BASE + 2,
+        updatedAt: NOW_BASE + 2,
+        localId: null,
+        addedAt: NOW_BASE + 2,
+        thumbForHash: undefined,
+        thumbSize: undefined,
+      },
+    ]
+
+    for (const record of records) {
+      await createFileRecordWithLocalObject(
+        record,
+        makeLocalObject({
+          fileId: record.id,
+          objectId: `obj-${record.id}`,
+          indexerURL: INDEXER_URL,
+          createdAt: record.createdAt,
+          updatedAt: record.updatedAt,
+        })
+      )
+    }
+
+    await setSyncUpCursor({ updatedAt: NOW_BASE + 1, id: 'file-1' })
+
+    const remoteNewer = {
+      name: 'name-2',
+      type: 'image/jpeg',
+      size: 103,
+      hash: 'hash-2',
+      createdAt: NOW_BASE + 2,
+      updatedAt: NOW_BASE + 1,
+      thumbForHash: undefined,
+      thumbSize: undefined,
+    }
+
+    meta.decodeFileMetadata.mockReturnValue(remoteNewer)
+
+    await runSyncUpMetadata(batchSize)
+
+    expect(sdk.getPinnedObject).toHaveBeenCalledTimes(1)
+    expect(sdk.getPinnedObject).toHaveBeenCalledWith('obj-file-2')
+  })
+})

--- a/src/managers/syncUpMetadata.ts
+++ b/src/managers/syncUpMetadata.ts
@@ -1,0 +1,224 @@
+import { logger } from '../lib/logger'
+import {
+  fileMetadataKeys,
+  readAllFileRecords,
+  type FileMetadata,
+} from '../stores/files'
+import { getIndexerURL } from '../stores/settings'
+import { getIsConnected, getPinnedObject, updateMetadata } from '../stores/sdk'
+import { createServiceInterval } from '../lib/serviceInterval'
+import { getSecureStoreJSON, setSecureStoreJSON } from '../stores/secureStore'
+import { z } from 'zod'
+import {
+  SYNC_UP_METADATA_INTERVAL,
+  SYNC_UP_METADATA_BATCH_SIZE,
+} from '../config'
+import {
+  encodeFileMetadata,
+  decodeFileMetadata,
+} from '../encoding/fileMetadata'
+
+type DiffEntry = { local: unknown; remote: unknown }
+type DiffResult = Record<keyof FileMetadata, DiffEntry>
+
+export function diffFileMetadata(
+  localMeta: FileMetadata,
+  remoteMeta: FileMetadata
+): Partial<DiffResult> {
+  const diffs: Partial<DiffResult> = {}
+  for (const key of fileMetadataKeys) {
+    const l = localMeta[key]
+    const r = remoteMeta[key]
+    if (l !== r) {
+      diffs[key] = { local: l, remote: r }
+    }
+  }
+  return diffs
+}
+
+/**
+ * Format field-level metadata diffs as git-style +/- lines.
+ * '+' denotes the newer value, '-' denotes the older value. Side labels: 'l' = local, 'r' = remote.
+ *
+ * Example (newerSide = 'local'):
+ * -r name: "old.jpg"
+ * +l name: "new.jpg"
+ * -r updatedAt: 1700000000000
+ * +l updatedAt: 1700005000000
+ */
+export function formatMetadataDiff(
+  diffs: Partial<DiffResult>,
+  isLocalNewer: boolean
+): string {
+  const lines: string[] = []
+  const keys = Object.keys(diffs) as (keyof FileMetadata)[]
+  for (const key of keys) {
+    const entry = diffs[key]
+    if (!entry) continue
+    const oldVal = isLocalNewer ? entry.remote : entry.local
+    const newVal = isLocalNewer ? entry.local : entry.remote
+    const oldStr = JSON.stringify(oldVal)
+    const newStr = JSON.stringify(newVal)
+    const oldSide = isLocalNewer ? 'r' : 'l'
+    const newSide = isLocalNewer ? 'l' : 'r'
+    lines.push(`-${oldSide} ${String(key)}: ${oldStr}`)
+    lines.push(`+${newSide} ${String(key)}: ${newStr}`)
+  }
+  return lines.join('\n')
+}
+
+function formatTimestamp(ts?: number): string {
+  if (!ts || ts <= 0) return 'n/a'
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).format(new Date(ts))
+}
+
+function formatDiff(params: {
+  fileId: string
+  objectId: string
+  localMeta: FileMetadata
+  remoteMeta: FileMetadata
+  diffs: Partial<DiffResult>
+  isLocalNewer: boolean
+}): string {
+  const { fileId, objectId, localMeta, remoteMeta, diffs, isLocalNewer } =
+    params
+  const headerLeft = `local (l) updated at ${formatTimestamp(
+    localMeta.updatedAt
+  )}`
+  const headerRight = `remote (r) updated at ${formatTimestamp(
+    remoteMeta.updatedAt
+  )}`
+  const status = isLocalNewer ? 'local newer' : 'remote newer'
+  const diff = formatMetadataDiff(diffs, isLocalNewer)
+  return `[syncUpMetadata] fileId=${fileId} objectId=${objectId}\n${headerLeft}    ${headerRight}\n${status} • ${diff}`
+}
+
+export type MetadataSyncResult = {
+  scanned: number
+  withDiffs: number
+  updatedRemote: number
+  skipped: number
+  failed: number
+}
+
+// Persistent cursor saved for next batch.
+const syncUpCursorCodec = z.codec(
+  z.object({
+    updatedAt: z.number(),
+    id: z.string(),
+  }),
+  z.object({
+    updatedAt: z.number(),
+    id: z.string(),
+  }),
+  {
+    decode: (stored) => stored,
+    encode: (domain) => domain,
+  }
+)
+
+type SyncUpCursor = {
+  updatedAt: number
+  id: string
+}
+
+export async function getSyncUpCursor(): Promise<SyncUpCursor | undefined> {
+  return getSecureStoreJSON('syncUpCursor', syncUpCursorCodec)
+}
+
+export async function setSyncUpCursor(
+  value: SyncUpCursor | undefined
+): Promise<void> {
+  await setSecureStoreJSON('syncUpCursor', value, syncUpCursorCodec)
+}
+
+/**
+ * Iterate files pinned to the current indexer, fetch latest remote metadata,
+ * diff against local file metadata, and if local is newer, push to remote.
+ * This function processes files with updatedAt after the cursor, to pick
+ * up any unsynced changes.
+ */
+export async function runSyncUpMetadata(batchSize: number): Promise<void> {
+  if (!getIsConnected()) {
+    logger.log('[syncUpMetadata] not connected to indexer, skipping')
+    return
+  }
+  const indexerURL = await getIndexerURL()
+  const after = await getSyncUpCursor()
+  logger.log(
+    `[syncUpMetadata] service tick: from ${after?.id ?? 'begin'} after=${
+      after?.updatedAt
+    }`
+  )
+  const batch = await readAllFileRecords({
+    order: 'ASC',
+    orderBy: 'updatedAt',
+    pinned: { indexerURL, isPinned: true },
+    limit: batchSize,
+    after: after
+      ? {
+          value: after.updatedAt,
+          id: after.id,
+        }
+      : undefined,
+  })
+  if (batch.length === 0) {
+    logger.log('[syncUpMetadata] no new updates')
+    return
+  }
+  for (const f of batch) {
+    const obj = f.objects[indexerURL]
+    if (!obj || !obj.id) continue
+    try {
+      const remote = await getPinnedObject(obj.id)
+      const remoteMeta = decodeFileMetadata(remote.metadata())
+      const diffs = diffFileMetadata(f, remoteMeta)
+      if (Object.keys(diffs).length === 0) continue
+      const isLocalNewer = (f.updatedAt || 0) >= (remoteMeta.updatedAt || 0)
+      logger.log(
+        formatDiff({
+          fileId: f.id,
+          objectId: obj.id,
+          localMeta: f,
+          remoteMeta,
+          diffs,
+          isLocalNewer,
+        })
+      )
+      if (isLocalNewer) {
+        await updateMetadata(remote, encodeFileMetadata(f))
+      }
+    } catch (e) {
+      logger.log('[syncUpMetadata] error', e)
+    }
+  }
+  const last = batch[batch.length - 1]
+  if (batch.length < batchSize) {
+    await setSyncUpCursor({
+      updatedAt: last.updatedAt + 1,
+      id: last.id,
+    })
+    logger.log('[syncUpMetadata] end reached')
+  } else {
+    await setSyncUpCursor({
+      updatedAt: last.updatedAt,
+      id: last.id,
+    })
+  }
+}
+
+export const initSyncUpMetadata = createServiceInterval({
+  name: 'syncUpMetadata',
+  worker: async () => {
+    return runSyncUpMetadata(SYNC_UP_METADATA_BATCH_SIZE)
+  },
+  getState: async () => true,
+  interval: SYNC_UP_METADATA_INTERVAL,
+})

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -29,6 +29,7 @@ import {
 } from '../managers/syncPhotosArchive'
 import { initBackgroundTasks } from '../managers/backgroundTasks'
 import { initThumbnailer } from '../managers/thumbnailer'
+import { initSyncUpMetadata } from '../managers/syncUpMetadata'
 
 export type AppState = {
   isInitializing: boolean
@@ -58,6 +59,7 @@ export async function initApp() {
   initSyncPhotosArchive()
   initBackgroundTasks()
   initThumbnailer()
+  initSyncUpMetadata()
 }
 
 export async function onboardIndexer(

--- a/src/stores/files.test.ts
+++ b/src/stores/files.test.ts
@@ -1,0 +1,122 @@
+import { initializeDB, resetDb } from '../db'
+import {
+  createFileRecord,
+  readAllFileRecords,
+  readAllFileRecordsCount,
+} from './files'
+
+jest.mock('./library', () => ({
+  librarySwr: {
+    triggerChange: jest.fn(),
+    addChangeCallback: jest.fn(),
+    getKey: jest.fn((key: string) => key),
+  },
+}))
+
+describe('files store queries', () => {
+  const base = 1_000
+
+  beforeEach(async () => {
+    await initializeDB()
+  })
+
+  afterEach(async () => {
+    await resetDb()
+    jest.clearAllMocks()
+  })
+
+  async function createRecord(params: {
+    id: string
+    createdAt: number
+    updatedAt: number
+  }) {
+    await createFileRecord({
+      id: params.id,
+      name: `${params.id}.jpg`,
+      type: 'image/jpeg',
+      size: 100,
+      hash: `hash-${params.id}`,
+      createdAt: params.createdAt,
+      updatedAt: params.updatedAt,
+      localId: null,
+      addedAt: params.createdAt,
+      thumbForHash: undefined,
+      thumbSize: undefined,
+    })
+  }
+
+  async function seedRecords() {
+    await createRecord({ id: 'file-old', createdAt: base, updatedAt: base })
+    await createRecord({
+      id: 'file-mid',
+      createdAt: base + 5,
+      updatedAt: base + 1_000,
+    })
+    await createRecord({
+      id: 'file-tie',
+      createdAt: base + 10,
+      updatedAt: base + 1_000,
+    })
+    await createRecord({
+      id: 'file-new',
+      createdAt: base + 15,
+      updatedAt: base + 2_000,
+    })
+  }
+
+  test('orders by updatedAt ascending when requested', async () => {
+    await seedRecords()
+
+    const rows = await readAllFileRecords({
+      order: 'ASC',
+      orderBy: 'updatedAt',
+    })
+
+    expect(rows.map((r) => r.id)).toEqual([
+      'file-old',
+      'file-mid',
+      'file-tie',
+      'file-new',
+    ])
+  })
+
+  test('orders by updatedAt descending when requested', async () => {
+    await seedRecords()
+
+    const rows = await readAllFileRecords({
+      order: 'DESC',
+      orderBy: 'updatedAt',
+    })
+
+    expect(rows.map((r) => r.id)).toEqual([
+      'file-new',
+      'file-tie',
+      'file-mid',
+      'file-old',
+    ])
+  })
+
+  test('applies updatedAt cursor for pagination', async () => {
+    await seedRecords()
+
+    const rows = await readAllFileRecords({
+      order: 'ASC',
+      orderBy: 'updatedAt',
+      after: { value: base + 1_000, id: 'file-mid' },
+    })
+
+    expect(rows.map((r) => r.id)).toEqual(['file-tie', 'file-new'])
+  })
+
+  test('count respects updatedAt ordering and cursor', async () => {
+    await seedRecords()
+
+    const count = await readAllFileRecordsCount({
+      order: 'ASC',
+      orderBy: 'updatedAt',
+      after: { value: base + 1_000, id: 'file-mid' },
+    })
+
+    expect(count).toBe(2)
+  })
+})

--- a/src/stores/files.ts
+++ b/src/stores/files.ts
@@ -115,16 +115,21 @@ export async function createManyFileRecords(
   }
 }
 
+type FileRecordCursorColumn = 'createdAt' | 'updatedAt'
+
+type FileRecordsQueryOpts = {
+  limit?: number
+  after?: { value: number; id: string }
+  order: 'ASC' | 'DESC'
+  orderBy?: FileRecordCursorColumn
+  pinned?: {
+    indexerURL: string
+    isPinned: boolean
+  }
+}
+
 function buildFileRecordsQuery(
-  opts: {
-    limit?: number
-    after?: { createdAt: number; id: string }
-    order: 'ASC' | 'DESC'
-    pinned?: {
-      indexerURL: string
-      isPinned: boolean
-    }
-  },
+  opts: FileRecordsQueryOpts,
   tableAlias: string = 'files'
 ): {
   where: string
@@ -132,18 +137,19 @@ function buildFileRecordsQuery(
   orderExpr: string
   limitExpr: string
 } {
-  const { limit, after, order, pinned } = opts
+  const { limit, after, order, pinned, orderBy } = opts
+  const sortColumn: FileRecordCursorColumn = orderBy ?? 'createdAt'
 
   const params: (string | number)[] = []
 
   let where = ''
   if (after) {
     if (order === 'ASC') {
-      where = `WHERE (${tableAlias}.createdAt > ?) OR (${tableAlias}.createdAt = ? AND ${tableAlias}.id > ?)`
+      where = `WHERE (${tableAlias}.${sortColumn} > ?) OR (${tableAlias}.${sortColumn} = ? AND ${tableAlias}.id > ?)`
     } else {
-      where = `WHERE (${tableAlias}.createdAt < ?) OR (${tableAlias}.createdAt = ? AND ${tableAlias}.id < ?)`
+      where = `WHERE (${tableAlias}.${sortColumn} < ?) OR (${tableAlias}.${sortColumn} = ? AND ${tableAlias}.id < ?)`
     }
-    params.push(after.createdAt, after.createdAt, after.id)
+    params.push(after.value, after.value, after.id)
   }
 
   if (pinned) {
@@ -154,7 +160,7 @@ function buildFileRecordsQuery(
     params.push(pinned.indexerURL)
   }
 
-  const orderExpr = `${tableAlias}.createdAt ${order}, ${tableAlias}.id ${order}`
+  const orderExpr = `${tableAlias}.${sortColumn} ${order}, ${tableAlias}.id ${order}`
   const limitExpr =
     limit !== undefined && Number.isFinite(limit) ? ` LIMIT ${limit | 0}` : ''
 
@@ -166,15 +172,9 @@ function buildFileRecordsQuery(
   }
 }
 
-export async function readAllFileRecordsCount(opts: {
-  limit?: number
-  after?: { createdAt: number; id: string }
-  order: 'ASC' | 'DESC'
-  pinned?: {
-    indexerURL: string
-    isPinned: boolean
-  }
-}): Promise<number> {
+export async function readAllFileRecordsCount(
+  opts: FileRecordsQueryOpts
+): Promise<number> {
   const { where, params, orderExpr, limitExpr } = buildFileRecordsQuery(opts)
 
   const row = await db().getFirstAsync<{ count: number }>(
@@ -184,15 +184,9 @@ export async function readAllFileRecordsCount(opts: {
   return row?.count ?? 0
 }
 
-export async function readAllFileRecords(opts: {
-  limit?: number
-  after?: { createdAt: number; id: string }
-  order: 'ASC' | 'DESC'
-  pinned?: {
-    indexerURL: string
-    isPinned: boolean
-  }
-}): Promise<FileRecord[]> {
+export async function readAllFileRecords(
+  opts: FileRecordsQueryOpts
+): Promise<FileRecord[]> {
   const { where, params, orderExpr, limitExpr } = buildFileRecordsQuery(
     opts,
     'f'
@@ -313,7 +307,7 @@ export async function updateFileRecord(
   const { id } = update
   const sets: string[] = []
   const params: (string | number | null)[] = []
-  const updatableFields = [
+  const updatableFields: (keyof FileRecordRow)[] = [
     'name',
     'type',
     'size',
@@ -334,6 +328,11 @@ export async function updateFileRecord(
 
   if (sets.length === 0) {
     return
+  }
+
+  if (!sets.includes('updatedAt = ?')) {
+    sets.push('updatedAt = ?')
+    params.push(Date.now())
   }
 
   const sql = `UPDATE files SET ${sets.join(', ')} WHERE id = ?`

--- a/src/stores/sdk.ts
+++ b/src/stores/sdk.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import { Sdk } from 'react-native-sia'
+import { Sdk, type PinnedObjectInterface } from 'react-native-sia'
 import authApp from '../lib/authApp'
 import { logger } from '../lib/logger'
 import { getIndexerURL } from './settings'
@@ -161,4 +161,31 @@ export function useIsAuthing(): boolean {
 
 export function getSdk(): Sdk | null {
   return useSdkStore.getState().sdk
+}
+
+/**
+ * Update the metadata of a pinned object.
+ */ export async function updateMetadata(
+  pinnedObject: PinnedObjectInterface,
+  metadata: ArrayBuffer
+): Promise<void> {
+  const sdk = getSdk()
+  if (!sdk) {
+    throw new Error('SDK not initialized')
+  }
+  pinnedObject.updateMetadata(metadata)
+  await sdk.saveObject(pinnedObject)
+}
+
+/**
+ * Fetch a pinned object by id.
+ */
+export async function getPinnedObject(
+  objectId: string
+): Promise<PinnedObjectInterface> {
+  const sdk = getSdk()
+  if (!sdk) {
+    throw new Error('SDK not initialized')
+  }
+  return sdk.object(objectId)
 }

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -33,7 +33,7 @@ export async function setRecoveryPhrase(
 
 export const [getIndexerURL, useIndexerURL] = createGetterAndSWRHook(
   getKey('indexerURL'),
-  () => getSecureStoreString('indexerURL', DEFAULT_INDEXER_URL)
+  () => getSecureStoreString<string>('indexerURL', DEFAULT_INDEXER_URL)
 )
 
 export async function setIndexerURL(value: string) {


### PR DESCRIPTION
- Adds a sync up metadata service. Together sync down events + sync up metadata provide basic two-way sync between devices based on updatedAt timestamps.
- This service churns through files with new local updates (updatedAt > cursor) and checks if the remote metadata is older than the local, if so it updates it.
- Local metadata may be newer if the user makes changes while offline or without connection to indexer, this ensure it is eventually synced. We will try to sync changes like file name, tags, folders immediately but there is always a chance we are not connected.
- This PR adds support for sorting by updatedAt to stores/files and adds an index to the table.