### PR TITLE
fix: reset zoom on file detail nav

### DIFF
--- a/src/components/FileViewer/index.tsx
+++ b/src/components/FileViewer/index.tsx
@@ -1,7 +1,10 @@
 import { StyleSheet, Text, TouchableHighlight, View } from 'react-native'
 import { useFileStatus } from '../../lib/file'
 import { CloudDownloadIcon, FileIcon } from 'lucide-react-native'
-import { ImageViewer } from '../MediaConsumers/ImageViewer'
+import {
+  ImageViewer,
+  type ImageViewerHandle,
+} from '../MediaConsumers/ImageViewer'
 import { VideoPlayer } from '../MediaConsumers/VideoPlayer'
 import { AudioPlayer } from '../MediaConsumers/AudioPlayer'
 import { PDFViewer } from '../MediaConsumers/PDFViewer'
@@ -12,6 +15,7 @@ import { useDownload } from '../../managers/downloader'
 import { useDownloadState } from '../../stores/downloads'
 import { colors } from '../../styles/colors'
 import { useCallback, useMemo } from 'react'
+import type { Ref } from 'react'
 import { FileRecord } from '../../stores/files'
 import {
   useAutoDownload,
@@ -24,12 +28,14 @@ export function FileViewer({
   header,
   fullscreen = true,
   customDownloader,
+  imageViewerRef,
 }: {
   file: FileRecord
   isShared?: boolean
   header?: React.ReactNode
   fullscreen?: boolean
   customDownloader?: () => void
+  imageViewerRef?: Ref<ImageViewerHandle>
 }) {
   const { type, name } = file
   const status = useFileStatus(file, isShared)
@@ -78,6 +84,7 @@ export function FileViewer({
     if (type?.includes('image')) {
       return (
         <ImageViewer
+          ref={imageViewerRef}
           uri={fileUri}
           style={fullscreen ? styles.mediaWithPadding : styles.media}
         />
@@ -144,6 +151,7 @@ export function FileViewer({
     name,
     file.size,
     DownloadPanel,
+    imageViewerRef,
   ])
 
   return (

--- a/src/components/MediaConsumers/ImageViewer.tsx
+++ b/src/components/MediaConsumers/ImageViewer.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useRef, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+  type Ref,
+} from 'react'
 import {
   ScrollView,
   Image,
@@ -9,13 +16,17 @@ import {
   Platform,
 } from 'react-native'
 
-export function ImageViewer({
-  uri,
-  style,
-}: {
+export type ImageViewerHandle = {
+  resetZoom: () => void
+}
+
+type Props = {
   uri: string
   style?: ViewStyle
-}) {
+  ref?: Ref<ImageViewerHandle>
+}
+
+export function ImageViewer({ uri, style, ref }: Props) {
   const scrollRef = useRef<ScrollView>(null)
   const [size, setSize] = useState({ w: 0, h: 0 })
 
@@ -24,7 +35,7 @@ export function ImageViewer({
     setSize({ w: width, h: height })
   }
 
-  const reset = () => {
+  const reset = useCallback(() => {
     if (Platform.OS === 'ios') {
       scrollRef.current?.scrollResponderZoomTo({
         x: 0,
@@ -37,11 +48,21 @@ export function ImageViewer({
       // Android does not implement zoomToRect; reset scroll position instead.
       scrollRef.current?.scrollTo({ x: 0, y: 0, animated: false })
     }
-  }
+  }, [size.w, size.h])
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      resetZoom: () => {
+        reset()
+      },
+    }),
+    [reset]
+  )
 
   useEffect(() => {
     if (size.w && size.h) reset()
-  }, [uri, size.w, size.h])
+  }, [reset, uri])
 
   return (
     <View style={[styles.wrap, style]} onLayout={onLayout}>

--- a/src/screens/FileDetailScreen.tsx
+++ b/src/screens/FileDetailScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import { View, StyleSheet } from 'react-native'
 import { FileDetails } from '../components/FileDetails'
 import { type NativeStackScreenProps } from '@react-navigation/native-stack'
@@ -9,18 +9,32 @@ import { palette } from '../styles/colors'
 import { FileDetailScreenHeader } from '../components/FileDetailScreenHeader'
 import { FileViewer } from '../components/FileViewer'
 import { FileDetailsControlBar } from '../components/FileDetailsControlBar'
+import { type ImageViewerHandle } from '../components/MediaConsumers/ImageViewer'
 
 type Props = NativeStackScreenProps<MainStackParamList, 'FileDetail'>
 
 export function FileDetailScreen({ route, navigation }: Props) {
   const [viewStyle, setViewStyle] = useState<'consume' | 'detail'>('consume')
+  const imageViewerRef = useRef<ImageViewerHandle>(null)
   const { data: file } = useFileDetails(route.params.id)
+
+  const handleSetViewStyle = useCallback(
+    (next: 'consume' | 'detail') => {
+      if (next === viewStyle) return
+      if (next === 'detail') {
+        imageViewerRef.current?.resetZoom()
+      }
+      setViewStyle(next)
+    },
+    [viewStyle]
+  )
 
   return (
     <View style={styles.container}>
       {file && viewStyle === 'consume' ? (
         <FileViewer
           file={file}
+          imageViewerRef={imageViewerRef}
           header={
             <FileDetailScreenHeader
               file={file}
@@ -51,7 +65,7 @@ export function FileDetailScreen({ route, navigation }: Props) {
       <FileDetailsControlBar
         route={route}
         viewStyle={viewStyle}
-        setViewStyle={setViewStyle}
+        setViewStyle={handleSetViewStyle}
         navigation={navigation}
       />
     </View>


### PR DESCRIPTION
This resets the image zoom position on file detail nav. It fixes a reported issue. That said, I think the issue creates some questions around the best way to do full screen in the file viewer. Which types? When? How do users get in and out of that. In any case, I consider this a stopgap fix while I examine other approaches across the Fileviewer.