### PR TITLE
fix: update file record updatedAt

### DIFF
--- a/src/components/FileDetails/FileMeta.tsx
+++ b/src/components/FileDetails/FileMeta.tsx
@@ -32,7 +32,7 @@ export function FileMeta({
   const fileNameInputProps = useInputValue({
     value: file.name ?? '',
     save: (value) => {
-      updateFileRecord({ ...file, name: value })
+      updateFileRecord({ id: file.id, name: value })
     },
   })
   const pinnedObjects = usePinnedObjects(file)

--- a/src/managers/syncDownEvents.ts
+++ b/src/managers/syncDownEvents.ts
@@ -213,7 +213,8 @@ async function handleFileRecord(
         ...existingFile,
         ...(metadata.updatedAt >= existingFile.updatedAt ? metadata : {}),
       },
-      localObject
+      localObject,
+      { includeUpdatedAt: true }
     )
     // Cancel any inflight upload for this file since we now have a pinned object.
     cancelUpload(existingFile.id)

--- a/src/managers/syncNewPhotos.test.ts
+++ b/src/managers/syncNewPhotos.test.ts
@@ -13,6 +13,12 @@ jest.mock('expo-media-library', () => ({
 }))
 jest.mock('../lib/mediaLibraryPermissions', () => ({
   ensureMediaLibraryPermission: jest.fn(),
+  getMediaLibraryPermissions: jest.fn().mockResolvedValue(true),
+  mediaLibraryPermissionsSwr: {
+    getKey: jest.fn((k: string) => [k]),
+    triggerChange: jest.fn(),
+    addChangeCallback: jest.fn(),
+  },
 }))
 jest.mock('../lib/processAssets', () => ({
   processAssets: jest.fn(),

--- a/src/managers/syncPhotosArchive.test.ts
+++ b/src/managers/syncPhotosArchive.test.ts
@@ -21,6 +21,12 @@ jest.mock('expo-media-library', () => ({
 jest.mock('../lib/mediaLibraryPermissions', () => ({
   __esModule: true,
   ensureMediaLibraryPermission: jest.fn(),
+  getMediaLibraryPermissions: jest.fn().mockResolvedValue(true),
+  mediaLibraryPermissionsSwr: {
+    getKey: jest.fn((k: string) => [k]),
+    triggerChange: jest.fn(),
+    addChangeCallback: jest.fn(),
+  },
 }))
 jest.mock('../lib/processAssets', () => ({
   __esModule: true,

--- a/src/stores/files.test.ts
+++ b/src/stores/files.test.ts
@@ -3,6 +3,8 @@ import {
   createFileRecord,
   readAllFileRecords,
   readAllFileRecordsCount,
+  readFileRecord,
+  updateFileRecord,
 } from './files'
 
 jest.mock('./library', () => ({
@@ -118,5 +120,69 @@ describe('files store queries', () => {
     })
 
     expect(count).toBe(2)
+  })
+})
+
+describe('updateFileRecord', () => {
+  beforeEach(async () => {
+    await initializeDB()
+  })
+
+  afterEach(async () => {
+    await resetDb()
+    jest.restoreAllMocks()
+    jest.clearAllMocks()
+  })
+
+  test('update file record ignores updatedAt when includeUpdatedAt is false', async () => {
+    const mockTime = 1_695_734_567_890
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(mockTime)
+    await createFileRecord({
+      id: 'file-new',
+      name: 'old name',
+      type: 'image/jpeg',
+      size: 100,
+      hash: 'hash-file-new',
+      createdAt: 100,
+      updatedAt: 100,
+      localId: null,
+      addedAt: 100,
+    })
+    await updateFileRecord({
+      id: 'file-new',
+      updatedAt: 4444,
+      name: 'new name',
+    })
+
+    const record = await readFileRecord('file-new')
+    expect(record).toMatchObject({ name: 'new name', updatedAt: mockTime })
+  })
+
+  test('update file record includes updatedAt when includeUpdatedAt is true', async () => {
+    const mockTime = 1_695_734_567_890
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(mockTime)
+    await createFileRecord({
+      id: 'file-new',
+      name: 'old name',
+      type: 'image/jpeg',
+      size: 100,
+      hash: 'hash-file-new',
+      createdAt: 100,
+      updatedAt: 100,
+      localId: null,
+      addedAt: 100,
+    })
+    await updateFileRecord(
+      {
+        id: 'file-new',
+        updatedAt: 4444,
+        name: 'new name',
+      },
+      false,
+      { includeUpdatedAt: true }
+    )
+    const record = await readFileRecord('file-new')
+    expect(record).toMatchObject({ name: 'new name', updatedAt: 4444 })
+    expect(nowSpy).not.toHaveBeenCalled()
   })
 })

--- a/src/stores/files.ts
+++ b/src/stores/files.ts
@@ -301,7 +301,8 @@ export async function readFileRecord(id: string): Promise<FileRecord | null> {
 /** Updates a file record. Ignores any empty values. */
 export async function updateFileRecord(
   update: Partial<FileRecordRow> & { id: string },
-  triggerUpdate: boolean = true
+  triggerUpdate: boolean = true,
+  options: { includeUpdatedAt?: boolean } = { includeUpdatedAt: false }
 ): Promise<void> {
   const { id } = update
   const sets: string[] = []
@@ -312,11 +313,13 @@ export async function updateFileRecord(
     'size',
     'hash',
     'createdAt',
-    'updatedAt',
     'thumbForHash',
     'thumbSize',
     'localId',
   ]
+  if (options.includeUpdatedAt) {
+    updatableFields.push('updatedAt')
+  }
   for (const field of updatableFields) {
     const nonEmptyUpdate = removeEmptyValues(update)
     if (field in nonEmptyUpdate) {
@@ -329,7 +332,7 @@ export async function updateFileRecord(
     return
   }
 
-  if (!sets.includes('updatedAt = ?')) {
+  if (!options.includeUpdatedAt) {
     sets.push('updatedAt = ?')
     params.push(Date.now())
   }
@@ -342,11 +345,12 @@ export async function updateFileRecord(
 }
 
 export async function updateManyFileRecords(
-  updates: Partial<FileRecordRow> & { id: string }[]
+  updates: Partial<FileRecordRow> & { id: string }[],
+  options: { includeUpdatedAt?: boolean } = { includeUpdatedAt: false }
 ): Promise<void> {
   await withTransactionLock(async () => {
     for (const update of updates) {
-      await updateFileRecord(update, false)
+      await updateFileRecord(update, false, options)
     }
   })
   if (updates.length > 0) {
@@ -400,11 +404,12 @@ export async function createFileRecordWithLocalObject(
 /** Update a file record and a local object in a single transaction. */
 export async function updateFileRecordWithLocalObject(
   fileRecord: Omit<FileRecord, 'objects'>,
-  localObject: LocalObject
+  localObject: LocalObject,
+  options: { includeUpdatedAt?: boolean } = { includeUpdatedAt: false }
 ): Promise<void> {
   try {
     await withTransactionLock(async () => {
-      await updateFileRecord(fileRecord, false)
+      await updateFileRecord(fileRecord, false, options)
       await upsertLocalObject(localObject, false)
     })
     await librarySwr.triggerChange()


### PR DESCRIPTION
- updateFileRecord now has two modes via an option.
    - includeUpdatedAt=false: it defaults to automatically incrementing the updatedAt timestamp.
    - includeUpdatedAt=true: used by the sync down events service which needs to sync in the metadata timestamp.