### PR TITLE
fix: media permissions

### DIFF
--- a/app.json
+++ b/app.json
@@ -31,7 +31,14 @@
         "backgroundColor": "#ffffff"
       },
       "edgeToEdgeEnabled": true,
-      "package": "sia.storage"
+      "package": "sia.storage",
+      "permissions": [
+        "android.permission.READ_EXTERNAL_STORAGE",
+        "android.permission.READ_MEDIA_IMAGES",
+        "android.permission.READ_MEDIA_VIDEO",
+        "android.permission.ACCESS_MEDIA_LOCATION",
+        "android.permission.READ_MEDIA_VISUAL_USER_SELECTED"
+      ]
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/src/lib/mediaLibraryPermissions.ts
+++ b/src/lib/mediaLibraryPermissions.ts
@@ -4,14 +4,24 @@ import { useCallback, useMemo } from 'react'
 import { useFocusEffect } from '@react-navigation/native'
 import useSWR from 'swr'
 import { palette } from '../styles/colors'
+import { buildSWRHelpers } from './swr'
 
 export async function ensureMediaLibraryPermission(): Promise<boolean> {
   const res = await MediaLibrary.requestPermissionsAsync()
   return res.granted === true
 }
 
+export async function getMediaLibraryPermissions(): Promise<boolean> {
+  const res = await MediaLibrary.getPermissionsAsync()
+  return res.granted === true
+}
+
+export const mediaLibraryPermissionsSwr = buildSWRHelpers(
+  'mediaLibraryPermissions'
+)
+
 export function useMediaLibraryPermissions() {
-  const perms = useSWR(['mediaLibrary', 'permissions'], () =>
+  const perms = useSWR(mediaLibraryPermissionsSwr.getKey(), () =>
     MediaLibrary.getPermissionsAsync()
   )
 
@@ -24,11 +34,8 @@ export function useMediaLibraryPermissions() {
   const photosAccess: 'all' | 'limited' | 'none' | 'unknown' = useMemo(() => {
     const p = perms.data
     if (!p) return 'unknown'
-    if (Platform.OS === 'ios') {
-      const ap = p.accessPrivileges as 'all' | 'limited' | 'none' | undefined
-      if (ap) return ap
-      return p.granted ? 'all' : 'none'
-    }
+    const accessPrivileges = p.accessPrivileges
+    if (accessPrivileges) return accessPrivileges
     return p.granted ? 'all' : 'none'
   }, [perms.data])
 

--- a/src/managers/syncNewPhotos.ts
+++ b/src/managers/syncNewPhotos.ts
@@ -12,12 +12,16 @@ import {
   setSecureStoreBoolean,
   setSecureStoreNumber,
 } from '../stores/secureStore'
-import { ensureMediaLibraryPermission } from '../lib/mediaLibraryPermissions'
+import {
+  ensureMediaLibraryPermission,
+  getMediaLibraryPermissions,
+  mediaLibraryPermissionsSwr,
+} from '../lib/mediaLibraryPermissions'
 
 const PAGE_SIZE = 200
 
 async function workForward(): Promise<void> {
-  if (!(await ensureMediaLibraryPermission())) return
+  if (!(await getMediaLibraryPermissions())) return
   const cursor = await getPhotosNewCursor()
 
   try {
@@ -75,6 +79,7 @@ export async function setAutoSyncNewPhotos(value: boolean) {
   if (value) {
     ensureMediaLibraryPermission()
   }
+  mediaLibraryPermissionsSwr.triggerChange()
 }
 
 export async function toggleAutoSyncNewPhotos() {

--- a/src/managers/syncPhotosArchive.ts
+++ b/src/managers/syncPhotosArchive.ts
@@ -12,12 +12,16 @@ import {
 } from '../stores/secureStore'
 import { createServiceInterval } from '../lib/serviceInterval'
 import { SYNC_PHOTOS_ARCHIVE_INTERVAL } from '../config'
-import { ensureMediaLibraryPermission } from '../lib/mediaLibraryPermissions'
+import {
+  ensureMediaLibraryPermission,
+  getMediaLibraryPermissions,
+  mediaLibraryPermissionsSwr,
+} from '../lib/mediaLibraryPermissions'
 
 const PAGE_SIZE = 1
 
 export async function workBackward() {
-  if (!(await ensureMediaLibraryPermission())) return
+  if (!(await getMediaLibraryPermissions())) return
   const cursor = await getPhotosArchiveCursor()
 
   try {
@@ -81,6 +85,7 @@ export async function setAutoSyncPhotosArchive(value: boolean) {
   if (value) {
     ensureMediaLibraryPermission()
   }
+  mediaLibraryPermissionsSwr.triggerChange()
 }
 
 export async function toggleAutoSyncPhotosArchive() {


### PR DESCRIPTION
- Add android permissions.
- Call get rather than request in the services. The request was making the permissions dialog pop up randomly if the user did not provide full access.