### PR TITLE
feat: add filesheet long press to gallery and filelist

### DIFF
--- a/src/components/FileActionsSheet.tsx
+++ b/src/components/FileActionsSheet.tsx
@@ -13,26 +13,23 @@ import { useToast } from '../lib/toastContext'
 import { ArrowDownToLineIcon } from 'lucide-react-native'
 import { removeFileFromCache } from '../stores/fileCache'
 import { useDownload } from '../managers/downloader'
-import { useSdk } from '../stores/sdk'
 import { useFileStatus } from '../lib/file'
 import { useReuploadFile } from '../managers/uploader'
 import { ActionSheetButton } from './ActionSheetButton'
 import { ActionSheet } from './ActionSheet'
-import { useFileDetails, deleteFileRecord } from '../stores/files'
-import { deleteLocalObjects } from '../stores/localObjects'
+import { useFileDetails } from '../stores/files'
 import { useSheetOpen, closeSheet } from '../stores/sheets'
 import { useShareAction } from '../hooks/useShareAction'
 import { logger } from '../lib/logger'
-import {
-  deleteAllIndexerObjects,
-  permanentlyDeleteFile,
-  deleteFileFromNetwork,
-} from '../lib/deleteFile'
+import { permanentlyDeleteFile, deleteFileFromNetwork } from '../lib/deleteFile'
 
 type Props = {
   sheetName?: string
   fileID: string
-  navigation: NativeStackScreenProps<MainStackParamList, 'FileDetail'>['navigation']
+  navigation?: NativeStackScreenProps<
+    MainStackParamList,
+    'FileDetail'
+  >['navigation']
 }
 
 export function FileActionsSheet({
@@ -95,7 +92,7 @@ export function FileActionsSheet({
     if (!file) return
     try {
       await permanentlyDeleteFile(file)
-      navigation.goBack()
+      if (navigation) navigation.goBack()
       toast.show('File deleted')
     } catch (e) {
       logger.log('[FileActionsSheet] failed to delete file', e)

--- a/src/components/FileGallery.tsx
+++ b/src/components/FileGallery.tsx
@@ -7,10 +7,15 @@ import { FileGalleryItem } from './FileGalleryItem'
 
 type Props = {
   onPressItem: (item: FileRecord) => void
+  onLongPressItem?: (item: FileRecord) => void
   numColumns?: number
 }
 
-export function FileGallery({ onPressItem, numColumns = 3 }: Props) {
+export function FileGallery({
+  onPressItem,
+  onLongPressItem,
+  numColumns = 3,
+}: Props) {
   const { data: files, size, setSize, isValidating, hasMore } = useFileList()
   const { isLoadingMore, handleEndReached } = useFlatListControls({
     data: files,
@@ -32,7 +37,11 @@ export function FileGallery({ onPressItem, numColumns = 3 }: Props) {
       automaticallyAdjustsScrollIndicatorInsets={false}
       contentContainerStyle={styles.galleryContent}
       renderItem={({ item }) => (
-        <FileGalleryItem file={item} onPressItem={onPressItem} />
+        <FileGalleryItem
+          file={item}
+          onPressItem={onPressItem}
+          onLongPressItem={onLongPressItem}
+        />
       )}
       onEndReachedThreshold={0.95}
       onEndReached={handleEndReached}

--- a/src/components/FileGalleryItem.tsx
+++ b/src/components/FileGalleryItem.tsx
@@ -1,7 +1,5 @@
 import { View, Pressable, StyleSheet } from 'react-native'
 import { colors } from '../styles/colors'
-import Clipboard from '@react-native-clipboard/clipboard'
-import { useToast } from '../lib/toastContext'
 import { type FileRecord } from '../stores/files'
 import { FileThumbnail } from './FileThumbnail'
 import { memo } from 'react'
@@ -11,10 +9,14 @@ import { UploadStatusIcon } from './UploadStatusIcon'
 type Props = {
   file: FileRecord
   onPressItem: (item: FileRecord) => void
+  onLongPressItem?: (item: FileRecord) => void
 }
 
-function FileGalleryItemComponent({ file, onPressItem }: Props) {
-  const toast = useToast()
+function FileGalleryItemComponent({
+  file,
+  onPressItem,
+  onLongPressItem,
+}: Props) {
   const status = useFileStatus(file)
   return (
     <View collapsable={false} style={styles.thumbCell}>
@@ -22,10 +24,9 @@ function FileGalleryItemComponent({ file, onPressItem }: Props) {
         accessibilityRole="button"
         onPress={() => onPressItem(file)}
         style={styles.thumbPress}
-        onLongPress={() => {
-          Clipboard.setString(file.id)
-          toast.show('Copied item id')
-        }}
+        onLongPress={
+          onLongPressItem ? () => onLongPressItem(file) : undefined
+        }
       >
         <FileThumbnail file={file} iconSize={24} thumbSize={512} />
         {status.data ? (
@@ -43,7 +44,8 @@ export const FileGalleryItem = memo(FileGalleryItemComponent, (prev, next) => {
     prev.file.id === next.file.id &&
     prev.file.updatedAt === next.file.updatedAt &&
     prev.file.objects === next.file.objects &&
-    prev.onPressItem === next.onPressItem
+    prev.onPressItem === next.onPressItem &&
+    prev.onLongPressItem === next.onLongPressItem
   )
 })
 

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -7,9 +7,10 @@ import { useFlatListControls } from '../hooks/useFlatListControls'
 
 type Props = {
   onPressItem: (item: FileRecord) => void
+  onLongPressItem?: (item: FileRecord) => void
 }
 
-export function FileList({ onPressItem }: Props) {
+export function FileList({ onPressItem, onLongPressItem }: Props) {
   const { data: files, size, setSize, isValidating, hasMore } = useFileList()
   const { isLoadingMore, handleEndReached } = useFlatListControls({
     data: files,
@@ -34,7 +35,11 @@ export function FileList({ onPressItem }: Props) {
         paddingBottom: 130,
       }}
       renderItem={({ item }) => (
-        <FileListItem file={item} onPressItem={onPressItem} />
+        <FileListItem
+          file={item}
+          onPressItem={onPressItem}
+          onLongPressItem={onLongPressItem}
+        />
       )}
       onEndReachedThreshold={0.9}
       onEndReached={handleEndReached}

--- a/src/components/FileListItem.tsx
+++ b/src/components/FileListItem.tsx
@@ -11,15 +11,19 @@ import { memo } from 'react'
 type Props = {
   file: FileRecord
   onPressItem: (item: FileRecord) => void
+  onLongPressItem?: (item: FileRecord) => void
 }
 
-function FileListItemComponent({ file, onPressItem }: Props) {
+function FileListItemComponent({ file, onPressItem, onLongPressItem }: Props) {
   const status = useFileStatus(file)
   return (
     <Pressable
       collapsable={false}
       style={styles.container}
       onPress={() => onPressItem(file)}
+      onLongPress={
+        onLongPressItem ? () => onLongPressItem(file) : undefined
+      }
     >
       <View style={styles.thumbnailContainer}>
         <FileThumbnail file={file} thumbSize={64} />
@@ -57,7 +61,8 @@ export const FileListItem = memo(FileListItemComponent, (prev, next) => {
     prev.file.id === next.file.id &&
     prev.file.updatedAt === next.file.updatedAt &&
     prev.file.objects === next.file.objects &&
-    prev.onPressItem === next.onPressItem
+    prev.onPressItem === next.onPressItem &&
+    prev.onLongPressItem === next.onLongPressItem
   )
 })
 

--- a/src/screens/LibraryScreen.tsx
+++ b/src/screens/LibraryScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 import { View, Text, StyleSheet, Image, ActivityIndicator } from 'react-native'
 import { colors, overlay, whiteA, palette } from '../styles/colors'
 import { Gradient } from '../components/Gradient'
@@ -22,6 +22,8 @@ import { IconButton } from '../components/IconButton'
 import { SettingsIcon } from 'lucide-react-native'
 import { LibraryLocalResetButton } from '../components/LibraryLocalResetButton'
 import { LibraryAppStatusIcon } from '../components/LibraryAppStatusIcon'
+import { FileActionsSheet } from '../components/FileActionsSheet'
+import { openSheet } from '../stores/sheets'
 
 type Props = NativeStackScreenProps<MainStackParamList, 'LibraryHome'>
 
@@ -30,12 +32,17 @@ export function LibraryScreen({ route, navigation }: Props) {
   const { selectedCategories, searchQuery } = useLibrary()
   const files = useFileList()
   const fileCount = useLibraryCount()
+  const [selectedFileID, setSelectedFileID] = useState<string | null>(null)
   const handleOpenDetail = useCallback(
     (file: FileRecord) => {
       navigation.navigate('FileDetail', { id: file.id })
     },
     [navigation]
   )
+  const handleOpenActions = useCallback((file: FileRecord) => {
+    setSelectedFileID(file.id)
+    openSheet('fileActions')
+  }, [])
 
   return (
     <View style={styles.container}>
@@ -100,9 +107,15 @@ export function LibraryScreen({ route, navigation }: Props) {
       ) : !!fileCount.data ? (
         files.data && files.data.length > 0 ? (
           viewMode.data == 'gallery' ? (
-            <FileGallery onPressItem={handleOpenDetail} />
+            <FileGallery
+              onPressItem={handleOpenDetail}
+              onLongPressItem={handleOpenActions}
+            />
           ) : (
-            <FileList onPressItem={handleOpenDetail} />
+            <FileList
+              onPressItem={handleOpenDetail}
+              onLongPressItem={handleOpenActions}
+            />
           )
         ) : (
           <View style={styles.emptyWrap}>
@@ -134,6 +147,9 @@ export function LibraryScreen({ route, navigation }: Props) {
       )}
       <AddFileActionSheet />
       <LibraryStatusSheet />
+      {selectedFileID ? (
+        <FileActionsSheet fileID={selectedFileID} sheetName="fileActions" />
+      ) : null}
       <LibraryControlBar navigation={navigation} route={route} />
     </View>
   )


### PR DESCRIPTION
[Screen Recording 2025-11-18 at 10.36.17 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/368d08a4-a4f2-408e-840d-d14bb4258cd9.mov" />](https://app.graphite.com/user-attachments/video/368d08a4-a4f2-408e-840d-d14bb4258cd9.mov)

Fairly straightforward. Took a bit of prop drilling but I think that's desirable here because we wouldn't want two implementations of this--one on FileList and one on Gallery. So we unify on the LibraryScreen. Removed a host of unused imports on FileActionSheet, while I was there. No change in functionality to that--just unused stuff hanging around!

Closes https://github.com/SiaFoundation/sia-mobile/issues/140