### PR TITLE
test: jest mocks

### DIFF
--- a/jest.setup.cjs
+++ b/jest.setup.cjs
@@ -45,6 +45,34 @@ jest.mock('react-native-fs', () => ({
 }))
 global.__rnfs = { rnfsStat, rnfsRead, rnfsReadFile, rnfsHash }
 
+const { setExpoFileSystemMock } = require('./mocks/expo-file-system')
+
+// Mock the Expo FileSystem API with a default implementation.
+jest.mock('expo-file-system', () => setExpoFileSystemMock())
+beforeEach(() => {
+  setExpoFileSystemMock()
+})
+
+// Mock the fs store module with a default implementation.
+const { setFsMock } = require('./mocks/fs')
+jest.mock('./src/stores/fs', () => setFsMock())
+beforeEach(() => {
+  setFsMock()
+})
+
+jest.mock('react-native', () => ({
+  Platform: {
+    OS: 'ios',
+    select: (o) => o?.ios ?? o?.native ?? o?.default,
+  },
+  Image: { getSize: jest.fn() },
+}))
+
+jest.mock('./src/lib/uniqueId', () => {
+  let c = 0
+  return { uniqueId: () => `uid-${++c}` }
+})
+
 // In-memory SecureStore for tests.
 jest.mock('./src/stores/secureStore', () => {
   const numStore = new Map()

--- a/mocks/expo-file-system.ts
+++ b/mocks/expo-file-system.ts
@@ -1,0 +1,134 @@
+export type ExpoFileSystemMock = {
+  File: new (...args: any[]) => {
+    uri: string
+    name: string
+    info: jest.Mock
+    delete: jest.Mock
+    copy: jest.Mock
+  }
+  Directory: new (...args: any[]) => {
+    uri: string
+    info: jest.Mock
+    list: jest.Mock
+    create: jest.Mock
+    delete: jest.Mock
+  }
+  Paths: { document: string; cache: string }
+}
+
+let methods = buildExpoFileSystemMockMethods()
+let mock = buildExpoFileSystemMock()
+
+type CustomMocks = {
+  File?: {
+    info?: jest.Mock
+    list?: jest.Mock
+    create?: jest.Mock
+    delete?: jest.Mock
+    copy?: jest.Mock
+  }
+  Directory?: {
+    info?: jest.Mock
+    list?: jest.Mock
+    create?: jest.Mock
+    delete?: jest.Mock
+  }
+}
+
+type ExpoFileSystemMockMethods = {
+  File: {
+    info: jest.Mock
+    list: jest.Mock
+    create: jest.Mock
+    delete: jest.Mock
+    copy: jest.Mock
+  }
+  Directory: {
+    info: jest.Mock
+    list: jest.Mock
+    create: jest.Mock
+    delete: jest.Mock
+  }
+}
+
+function buildExpoFileSystemMockMethods(
+  customMocks: CustomMocks = {}
+): ExpoFileSystemMockMethods {
+  return {
+    File: {
+      info: jest.fn((uri: string) => ({ exists: true, size: 100, uri })),
+      list: jest.fn(() => []),
+      create: jest.fn(() => {}),
+      delete: jest.fn(() => {}),
+      copy: jest.fn(() => {}),
+      ...customMocks.File,
+    },
+    Directory: {
+      info: jest.fn((uri: string) => ({ exists: true })),
+      list: jest.fn(() => []),
+      create: jest.fn(() => {}),
+      delete: jest.fn(() => {}),
+      ...customMocks.Directory,
+    },
+  }
+}
+/**
+ * Creates a mock of the Expo FileSystem API with reasonable defaults.
+ * These can be overridden by the test suite to provide custom behavior.
+ */
+export function buildExpoFileSystemMock(): ExpoFileSystemMock {
+  class MockDirectory {
+    uri: string
+    constructor(root: string, name: string) {
+      this.uri = `${root}/${name}`
+    }
+    info = methods.Directory.info
+    list = methods.Directory.list
+    create = methods.Directory.create
+    delete = methods.Directory.delete
+  }
+
+  class MockFile {
+    uri: string
+    name: string
+    constructor(dirOrUri: any, name?: string) {
+      if (typeof dirOrUri === 'string' && typeof name === 'string') {
+        this.uri = `${dirOrUri}/${name}`
+        this.name = name
+      } else if (dirOrUri && typeof dirOrUri.uri === 'string' && name) {
+        this.uri = `${dirOrUri.uri}/${name}`
+        this.name = name
+      } else if (typeof dirOrUri === 'string') {
+        this.uri = dirOrUri
+        const parts = dirOrUri.split('/')
+        this.name = parts.pop() || dirOrUri
+      } else {
+        this.uri = 'file://mock'
+        this.name = 'mock'
+      }
+    }
+    info = methods.File.info
+    list = methods.File.list
+    create = methods.File.create
+    delete = methods.File.delete
+    copy = methods.File.copy
+  }
+  const mock = {
+    File: MockFile,
+    Directory: MockDirectory,
+    Paths: { document: 'document', cache: 'cache' },
+  }
+  return mock
+}
+
+export function setExpoFileSystemMock(): ExpoFileSystemMock {
+  mock = buildExpoFileSystemMock()
+  return mock
+}
+
+export function setExpoFileSystemMockMethods(
+  customMocks: CustomMocks = {}
+): ExpoFileSystemMockMethods {
+  methods = buildExpoFileSystemMockMethods(customMocks)
+  return methods
+}

--- a/mocks/fs.ts
+++ b/mocks/fs.ts
@@ -1,0 +1,52 @@
+import { extFromMime } from '../src/lib/fileTypes'
+import { FsFileInfo } from '../src/stores/fs'
+import { File } from 'expo-file-system'
+
+type FsMock = {
+  getFsFileUri: jest.Mock
+  copyFileToFs: jest.Mock
+  fsStorageDirectory: {
+    info: jest.Mock
+    create: jest.Mock
+    list: jest.Mock
+  }
+  listFilesInFsStorageDirectory: jest.Mock
+}
+
+function buildMockPath(file: FsFileInfo) {
+  return `fs://files/${file.id}.${extFromMime(file.type)}`
+}
+
+let current = {
+  mock: buildFsMock(),
+}
+
+/**
+ * Creates a mock of the fs store module with reasonable defaults.
+ * These can be overridden by the test suite to provide custom behavior.
+ */
+export function buildFsMock(): FsMock {
+  const cachedIds = new Set()
+  const mock = {
+    ...jest.requireActual('../src/stores/fs'),
+    getFsFileUri: jest.fn(async (file) => {
+      if (file.localId) return buildMockPath(file)
+      return cachedIds.has(file.id) ? buildMockPath(file) : null
+    }),
+    getFsFileForId: jest.fn(async (file: FsFileInfo) => {
+      return new File(buildMockPath(file))
+    }),
+    fsStorageDirectory: {
+      info: jest.fn(() => ({ exists: true })),
+      create: jest.fn(() => {}),
+      list: jest.fn(() => []),
+    },
+    listFilesInFsStorageDirectory: jest.fn(() => []),
+  }
+  return mock
+}
+
+export function setFsMock() {
+  current.mock = buildFsMock()
+  return current.mock
+}

--- a/src/managers/syncUpMetadata.test.ts
+++ b/src/managers/syncUpMetadata.test.ts
@@ -15,11 +15,9 @@ jest.mock('../stores/sdk', () => ({
   getPinnedObject: jest.fn(),
   updateMetadata: jest.fn(),
 }))
-
 jest.mock('../stores/settings', () => ({
   getIndexerURL: jest.fn(),
 }))
-
 jest.mock('../encoding/fileMetadata', () => ({
   decodeFileMetadata: jest.fn(),
   encodeFileMetadata: jest.fn(),

--- a/src/managers/thumbnailScanner.test.ts
+++ b/src/managers/thumbnailScanner.test.ts
@@ -10,17 +10,7 @@ import {
   ImageManipulator,
   type ImageManipulatorContext,
 } from 'expo-image-manipulator'
-jest.mock('../lib/logger', () => ({
-  logger: { log: jest.fn() },
-}))
 
-jest.mock('react-native', () => ({
-  Platform: {
-    OS: 'ios',
-    select: (o: any) => o?.ios ?? o?.native ?? o?.default,
-  },
-  Image: { getSize: jest.fn() },
-}))
 jest.mock('expo-image-manipulator', () => ({
   ImageManipulator: { manipulate: jest.fn() },
   SaveFormat: { WEBP: 'webp' },
@@ -28,28 +18,12 @@ jest.mock('expo-image-manipulator', () => ({
 jest.mock('expo-video-thumbnails', () => ({
   getThumbnailAsync: jest.fn(),
 }))
-jest.mock('expo-file-system', () => ({
-  File: jest.fn((uri: string) => ({
-    uri,
-    info: jest.fn(() => ({ exists: true, size: 5000, uri })),
-  })),
-}))
 jest.mock('../stores/fileCache', () => ({
   getFileUri: jest.fn(),
   copyFileToCache: jest.fn(),
   clearCache: jest.fn(),
 }))
 jest.mock('../lib/contentHash', () => ({ calculateContentHash: jest.fn() }))
-jest.mock('../lib/fileTypes', () => ({
-  getMimeType: jest.fn(({ type }: { type?: string }) => type),
-}))
-jest.mock('../lib/uniqueId', () => {
-  let c = 0
-  return { uniqueId: () => `thumb-id-${++c}` }
-})
-jest.mock('../stores/settings', () => ({
-  getAutoGenerateThumbnails: jest.fn(async () => true),
-}))
 
 const getFileUriMock = jest.mocked(getFileUri)
 const copyFileToCacheMock = jest.mocked(copyFileToCache)
@@ -61,7 +35,6 @@ const videoThumbMock = jest.mocked(VideoThumbnails.getThumbnailAsync)
 beforeEach(async () => {
   await initializeDB()
   jest.clearAllMocks()
-  require('../stores/fileCache').clearCache()
 
   getFileUriMock.mockResolvedValue('file://source.jpg')
   copyFileToCacheMock.mockResolvedValue('file://cache/thumb.webp')


### PR DESCRIPTION
- Adds mock helpers for the expo file system and our fs abstraction.
- Loads these by default in our jest setup file which tries to cover all native modules, and general modules that most tests need mocked.
- They can still be overwritten with custom mocks per test.
- Removed some per test mocks that are covered by the base config.