### PR TITLE
fix: settings layout scroll

### DIFF
--- a/src/components/SettingsLayout.tsx
+++ b/src/components/SettingsLayout.tsx
@@ -1,4 +1,10 @@
-import { View, StyleSheet, StyleProp, ViewStyle } from 'react-native'
+import {
+  ScrollView,
+  StyleProp,
+  StyleSheet,
+  View,
+  ViewStyle,
+} from 'react-native'
 import { colors } from '../styles/colors'
 
 type Props = {
@@ -6,8 +12,20 @@ type Props = {
   style?: StyleProp<ViewStyle>
 }
 
-export function SettingsLayout({ children, style }: Props) {
-  return <View style={[styles.container, style]}>{children}</View>
+export function SettingsScrollLayout({ children, style }: Props) {
+  return (
+    <ScrollView style={[styles.container]}>
+      <View style={[styles.content, style]}>{children}</View>
+    </ScrollView>
+  )
+}
+
+export function SettingsFullLayout({ children, style }: Props) {
+  return (
+    <View style={[styles.container, { height: '100%' }, style]}>
+      {children}
+    </View>
+  )
 }
 
 const styles = StyleSheet.create({
@@ -17,6 +35,9 @@ const styles = StyleSheet.create({
     borderTopWidth: StyleSheet.hairlineWidth,
     borderBottomColor: colors.borderSubtle,
     borderBottomWidth: StyleSheet.hairlineWidth,
-    height: '100%',
+  },
+  content: {
+    paddingTop: 24,
+    paddingBottom: 64,
   },
 })

--- a/src/screens/HostDetailScreen.tsx
+++ b/src/screens/HostDetailScreen.tsx
@@ -10,7 +10,7 @@ import Map from '../components/Map/Map'
 import { InfoCard } from '../components/InfoCard'
 import { RowGroup } from '../components/Group'
 import { LabeledValueRow } from '../components/LabeledValueRow'
-import { SettingsLayout } from '../components/SettingsLayout'
+import { SettingsScrollLayout } from '../components/SettingsLayout'
 
 type Props = NativeStackScreenProps<SettingsStackParamList, 'HostDetail'>
 
@@ -36,7 +36,7 @@ export function HostDetailScreen({ route }: Props) {
     )
   }
   return (
-    <SettingsLayout style={styles.container}>
+    <SettingsScrollLayout style={{ paddingHorizontal: 24, gap: 24 }}>
       <RowGroup title="Info">
         <InfoCard>
           <LabeledValueRow label="Public Key" value={publicKey} />
@@ -67,17 +67,11 @@ export function HostDetailScreen({ route }: Props) {
           </Map>
         </InfoCard>
       </RowGroup>
-    </SettingsLayout>
+    </SettingsScrollLayout>
   )
 }
 
 const styles = StyleSheet.create({
-  container: {
-    paddingHorizontal: 16,
-    paddingTop: 24,
-    paddingBottom: 24,
-    gap: 24,
-  },
   card: {
     backgroundColor: colors.bgSurface,
     borderColor: colors.borderMutedLight,

--- a/src/screens/HostListScreen.tsx
+++ b/src/screens/HostListScreen.tsx
@@ -1,12 +1,12 @@
 import { View, StyleSheet, Pressable } from 'react-native'
-import { colors, palette } from '../styles/colors'
+import { palette, colors } from '../styles/colors'
 import { ListIcon, MapIcon } from 'lucide-react-native'
 import { HostsList } from '../components/HostsList'
 import { type NativeStackScreenProps } from '@react-navigation/native-stack'
 import { type SettingsStackParamList } from '../stacks/types'
 import { useState, useLayoutEffect } from 'react'
 import HostsMap from '../components/HostsMap'
-import { SettingsLayout } from '../components/SettingsLayout'
+import { SettingsFullLayout } from '../components/SettingsLayout'
 
 type Props = NativeStackScreenProps<SettingsStackParamList, 'Hosts'>
 
@@ -57,13 +57,13 @@ export function HostListScreen({ navigation }: Props) {
   }
 
   return (
-    <SettingsLayout>
+    <SettingsFullLayout>
       {viewMode === 'list' ? (
         <HostsList onSelectHost={handleSelectHost} />
       ) : (
         <HostsMap onSelectHost={handleSelectHost} />
       )}
-    </SettingsLayout>
+    </SettingsFullLayout>
   )
 }
 

--- a/src/screens/SettingsAdvancedScreen.tsx
+++ b/src/screens/SettingsAdvancedScreen.tsx
@@ -1,12 +1,11 @@
-import { StyleSheet } from 'react-native'
 import { type NativeStackScreenProps } from '@react-navigation/native-stack'
 import { type SettingsStackParamList } from '../stacks/types'
 import { SettingsRecoveryPhrase } from '../components/SettingsRecoveryPhrase'
-import { SettingsLayout } from '../components/SettingsLayout'
 import { useSettingsHeader } from '../hooks/useSettingsHeader'
 import { SettingsAdvancedAccount } from '../components/SettingsAdvancedAccount'
 import { SettingsAdvancedDangerZone } from '../components/SettingsAdvancedDangerZone'
 import { SettingsAdvancedInfo } from '../components/SettingsAdvancedInfo'
+import { SettingsScrollLayout } from '../components/SettingsLayout'
 
 type Props = NativeStackScreenProps<SettingsStackParamList, 'Advanced'>
 
@@ -14,20 +13,11 @@ export function SettingsAdvancedScreen(props: Props) {
   useSettingsHeader()
 
   return (
-    <SettingsLayout style={styles.container}>
+    <SettingsScrollLayout style={{ paddingHorizontal: 24, gap: 24 }}>
       <SettingsAdvancedAccount />
       <SettingsRecoveryPhrase />
       <SettingsAdvancedInfo {...props} />
       <SettingsAdvancedDangerZone />
-    </SettingsLayout>
+    </SettingsScrollLayout>
   )
 }
-
-const styles = StyleSheet.create({
-  container: {
-    paddingHorizontal: 16,
-    paddingTop: 24,
-    paddingBottom: 24,
-    gap: 24,
-  },
-})

--- a/src/screens/SettingsDebugScreen.tsx
+++ b/src/screens/SettingsDebugScreen.tsx
@@ -1,9 +1,8 @@
-import { StyleSheet } from 'react-native'
 import { type NativeStackScreenProps } from '@react-navigation/native-stack'
 import { type SettingsStackParamList } from '../stacks/types'
-import { SettingsLayout } from '../components/SettingsLayout'
 import { useSettingsHeader } from '../hooks/useSettingsHeader'
 import { SettingsDebugHash } from '../components/SettingsDebugHash'
+import { SettingsScrollLayout } from '../components/SettingsLayout'
 
 type Props = NativeStackScreenProps<SettingsStackParamList, 'Debug'>
 
@@ -11,16 +10,8 @@ export function SettingsDebugScreen(_props: Props) {
   useSettingsHeader()
 
   return (
-    <SettingsLayout style={styles.container}>
+    <SettingsScrollLayout style={{ paddingHorizontal: 24, gap: 24 }}>
       <SettingsDebugHash />
-    </SettingsLayout>
+    </SettingsScrollLayout>
   )
 }
-
-const styles = StyleSheet.create({
-  container: {
-    paddingHorizontal: 16,
-    paddingTop: 24,
-    paddingBottom: 24,
-  },
-})

--- a/src/screens/SettingsHomeScreen.tsx
+++ b/src/screens/SettingsHomeScreen.tsx
@@ -2,15 +2,15 @@ import { View, Text, Pressable, StyleSheet } from 'react-native'
 import { colors, palette } from '../styles/colors'
 import { type NativeStackScreenProps } from '@react-navigation/native-stack'
 import { type SettingsStackParamList } from '../stacks/types'
-import { SettingsLayout } from '../components/SettingsLayout'
 import { useSettingsHeader } from '../hooks/useSettingsHeader'
+import { SettingsScrollLayout } from '../components/SettingsLayout'
 
 type Props = NativeStackScreenProps<SettingsStackParamList, 'SettingsHome'>
 
 export function SettingsHomeScreen({ navigation }: Props) {
   useSettingsHeader()
   return (
-    <SettingsLayout style={styles.container}>
+    <SettingsScrollLayout>
       <Pressable
         accessibilityRole="button"
         onPress={() => navigation.navigate('Indexer')}
@@ -58,14 +58,11 @@ export function SettingsHomeScreen({ navigation }: Props) {
           <Text style={styles.rowChevron}>›</Text>
         </View>
       </Pressable>
-    </SettingsLayout>
+    </SettingsScrollLayout>
   )
 }
 
 const styles = StyleSheet.create({
-  container: {
-    paddingTop: 32,
-  },
   rowItem: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/src/screens/SettingsIndexerScreen.tsx
+++ b/src/screens/SettingsIndexerScreen.tsx
@@ -9,12 +9,12 @@ import { LabeledValueRow } from '../components/LabeledValueRow'
 import { InputRow } from '../components/InputRow'
 import { useIndexerURL } from '../stores/settings'
 import { useChangeIndexer } from '../hooks/useChangeIndexer'
-import { SettingsLayout } from '../components/SettingsLayout'
 import { useSettingsHeader } from '../hooks/useSettingsHeader'
 import { humanSize } from '../lib/humanSize'
 import { useAccount } from '../hooks/useAccount'
 import { type NativeStackScreenProps } from '@react-navigation/native-stack'
 import { type SettingsStackParamList } from '../stacks/types'
+import { SettingsScrollLayout } from '../components/SettingsLayout'
 
 type Props = NativeStackScreenProps<SettingsStackParamList, 'Indexer'>
 
@@ -25,7 +25,7 @@ export function SettingsIndexerScreen(_props: Props) {
   useSettingsHeader()
   const account = useAccount()
   return (
-    <SettingsLayout style={styles.container}>
+    <SettingsScrollLayout style={{ paddingHorizontal: 24, gap: 24 }}>
       <RowGroup
         title="Current Indexer"
         indicator={
@@ -38,7 +38,9 @@ export function SettingsIndexerScreen(_props: Props) {
             <Text
               style={[
                 styles.statusText,
-                { color: isConnected ? palette.green[500] : palette.red[500] },
+                {
+                  color: isConnected ? palette.green[500] : palette.red[500],
+                },
               ]}
             >
               {isConnected ? 'Connected' : 'Offline'}
@@ -90,17 +92,11 @@ export function SettingsIndexerScreen(_props: Props) {
             : 'Connect'}
         </Button>
       </View>
-    </SettingsLayout>
+    </SettingsScrollLayout>
   )
 }
 
 const styles = StyleSheet.create({
-  container: {
-    paddingHorizontal: 16,
-    paddingTop: 24,
-    paddingBottom: 24,
-    gap: 24,
-  },
   cellRowBottom: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/src/screens/SettingsLogsScreen.tsx
+++ b/src/screens/SettingsLogsScreen.tsx
@@ -2,9 +2,9 @@ import { LogView } from '../components/LogView'
 import { useLogs } from '../stores/logs'
 import { type NativeStackScreenProps } from '@react-navigation/native-stack'
 import { type SettingsStackParamList } from '../stacks/types'
-import { SettingsLayout } from '../components/SettingsLayout'
 import { useSettingsHeader } from '../hooks/useSettingsHeader'
 import { SettingsLogsControlBar } from '../components/SettingsLogsControlBar'
+import { SettingsFullLayout } from '../components/SettingsLayout'
 
 type Props = NativeStackScreenProps<SettingsStackParamList, 'Logs'>
 
@@ -13,9 +13,9 @@ export function SettingsLogsScreen({ route, navigation }: Props) {
   useSettingsHeader()
 
   return (
-    <SettingsLayout>
+    <SettingsFullLayout>
       <LogView logs={logs} />
       <SettingsLogsControlBar navigation={navigation} route={route} />
-    </SettingsLayout>
+    </SettingsFullLayout>
   )
 }

--- a/src/screens/SettingsSyncScreen.tsx
+++ b/src/screens/SettingsSyncScreen.tsx
@@ -1,12 +1,11 @@
-import { StyleSheet } from 'react-native'
 import { type NativeStackScreenProps } from '@react-navigation/native-stack'
 import { type SettingsStackParamList } from '../stacks/types'
-import { SettingsLayout } from '../components/SettingsLayout'
 import { useSettingsHeader } from '../hooks/useSettingsHeader'
 import { SettingsSyncPhotos } from '../components/SettingsSyncPhotos'
 import { SettingsAdvancedSync } from '../components/SettingsAdvancedSync'
 import { SettingsAdvancedTransfers } from '../components/SettingsAdvancedTransfers'
 import { useShowAdvanced } from '../stores/settings'
+import { SettingsScrollLayout } from '../components/SettingsLayout'
 
 type Props = NativeStackScreenProps<SettingsStackParamList, 'Sync'>
 
@@ -15,7 +14,7 @@ export function SettingsSyncScreen(_props: Props) {
   const showAdvanced = useShowAdvanced()
 
   return (
-    <SettingsLayout style={styles.container}>
+    <SettingsScrollLayout style={{ paddingHorizontal: 24, gap: 24 }}>
       <SettingsSyncPhotos />
       {showAdvanced.data ? (
         <>
@@ -23,15 +22,6 @@ export function SettingsSyncScreen(_props: Props) {
           <SettingsAdvancedTransfers />
         </>
       ) : null}
-    </SettingsLayout>
+    </SettingsScrollLayout>
   )
 }
-
-const styles = StyleSheet.create({
-  container: {
-    paddingHorizontal: 16,
-    paddingTop: 24,
-    paddingBottom: 24,
-    gap: 24,
-  },
-})


### PR DESCRIPTION
- Fixes an issue where the sync settings screen did not allow scrolling.
- Added two views, each scroll screen now decides horizontal padding and gaps.