### PR TITLE
feat: local file eviction service

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,3 +1,5 @@
+import { daysInMs, minutesInMs, secondsInMs } from '../lib/time'
+
 // App key, used to identify itself to the indexer. 32 bytes hex string.
 export const APP_KEY =
   'ac38d91cfb250d50820a0c658628662b8c2dcfc6a5f3fe4d5755eb0a7b67eeac'
@@ -20,16 +22,24 @@ export const SCANNER_MAX_TOTAL_UPLOADS_FACTOR = 2
 // Max amount of files to add to the queue each scan as a factor of the max transfers.
 export const SCANNER_ADD_TO_QUEUE_FACTOR = 2
 // Scan interval.
-export const SCANNER_INTERVAL = 5_000 // 5 seconds
+export const SCANNER_INTERVAL = secondsInMs(5) // 5 seconds
 // Sync events interval.
-export const SYNC_EVENTS_INTERVAL = 10_000 // 10 seconds
+export const SYNC_EVENTS_INTERVAL = secondsInMs(10) // 10 seconds
 // Sync new photos interval.
-export const SYNC_NEW_PHOTOS_INTERVAL = 30_000 // 30 seconds
+export const SYNC_NEW_PHOTOS_INTERVAL = secondsInMs(30) // 30 seconds
 // Sync archive photos interval.
-export const SYNC_PHOTOS_ARCHIVE_INTERVAL = 5_000 // 5 seconds
+export const SYNC_PHOTOS_ARCHIVE_INTERVAL = secondsInMs(5) // 5 seconds
 // Thumbnail scanner interval.
-export const THUMBNAIL_SCANNER_INTERVAL = 5_000 // 5 seconds
+export const THUMBNAIL_SCANNER_INTERVAL = secondsInMs(5) // 5 seconds
+// Maximum number of bytes to retain in the local file system before evicting.
+export const FS_MAX_BYTES = 1_000_000_000 // 1 GB
+// File system orphaned file cleanup frequency.
+export const FS_ORPHAN_FREQUENCY = daysInMs(7) // 7 days
+// File system file eviction frequency.
+export const FS_EVICTION_FREQUENCY = minutesInMs(60) // 60 minutes
+// Age threshold for considering files evictable.
+export const FS_EVICTABLE_MIN_AGE = daysInMs(7) // 7 days
 // Sync up metadata interval.
-export const SYNC_UP_METADATA_INTERVAL = 10_000 // 10 seconds
+export const SYNC_UP_METADATA_INTERVAL = secondsInMs(10) // 10 seconds
 // Sync up metadata batch size.
 export const SYNC_UP_METADATA_BATCH_SIZE = 500 // 500 files

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -1,0 +1,11 @@
+export function daysInMs(days: number): number {
+  return days * 24 * 60 * 60 * 1_000
+}
+
+export function minutesInMs(minutes: number): number {
+  return minutes * 60 * 1_000
+}
+
+export function secondsInMs(seconds: number): number {
+  return seconds * 1_000
+}

--- a/src/managers/fsEvictionScanner.test.ts
+++ b/src/managers/fsEvictionScanner.test.ts
@@ -1,0 +1,191 @@
+import { daysInMs } from '../lib/time'
+import { runFsEvictionScanner } from './fsEvictionScanner'
+import { initializeDB, resetDb } from '../db'
+import {
+  createFileRecord,
+  createFileRecordWithLocalObject,
+  type FileRecord,
+} from '../stores/files'
+import { type LocalObject } from '../encoding/localObject'
+import { readFsFileMetadata, upsertFsFileMetadata } from '../stores/fs'
+import {
+  getSecureStoreNumber,
+  setSecureStoreNumber,
+} from '../stores/secureStore'
+
+jest.mock('../config', () => {
+  const daysInMs = jest.requireActual('../lib/time').daysInMs
+  const actual = jest.requireActual('../config')
+  return {
+    ...actual,
+    FS_MAX_BYTES: 1_000,
+    FS_EVICTION_FREQUENCY: 60_000,
+    FS_EVICTABLE_MIN_AGE: daysInMs(7),
+  }
+})
+
+const now = 1_000_000_000
+const indexerURL = 'https://indexer.com'
+
+describe('fsEvictionScanner', () => {
+  beforeEach(async () => {
+    jest.spyOn(Date, 'now').mockReturnValue(now)
+    await initializeDB()
+    await setSecureStoreNumber('fsEvictionLastRun', 0)
+  })
+
+  afterEach(async () => {
+    jest.spyOn(Date, 'now').mockRestore()
+    await resetDb()
+  })
+
+  it('does nothing when total size is below limit', async () => {
+    await createRemoteFile({
+      id: 'file-1',
+      size: 200,
+      usedAt: now - daysInMs(1000),
+    })
+    const result = await runFsEvictionScanner()
+
+    expect(await readFsFileMetadata('file-1')).toBeDefined()
+    expect(await getSecureStoreNumber('fsEvictionLastRun', now)).toBe(now)
+    expect(result).toBeUndefined()
+  })
+
+  it('never evicts local-only files', async () => {
+    await createLocalOnlyFile({
+      id: 'file-2',
+      size: 300,
+      usedAt: now - daysInMs(500),
+    })
+    await createRemoteFile({
+      id: 'file-3',
+      size: 400,
+      usedAt: now - daysInMs(1000),
+    })
+    const result = await runFsEvictionScanner()
+
+    expect(await readFsFileMetadata('file-2')).toBeDefined()
+    expect(await readFsFileMetadata('file-3')).toBeDefined()
+    expect(await getSecureStoreNumber('fsEvictionLastRun', now)).toBe(now)
+    expect(result).toBeUndefined()
+  })
+
+  it('evicts oldest remote files until under limit', async () => {
+    // Keep
+    await createLocalOnlyFile({
+      id: 'file-1',
+      size: 500,
+      usedAt: now - daysInMs(100),
+    })
+    // Evict
+    await createRemoteFile({
+      id: 'file-2',
+      size: 100,
+      usedAt: now - daysInMs(10),
+    })
+    // Keep
+    await createLocalOnlyFile({
+      id: 'file-3',
+      size: 300,
+      usedAt: now - daysInMs(5),
+    })
+    // Evict
+    await createRemoteFile({
+      id: 'file-4',
+      size: 100,
+      usedAt: now - daysInMs(10),
+    })
+    // Keep because we are now below the limit.
+    // This file is newer so others were considered earlier.
+    await createRemoteFile({
+      id: 'file-5',
+      size: 400,
+      usedAt: now - daysInMs(1),
+    })
+    const result = await runFsEvictionScanner()
+
+    expect(result).toEqual({
+      processedRows: 2,
+      evicted: 2,
+      currentSize: 1200,
+    })
+    expect(await readFsFileMetadata('file-1')).toBeDefined()
+    expect(await readFsFileMetadata('file-2')).toBeNull()
+    expect(await readFsFileMetadata('file-3')).toBeDefined()
+    expect(await readFsFileMetadata('file-4')).toBeNull()
+    expect(await readFsFileMetadata('file-5')).toBeDefined()
+    expect(await getSecureStoreNumber('fsEvictionLastRun', 0)).toBe(now)
+  })
+})
+
+async function createRemoteFile(params: {
+  id: string
+  size: number
+  usedAt: number
+}) {
+  const record = makeFileRecord(params.id, params.size)
+  const localObject = makeLocalObject({
+    fileId: params.id,
+    objectId: `obj-${params.id}`,
+    indexerURL,
+    createdAt: params.usedAt,
+    updatedAt: params.usedAt,
+  })
+  await createFileRecordWithLocalObject(record, localObject)
+  await upsertFsFileMetadata({
+    fileId: params.id,
+    size: params.size,
+    addedAt: params.usedAt,
+    usedAt: params.usedAt,
+  })
+}
+
+async function createLocalOnlyFile(params: {
+  id: string
+  size: number
+  usedAt: number
+}) {
+  await createFileRecord(makeFileRecord(params.id, params.size))
+  await upsertFsFileMetadata({
+    fileId: params.id,
+    size: params.size,
+    addedAt: params.usedAt,
+    usedAt: params.usedAt,
+  })
+}
+
+function makeFileRecord(id: string, size: number): FileRecord {
+  return {
+    id,
+    name: `${id}.jpg`,
+    type: 'image/jpeg',
+    size,
+    hash: `hash-${id}`,
+    createdAt: now,
+    updatedAt: now,
+    addedAt: now,
+    localId: null,
+    objects: {},
+  }
+}
+
+function makeLocalObject(params: {
+  fileId: string
+  objectId: string
+  indexerURL: string
+  createdAt: number
+  updatedAt: number
+}): LocalObject {
+  return {
+    id: params.objectId,
+    fileId: params.fileId,
+    indexerURL: params.indexerURL,
+    slabs: [],
+    encryptedMasterKey: new Uint8Array([1]).buffer,
+    encryptedMetadata: new Uint8Array([2]).buffer,
+    signature: new Uint8Array([3]).buffer,
+    createdAt: new Date(params.createdAt),
+    updatedAt: new Date(params.updatedAt),
+  }
+}

--- a/src/managers/fsEvictionScanner.ts
+++ b/src/managers/fsEvictionScanner.ts
@@ -1,0 +1,150 @@
+import {
+  FS_MAX_BYTES,
+  FS_EVICTION_FREQUENCY,
+  FS_EVICTABLE_MIN_AGE,
+} from '../config'
+import { db } from '../db'
+import { logger } from '../lib/logger'
+import { createServiceInterval } from '../lib/serviceInterval'
+import {
+  calcFsFilesMetadataTotalSize,
+  removeFsFile,
+  type FsFileInfo,
+  FsMetaRow,
+} from '../stores/fs'
+import {
+  getSecureStoreNumber,
+  setSecureStoreNumber,
+} from '../stores/secureStore'
+
+/**
+ * fsEvictionScanner evicts stale files from the file system under the following rules:
+ * - Local-only files are always retained no matter how much space they take up.
+ * - Only start eviction if we are above the FS_MAX_BYTES limit.
+ * - Only evict a specific file if it is older than FS_EVICTABLE_MIN_AGE.
+ */
+export async function runFsEvictionScanner(): Promise<
+  | {
+      processedRows: number
+      evicted: number
+      currentSize: number
+    }
+  | undefined
+> {
+  const lastRun = await getFsEvictionLastRun()
+  if (Date.now() - lastRun < FS_EVICTION_FREQUENCY) {
+    return
+  }
+  try {
+    const totalSize = await calcFsFilesMetadataTotalSize()
+    if (totalSize <= FS_MAX_BYTES) {
+      setFsEvictionLastRun()
+      return
+    }
+
+    let currentSize = totalSize
+    logger.log('[fsEvictionScanner] total size over limit', { totalSize })
+
+    let processedRows = 0
+    let evicted = 0
+
+    const batchSize = 100
+    while (currentSize > FS_MAX_BYTES) {
+      const thresholdUsedAt = Date.now() - FS_EVICTABLE_MIN_AGE
+      const batch = await readFsEvictionCandidates({
+        limit: batchSize,
+        maxUsedAt: thresholdUsedAt,
+      })
+
+      for (const row of batch) {
+        if (currentSize <= FS_MAX_BYTES) break
+
+        const fsInfo: FsFileInfo = {
+          id: row.fileId,
+          type: row.type,
+        }
+
+        try {
+          await removeFsFile(fsInfo)
+          currentSize -= row.size
+          evicted += 1
+        } catch (error) {
+          logger.log('[fsEvictionScanner] failed to remove file', {
+            fileId: row.fileId,
+            error,
+          })
+        }
+      }
+
+      processedRows += batch.length
+
+      if (batch.length < batchSize) {
+        break
+      }
+    }
+
+    const results = {
+      processedRows,
+      evicted,
+      currentSize,
+    }
+    logger.log(
+      `[fsEvictionScanner] summary processedRows=${processedRows} evicted=${evicted} currentSize=${currentSize}`
+    )
+    return results
+  } catch (error) {
+    logger.log('[fsEvictionScanner] error during scan', error)
+  } finally {
+    await setFsEvictionLastRun()
+  }
+}
+
+type FsEvictionCandidate = FsMetaRow & {
+  type: string
+}
+
+/**
+ * readFsEvictionCandidates reads the files that are eligible for eviction.
+ * - Only files that are older than FS_EVICTABLE_MIN_AGE are considered.
+ * - Only files that are not local-only are considered (at least one associated object).
+ */
+export async function readFsEvictionCandidates(params: {
+  limit: number
+  maxUsedAt: number
+}): Promise<FsEvictionCandidate[]> {
+  const { limit, maxUsedAt } = params
+  return db().getAllAsync<FsEvictionCandidate>(
+    `SELECT fs.fileId AS fileId,
+            fs.size AS size,
+            fs.addedAt AS addedAt,
+            fs.usedAt AS usedAt,
+            f.type AS type
+     FROM fs
+     JOIN files f ON f.id = fs.fileId
+     WHERE fs.usedAt <= ?
+       AND EXISTS (
+         SELECT 1 FROM objects o WHERE o.fileId = fs.fileId
+       )
+     ORDER BY fs.usedAt ASC, fs.fileId ASC
+     LIMIT ?`,
+    maxUsedAt,
+    limit
+  )
+}
+
+export const initFsEvictionScanner = createServiceInterval({
+  name: 'fsEvictionScanner',
+  worker: async () => {
+    await runFsEvictionScanner()
+  },
+  getState: async () => true,
+  interval: 30_000,
+})
+
+export async function setFsEvictionLastRun(): Promise<void> {
+  await setSecureStoreNumber('fsEvictionLastRun', Date.now())
+}
+
+export async function getFsEvictionLastRun(): Promise<number> {
+  return await getSecureStoreNumber('fsEvictionLastRun', 0)
+}

--- a/src/managers/fsOrphanScanner.test.ts
+++ b/src/managers/fsOrphanScanner.test.ts
@@ -1,0 +1,119 @@
+import { FS_ORPHAN_FREQUENCY } from '../config'
+import { runFsOrphanScanner } from './fsOrphanScanner'
+import { initializeDB, resetDb } from '../db'
+import {
+  readFsFileMetadata,
+  upsertFsFileMetadata,
+  listFilesInFsStorageDirectory,
+} from '../stores/fs'
+import { createFileRecord } from '../stores/files'
+import {
+  getSecureStoreNumber,
+  setSecureStoreNumber,
+} from '../stores/secureStore'
+import { File } from 'expo-file-system'
+
+const listFilesInFsStorageDirectoryMock = jest.mocked(
+  listFilesInFsStorageDirectory
+)
+
+function makeFile(name: string): jest.Mocked<File> {
+  return {
+    name,
+    uri: `file://${name}`,
+    delete: jest.fn(),
+  } as unknown as jest.Mocked<File>
+}
+
+const now = 1_000_000_000
+
+describe('fsOrphanScanner', () => {
+  beforeEach(async () => {
+    jest.spyOn(Date, 'now').mockReturnValue(now)
+    listFilesInFsStorageDirectoryMock.mockImplementation(() => [])
+    await initializeDB()
+    await setSecureStoreNumber('fsOrphanLastRun', 0)
+  })
+
+  afterEach(async () => {
+    jest.spyOn(Date, 'now').mockRestore()
+    listFilesInFsStorageDirectoryMock.mockRestore()
+    await resetDb()
+  })
+
+  it('skips run when last run was recent', async () => {
+    await setSecureStoreNumber('fsOrphanLastRun', now - FS_ORPHAN_FREQUENCY / 2)
+
+    const result = await runFsOrphanScanner()
+
+    expect(listFilesInFsStorageDirectoryMock).not.toHaveBeenCalled()
+    expect(await getSecureStoreNumber('fsOrphanLastRun', 0)).toBe(
+      now - FS_ORPHAN_FREQUENCY / 2
+    )
+    expect(result).toBeUndefined()
+  })
+
+  it('records timestamp even when there are no files', async () => {
+    const result = await runFsOrphanScanner()
+
+    expect(await getSecureStoreNumber('fsOrphanLastRun', 0)).toBe(now)
+    expect(result).toBeUndefined()
+  })
+
+  it('removes files that have no metadata entry', async () => {
+    const file = makeFile('file-1.jpg')
+    listFilesInFsStorageDirectoryMock.mockImplementation(() => [file])
+
+    const result = await runFsOrphanScanner()
+
+    expect(file.delete).toHaveBeenCalledTimes(1)
+    expect(await readFsFileMetadata('file-1')).toBeNull()
+    expect(await getSecureStoreNumber('fsOrphanLastRun', 0)).toBe(now)
+    expect(result).toEqual({ removed: 1 })
+  })
+
+  it('keeps files that still have metadata', async () => {
+    const file = makeFile('file-2.jpg')
+    listFilesInFsStorageDirectoryMock.mockImplementation(() => [file])
+    await createFileRecord({
+      id: 'file-2',
+      name: 'file-2.jpg',
+      type: 'image/jpeg',
+      size: 100,
+      hash: 'hash-file-2',
+      createdAt: now,
+      updatedAt: now,
+      addedAt: now,
+      localId: null,
+    })
+    await upsertFsFileMetadata({
+      fileId: 'file-2',
+      size: 100,
+      addedAt: now,
+      usedAt: now,
+    })
+
+    const result = await runFsOrphanScanner()
+
+    expect(file.delete).not.toHaveBeenCalled()
+    expect((await readFsFileMetadata('file-2'))?.fileId).toBe('file-2')
+    expect(await getSecureStoreNumber('fsOrphanLastRun', 0)).toBe(now)
+    expect(result).toEqual({ removed: 0 })
+  })
+  it('deletes files that have no associated files table row', async () => {
+    const file = makeFile('file-1.jpg')
+    listFilesInFsStorageDirectoryMock.mockImplementation(() => [file])
+    await upsertFsFileMetadata({
+      fileId: 'file-1',
+      size: 100,
+      addedAt: now,
+      usedAt: now,
+    })
+
+    const result = await runFsOrphanScanner()
+
+    expect(file.delete).toHaveBeenCalledTimes(1)
+    expect(await readFsFileMetadata('file-1')).toBeNull()
+    expect(result).toEqual({ removed: 1 })
+  })
+})

--- a/src/managers/fsOrphanScanner.ts
+++ b/src/managers/fsOrphanScanner.ts
@@ -1,0 +1,104 @@
+import { FS_ORPHAN_FREQUENCY } from '../config'
+import { db } from '../db'
+import { logger } from '../lib/logger'
+import { createServiceInterval } from '../lib/serviceInterval'
+import {
+  deleteFsFileMetadata,
+  fsTriggerRefresh,
+  listFilesInFsStorageDirectory,
+} from '../stores/fs'
+import {
+  getSecureStoreNumber,
+  setSecureStoreNumber,
+} from '../stores/secureStore'
+
+function extractFileIdFromName(name: string): string | null {
+  const dotIndex = name.lastIndexOf('.')
+  if (dotIndex === -1) return name || null
+  return name.slice(0, dotIndex) || null
+}
+
+/**
+ * fsOrphanScanner scans the file system for files that are not indexed in the database.
+ * - If a file is not indexed, it is deleted from the file system.
+ * Files may be orphaned if they are from a different account, previous version of app,
+ * left after an error, or other edge cases.
+ */
+export async function runFsOrphanScanner(): Promise<
+  { removed: number } | undefined
+> {
+  const lastRun = await getFsOrphanLastRun()
+  if (Date.now() - lastRun < FS_ORPHAN_FREQUENCY) {
+    return
+  }
+
+  try {
+    const files = listFilesInFsStorageDirectory()
+    if (files.length === 0) return
+
+    let removed = 0
+    for (const file of files) {
+      const fileId = extractFileIdFromName(file.name)
+      if (!fileId) continue
+
+      const orphaned = await isFsFileOrphaned(fileId)
+      if (!orphaned) continue
+
+      try {
+        file.delete()
+        removed += 1
+        await deleteFsFileMetadata(fileId)
+        await fsTriggerRefresh(fileId)
+        logger.log(
+          `[fsOrphanScanner] removed unindexed file fileId=${fileId} uri=${file.uri}`
+        )
+      } catch (error) {
+        logger.log(
+          `[fsOrphanScanner] failed to delete file fileId=${fileId} uri=${file.uri} error=${error}`
+        )
+      }
+    }
+
+    if (removed > 0) {
+      logger.log(`[fsOrphanScanner] summary removed=${removed}`)
+    }
+    return { removed }
+  } catch (error) {
+    logger.log('[fsOrphanScanner] error during scan', error)
+  } finally {
+    await setFsOrphanLastRun()
+  }
+}
+
+/**
+ * isFsFileOrphaned checks if an fs file is orphaned:
+ * - no longer represented in the fs metadata table, or
+ * - still in the fs metadata table but missing from the files table.
+ */
+export async function isFsFileOrphaned(fileId: string): Promise<boolean> {
+  const row = await db().getFirstAsync<{ hasFs: number; hasFile: number }>(
+    `SELECT
+        EXISTS(SELECT 1 FROM fs WHERE fileId = ?) AS hasFs,
+        EXISTS(SELECT 1 FROM files WHERE id = ?) AS hasFile`,
+    fileId,
+    fileId
+  )
+  return !(row?.hasFs === 1 && row?.hasFile === 1)
+}
+
+export const initFsOrphanScanner = createServiceInterval({
+  name: 'fsOrphanScanner',
+  worker: async () => {
+    await runFsOrphanScanner()
+  },
+  getState: async () => true,
+  interval: 30_000,
+})
+
+export async function setFsOrphanLastRun(): Promise<void> {
+  await setSecureStoreNumber('fsOrphanLastRun', Date.now())
+}
+
+export async function getFsOrphanLastRun(): Promise<number> {
+  return await getSecureStoreNumber('fsOrphanLastRun', 0)
+}

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -31,6 +31,8 @@ import {
 import { initBackgroundTasks } from '../managers/backgroundTasks'
 import { initSyncUpMetadata } from '../managers/syncUpMetadata'
 import { initThumbnailScanner } from '../managers/thumbnailScanner'
+import { initFsOrphanScanner } from '../managers/fsOrphanScanner'
+import { initFsEvictionScanner } from '../managers/fsEvictionScanner'
 import { shutdownAllServiceIntervals } from '../lib/serviceInterval'
 
 export type InitStep = {
@@ -117,6 +119,8 @@ export async function initApp(): Promise<void> {
       initBackgroundTasks()
       initSyncUpMetadata()
       initThumbnailScanner()
+      initFsOrphanScanner()
+      initFsEvictionScanner()
     },
   })
 

--- a/src/stores/fs.ts
+++ b/src/stores/fs.ts
@@ -160,31 +160,6 @@ export async function readFsFileMetadata(
   )
 }
 
-export async function readFsFilesMetadataOldest(params: {
-  limit: number
-  maxUsedAt?: number
-}): Promise<FsMetaRow[]> {
-  const { limit, maxUsedAt } = params
-  if (typeof maxUsedAt === 'number') {
-    return db().getAllAsync<FsMetaRow>(
-      `SELECT fileId, size, addedAt, usedAt
-       FROM ${fsMetadataTable}
-       WHERE usedAt <= ?
-       ORDER BY usedAt ASC, fileId ASC
-       LIMIT ?`,
-      maxUsedAt,
-      limit
-    )
-  }
-  return db().getAllAsync<FsMetaRow>(
-    `SELECT fileId, size, addedAt, usedAt
-     FROM ${fsMetadataTable}
-     ORDER BY usedAt ASC, fileId ASC
-     LIMIT ?`,
-    limit
-  )
-}
-
 export async function updateFsFileMetadataUsedAt(
   fileId: string,
   usedAt: number = Date.now()


### PR DESCRIPTION
The following two services maintain the local file system storage usage and clean up files.

- Adds fsEvictionScanner which  evicts stale files from the file system under the following rules:
    - Local-only files are always retained no matter how much space they take up.
    - Only start eviction if we are above the FS_MAX_BYTES limit.
    - Only evict a specific file if it is older than FS_EVICTABLE_MIN_AGE.
- Adds fsOrphanScanner which  scans the file system for files that are not indexed in the database.
    - If a file is not indexed, it is deleted from the file system.
    - Files may be orphaned if they are from a different account, previous version of app, left after an error, or other edge cases.