### PR TITLE
refactor: use more direct and sychronous hasOnboarded get and set

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -7,12 +7,16 @@ import {
 } from '@react-navigation/native'
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context'
 import { ToastProvider } from './lib/toastContext'
-import { initApp, shutdownApp, useShowSplash } from './stores/app'
+import {
+  initApp,
+  shutdownApp,
+  useHasOnboardedStatus,
+  useShowSplash,
+} from './stores/app'
 import useLinkedURL from './hooks/useLinkedURL'
 import { useReconnectIndexer } from './hooks/useReconnectIndexer'
 import { RootTabs } from './stacks/RootTabs'
 import { uniqueId } from './lib/uniqueId'
-import { useHasOnboarded } from './stores/settings'
 import { ShareIntentProvider } from 'expo-share-intent'
 import { ShareIntentConsumer } from './components/ShareIntentConsumer'
 import { AppSplash } from './components/AppSplash'
@@ -20,7 +24,7 @@ import { AppSplash } from './components/AppSplash'
 export function Root() {
   const navigationRef = useNavigationContainerRef<any>()
   useReconnectIndexer()
-  const { data: hasOnboarded } = useHasOnboarded()
+  const hasOnboarded = useHasOnboardedStatus()
   const showSplash = useShowSplash()
 
   useEffect(() => {

--- a/src/components/ShareIntentConsumer.tsx
+++ b/src/components/ShareIntentConsumer.tsx
@@ -1,13 +1,13 @@
 import { useEffect } from 'react'
 import { useShareIntentContext } from 'expo-share-intent'
-import { useHasOnboarded } from '../stores/settings'
+import { useHasOnboardedStatus } from '../stores/app'
 import { processAssets } from '../lib/processAssets'
 import { useUploader } from '../managers/uploader'
 import { useToast } from '../lib/toastContext'
 import { logger } from '../lib/logger'
 
 export function ShareIntentConsumer() {
-  const { data: hasOnboarded } = useHasOnboarded()
+  const hasOnboarded = useHasOnboardedStatus()
   const { hasShareIntent, shareIntent, resetShareIntent } =
     useShareIntentContext()
   const uploader = useUploader()

--- a/src/hooks/useAppStatus.tsx
+++ b/src/hooks/useAppStatus.tsx
@@ -6,8 +6,7 @@ import {
 } from 'lucide-react-native'
 import { palette } from '../styles/colors'
 import { useIsConnected } from '../stores/sdk'
-import { useIsInitializing } from '../stores/app'
-import { useHasOnboarded } from '../stores/settings'
+import { useHasOnboardedStatus, useIsInitializing } from '../stores/app'
 import { useUploadScannerStatus } from '../managers/uploadScanner'
 import { useIsOnline } from './useIsOnline'
 
@@ -21,7 +20,7 @@ export type AppStatus = {
 export function useAppStatus(): AppStatus {
   const isInitializing = useIsInitializing()
   const isConnected = useIsConnected()
-  const hasOnboarded = useHasOnboarded()
+  const hasOnboarded = useHasOnboardedStatus()
   const uploadsProgress = useUploadScannerStatus()
   const isOnline = useIsOnline()
 

--- a/src/screens/FinishedOnboardingScreen.tsx
+++ b/src/screens/FinishedOnboardingScreen.tsx
@@ -11,7 +11,7 @@ import {
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 import { Button } from '../components/Button'
 import BlocksGrid from '../components/BlocksGrid'
-import { setHasOnboarded } from '../stores/settings'
+import { setHasOnboardedStatus } from '../stores/app'
 import { palette } from '../styles/colors'
 import BlocksShape from '../components/BlocksShape'
 
@@ -136,7 +136,7 @@ export default function FinishedOnboardingScreen() {
         <Button
           variant="primary"
           onPress={async () => {
-            await setHasOnboarded(true)
+            await setHasOnboardedStatus(true)
           }}
         >
           Upload files

--- a/src/stacks/RootTabs.tsx
+++ b/src/stacks/RootTabs.tsx
@@ -4,14 +4,19 @@ import { MainStack } from './MainStack'
 import { SettingsStack } from './SettingsStack'
 import { type RootTabParamList } from './types'
 import { AuthStack } from './AuthStack'
-import { useHasOnboarded } from '../stores/settings'
+import { useHasOnboardedStatus } from '../stores/app'
 import { ImportStack } from './ImportStack'
 
 const Tab = createBottomTabNavigator<RootTabParamList>()
 
 export function RootTabs() {
-  const hasOnboarded = useHasOnboarded()
-  if (!hasOnboarded.data) {
+  const hasOnboarded = useHasOnboardedStatus()
+  // We should never reach this null because initApp() should have
+  // already set this field true or false by the time we get here.
+  if (hasOnboarded === undefined) {
+    return null
+  }
+  if (!hasOnboarded) {
     return <AuthStack />
   }
   return (

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -1,7 +1,11 @@
 import { create } from 'zustand'
 import { createGetterAndSelector } from '../lib/selectors'
 import { deleteAllFileRecords } from './files'
-import { getHasOnboarded, setRecoveryPhrase, setHasOnboarded } from './settings'
+import {
+  getSecureStoreHasOnboarded,
+  setRecoveryPhrase,
+  setSecureStoreHasOnboarded,
+} from './settings'
 import {
   initSdk,
   reconnect,
@@ -43,6 +47,7 @@ type AppInitState = {
   steps: Map<string, InitStep>
   isInitializing: boolean
   initializationError: string | null
+  hasOnboarded: boolean | undefined
 }
 
 const useAppInitStore = create<AppInitState>(() => {
@@ -50,15 +55,26 @@ const useAppInitStore = create<AppInitState>(() => {
     steps: new Map<string, InitStep>(),
     isInitializing: true,
     initializationError: null,
+    hasOnboarded: undefined,
   }
 })
 
 const { setState } = useAppInitStore
 
+function setHasOnboardedState(value: boolean) {
+  setState({ hasOnboarded: value })
+}
+
+export async function setHasOnboardedStatus(value: boolean) {
+  await setSecureStoreHasOnboarded(value)
+  setHasOnboardedState(value)
+}
+
 export async function initApp(): Promise<void> {
   startInitState()
 
-  const hasOnboarded = await getHasOnboarded()
+  const hasOnboarded = await getSecureStoreHasOnboarded()
+  setHasOnboardedState(hasOnboarded)
 
   const steps: StepDefinition[] = [
     {
@@ -157,7 +173,7 @@ export async function resetApp() {
       runner: async () => {
         await resetData()
         await setRecoveryPhrase('')
-        await setHasOnboarded(false)
+        await setHasOnboardedStatus(false)
         await resetSdk()
         await resetPhotosNewCursor()
         await resetPhotosArchiveCursor()
@@ -198,6 +214,9 @@ export const [getShowSplash, useShowSplash] = createGetterAndSelector(
   (s) => s.isInitializing || s.initializationError
 )
 
+export const [getHasOnboardedStatus, useHasOnboardedStatus] =
+  createGetterAndSelector(useAppInitStore, (s) => s.hasOnboarded)
+
 // helpers
 
 function startInitState(): void {
@@ -205,6 +224,7 @@ function startInitState(): void {
     steps: new Map<string, InitStep>(),
     isInitializing: true,
     initializationError: null,
+    hasOnboarded: undefined,
   })
 }
 

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -43,14 +43,12 @@ export async function setIndexerURL(value: string) {
 
 // Has Onboarded
 
-export const [getHasOnboarded, useHasOnboarded] = createGetterAndSWRHook(
-  getKey('hasOnboarded'),
-  () => getSecureStoreBoolean('hasOnboarded')
-)
+export function getSecureStoreHasOnboarded() {
+  return getSecureStoreBoolean('hasOnboarded')
+}
 
-export async function setHasOnboarded(value: boolean) {
+export async function setSecureStoreHasOnboarded(value: boolean) {
   await setSecureStoreBoolean('hasOnboarded', value)
-  triggerChange('hasOnboarded')
 }
 
 // Show Advanced


### PR DESCRIPTION
[Screen Recording 2025-11-18 at 1.31.30 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/7759f2ba-e218-46ab-8d8c-52ae60e0aaaa.mov" />](https://app.graphite.com/user-attachments/video/7759f2ba-e218-46ab-8d8c-52ae60e0aaaa.mov)

I don't know that this is necessary, so feel free to suggest we not merge this. 

My thought is that if there is anything going sideways with SWR--some intermediate state and/or mutation/key issue, this cuts out that complexity in favor of a zustand store value that we must make sure stays in sync. It's definitely a trade-off, but I like it because it eliminates some library-side complexity with SWR in favor of another library that seems less complex with zustand. I think this also makes us more directly synchronous for this value.

One danger after this PR would be if someone calls `setSecureStoreHasOnboarded` on its own instead of using setHasOnboardedStatus in `app.ts`. We would get out of sync, but our surface area is low--the "Upload Files" button on the `FinishedOnboardingScreen` and the `Reset App` button.

Closes https://github.com/SiaFoundation/sia-mobile/issues/227 

We can open a new ticket if we see it again.