### PR TITLE
feat: app init steps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,6 @@
         "expo-media-library": "^18.2.0",
         "expo-secure-store": "15.0.2",
         "expo-share-intent": "^5.1.0",
-        "expo-splash-screen": "^31.0.9",
         "expo-sqlite": "^15.2.14",
         "expo-updates": "~29.0.6",
         "expo-video": "~3.0.11",
@@ -880,8 +879,6 @@
     "expo-server": ["expo-server@1.0.4", "", {}, "sha512-IN06r3oPxFh3plSXdvBL7dx0x6k+0/g0bgxJlNISs6qL5Z+gyPuWS750dpTzOeu37KyBG0RcyO9cXUKzjYgd4A=="],
 
     "expo-share-intent": ["expo-share-intent@5.1.0", "", { "dependencies": { "@expo/config-plugins": "~10.1.1", "expo-constants": "~18.0.8", "expo-linking": "~7.1.7" }, "peerDependencies": { "expo": "^54", "react": "*", "react-native": "*" } }, "sha512-J0qDH/jyga9WpEM+A0PwCtvCobfqEMVFgccOa2LLXu1QD1WpNspXvvtj4gdVGBj8U1l15zbVaOuHLwY9vjsNQg=="],
-
-    "expo-splash-screen": ["expo-splash-screen@31.0.10", "", { "dependencies": { "@expo/prebuild-config": "^54.0.3" }, "peerDependencies": { "expo": "*" } }, "sha512-i6g9IK798mae4yvflstQ1HkgahIJ6exzTCTw4vEdxV0J2SwiW3Tj+CwRjf0te7Zsb+7dDQhBTmGZwdv00VER2A=="],
 
     "expo-sqlite": ["expo-sqlite@15.2.14", "", { "dependencies": { "await-lock": "^2.2.2" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-6tWnEE0fcir30/e7eVwjeC7eKdncfVnIgo2JvnKpRndedyiFMXLMyOQWNVGnuhnSrPV2BHvGGjLByS/j5VgH4w=="],
 

--- a/index.ts
+++ b/index.ts
@@ -3,7 +3,6 @@ import './polyfills'
 import { Root } from './src/Root'
 import { initSia, setLogger } from 'react-native-sia'
 import { logger, rustLogger } from './src/lib/logger'
-import { initializeDB } from './src/db'
 
 logger.log('initSia and uniffi...')
 
@@ -15,5 +14,4 @@ initSia().then(() => {
   setLogger(rustLogger, 'debug')
   registerRootComponent(Root)
   logger.log('App initialized')
-  initializeDB()
 })

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "expo-media-library": "^18.2.0",
     "expo-secure-store": "15.0.2",
     "expo-share-intent": "^5.1.0",
-    "expo-splash-screen": "^31.0.9",
     "expo-sqlite": "^15.2.14",
     "expo-updates": "~29.0.6",
     "expo-video": "~3.0.11",

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -7,8 +7,7 @@ import {
 } from '@react-navigation/native'
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context'
 import { ToastProvider } from './lib/toastContext'
-import { initApp, shutdownApp } from './stores/app'
-import * as SplashScreen from 'expo-splash-screen'
+import { initApp, shutdownApp, useShowSplash } from './stores/app'
 import useLinkedURL from './hooks/useLinkedURL'
 import { useReconnectIndexer } from './hooks/useReconnectIndexer'
 import { RootTabs } from './stacks/RootTabs'
@@ -16,13 +15,13 @@ import { uniqueId } from './lib/uniqueId'
 import { useHasOnboarded } from './stores/settings'
 import { ShareIntentProvider } from 'expo-share-intent'
 import { ShareIntentConsumer } from './components/ShareIntentConsumer'
-
-SplashScreen.preventAutoHideAsync()
+import { AppSplash } from './components/AppSplash'
 
 export function Root() {
   const navigationRef = useNavigationContainerRef<any>()
   useReconnectIndexer()
   const { data: hasOnboarded } = useHasOnboarded()
+  const showSplash = useShowSplash()
 
   useEffect(() => {
     initApp()
@@ -61,10 +60,16 @@ export function Root() {
         />
         <ShareIntentProvider>
           <ToastProvider>
-            <ShareIntentConsumer />
-            <NavigationContainer ref={navigationRef}>
-              <RootTabs />
-            </NavigationContainer>
+            {showSplash ? (
+              <AppSplash />
+            ) : (
+              <>
+                <ShareIntentConsumer />
+                <NavigationContainer ref={navigationRef}>
+                  <RootTabs />
+                </NavigationContainer>
+              </>
+            )}
           </ToastProvider>
         </ShareIntentProvider>
       </SafeAreaView>

--- a/src/components/AppSplash.tsx
+++ b/src/components/AppSplash.tsx
@@ -1,0 +1,103 @@
+import React from 'react'
+import { StyleSheet, Text, View } from 'react-native'
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
+import { TriangleAlertIcon } from 'lucide-react-native'
+import { palette } from '../styles/colors'
+import { useCurrentInitStep, useInitializationError } from '../stores/app'
+import BlocksGrid from './BlocksGrid'
+import BlocksLoader from './BlocksLoader'
+
+export function AppSplash() {
+  const currentStep = useCurrentInitStep()
+  const initializationError = useInitializationError()
+  const { top, bottom } = useSafeAreaInsets()
+
+  return (
+    <SafeAreaView style={styles.screen}>
+      <BlocksGrid
+        cols={5}
+        rows={12}
+        tileScale={0.12}
+        animation="swap"
+        opacity={0.12}
+        inset={{ top, bottom }}
+        style={StyleSheet.absoluteFillObject}
+      />
+      <View
+        style={[
+          styles.centerWrap,
+          { paddingTop: top + 12, paddingBottom: bottom + 12 },
+        ]}
+      >
+        {initializationError && currentStep ? (
+          <View style={styles.errorWrap}>
+            <View style={styles.errorIconWrap}>
+              <TriangleAlertIcon size={48} color={palette.red[500]} />
+            </View>
+            <Text style={styles.errorTitle}>{currentStep.label}</Text>
+            <Text style={styles.errorMessage}>{currentStep.message}</Text>
+            <Text style={styles.errorHint}>
+              Please report this issue to the team or restart the app to try
+              again.
+            </Text>
+          </View>
+        ) : (
+          <View style={styles.waitingWrap}>
+            <BlocksLoader colorStart={1} size={20} />
+            <Text style={styles.waitingText}>
+              {currentStep?.message ?? 'Getting things ready...'}
+            </Text>
+          </View>
+        )}
+      </View>
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: '#000',
+  },
+  centerWrap: {
+    flex: 1,
+    paddingHorizontal: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  waitingWrap: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 24,
+  },
+  waitingText: {
+    color: 'white',
+    fontSize: 14,
+  },
+  errorWrap: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    maxWidth: '80%',
+  },
+  errorIconWrap: {
+    paddingBottom: 8,
+  },
+  errorTitle: {
+    color: 'white',
+    fontSize: 20,
+    fontWeight: '700',
+  },
+  errorMessage: {
+    color: palette.red[500],
+    fontSize: 14,
+    textAlign: 'center',
+    lineHeight: 20,
+  },
+  errorHint: {
+    color: palette.gray[400],
+    fontSize: 13,
+    textAlign: 'center',
+    lineHeight: 18,
+  },
+})

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,16 +1,18 @@
 import * as SQLite from 'expo-sqlite'
 import { runMigrations } from './migrations'
+import { type MigrationProgressHandler } from './migrations/types'
 import { logger } from '../lib/logger'
 import { Mutex } from '../lib/mutex'
 
 export let database: SQLite.SQLiteDatabase
 const dbName = 'app.db'
 
-export async function initializeDB(): Promise<void> {
+export async function initializeDB(options?: {
+  onProgress?: MigrationProgressHandler
+}): Promise<void> {
   logger.log('[db] initializing database...')
   database = await SQLite.openDatabaseAsync(dbName)
-  // Run pending database migrations at startup.
-  await runMigrations(database)
+  await runMigrations(database, options?.onProgress)
   logger.log('[db] database initialized')
 }
 

--- a/src/db/migrations/0001_init_schema.ts
+++ b/src/db/migrations/0001_init_schema.ts
@@ -80,5 +80,6 @@ async function up(db: SQLite.SQLiteDatabase): Promise<void> {
 
 export const migration_0001_init_schema: Migration = {
   id: '0001_init_schema',
+  description: 'Initialize core storage schema.',
   up,
 }

--- a/src/db/migrations/0002_add_thumbnail_columns.ts
+++ b/src/db/migrations/0002_add_thumbnail_columns.ts
@@ -39,5 +39,6 @@ async function up(db: SQLite.SQLiteDatabase): Promise<void> {
 
 export const migration_0002_add_thumbnail_columns: Migration = {
   id: '0002_add_thumbnail_columns',
+  description: 'Add thumbnail metadata columns and indexes.',
   up,
 }

--- a/src/db/migrations/0003_add_updated_at_index.ts
+++ b/src/db/migrations/0003_add_updated_at_index.ts
@@ -17,5 +17,6 @@ async function up(db: SQLite.SQLiteDatabase): Promise<void> {
 
 export const migration_0003_add_updated_at_index: Migration = {
   id: '0003_add_updated_at_index',
+  description: 'Add updatedAt index for sync queries.',
   up,
 }

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -2,7 +2,7 @@
  * Database migrations runner.
  *
  * How it works:
- * - Migrations live in `src/db/migrations` and export `{ id, up }`.
+ * - Migrations live in `src/db/migrations` and export `{ id, description, up }`.
  * - Applied migrations are tracked in the SQLite table `migrations (id TEXT PRIMARY KEY, appliedAt INTEGER)`.
  * - On app startup, `runMigrations` executes migrations not present in the table.
  * - Each migration runs inside a transaction; failures roll back and are not recorded.
@@ -18,7 +18,7 @@
  */
 import * as SQLite from 'expo-sqlite'
 import { logger } from '../../lib/logger'
-import { type Migration } from './types'
+import { type Migration, type MigrationProgressHandler } from './types'
 import { migration_0001_init_schema } from './0001_init_schema'
 import { migration_0002_add_thumbnail_columns } from './0002_add_thumbnail_columns'
 import { migration_0003_add_updated_at_index } from './0003_add_updated_at_index'
@@ -29,7 +29,10 @@ const migrations: Migration[] = [
   migration_0003_add_updated_at_index,
 ]
 
-export async function runMigrations(db: SQLite.SQLiteDatabase): Promise<void> {
+export async function runMigrations(
+  db: SQLite.SQLiteDatabase,
+  onProgress?: MigrationProgressHandler
+): Promise<void> {
   logger.log('[db] checking migrations...')
   await db.execAsync(
     `CREATE TABLE IF NOT EXISTS migrations (
@@ -52,10 +55,16 @@ export async function runMigrations(db: SQLite.SQLiteDatabase): Promise<void> {
     )
   }
   for (const m of migrations) {
-    if (applied.has(m.id)) continue
+    if (applied.has(m.id)) {
+      continue
+    }
     logger.log('[db] applying migration', m.id)
+    onProgress?.({
+      id: m.id,
+      message: m.description,
+    })
     await db.withTransactionAsync(async () => {
-      await m.up(db)
+      await m.up(db, onProgress)
       await db.runAsync(
         'INSERT INTO migrations (id, appliedAt) VALUES (?, ?)',
         m.id,

--- a/src/db/migrations/types.ts
+++ b/src/db/migrations/types.ts
@@ -1,6 +1,17 @@
 import * as SQLite from 'expo-sqlite'
 
+export type MigrationProgressEvent = {
+  id: string
+  message: string
+}
+
+export type MigrationProgressHandler = (event: MigrationProgressEvent) => void
+
 export type Migration = {
   id: string
-  up: (db: SQLite.SQLiteDatabase) => Promise<void>
+  description: string
+  up: (
+    db: SQLite.SQLiteDatabase,
+    onProgress?: MigrationProgressHandler
+  ) => Promise<void>
 }

--- a/src/hooks/useAppStatus.tsx
+++ b/src/hooks/useAppStatus.tsx
@@ -1,7 +1,5 @@
 import React from 'react'
 import {
-  CheckCheckIcon,
-  CheckIcon,
   CircleCheckIcon,
   TriangleAlertIcon,
   UploadCloudIcon,

--- a/src/lib/serviceInterval.ts
+++ b/src/lib/serviceInterval.ts
@@ -72,3 +72,12 @@ export function createServiceInterval({
 
   return init
 }
+
+export function shutdownAllServiceIntervals() {
+  schedulerStateMap.forEach((state) => {
+    if (state.timeoutId) {
+      clearTimeout(state.timeoutId)
+    }
+  })
+  schedulerStateMap.clear()
+}

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
+import { createGetterAndSelector } from '../lib/selectors'
 import { deleteAllFileRecords } from './files'
 import { getHasOnboarded, setRecoveryPhrase, setHasOnboarded } from './settings'
-import * as SplashScreen from 'expo-splash-screen'
 import {
   initSdk,
   reconnect,
@@ -14,7 +14,7 @@ import { cancelAllUploads } from './uploads'
 import { cancelAllDownloads } from './downloads'
 import { initLogger } from './logs'
 import { ensureCacheDir } from './fileCache'
-import { resetDb } from '../db'
+import { initializeDB, resetDb } from '../db'
 import {
   initSyncDownEvents,
   resetSyncDownCursor,
@@ -30,36 +30,97 @@ import {
 import { initBackgroundTasks } from '../managers/backgroundTasks'
 import { initSyncUpMetadata } from '../managers/syncUpMetadata'
 import { initThumbnailScanner } from '../managers/thumbnailScanner'
+import { shutdownAllServiceIntervals } from '../lib/serviceInterval'
 
-export type AppState = {
-  isInitializing: boolean
+export type InitStep = {
+  id: string
+  label: string
+  message: string
+  startedAt: number
 }
 
-const useAppStore = create<AppState>(() => {
+type AppInitState = {
+  steps: Map<string, InitStep>
+  isInitializing: boolean
+  initializationError: string | null
+}
+
+const useAppInitStore = create<AppInitState>(() => {
   return {
+    steps: new Map<string, InitStep>(),
     isInitializing: true,
+    initializationError: null,
   }
 })
 
-const { setState } = useAppStore
+const { setState } = useAppInitStore
 
-export async function initApp() {
-  initLogger()
-  await ensureCacheDir()
+export async function initApp(): Promise<void> {
+  startInitState()
+
   const hasOnboarded = await getHasOnboarded()
+
+  const steps: StepDefinition[] = [
+    {
+      id: 'prepare',
+      label: 'Starting application',
+      message: 'Initializing...',
+      runner: async () => {
+        initLogger()
+        await ensureCacheDir()
+      },
+    },
+    {
+      id: 'migrations',
+      label: 'Initializing database',
+      message: 'Updating schema...',
+      runner: async (updateDetail) => {
+        await initializeDB({
+          onProgress: (event) => {
+            updateDetail(event.message)
+          },
+        })
+      },
+    },
+  ]
+
   if (hasOnboarded) {
-    await initSdk()
-    await reconnect()
+    steps.push({
+      id: 'connect',
+      label: 'Connecting to indexer',
+      message: 'Initializing SDK...',
+      runner: async (updateDetail) => {
+        const sdk = await initSdk()
+        if (!sdk) {
+          throw new Error('Failed to initialize SDK.')
+        }
+        updateDetail('Connecting to indexer...')
+        const connected = await reconnect()
+        if (!connected) {
+          throw new Error('Failed to connect to indexer.')
+        }
+      },
+    })
   }
-  setState({ isInitializing: false })
-  await SplashScreen.hideAsync()
-  initUploadScanner()
-  initSyncDownEvents()
-  initSyncNewPhotos()
-  initSyncPhotosArchive()
-  initBackgroundTasks()
-  initSyncUpMetadata()
-  initThumbnailScanner()
+
+  steps.push({
+    id: 'services',
+    label: 'Starting background services',
+    message: 'Launching background services...',
+    runner: async () => {
+      initUploadScanner()
+      initSyncDownEvents()
+      initSyncNewPhotos()
+      initSyncPhotosArchive()
+      initBackgroundTasks()
+      initSyncUpMetadata()
+      initThumbnailScanner()
+    },
+  })
+
+  await runSteps(steps)
+
+  endInitState()
 }
 
 export async function onboardIndexer(
@@ -85,16 +146,131 @@ export async function resetData() {
 }
 
 export async function resetApp() {
-  await resetData()
-  await setRecoveryPhrase('')
-  await setHasOnboarded(false)
-  await resetSdk()
-  await resetPhotosNewCursor()
-  await resetPhotosArchiveCursor()
+  startInitState()
+  shutdownAllServiceIntervals()
+
+  await runSteps([
+    {
+      id: 'reset',
+      label: 'Resetting application',
+      message: 'Clearing data...',
+      runner: async () => {
+        await resetData()
+        await setRecoveryPhrase('')
+        await setHasOnboarded(false)
+        await resetSdk()
+        await resetPhotosNewCursor()
+        await resetPhotosArchiveCursor()
+      },
+    },
+  ])
+
+  await initApp()
 }
 
 // selectors
 
+export const [getInitSteps, useInitSteps] = createGetterAndSelector(
+  useAppInitStore,
+  (state) => {
+    const steps = Array.from(state.steps.values())
+    return steps.sort((a, b) => a.startedAt - b.startedAt)
+  }
+)
+
+export const [getCurrentInitStep, useCurrentInitStep] = createGetterAndSelector(
+  useAppInitStore,
+  (state) => {
+    const steps = Array.from(state.steps.values())
+    return steps.sort((a, b) => a.startedAt - b.startedAt).at(-1)
+  }
+)
+
+export const [getInitializationError, useInitializationError] =
+  createGetterAndSelector(useAppInitStore, (state) => state.initializationError)
+
 export function useIsInitializing(): boolean {
-  return useAppStore((s) => s.isInitializing)
+  return useAppInitStore((s) => s.isInitializing)
+}
+
+export const [getShowSplash, useShowSplash] = createGetterAndSelector(
+  useAppInitStore,
+  (s) => s.isInitializing || s.initializationError
+)
+
+// helpers
+
+function startInitState(): void {
+  setState({
+    steps: new Map<string, InitStep>(),
+    isInitializing: true,
+    initializationError: null,
+  })
+}
+
+function endInitState(): void {
+  setState({
+    steps: new Map<string, InitStep>(),
+    isInitializing: false,
+    initializationError: null,
+  })
+}
+
+function nextInitStep(step: Omit<InitStep, 'startedAt'>): void {
+  const nextStep = {
+    ...step,
+    startedAt: Date.now(),
+  }
+  setState((state) => {
+    const newSteps = new Map(state.steps)
+    newSteps.set(step.id, nextStep)
+    return { steps: newSteps }
+  })
+}
+
+function updateInitStep(step: { id: string; message?: string }): void {
+  setState((state) => {
+    const prev = state.steps.get(step.id)
+    if (!prev) return state
+    const next: InitStep = {
+      ...prev,
+      ...step,
+    }
+    const newSteps = new Map(state.steps)
+    newSteps.set(step.id, next)
+    return { steps: newSteps }
+  })
+}
+
+type StepDefinition = {
+  id: string
+  label: string
+  message: string
+  runner: (updateMessage: (message: string) => void) => Promise<void>
+}
+
+async function runSteps(steps: StepDefinition[]): Promise<void> {
+  for (const stepDef of steps) {
+    nextInitStep({
+      id: stepDef.id,
+      label: stepDef.label,
+      message: stepDef.message,
+    })
+
+    const updateMessage = (message: string) => {
+      updateInitStep({
+        id: stepDef.id,
+        message,
+      })
+    }
+
+    try {
+      await stepDef.runner(updateMessage)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      updateMessage(message)
+      setState((state) => ({ ...state, initializationError: message }))
+      return // Stop execution on error
+    }
+  }
 }


### PR DESCRIPTION
- Adds a custom splash screen that allows displaying initialization steps and feedback to the user. This will be useful for any longer running work we need to do after users upgrade to a new version of the app.
- The main app is now not mounted until after the splash screen and app init is complete. This means that we will now have a guarantee nothing else is happening in the background such as components triggering db queries.
- Adds support for migrations to update the init progress message.
- Resetting the app now shuts down all services.

[init.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/08aa0e8b-ad1c-4f92-816f-4c95f8b18c0a.mp4" />](https://app.graphite.com/user-attachments/video/08aa0e8b-ad1c-4f92-816f-4c95f8b18c0a.mp4)

