### PR TITLE
fix: sqlite null value android support

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -48,3 +48,38 @@ export async function withTransactionLock<T>(fn: () => Promise<T>): Promise<T> {
     return out
   })
 }
+
+/**
+ * Generic INSERT helper that:
+ * - Inlines SQL NULL for nullish fields to avoid Android varargs null bridging issues.
+ * - Binds only primitives (string | number) for the remaining fields.
+ */
+export async function insert<
+  T extends Record<string, string | number | boolean | null | undefined>
+>(table: string, row: T): Promise<SQLite.SQLiteRunResult> {
+  const columns = Object.keys(row)
+  const valuesSql: string[] = []
+  const params: (string | number)[] = []
+
+  for (const key of columns) {
+    const value = row[key]
+    if (value === null || value === undefined) {
+      valuesSql.push('NULL')
+      continue
+    }
+    valuesSql.push('?')
+    if (typeof value === 'number' || typeof value === 'string') {
+      params.push(value)
+    } else if (typeof value === 'boolean') {
+      params.push(value ? 1 : 0)
+    } else {
+      // Fallback: store as string representation.
+      params.push(String(value))
+    }
+  }
+
+  const sql = `INSERT INTO ${table} (${columns.join(
+    ', '
+  )}) VALUES (${valuesSql.join(', ')})`
+  return await database.runAsync(sql, params)
+}

--- a/src/stores/files.ts
+++ b/src/stores/files.ts
@@ -4,7 +4,7 @@ import {
 } from '../encoding/localObject'
 import { upsertLocalObject, readLocalObjectsForFile } from './localObjects'
 import { logger } from '../lib/logger'
-import { db, withTransactionLock } from '../db'
+import { db, insert, withTransactionLock } from '../db'
 import useSWR from 'swr'
 import { createGetterAndSWRHook } from '../lib/selectors'
 import { LocalObjectRow } from '../encoding/localObject'
@@ -83,8 +83,7 @@ export async function createFileRecord(
     thumbForHash,
     thumbSize,
   } = fileRecord
-  await db().runAsync(
-    'INSERT INTO files (id, name, size, createdAt, updatedAt, type, localId, hash, addedAt, thumbForHash, thumbSize) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+  await insert('files', {
     id,
     name,
     size,
@@ -94,9 +93,9 @@ export async function createFileRecord(
     localId,
     hash,
     addedAt,
-    thumbForHash ?? null,
-    thumbSize ?? null
-  )
+    thumbForHash,
+    thumbSize,
+  })
   if (triggerUpdate) {
     await librarySwr.triggerChange()
   }


### PR DESCRIPTION
- Android complains about passing null values to expo-sqlite, PR adds an `insert`​ method that builds query in Android-safe way.