### PR TITLE
refactor: remove audio player bottom padding

### DIFF
--- a/src/components/MediaConsumers/AudioPlayer.tsx
+++ b/src/components/MediaConsumers/AudioPlayer.tsx
@@ -74,7 +74,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     gap: 40,
-    paddingBottom: 128,
   },
   audioInfo: { gap: 10, alignItems: 'center' },
   audioControlsRow: { alignItems: 'center', gap: 10 },


### PR DESCRIPTION
More unification. This brings the audio player from vertically upper center to dead center, same as other file types.