### PR TITLE
refactor: copy all new files to fs

### DIFF
--- a/src/lib/processAssets.test.ts
+++ b/src/lib/processAssets.test.ts
@@ -2,93 +2,69 @@ import { processAssets } from './processAssets'
 import { calculateContentHash } from './contentHash'
 import {
   createFileRecord,
-  FileRecord,
   readAllFileRecords,
   readFileRecord,
 } from '../stores/files'
 import { initializeDB, resetDb } from '../db'
-import { copyFileToCache, getLocalUri } from '../stores/fileCache'
-import { Platform } from 'react-native'
+import {
+  copyFileToFs,
+  readFsFileMetadata,
+  upsertFsFileMetadata,
+} from '../stores/fs'
+import { getMediaLibraryUri } from './mediaLibrary'
+import { setExpoFileSystemMockMethods } from '../../mocks/expo-file-system'
 
-jest.mock('./uniqueId', () => {
-  let c = 0
-  return { uniqueId: () => `uid-${++c}` }
-})
-jest.mock('react-native', () => ({
-  Platform: { OS: 'ios' },
+jest.mock('./mediaLibrary', () => ({
+  getMediaLibraryUri: jest.fn(),
 }))
 jest.mock('./contentHash', () => ({
   calculateContentHash: jest.fn(async (uri: string) => `sha256|hash:${uri}`),
 }))
-jest.mock('../stores/fileCache', () => {
-  const cachedIds = new Set<string>()
-  return {
-    getFileUri: jest.fn(async (file: FileRecord) => {
-      if (file.localId) return `file://${file.localId}`
-      return cachedIds.has(file.id) ? `file://${file.id}` : null
-    }),
-    getLocalUri: jest.fn(),
-    copyFileToCache: jest.fn(async (file: { id: string }) => {
-      cachedIds.add(file.id)
-      return `file://${file.id}`
-    }),
-    clearCache: jest.fn(() => {
-      cachedIds.clear()
-    }),
-  }
-})
-jest.mock('expo-file-system', () => ({
-  File: jest.fn((uri: string) => ({
-    uri,
-    info: jest.fn(() => ({ exists: true, size: 333, uri })),
-  })),
-}))
-
 jest.mock('../managers/thumbnailer', () => ({
   generateThumbnails: jest.fn(),
 }))
 
 beforeEach(async () => {
   await initializeDB()
+  jest.spyOn(require('../stores/files'), 'createFileRecord')
+  jest.spyOn(require('../stores/fs'), 'upsertFsFileMetadata')
+  jest.spyOn(require('../stores/fs'), 'copyFileToFs')
   jest.clearAllMocks()
-  require('../stores/fileCache').clearCache()
 })
+
 afterEach(async () => {
   await resetDb()
+  jest.restoreAllMocks()
+  jest.clearAllMocks()
 })
 
 describe('processAssets', () => {
   it('creates a new record when no duplicates exist', async () => {
-    jest
-      .mocked(getLocalUri)
-      .mockImplementation(async (localId: string | null) => {
-        if (localId === '1') return 'file://1'
-        return null
-      })
     const assets = [
       {
         id: '1',
         name: 'a.jpg',
-        size: 100,
         sourceUri: 'file://1',
         type: 'image/jpeg',
         timestamp: '2021-01-01',
       },
     ]
 
-    const { files } = await processAssets(assets)
+    const fileId = 'uid-1'
 
+    const { files } = await processAssets(assets)
     expect(files).toHaveLength(1)
     const rows = await readAllFileRecords({ order: 'ASC' })
     expect(rows).toHaveLength(1)
     expect(rows[0]).toMatchObject({
-      id: 'uid-1',
+      id: fileId,
       name: 'a.jpg',
-      size: 100,
     })
-    expect(copyFileToCache).not.toHaveBeenCalled()
+    const meta = await readFsFileMetadata(fileId)
+    expect(meta).toMatchObject({
+      fileId,
+    })
   })
-
   it('updates existing by localId and does not create new records', async () => {
     await createFileRecord(
       {
@@ -106,7 +82,7 @@ describe('processAssets', () => {
     )
 
     jest
-      .mocked(getLocalUri)
+      .mocked(getMediaLibraryUri)
       .mockImplementation(async (localId: string | null) => {
         if (localId === '1') return 'file://1'
         return null
@@ -115,7 +91,6 @@ describe('processAssets', () => {
       {
         id: '1',
         name: 'new.jpg',
-        size: 200,
         sourceUri: 'file://1',
         type: 'image/jpeg',
         timestamp: '2021-01-01',
@@ -131,21 +106,20 @@ describe('processAssets', () => {
     expect(updated).toMatchObject({
       id: 'existing-1',
       name: 'new.jpg',
-      size: 200,
+      size: 5,
     })
-    expect(copyFileToCache).not.toHaveBeenCalled()
+    expect(copyFileToFs).toHaveBeenCalledTimes(0)
   })
-
-  it('updates existing by hash and does not create new records', async () => {
+  it('updates and copies existing by hash but does not create a new record', async () => {
     await createFileRecord(
       {
-        id: 'existing-hash',
-        name: 'old-h.jpg',
+        id: 'existing',
+        name: 'existing.jpg',
         size: 10,
         createdAt: 1,
         updatedAt: 1,
         type: 'image/jpeg',
-        hash: 'sha256|hash:file://2',
+        hash: 'sha256|existing-hash',
         localId: null,
         addedAt: 1,
       },
@@ -153,49 +127,72 @@ describe('processAssets', () => {
     )
 
     jest
-      .mocked(getLocalUri)
-      .mockImplementation(async (localId: string | null) => {
-        if (localId === '2') return 'file://2'
-        return null
-      })
+      .mocked(calculateContentHash)
+      .mockImplementation(async () => 'sha256|existing-hash')
     const assets = [
       {
-        id: '2',
-        name: 'new-h.jpg',
-        size: 300,
-        sourceUri: 'file://2',
+        id: 'same-hash',
+        name: 'same-hash.jpg',
+        sourceUri: 'file://same-hash.jpg',
         type: 'image/jpeg',
         timestamp: '2021-01-01',
       },
     ]
     const { files, updatedFiles } = await processAssets(assets)
 
-    expect(updatedFiles).toHaveLength(1)
     expect(files).toHaveLength(0)
-    const updated = await readFileRecord('existing-hash')
+    expect(updatedFiles).toHaveLength(1)
+    const updated = await readFileRecord('existing')
     expect(updated).toMatchObject({
-      id: 'existing-hash',
-      name: 'new-h.jpg',
-      size: 300,
+      id: 'existing',
+      name: 'same-hash.jpg',
     })
-    expect(copyFileToCache).not.toHaveBeenCalled()
+    expect(copyFileToFs).toHaveBeenCalledTimes(1)
+    expect(copyFileToFs).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'existing' }),
+      expect.objectContaining({ uri: 'file://same-hash.jpg' })
+    )
   })
-
-  it('copies sourceUri to cache when asset lacks valid id', async () => {
-    jest.mocked(getLocalUri).mockImplementation(async () => {
+  it('dedupes on hash within new files', async () => {
+    jest.mocked(getMediaLibraryUri).mockImplementation(async () => {
       return null
     })
+    jest
+      .mocked(calculateContentHash)
+      .mockImplementation(async () => 'sha256|same-for-all')
     const assets = [
       {
         id: undefined,
-        name: 'no-id.jpg',
+        name: '1.jpg',
         size: 123,
-        sourceUri: 'file:///tmp/no-id.jpg',
+        sourceUri: 'file://1.jpg',
         type: 'image/jpeg',
         timestamp: '2021-01-01',
       },
       {
-        id: 'invalid',
+        id: undefined,
+        name: '2.jpg',
+        size: 123,
+        sourceUri: 'file://2.jpg',
+        type: 'image/png',
+        timestamp: '2021-01-01',
+      },
+    ]
+
+    const { files } = await processAssets(assets)
+    expect(files).toHaveLength(1)
+    const file = await readFileRecord(files[0].id)
+    expect(file).toMatchObject({
+      type: 'image/jpeg',
+    })
+  })
+  it('grabs the highest quality file when localId is valid', async () => {
+    jest.mocked(getMediaLibraryUri).mockImplementation(async () => {
+      return 'file:///full-quality.jpg'
+    })
+    const assets = [
+      {
+        id: 'valid',
         name: 'no-id.jpg',
         size: 123,
         sourceUri: 'file:///tmp/no-id.jpg',
@@ -206,33 +203,51 @@ describe('processAssets', () => {
 
     const { files } = await processAssets(assets)
 
-    expect(files).toHaveLength(2)
-    expect(copyFileToCache).toHaveBeenCalledTimes(2)
-    expect(copyFileToCache).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({ id: files[0].id, type: 'image/jpeg' }),
-      expect.objectContaining({ uri: 'file:///tmp/no-id.jpg' })
-    )
-    expect(copyFileToCache).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({ id: files[1].id, type: 'image/jpeg' }),
-      expect.objectContaining({ uri: 'file:///tmp/no-id.jpg' })
-    )
+    expect(files).toHaveLength(1)
+    expect(getMediaLibraryUri).toHaveBeenCalledTimes(1)
+    expect(getMediaLibraryUri).toHaveBeenCalledWith('valid')
 
-    const rows = await readAllFileRecords({ order: 'ASC' })
-    expect(rows).toHaveLength(2)
-    expect(rows[0]).toMatchObject({
-      name: 'no-id.jpg',
-      localId: null,
-      size: 123,
+    expect(copyFileToFs).toHaveBeenCalledTimes(1)
+    expect(copyFileToFs).toHaveBeenCalledWith(
+      expect.objectContaining({ id: files[0].id, type: 'image/jpeg' }),
+      expect.objectContaining({ uri: 'file:///full-quality.jpg' })
+    )
+  })
+  it('uses sourceUri when localId is not valid', async () => {
+    jest.mocked(getMediaLibraryUri).mockImplementation(async () => {
+      return null
     })
-    expect(rows[1]).toMatchObject({
-      name: 'no-id.jpg',
-      localId: null,
-      size: 123,
+    const assets = [
+      {
+        id: 'invalid',
+        name: 'file.jpg',
+        sourceUri: 'file:///source.jpg',
+        type: 'image/jpeg',
+        timestamp: '2021-01-01',
+      },
+    ]
+
+    const { files } = await processAssets(assets)
+
+    expect(files).toHaveLength(1)
+    expect(getMediaLibraryUri).toHaveBeenCalledTimes(1)
+    expect(getMediaLibraryUri).toHaveBeenCalledWith('invalid')
+    expect(copyFileToFs).toHaveBeenCalledTimes(1)
+    const file = await readFileRecord(files[0].id)
+    expect(file).toMatchObject({
+      id: files[0].id,
+    })
+    const meta = await readFsFileMetadata(files[0].id)
+    expect(meta).toMatchObject({
+      fileId: files[0].id,
     })
   })
   it('adds file size to new files', async () => {
+    setExpoFileSystemMockMethods({
+      File: {
+        info: jest.fn((uri: string) => ({ exists: true, size: 333, uri })),
+      },
+    })
     const assets = [
       {
         id: undefined,

--- a/src/lib/processAssets.ts
+++ b/src/lib/processAssets.ts
@@ -9,14 +9,14 @@ import {
 } from '../stores/files'
 import { MimeType, getMimeType } from './fileTypes'
 import { calculateContentHash } from './contentHash'
-import { copyFileToCache, getLocalUri } from '../stores/fileCache'
+import { copyFileToFs } from '../stores/fs'
 import { File } from 'expo-file-system'
 import { generateThumbnails } from '../managers/thumbnailer'
+import { getMediaLibraryUri } from './mediaLibrary'
 
 type Asset = {
   id: string | undefined
   sourceUri: string | undefined
-  size: number | undefined
   type: string | undefined
   name: string | undefined
   timestamp: string | undefined
@@ -36,7 +36,8 @@ type CandidateFileRecord = {
   statusDetails:
     | 'foundByLocalId'
     | 'foundByContentHash'
-    | 'noFileUri'
+    | 'noUri'
+    | 'invalidUri'
     | 'noFileSize'
     | 'noContentHash'
     | null
@@ -46,7 +47,7 @@ type CandidateFileRecord = {
  * processAssets imports a list of assets from any source.
  * This function will:
  * - Check for duplicates by localId and hash.
- * - Copy files without a local ID to the app's file cache.
+ * - Copy every asset to the app's file cache.
  * - Add content hashes to files that are new.
  * - Create new file records for the assets.
  * - Update the metadata of any existing files.
@@ -64,11 +65,9 @@ export async function processAssets(
   const candidateFiles: CandidateFileRecord[] = (assets ?? []).map((a) => ({
     id: uniqueId(),
     localId: a.id ?? null,
-    // If the asset does not have an valid id, pass a sourceUri so we can copy the
-    // file to the app's file cache.
     sourceUri: a.sourceUri ?? null,
     name: a.name ?? defaultFileName,
-    size: a.size ?? null,
+    size: null,
     createdAt: new Date(a.timestamp ?? Date.now()).getTime(),
     updatedAt: new Date(a.timestamp ?? Date.now()).getTime(),
     type: getMimeType({
@@ -95,43 +94,49 @@ export async function processAssets(
     }
   }
 
-  // Ensure we have a valid local URI for the file.
+  // Copy files to the app's file cache.
   // Add content hash and file size to files that are still new.
   await Promise.all(
     candidateFiles
       .filter((f) => f.status === 'new')
       .map(async (f) => {
-        let fileUri = await getLocalUri(f.localId)
-        // The localId Was not a valid Media Library or MediaStore ID.
-        if (!fileUri) {
+        // Verify that the localId is a valid Media Library or MediaStore ID.
+        const localUri = await getMediaLibraryUri(f.localId)
+        if (!localUri) {
           f.localId = null
         }
-        if (!fileUri && f.sourceUri) {
-          logger.log(
-            `[processAssets] copying file without valid localId to cache id=${f.id} sourceUri=${f.sourceUri}`
-          )
-          fileUri = await copyFileToCache(f, new File(f.sourceUri))
-        }
-        if (!fileUri) {
+
+        // Verify we have a URI.
+        const bestUri = localUri ?? f.sourceUri
+        if (!bestUri) {
           f.status = 'incomplete'
-          f.statusDetails = 'noFileUri'
+          f.statusDetails = 'noUri'
           return
         }
-        if (!f.size) {
-          // Try again to get the file size.
-          f.size = getFileSize(fileUri)
-          if (!f.size) {
-            f.status = 'incomplete'
-            f.statusDetails = 'noFileSize'
-            return
-          }
+
+        // Copy the file to the app's file cache.
+        const fileUri = await copyFileToFs(f, new File(bestUri))
+        if (!fileUri) {
+          f.status = 'incomplete'
+          f.statusDetails = 'invalidUri'
+          return
         }
-        f.hash = await calculateContentHash(fileUri)
-        if (!f.hash) {
+
+        const hash = await calculateContentHash(fileUri)
+        if (!hash) {
           f.status = 'incomplete'
           f.statusDetails = 'noContentHash'
           return
         }
+        f.hash = hash
+
+        const size = getFileSize(fileUri)
+        if (!size) {
+          f.status = 'incomplete'
+          f.statusDetails = 'noFileSize'
+          return
+        }
+        f.size = size
       })
   )
 
@@ -152,7 +157,20 @@ export async function processAssets(
     }
   }
 
-  // Assert that the files are new and have a content hash.
+  // Mark any hash-based duplicates within the new files as existing.
+  const hashSet = new Set<string>()
+  for (const f of candidateFiles.filter(
+    (f) => f.status === 'new' && f.hash !== null
+  )) {
+    const exists = hashSet.has(f.hash!)
+    if (exists) {
+      f.status = 'existing'
+      f.statusDetails = 'foundByContentHash'
+    }
+    hashSet.add(f.hash!)
+  }
+
+  // Assert that the files are new and have a content hash and size.
   const newFiles: FileRecord[] = candidateFiles
     .filter((f) => f.status === 'new' && f.hash !== null && f.size !== null)
     .map((f) => ({

--- a/src/managers/thumbnailer.ts
+++ b/src/managers/thumbnailer.ts
@@ -186,7 +186,7 @@ export async function ensureThumbnailForSize(params: {
     }
 
     // Create file record with thumbForHash set from the start to avoid flicker.
-    const fileSize = new File(cacheUri).info().size ?? 0
+    const fileSize = new File(fileUri).info().size ?? 0
     const now = Date.now()
     await createFileRecord(
       {

--- a/src/managers/uploadToNetwork.ts
+++ b/src/managers/uploadToNetwork.ts
@@ -1,10 +1,5 @@
 import { Sdk, encodedSize } from 'react-native-sia'
 import { File } from 'expo-file-system'
-import {
-  getCacheTmpUploadFileForId,
-  getLocalUri,
-  removeCacheTmpUploadFileForId,
-} from '../stores/fileCache'
 import { updateUploadProgress } from '../stores/uploads'
 import { encodeFileMetadata } from '../encoding/fileMetadata'
 import { logger } from '../lib/logger'
@@ -31,23 +26,7 @@ export async function uploadToNetwork(params: {
     return
   }
 
-  let stream: ReadableStream<Uint8Array<ArrayBuffer>>
-  if (file.localId) {
-    logger.log(
-      '[uploadToNetwork] file is a localId asset, streaming from tmp file...'
-    )
-    const localUri = await getLocalUri(file.localId)
-    if (!localUri) {
-      throw new Error('Local URI not found')
-    }
-    const source = new File(localUri)
-    const tmp = await getCacheTmpUploadFileForId(file)
-    source.copy(tmp)
-    stream = tmp.stream()
-  } else {
-    logger.log('[uploadToNetwork] file is in app cache, streaming directly...')
-    stream = new File(fileUri).stream()
-  }
+  const stream = new File(fileUri).stream()
 
   const totalEncodedSize = encodedSize(
     BigInt(fileSize),
@@ -134,7 +113,4 @@ export async function uploadToNetwork(params: {
   await upsertLocalObject(localObject)
 
   signal.removeEventListener('abort', onAbort)
-  if (file.localId) {
-    await removeCacheTmpUploadFileForId(file)
-  }
 }


### PR DESCRIPTION
- This PR changes processAssets so that we always move files into the app's filesystem. We no longer consider a URI referencing the system media library a viable reference to the file.
- Relying on the device's external media library assets to save a little space causes more issues than its worth. When these assets are deleted or permissions change we lose access to the file, if the file is not uploaded yet this is an issue. This also is likely why thumbnails sometimes disappear on Android.
- This change also means we can remove the special case code for media library assets in uploadToNetwork.