### PR TITLE
refactor: add centered play overlay to VideoPlayer

### DIFF
--- a/src/components/MediaConsumers/VideoPlayer.tsx
+++ b/src/components/MediaConsumers/VideoPlayer.tsx
@@ -1,5 +1,9 @@
-import { ViewStyle } from 'react-native'
+import { useRef, useState } from 'react'
+import { Pressable, StyleSheet, View, ViewStyle } from 'react-native'
 import { useVideoPlayer, VideoView } from 'expo-video'
+import { PlayIcon } from 'lucide-react-native'
+import { palette } from '../../styles/colors'
+import { logger } from '../../lib/logger'
 
 export function VideoPlayer({
   source,
@@ -9,13 +13,67 @@ export function VideoPlayer({
   style?: ViewStyle
 }) {
   const player = useVideoPlayer(source)
+  const videoRef = useRef<VideoView>(null)
+  const [showNativeControls, setShowNativeControls] = useState(false)
+  const [isPlaying, setIsPlaying] = useState(false)
+
+  const onPlayPress = async () => {
+    setIsPlaying(true)
+    player.play()
+    try {
+      await videoRef.current?.enterFullscreen()
+    } catch (error) {
+      logger.log('[VideoPlayer] Failed to enter fullscreen:', error)
+    }
+  }
+
   return (
-    <VideoView
-      style={[{ flex: 1 }, style]}
-      player={player}
-      allowsFullscreen
-      allowsPictureInPicture
-      contentFit="contain"
-    />
+    <View style={[styles.container, style]}>
+      <VideoView
+        ref={videoRef}
+        style={StyleSheet.absoluteFill}
+        player={player}
+        allowsFullscreen
+        allowsPictureInPicture
+        contentFit="contain"
+        nativeControls={showNativeControls}
+        onFullscreenEnter={() => setShowNativeControls(true)}
+        onFullscreenExit={() => {
+          setShowNativeControls(false)
+          player.pause()
+          setIsPlaying(false)
+        }}
+      />
+      {!isPlaying && (
+        <View style={styles.playIconContainer} pointerEvents="box-none">
+          <Pressable
+            style={styles.playButton}
+            onPress={onPlayPress}
+            hitSlop={12}
+            accessibilityRole="button"
+            accessibilityLabel="Play video in fullscreen"
+          >
+            <PlayIcon color={palette.gray[200]} size={56} />
+          </Pressable>
+        </View>
+      )}
+    </View>
   )
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  playIconContainer: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'center',
+    alignItems: 'center',
+    zIndex: 1,
+  },
+  playButton: {
+    padding: 20,
+    borderRadius: 999,
+    backgroundColor: 'rgba(0,0,0,0.6)',
+  },
+})


### PR DESCRIPTION
[Screen Recording 2025-11-19 at 2.50.51 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/fa41d266-7878-4d66-9a37-60756d2a1856.mov" />](https://app.graphite.com/user-attachments/video/fa41d266-7878-4d66-9a37-60756d2a1856.mov)

This is prep for a fullscreen consumption view for all media types, letting us treat, from a design perspective, video that is not playing in the same way we treat images. This is very useful. I also see this kind of pattern elsewhere and suspect it's for the same reason.

I also don't think people really care about playing a video non full screen in this context, so we can go all in here and lean into that behavior.