### PR TITLE
fix: file map label and temp disable only android

### DIFF
--- a/src/components/FileDetails/FileMap.android.tsx
+++ b/src/components/FileDetails/FileMap.android.tsx
@@ -1,0 +1,5 @@
+import { type FileRecord } from '../../stores/files'
+
+export function FileMap({ file }: { file: FileRecord }) {
+  return null
+}

--- a/src/components/FileDetails/FileMeta.tsx
+++ b/src/components/FileDetails/FileMeta.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useMemo } from 'react'
-import { View, Text, StyleSheet } from 'react-native'
+import { View, Text, StyleSheet, useWindowDimensions } from 'react-native'
 import { colors, palette } from '../../styles/colors'
 import { updateFileRecord, type FileRecord } from '../../stores/files'
 import { FileStatus } from '../../lib/file'
@@ -15,6 +15,7 @@ import { usePinnedObjects } from '../../hooks/usePinnedObjects'
 import useSWR from 'swr'
 import { readThumbnailsByHash, thumbnailSwr } from '../../stores/thumbnails'
 import { getFileUri } from '../../stores/fileCache'
+import { FileMap } from './FileMap'
 
 export function FileMeta({
   file,
@@ -47,6 +48,7 @@ export function FileMeta({
       )
     }
   )
+  const { height: windowHeight } = useWindowDimensions()
   return (
     <View style={styles.container}>
       <RowGroup title="Details">
@@ -114,6 +116,13 @@ export function FileMeta({
             value={file.type ?? '—'}
             showDividerTop
           />
+        </InfoCard>
+      </RowGroup>
+      <RowGroup title="File shard storage locations">
+        <InfoCard>
+          <View style={{ height: Math.round(windowHeight * 0.5) }}>
+            <FileMap file={file} />
+          </View>
         </InfoCard>
       </RowGroup>
       {showAdvanced.data && (

--- a/src/components/FileDetails/index.tsx
+++ b/src/components/FileDetails/index.tsx
@@ -1,10 +1,9 @@
 import React from 'react'
-import { View, StyleSheet, ScrollView, useWindowDimensions } from 'react-native'
+import { View, StyleSheet, ScrollView } from 'react-native'
 import { colors, palette } from '../../styles/colors'
 import { type FileRecord } from '../../stores/files'
 import { useFileStatus } from '../../lib/file'
 import { FileMeta } from './FileMeta'
-// import { FileMap } from './FileMap'
 
 export function FileDetails({
   file,
@@ -14,15 +13,11 @@ export function FileDetails({
   header?: React.ReactNode
 }) {
   const status = useFileStatus(file)
-  const { height: windowHeight } = useWindowDimensions()
 
   return (
     <View style={styles.container}>
       <ScrollView contentContainerStyle={styles.scrollContent}>
         {header}
-        <View style={{ height: Math.round(windowHeight * 0.5) }}>
-          {/* <FileMap file={file} /> */}
-        </View>
         <View style={styles.metaContainer}>
           {status.data ? <FileMeta file={file} status={status.data} /> : null}
         </View>
@@ -35,7 +30,6 @@ const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: palette.gray[950] },
   scrollContent: { paddingBottom: 96 },
   metaContainer: {
-    marginTop: 16,
     backgroundColor: colors.bgElevated,
   },
 })


### PR DESCRIPTION
- Move map to section with a label/heading.
- Temp disable map on android until first release.

![Screenshot 2025-11-13 at 3.09.34 PM.png](https://app.graphite.com/user-attachments/assets/9ab915ec-0db6-4615-bfc1-797be9537417.png)