### PR TITLE
fix: control bar layout on android

### DIFF
--- a/src/components/BottomControlBar.tsx
+++ b/src/components/BottomControlBar.tsx
@@ -1,18 +1,19 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import {
   View,
   StyleSheet,
-  Platform,
-  KeyboardAvoidingView,
   StyleProp,
   ViewStyle,
+  Keyboard,
+  Platform,
+  type KeyboardEvent,
 } from 'react-native'
 import { colors, overlay, whiteA, palette } from '../styles/colors'
 import { Gradient } from './Gradient'
 
 type Props = {
   children?: React.ReactNode
-  overlayTop?: React.ReactNode
+  controlsTop?: React.ReactNode
   keyboardAware?: boolean
   style?: StyleProp<ViewStyle>
 }
@@ -20,41 +21,38 @@ type Props = {
 export function BottomControlBar({
   style,
   children,
-  overlayTop,
+  controlsTop,
   keyboardAware = false,
 }: Props) {
+  const keyboardOffset = useKeyboardOffset(keyboardAware)
+
   return (
     <View style={styles.container} pointerEvents="box-none">
-      <KeyboardAvoidingView
-        enabled={keyboardAware}
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-        style={{ flex: 1 }}
-        pointerEvents="box-none"
+      <View
+        style={[
+          styles.keyboardAwareContainer,
+          { paddingBottom: 30 + keyboardOffset },
+        ]}
       >
-        <View style={styles.wrapFlex} pointerEvents="box-none">
-          <Gradient
-            fadeTo="bottom"
-            overlayTopColor={overlay.gradientLight}
-            overlayBottomColor={overlay.gradientDark}
-            style={{
-              position: 'absolute',
-              zIndex: 1,
-              left: 0,
-              right: 0,
-              bottom: 0,
-              height: overlayTop ? 320 : 150,
-            }}
-          />
-          <View style={[styles.contents, style]}>
-            {overlayTop ? (
-              <View style={[styles.overlayTop]} pointerEvents="box-none">
-                {overlayTop}
-              </View>
-            ) : null}
-            <View style={styles.bar}>{children}</View>
-          </View>
+        <Gradient
+          fadeTo="bottom"
+          overlayTopColor={overlay.gradientLight}
+          overlayBottomColor={overlay.gradientDark}
+          style={[
+            styles.gradient,
+            {
+              bottom: keyboardOffset,
+              height: controlsTop ? 180 : 100,
+            },
+          ]}
+        />
+        <View style={[styles.contents, style]}>
+          {controlsTop ? (
+            <View style={styles.controlsTop}>{controlsTop}</View>
+          ) : null}
+          <View style={styles.bar}>{children}</View>
         </View>
-      </KeyboardAvoidingView>
+      </View>
     </View>
   )
 }
@@ -67,23 +65,33 @@ const styles = StyleSheet.create({
     right: 0,
     top: 0,
     bottom: 0,
-    flexDirection: 'row',
-    justifyContent: 'center',
+    flexDirection: 'column',
+    justifyContent: 'flex-end',
     alignItems: 'center',
+  },
+  keyboardAwareContainer: {
+    flex: 1,
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    alignSelf: 'stretch',
+    width: '100%',
+    pointerEvents: 'box-none',
+  },
+  gradient: {
+    position: 'absolute',
+    zIndex: 1,
+    left: 0,
+    right: 0,
   },
   contents: {
     flexDirection: 'row',
     zIndex: 2,
-  },
-  wrapFlex: {
-    flex: 1,
-    justifyContent: 'flex-end',
-    alignItems: 'center',
-    paddingBottom: 30,
     width: '100%',
+    flexShrink: 0,
   },
   bar: {
     flex: 1,
+    flexShrink: 0,
     height: 56,
     borderRadius: 26,
     backgroundColor: overlay.panelStrong,
@@ -98,13 +106,14 @@ const styles = StyleSheet.create({
     borderColor: whiteA.a08,
     borderWidth: StyleSheet.hairlineWidth,
   },
-  overlayTop: {
+  controlsTop: {
     position: 'absolute',
     zIndex: 3,
     left: 0,
     right: 0,
     bottom: 56 + 12, // Bar height + gap.
     alignSelf: 'center',
+    pointerEvents: 'box-none',
   },
   label: { fontSize: 10, color: colors.textMuted },
   disabled: { opacity: 0.3 },
@@ -114,4 +123,38 @@ export const iconColors = {
   active: colors.accentActive,
   inactive: whiteA.a70,
   white: palette.gray[50],
+}
+
+/** Returns the height of the keyboard when it is visible. */
+function useKeyboardOffset(enabled: boolean) {
+  const [offset, setOffset] = useState(0)
+
+  useEffect(() => {
+    if (!enabled) {
+      setOffset(0)
+      return
+    }
+
+    const showEvent =
+      Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow'
+    const hideEvent =
+      Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide'
+
+    const handleShow = (event: KeyboardEvent) => {
+      setOffset(event.endCoordinates?.height ?? 0)
+    }
+    const handleHide = () => {
+      setOffset(0)
+    }
+
+    const showSub = Keyboard.addListener(showEvent, handleShow)
+    const hideSub = Keyboard.addListener(hideEvent, handleHide)
+
+    return () => {
+      showSub.remove()
+      hideSub.remove()
+    }
+  }, [enabled])
+
+  return offset
 }

--- a/src/components/FileGallery.tsx
+++ b/src/components/FileGallery.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { FlatList, StyleSheet, ActivityIndicator } from 'react-native'
+import { FlatList, StyleSheet, ActivityIndicator, Platform } from 'react-native'
 import { type FileRecord } from '../stores/files'
 import { useFileList } from '../stores/library'
 import { useFlatListControls } from '../hooks/useFlatListControls'
@@ -40,6 +40,7 @@ export function FileGallery({ onPressItem, numColumns = 3 }: Props) {
       windowSize={9}
       maxToRenderPerBatch={20}
       updateCellsBatchingPeriod={20}
+      showsVerticalScrollIndicator={false}
       ListFooterComponent={isLoadingMore ? <ActivityIndicator /> : null}
       removeClippedSubviews
     />
@@ -47,5 +48,8 @@ export function FileGallery({ onPressItem, numColumns = 3 }: Props) {
 }
 
 const styles = StyleSheet.create({
-  galleryContent: { paddingTop: 130, paddingBottom: 130 },
+  galleryContent: {
+    paddingTop: Platform.OS === 'android' ? 150 : 130,
+    paddingBottom: 130,
+  },
 })

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { FlatList, ActivityIndicator } from 'react-native'
+import { FlatList, ActivityIndicator, Platform } from 'react-native'
 import { FileRecord } from '../stores/files'
 import { useFileList } from '../stores/library'
 import { FileListItem } from './FileListItem'
@@ -29,7 +29,7 @@ export function FileList({ onPressItem }: Props) {
       automaticallyAdjustKeyboardInsets={false}
       automaticallyAdjustsScrollIndicatorInsets={false}
       contentContainerStyle={{
-        paddingTop: 130,
+        paddingTop: Platform.OS === 'android' ? 150 : 130,
         gap: 8,
         paddingBottom: 130,
       }}
@@ -42,6 +42,7 @@ export function FileList({ onPressItem }: Props) {
       windowSize={9}
       maxToRenderPerBatch={20}
       updateCellsBatchingPeriod={20}
+      showsVerticalScrollIndicator={false}
       ListFooterComponent={isLoadingMore ? <ActivityIndicator /> : null}
       removeClippedSubviews
     />

--- a/src/components/LibraryControlBar.tsx
+++ b/src/components/LibraryControlBar.tsx
@@ -21,7 +21,7 @@ export function LibraryControlBar({ route, navigation }: Props) {
     <BottomControlBar
       keyboardAware
       style={{ width: '90%', maxWidth: 600 }}
-      overlayTop={searchActive ? <LibraryControlsSearchMenus /> : null}
+      controlsTop={searchActive ? <LibraryControlsSearchMenus /> : null}
     >
       {searchActive ? (
         <FileSearchBar onExit={() => setSearchActive(false)} />


### PR DESCRIPTION
- The control bar no longer gets mangled on Android after toggling the keyboard or reopening the app.
    - Swapped out KeyboardAvoidingView for a measurement hook.
- Also adjusts library screen padding on Android.