### PR TITLE
fix: add sql helpers to fix android

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -50,38 +50,3 @@ export async function withTransactionLock<T>(fn: () => Promise<T>): Promise<T> {
     return out
   })
 }
-
-/**
- * Generic INSERT helper that:
- * - Inlines SQL NULL for nullish fields to avoid Android varargs null bridging issues.
- * - Binds only primitives (string | number) for the remaining fields.
- */
-export async function insert<
-  T extends Record<string, string | number | boolean | null | undefined>
->(table: string, row: T): Promise<SQLite.SQLiteRunResult> {
-  const columns = Object.keys(row)
-  const valuesSql: string[] = []
-  const params: (string | number)[] = []
-
-  for (const key of columns) {
-    const value = row[key]
-    if (value === null || value === undefined) {
-      valuesSql.push('NULL')
-      continue
-    }
-    valuesSql.push('?')
-    if (typeof value === 'number' || typeof value === 'string') {
-      params.push(value)
-    } else if (typeof value === 'boolean') {
-      params.push(value ? 1 : 0)
-    } else {
-      // Fallback: store as string representation.
-      params.push(String(value))
-    }
-  }
-
-  const sql = `INSERT INTO ${table} (${columns.join(
-    ', '
-  )}) VALUES (${valuesSql.join(', ')})`
-  return await database.runAsync(sql, params)
-}

--- a/src/db/sql.ts
+++ b/src/db/sql.ts
@@ -1,0 +1,158 @@
+import * as SQLite from 'expo-sqlite'
+import { db } from '.'
+
+type SqlValue = string | number | boolean | null | undefined
+type SqlBindable = string | number | boolean
+
+/**
+ * Generic INSERT helper that:
+ * - Inlines SQL NULL for nullish fields to avoid Android varargs null bridging issues.
+ * - Binds only primitives (string | number) for the remaining fields.
+ */
+const insertConflictClauses = [
+  'OR ROLLBACK',
+  'OR ABORT',
+  'OR REPLACE',
+  'OR FAIL',
+  'OR IGNORE',
+] as const
+
+type InsertConflictClause = (typeof insertConflictClauses)[number]
+
+type InsertOptions = {
+  conflictClause?: InsertConflictClause
+}
+
+export async function sqlInsert<
+  T extends Record<string, string | number | boolean | null | undefined>
+>(
+  table: string,
+  row: T,
+  options?: InsertOptions
+): Promise<SQLite.SQLiteRunResult> {
+  const columns = Object.keys(row)
+  const valuesSql: string[] = []
+  const params: SqlBindable[] = []
+
+  for (const key of columns) {
+    const value = row[key]
+    if (value === null || value === undefined) {
+      valuesSql.push('NULL')
+      continue
+    }
+    valuesSql.push('?')
+    params.push(value)
+  }
+
+  const verb = options?.conflictClause
+    ? `INSERT ${options.conflictClause}`
+    : 'INSERT'
+
+  const sql = `${verb} INTO ${table} (${columns.join(
+    ', '
+  )}) VALUES (${valuesSql.join(', ')})`
+  return await runSql(sql, params)
+}
+
+function normalizeSqlValue(value: SqlValue): string | number {
+  if (value === null || value === undefined) {
+    throw new Error(
+      'Attempted to bind nullish SQL parameter. Inline NULL in the statement instead.'
+    )
+  }
+  if (typeof value === 'boolean') {
+    return value ? 1 : 0
+  }
+  if (typeof value === 'string' || typeof value === 'number') {
+    return value
+  }
+  return String(value)
+}
+
+export async function runSql(
+  sql: string,
+  params: SqlValue[] = []
+): Promise<SQLite.SQLiteRunResult> {
+  const normalized = params.map((value) => normalizeSqlValue(value))
+  return await db().runAsync(sql, ...normalized)
+}
+
+type SqlFragment = {
+  clause: string
+  params: SqlBindable[]
+}
+
+function buildSqlAssignments(fields: Record<string, SqlValue>): SqlFragment {
+  const assignments: string[] = []
+  const params: SqlBindable[] = []
+
+  for (const column of Object.keys(fields)) {
+    const value = fields[column]
+    if (value === undefined) {
+      continue
+    }
+    if (value === null) {
+      assignments.push(`${column} = NULL`)
+      continue
+    }
+    assignments.push(`${column} = ?`)
+    params.push(value)
+  }
+
+  return {
+    clause: assignments.join(', '),
+    params,
+  }
+}
+
+function buildSqlWhereClause(
+  conditions?: Record<string, SqlValue>
+): SqlFragment {
+  if (!conditions) {
+    return { clause: '', params: [] }
+  }
+
+  const parts: string[] = []
+  const params: SqlBindable[] = []
+
+  for (const column of Object.keys(conditions)) {
+    const value = conditions[column]
+    if (value === undefined) {
+      continue
+    }
+    if (value === null) {
+      parts.push(`${column} IS NULL`)
+      continue
+    }
+    parts.push(`${column} = ?`)
+    params.push(value)
+  }
+
+  const clause = parts.length ? ` WHERE ${parts.join(' AND ')}` : ''
+
+  return { clause, params }
+}
+
+export async function sqlUpdate(
+  table: string,
+  fields: Record<string, SqlValue>,
+  conditions: Record<string, SqlValue>
+): Promise<SQLite.SQLiteRunResult> {
+  const { clause: assignments, params: setParams } = buildSqlAssignments(fields)
+  if (!assignments) {
+    return Promise.resolve({ changes: 0, lastInsertRowId: 0 })
+  }
+
+  const { clause: where, params: whereParams } = buildSqlWhereClause(conditions)
+  const sql = `UPDATE ${table} SET ${assignments}${where}`
+  return await runSql(sql, [...setParams, ...whereParams])
+}
+
+export async function sqlDelete(
+  table: string,
+  conditions?: Record<string, SqlValue>
+): Promise<SQLite.SQLiteRunResult> {
+  const { clause, params } = buildSqlWhereClause(conditions)
+  const sql = `DELETE FROM ${table}${clause}`
+  return await runSql(sql, params)
+}

--- a/src/stores/files.ts
+++ b/src/stores/files.ts
@@ -4,13 +4,13 @@ import {
 } from '../encoding/localObject'
 import { upsertLocalObject, readLocalObjectsForFile } from './localObjects'
 import { logger } from '../lib/logger'
-import { db, insert, withTransactionLock } from '../db'
+import { db, withTransactionLock } from '../db'
+import { sqlDelete, sqlInsert, sqlUpdate } from '../db/sql'
 import useSWR from 'swr'
 import { createGetterAndSWRHook } from '../lib/selectors'
 import { LocalObjectRow } from '../encoding/localObject'
 import { getIndexerURL } from './settings'
 import { librarySwr } from './library'
-import { removeEmptyValues } from '../lib/object'
 import { keysOf } from '../lib/types'
 
 /** Valid thumbnail sizes in pixels. */
@@ -83,7 +83,7 @@ export async function createFileRecord(
     thumbForHash,
     thumbSize,
   } = fileRecord
-  await insert('files', {
+  await sqlInsert('files', {
     id,
     name,
     size,
@@ -305,8 +305,7 @@ export async function updateFileRecord(
   options: { includeUpdatedAt?: boolean } = { includeUpdatedAt: false }
 ): Promise<void> {
   const { id } = update
-  const sets: string[] = []
-  const params: (string | number | null)[] = []
+  const assignments: Record<string, string | number | boolean | null> = {}
   const updatableFields: (keyof FileRecordRow)[] = [
     'name',
     'type',
@@ -321,24 +320,22 @@ export async function updateFileRecord(
     updatableFields.push('updatedAt')
   }
   for (const field of updatableFields) {
-    const nonEmptyUpdate = removeEmptyValues(update)
-    if (field in nonEmptyUpdate) {
-      sets.push(`${field} = ?`)
-      params.push(nonEmptyUpdate[field as keyof typeof nonEmptyUpdate] ?? null)
+    const value = update[field]
+    if (value === undefined || value === null) {
+      continue
     }
-  }
-
-  if (sets.length === 0) {
-    return
+    assignments[field] = value
   }
 
   if (!options.includeUpdatedAt) {
-    sets.push('updatedAt = ?')
-    params.push(Date.now())
+    assignments.updatedAt = Date.now()
   }
 
-  const sql = `UPDATE files SET ${sets.join(', ')} WHERE id = ?`
-  await db().runAsync(sql, ...params, id)
+  if (!Object.keys(assignments).length) {
+    return
+  }
+
+  await sqlUpdate('files', assignments, { id })
   if (triggerUpdate) {
     await librarySwr.triggerChange()
   }
@@ -362,7 +359,7 @@ export async function deleteFileRecord(
   id: string,
   triggerUpdate: boolean = true
 ): Promise<void> {
-  await db().runAsync('DELETE FROM files WHERE id = ?', id)
+  await sqlDelete('files', { id })
   if (triggerUpdate) {
     await librarySwr.triggerChange()
   }
@@ -374,14 +371,14 @@ export async function deleteFileRecordAndThumbnails(id: string): Promise<void> {
   if (!original) return
   const hash = original.hash
   await withTransactionLock(async () => {
-    await db().runAsync('DELETE FROM files WHERE thumbForHash = ?', hash)
-    await db().runAsync('DELETE FROM files WHERE id = ?', id)
+    await sqlDelete('files', { thumbForHash: hash })
+    await sqlDelete('files', { id })
   })
   await librarySwr.triggerChange()
 }
 
 export async function deleteAllFileRecords(): Promise<void> {
-  await db().runAsync('DELETE FROM files')
+  await sqlDelete('files')
 }
 
 /** Commit a file record and a local object in a single transaction. */

--- a/src/stores/localObjects.ts
+++ b/src/stores/localObjects.ts
@@ -1,4 +1,5 @@
 import { db } from '../db'
+import { sqlDelete, sqlInsert } from '../db/sql'
 import {
   type LocalObject,
   type LocalObjectRow,
@@ -23,18 +24,20 @@ export async function upsertLocalObject(
   triggerUpdate: boolean = true
 ): Promise<void> {
   const e = localObjectToStorageRow(object)
-  await db().runAsync(
-    `INSERT OR REPLACE INTO objects (fileId, indexerURL, id, slabs, encryptedMasterKey, encryptedMetadata, signature, createdAt, updatedAt)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    e.fileId,
-    e.indexerURL,
-    e.id,
-    e.slabs,
-    e.encryptedMasterKey,
-    e.encryptedMetadata,
-    e.signature,
-    e.createdAt,
-    e.updatedAt
+  await sqlInsert(
+    'objects',
+    {
+      fileId: e.fileId,
+      indexerURL: e.indexerURL,
+      id: e.id,
+      slabs: e.slabs,
+      encryptedMasterKey: e.encryptedMasterKey,
+      encryptedMetadata: e.encryptedMetadata,
+      signature: e.signature,
+      createdAt: e.createdAt,
+      updatedAt: e.updatedAt,
+    },
+    { conflictClause: 'OR REPLACE' }
   )
   if (triggerUpdate) {
     await librarySwr.triggerChange()
@@ -42,7 +45,7 @@ export async function upsertLocalObject(
 }
 
 export async function deleteLocalObjects(fileId: string): Promise<void> {
-  await db().runAsync(`DELETE FROM objects WHERE fileId = ?`, fileId)
+  await sqlDelete('objects', { fileId })
   await librarySwr.triggerChange()
 }
 


### PR DESCRIPTION
- Add conflict clause support to our sql insert helper​ so we can use it for the upsert methods.
- Add similar helpers for delete and update to avoid some Android issues with NULL values.
- All mutative queries now convert nullish values to NULL in queries.