### PR TITLE
feat: improve action sheet

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,5 +2,6 @@ module.exports = function (api) {
   api.cache(true)
   return {
     presets: ['babel-preset-expo'],
+    plugins: ['react-native-reanimated/plugin'],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "dependencies": {
         "@azure/core-asynciterator-polyfill": "^1.0.2",
         "@bacons/text-decoder": "^0.0.0",
+        "@gorhom/bottom-sheet": "^5.2.6",
         "@react-native-clipboard/clipboard": "^1.16.3",
         "@react-native-community/netinfo": "^11.4.1",
         "@react-native/new-app-screen": "0.81.0",
@@ -270,6 +271,8 @@
 
     "@craftzdog/react-native-buffer": ["@craftzdog/react-native-buffer@6.1.1", "", { "dependencies": { "ieee754": "^1.2.1", "react-native-quick-base64": "^2.2.2" } }, "sha512-YXJ0Jr4V+Hk2CZXpQw0A0NJeuiW2Rv6rAAutJCZ2k/JG13vLsppUibkJ8exSMxODtH9yJUrLiR96rilG3pFZ4Q=="],
 
+    "@egjs/hammerjs": ["@egjs/hammerjs@2.0.17", "", { "dependencies": { "@types/hammerjs": "^2.0.36" } }, "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A=="],
+
     "@expo/cli": ["@expo/cli@54.0.13", "", { "dependencies": { "@0no-co/graphql.web": "^1.0.8", "@expo/code-signing-certificates": "^0.0.5", "@expo/config": "~12.0.10", "@expo/config-plugins": "~54.0.2", "@expo/devcert": "^1.1.2", "@expo/env": "~2.0.7", "@expo/image-utils": "^0.8.7", "@expo/json-file": "^10.0.7", "@expo/mcp-tunnel": "~0.0.7", "@expo/metro": "~54.1.0", "@expo/metro-config": "~54.0.7", "@expo/osascript": "^2.3.7", "@expo/package-manager": "^1.9.8", "@expo/plist": "^0.4.7", "@expo/prebuild-config": "^54.0.6", "@expo/schema-utils": "^0.1.7", "@expo/spawn-async": "^1.7.2", "@expo/ws-tunnel": "^1.0.1", "@expo/xcpretty": "^4.3.0", "@react-native/dev-middleware": "0.81.5", "@urql/core": "^5.0.6", "@urql/exchange-retry": "^1.3.0", "accepts": "^1.3.8", "arg": "^5.0.2", "better-opn": "~3.0.2", "bplist-creator": "0.1.0", "bplist-parser": "^0.3.1", "chalk": "^4.0.0", "ci-info": "^3.3.0", "compression": "^1.7.4", "connect": "^3.7.0", "debug": "^4.3.4", "env-editor": "^0.4.1", "expo-server": "^1.0.2", "freeport-async": "^2.0.0", "getenv": "^2.0.0", "glob": "^10.4.2", "lan-network": "^0.1.6", "minimatch": "^9.0.0", "node-forge": "^1.3.1", "npm-package-arg": "^11.0.0", "ora": "^3.4.0", "picomatch": "^3.0.1", "pretty-bytes": "^5.6.0", "pretty-format": "^29.7.0", "progress": "^2.0.3", "prompts": "^2.3.2", "qrcode-terminal": "0.11.0", "require-from-string": "^2.0.2", "requireg": "^0.2.2", "resolve": "^1.22.2", "resolve-from": "^5.0.0", "resolve.exports": "^2.0.3", "semver": "^7.6.0", "send": "^0.19.0", "slugify": "^1.3.4", "source-map-support": "~0.5.21", "stacktrace-parser": "^0.1.10", "structured-headers": "^0.4.1", "tar": "^7.4.3", "terminal-link": "^2.1.1", "undici": "^6.18.2", "wrap-ansi": "^7.0.0", "ws": "^8.12.1" }, "peerDependencies": { "expo": "*", "expo-router": "*", "react-native": "*" }, "optionalPeers": ["expo-router", "react-native"], "bin": { "expo-internal": "build/bin/cli" } }, "sha512-wUJVTByZzDN0q8UjXDlu6WD2BWoTJCKVVBGUBNmvViDX4FhnESwefmtXPoO54QUUKs6vY89WZryHllGArGfLLw=="],
 
     "@expo/code-signing-certificates": ["@expo/code-signing-certificates@0.0.5", "", { "dependencies": { "node-forge": "^1.2.1", "nullthrows": "^1.1.1" } }, "sha512-BNhXkY1bblxKZpltzAx98G2Egj9g1Q+JRcvR7E99DOj862FTCX+ZPsAUtPTr7aHxwtrL7+fL3r0JSmM9kBm+Bw=="],
@@ -319,6 +322,10 @@
     "@expo/ws-tunnel": ["@expo/ws-tunnel@1.0.6", "", {}, "sha512-nDRbLmSrJar7abvUjp3smDwH8HcbZcoOEa5jVPUv9/9CajgmWw20JNRwTuBRzWIWIkEJDkz20GoNA+tSwUqk0Q=="],
 
     "@expo/xcpretty": ["@expo/xcpretty@4.3.2", "", { "dependencies": { "@babel/code-frame": "7.10.4", "chalk": "^4.1.0", "find-up": "^5.0.0", "js-yaml": "^4.1.0" }, "bin": { "excpretty": "build/cli.js" } }, "sha512-ReZxZ8pdnoI3tP/dNnJdnmAk7uLT4FjsKDGW7YeDdvdOMz2XCQSmSCM9IWlrXuWtMF9zeSB6WJtEhCQ41gQOfw=="],
+
+    "@gorhom/bottom-sheet": ["@gorhom/bottom-sheet@5.2.6", "", { "dependencies": { "@gorhom/portal": "1.0.14", "invariant": "^2.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-native": "*", "react": "*", "react-native": "*", "react-native-gesture-handler": ">=2.16.1", "react-native-reanimated": ">=3.16.0 || >=4.0.0-" }, "optionalPeers": ["@types/react", "@types/react-native"] }, "sha512-vmruJxdiUGDg+ZYcDmS30XDhq/h/+QkINOI5LY/uGjx8cPGwgJW0H6AB902gNTKtccbiKe/rr94EwdmIEz+LAQ=="],
+
+    "@gorhom/portal": ["@gorhom/portal@1.0.14", "", { "dependencies": { "nanoid": "^3.3.1" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-MXyL4xvCjmgaORr/rtryDNFy3kU4qUbKlwtQqqsygd0xX3mhKjOLn6mQK8wfu0RkoE0pBE0nAasRoHua+/QZ7A=="],
 
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
@@ -443,6 +450,8 @@
     "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
 
     "@types/graceful-fs": ["@types/graceful-fs@4.1.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ=="],
+
+    "@types/hammerjs": ["@types/hammerjs@2.0.46", "", {}, "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw=="],
 
     "@types/istanbul-lib-coverage": ["@types/istanbul-lib-coverage@2.0.6", "", {}, "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w=="],
 
@@ -988,6 +997,8 @@
 
     "hermes-parser": ["hermes-parser@0.29.1", "", { "dependencies": { "hermes-estree": "0.29.1" } }, "sha512-xBHWmUtRC5e/UL0tI7Ivt2riA/YBq9+SiYFU7C1oBa/j2jYGlIF9043oak1F47ihuDIxQ5nbsKueYJDRY02UgA=="],
 
+    "hoist-non-react-statics": ["hoist-non-react-statics@3.3.2", "", { "dependencies": { "react-is": "^16.7.0" } }, "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw=="],
+
     "hosted-git-info": ["hosted-git-info@7.0.2", "", { "dependencies": { "lru-cache": "^10.0.1" } }, "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@3.0.0", "", { "dependencies": { "whatwg-encoding": "^2.0.0" } }, "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA=="],
@@ -1421,6 +1432,8 @@
     "react-native-blob-util": ["react-native-blob-util@0.23.2", "", { "dependencies": { "base-64": "0.1.0", "glob": "^10.3.10" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-ZsUUFQYyZ7BI57c31XdPCkPlteoH7+PvcVy2w6wh1OPSUWGtKL79pj7fa6MepMX0v87fn0V9Heq0n6OjEpLdCw=="],
 
     "react-native-fs": ["react-native-fs@2.20.0", "", { "dependencies": { "base-64": "^0.1.0", "utf8": "^3.0.0" }, "peerDependencies": { "react-native": "*", "react-native-windows": "*" }, "optionalPeers": ["react-native-windows"] }, "sha512-VkTBzs7fIDUiy/XajOSNk0XazFE9l+QlMAce7lGuebZcag5CnjszB+u4BdqzwaQOdcYb5wsJIsqq4kxInIRpJQ=="],
+
+    "react-native-gesture-handler": ["react-native-gesture-handler@2.29.1", "", { "dependencies": { "@egjs/hammerjs": "^2.0.17", "hoist-non-react-statics": "^3.3.0", "invariant": "^2.2.4" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-du3qmv0e3Sm7qsd9SfmHps+AggLiylcBBQ8ztz7WUtd8ZjKs5V3kekAbi9R2W9bRLSg47Ntp4GGMYZOhikQdZA=="],
 
     "react-native-get-random-values": ["react-native-get-random-values@1.11.0", "", { "dependencies": { "fast-base64-decode": "^1.0.0" }, "peerDependencies": { "react-native": ">=0.56" } }, "sha512-4BTbDbRmS7iPdhYLRcz3PGFIpFJBwNZg9g42iwa2P6FOv9vZj/xJc678RZXnLNZzd0qd7Q3CCF6Yd+CU2eoXKQ=="],
 
@@ -1899,6 +1912,8 @@
     "finalhandler/on-finished": ["on-finished@2.3.0", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww=="],
 
     "finalhandler/statuses": ["statuses@1.5.0", "", {}, "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="],
+
+    "hoist-non-react-statics/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@azure/core-asynciterator-polyfill": "^1.0.2",
     "@bacons/text-decoder": "^0.0.0",
+    "@gorhom/bottom-sheet": "^5.2.6",
     "@react-native-clipboard/clipboard": "^1.16.3",
     "@react-native-community/netinfo": "^11.4.1",
     "@react-native/new-app-screen": "0.81.0",

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -16,6 +16,8 @@ import { useHasOnboarded } from './stores/settings'
 import { ShareIntentProvider } from 'expo-share-intent'
 import { ShareIntentConsumer } from './components/ShareIntentConsumer'
 import { AppSplash } from './components/AppSplash'
+import { GestureHandlerRootView } from 'react-native-gesture-handler'
+import { BottomSheetModalProvider } from '@gorhom/bottom-sheet'
 
 export function Root() {
   const navigationRef = useNavigationContainerRef<any>()
@@ -49,31 +51,35 @@ export function Root() {
   })
 
   return (
-    <SafeAreaProvider>
-      <SafeAreaView style={styles.safe} edges={['left', 'right']}>
-        <StatusBar
-          barStyle={Platform.select({
-            ios: 'light-content',
-            android: 'light-content',
-            default: 'light-content',
-          })}
-        />
-        <ShareIntentProvider>
-          <ToastProvider>
-            {showSplash ? (
-              <AppSplash />
-            ) : (
-              <>
-                <ShareIntentConsumer />
-                <NavigationContainer ref={navigationRef}>
-                  <RootTabs />
-                </NavigationContainer>
-              </>
-            )}
-          </ToastProvider>
-        </ShareIntentProvider>
-      </SafeAreaView>
-    </SafeAreaProvider>
+    <GestureHandlerRootView style={styles.gestureRoot}>
+      <SafeAreaProvider>
+        <ToastProvider>
+          <SafeAreaView style={styles.safe} edges={['left', 'right']}>
+            <StatusBar
+              barStyle={Platform.select({
+                ios: 'light-content',
+                android: 'light-content',
+                default: 'light-content',
+              })}
+            />
+            <ShareIntentProvider>
+              <BottomSheetModalProvider>
+                {showSplash ? (
+                  <AppSplash />
+                ) : (
+                  <>
+                    <ShareIntentConsumer />
+                    <NavigationContainer ref={navigationRef}>
+                      <RootTabs />
+                    </NavigationContainer>
+                  </>
+                )}
+              </BottomSheetModalProvider>
+            </ShareIntentProvider>
+          </SafeAreaView>
+        </ToastProvider>
+      </SafeAreaProvider>
+    </GestureHandlerRootView>
   )
 }
 

--- a/src/components/ActionSheet.tsx
+++ b/src/components/ActionSheet.tsx
@@ -1,16 +1,61 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
-  Animated,
-  Modal,
-  Pressable,
+  LayoutChangeEvent,
   StyleSheet,
   View,
   type StyleProp,
   type ViewStyle,
-  Easing,
+  useWindowDimensions,
 } from 'react-native'
+import {
+  BottomSheetBackdrop,
+  BottomSheetModal as GorhomBottomSheetModal,
+  BottomSheetScrollView,
+  type BottomSheetBackdropProps,
+  type BottomSheetModal,
+  BottomSheetView,
+} from '@gorhom/bottom-sheet'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import { blackA, palette } from '../styles/colors'
+import { palette } from '../styles/colors'
+
+const styles = StyleSheet.create({
+  background: {
+    backgroundColor: palette.gray[800],
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    shadowColor: palette.gray[950],
+    shadowOffset: { width: 0, height: -4 },
+    shadowOpacity: 0.12,
+    shadowRadius: 20,
+    elevation: 8,
+  },
+  content: {
+    paddingTop: 12,
+    paddingHorizontal: 16,
+    gap: 6,
+  },
+  handle: {
+    paddingTop: 12,
+    paddingBottom: 8,
+  },
+  handleIndicator: {
+    width: 46,
+    height: 5,
+    borderRadius: 999,
+    backgroundColor: palette.gray[600],
+  },
+})
+
+const flattenedHandleStyle = StyleSheet.flatten(styles.handle) ?? {}
+const flattenedIndicatorStyle = StyleSheet.flatten(styles.handleIndicator) ?? {}
+
+const HANDLE_EXTRA_HEIGHT =
+  Number(flattenedHandleStyle.paddingTop ?? 0) +
+  Number(flattenedHandleStyle.paddingBottom ?? 0) +
+  Number(flattenedIndicatorStyle.height ?? 0)
+
+const SNAP_POINT_TOLERANCE = 6
+const DEFAULT_SNAP_POINTS: Array<number | string> = ['44%', '82%']
 
 type Props = {
   visible: boolean
@@ -18,9 +63,10 @@ type Props = {
   children: React.ReactNode
   contentStyle?: StyleProp<ViewStyle>
   backdropOpacity?: number
+  snapPoints?: Array<number | string>
+  initialSnapIndex?: number
+  enableContentPanningGesture?: boolean
 }
-
-const AnimatedPressable = Animated.createAnimatedComponent(Pressable)
 
 export function ActionSheet({
   visible,
@@ -28,137 +74,273 @@ export function ActionSheet({
   children,
   contentStyle,
   backdropOpacity = 0.35,
+  snapPoints,
+  initialSnapIndex,
+  enableContentPanningGesture = true,
 }: Props) {
   const insets = useSafeAreaInsets()
+  const { height: windowHeight } = useWindowDimensions()
+  const bottomSheetRef = useRef<BottomSheetModal>(null)
+  const [contentHeight, setContentHeight] = useState<number | null>(null)
+  const [currentIndex, setCurrentIndex] = useState<number>(-1)
 
-  const [mounted, setMounted] = useState<boolean>(visible)
-  const [sheetHeight, setSheetHeight] = useState<number>(0)
-  const progress = useRef(new Animated.Value(0)).current
+  const contentPaddingBottom = useMemo(() => {
+    return Math.max(16, insets.bottom + 12)
+  }, [insets.bottom])
 
-  const openSpringConfig = useMemo(
-    () => ({
-      toValue: 1,
-      damping: 80,
-      stiffness: 900,
-      mass: 0.9,
-      velocity: 2,
-      useNativeDriver: true,
-    }),
-    []
-  )
+  const availableHeight = useMemo(() => {
+    return Math.max(windowHeight - Math.max(insets.top, 0), 1)
+  }, [insets.top, windowHeight])
 
-  const closeTimingConfig = useMemo(
-    () => ({
-      toValue: 0,
-      duration: 140,
-      easing: Easing.in(Easing.cubic),
-      useNativeDriver: true,
-    }),
-    []
-  )
+  // Calculate the snap points and the initial snap index.
+  const { snapHeights, resolvedInitialIndex } = useMemo(() => {
+    const configuredHeights = calculateConfiguredHeights(
+      snapPoints,
+      availableHeight
+    )
 
-  useEffect(() => {
-    if (visible) {
-      if (!mounted) {
-        setMounted(true)
-        progress.setValue(0)
-        return
-      }
-      if (sheetHeight > 0) {
-        Animated.spring(progress, openSpringConfig).start()
-      }
-    } else if (mounted) {
-      Animated.timing(progress, closeTimingConfig).start(({ finished }) => {
-        if (finished) setMounted(false)
-      })
+    const totalContentHeight =
+      contentHeight !== null ? contentHeight + HANDLE_EXTRA_HEIGHT : null
+
+    const finalSnapHeights = buildFinalSnapHeights(
+      configuredHeights,
+      totalContentHeight,
+      availableHeight
+    )
+
+    const initialIndex = resolveInitialSnapIndex(
+      initialSnapIndex,
+      finalSnapHeights,
+      totalContentHeight
+    )
+
+    return {
+      snapHeights: finalSnapHeights,
+      resolvedInitialIndex: initialIndex,
     }
-  }, [
-    visible,
-    mounted,
-    sheetHeight,
-    progress,
-    openSpringConfig,
-    closeTimingConfig,
-  ])
+  }, [availableHeight, contentHeight, initialSnapIndex, snapPoints])
 
-  if (!mounted) return null
+  const renderBackdrop = useCallback(
+    (props: BottomSheetBackdropProps) => (
+      <BottomSheetBackdrop
+        {...props}
+        pressBehavior="close"
+        appearsOnIndex={0}
+        disappearsOnIndex={-1}
+        opacity={backdropOpacity}
+      />
+    ),
+    [backdropOpacity]
+  )
+
+  const contentContainerStyle = useMemo<ViewStyle>(() => {
+    const extra = StyleSheet.flatten(contentStyle) ?? {}
+    return {
+      ...styles.content,
+      paddingBottom: contentPaddingBottom,
+      ...extra,
+    }
+  }, [contentPaddingBottom, contentStyle])
+
+  // Enable scrolling only when at full screen and content still overflows.
+  const shouldEnableScroll = useMemo(() => {
+    if (contentHeight === null || snapHeights.length === 0) return false
+
+    const totalContentHeight = contentHeight + HANDLE_EXTRA_HEIGHT
+    const clampedIndex = clampIndex(currentIndex, snapHeights.length - 1)
+    const atFullScreen = isAtFullScreenHeight(
+      snapHeights[clampedIndex],
+      availableHeight
+    )
+
+    return atFullScreen && totalContentHeight > availableHeight
+  }, [availableHeight, contentHeight, currentIndex, snapHeights])
+
+  const handleDismiss = useCallback(() => {
+    onRequestClose()
+    setCurrentIndex(-1)
+  }, [onRequestClose])
+
+  const handleSheetChange = useCallback((index: number) => {
+    setCurrentIndex(index)
+  }, [])
+
+  // Present the sheet when it becomes visible.
+  useEffect(() => {
+    const sheet = bottomSheetRef.current
+    if (!sheet || !visible) return
+
+    sheet.present()
+    if (resolvedInitialIndex >= 0) {
+      sheet.snapToIndex(resolvedInitialIndex)
+    }
+  }, [resolvedInitialIndex, visible])
+
+  // Dismiss the sheet when it becomes hidden.
+  useEffect(() => {
+    const sheet = bottomSheetRef.current
+    if (!sheet || visible) return
+
+    sheet.dismiss()
+  }, [visible])
+
+  // Update the current index when the sheet becomes visible or hidden.
+  useEffect(() => {
+    setCurrentIndex(visible ? resolvedInitialIndex : -1)
+  }, [resolvedInitialIndex, visible])
+
+  // Measure the content height and update the state.
+  const handleContentLayout = useCallback((event: LayoutChangeEvent) => {
+    const { height } = event.nativeEvent.layout
+    setContentHeight((prev) => {
+      if (prev === null) return height
+      return Math.abs(prev - height) <= 1 ? prev : height
+    })
+  }, [])
 
   return (
-    <Modal
-      visible={mounted}
-      transparent
-      animationType="none"
-      onRequestClose={onRequestClose}
+    <GorhomBottomSheetModal
+      ref={bottomSheetRef}
+      snapPoints={snapHeights}
+      index={resolvedInitialIndex}
+      handleStyle={styles.handle}
+      handleIndicatorStyle={styles.handleIndicator}
+      backgroundStyle={styles.background}
+      backdropComponent={renderBackdrop}
+      enablePanDownToClose
+      enableContentPanningGesture={enableContentPanningGesture}
+      keyboardBehavior="interactive"
+      onDismiss={handleDismiss}
+      onChange={handleSheetChange}
+      overDragResistanceFactor={4.5}
     >
-      <View style={styles.root}>
-        <AnimatedPressable
-          accessibilityRole="button"
-          onPress={onRequestClose}
-          style={[
-            styles.backdrop,
-            {
-              opacity: progress.interpolate({
-                inputRange: [0, 1],
-                outputRange: [0, backdropOpacity],
-              }),
-            },
-          ]}
-        />
-        <Animated.View
-          onLayout={(e) => {
-            const h = e.nativeEvent.layout.height
-            if (h > 0 && h !== sheetHeight) setSheetHeight(h)
-          }}
-          style={[
-            styles.sheet,
-            { paddingBottom: Math.max(16, insets.bottom + 12) },
-            sheetHeight === 0
-              ? { opacity: 0 }
-              : {
-                  transform: [
-                    {
-                      translateY: progress.interpolate({
-                        inputRange: [0, 1],
-                        outputRange: [
-                          sheetHeight + Math.max(16, insets.bottom + 12),
-                          0,
-                        ],
-                        extrapolate: 'clamp',
-                      }),
-                    },
-                  ],
-                },
-            contentStyle,
-          ]}
+      {shouldEnableScroll ? (
+        <BottomSheetScrollView
+          contentContainerStyle={contentContainerStyle}
+          showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+        >
+          <View onLayout={handleContentLayout}>{children}</View>
+        </BottomSheetScrollView>
+      ) : (
+        <BottomSheetView
+          onLayout={handleContentLayout}
+          style={contentContainerStyle}
         >
           {children}
-        </Animated.View>
-      </View>
-    </Modal>
+        </BottomSheetView>
+      )}
+    </GorhomBottomSheetModal>
   )
 }
 
-const styles = StyleSheet.create({
-  root: {
-    flex: 1,
-    justifyContent: 'flex-end',
-  },
-  backdrop: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: blackA.a100,
-  },
-  sheet: {
-    backgroundColor: 'white',
-    paddingVertical: 8,
-    paddingHorizontal: 12,
-    borderTopLeftRadius: 14,
-    borderTopRightRadius: 14,
-    shadowColor: palette.gray[950],
-    shadowOffset: { width: 0, height: -2 },
-    shadowOpacity: 0.08,
-    shadowRadius: 12,
-    elevation: 6,
-  },
-})
+/**
+ * Convert a snap point from percentages or pixels to pixels.
+ */
+function convertSnapPointToPixels(
+  point: number | string,
+  availableHeight: number
+): number | null {
+  if (typeof point === 'number' && Number.isFinite(point)) {
+    return Math.min(point, availableHeight)
+  }
+  if (typeof point === 'string') {
+    const value = Number.parseFloat(point)
+    if (Number.isFinite(value)) {
+      return Math.min((value / 100) * availableHeight, availableHeight)
+    }
+  }
+  return null
+}
 
-export default ActionSheet
+/**
+ * Convert the configured snap points from percentages or pixels to pixels.
+ */
+function calculateConfiguredHeights(
+  snapPoints: Array<number | string> | undefined,
+  availableHeight: number
+): number[] {
+  const rawPoints =
+    snapPoints && snapPoints.length > 0 ? snapPoints : DEFAULT_SNAP_POINTS
+  return rawPoints
+    .map((point) => convertSnapPointToPixels(point, availableHeight))
+    .filter((h): h is number => h !== null && h > 0)
+    .sort((a, b) => a - b)
+}
+
+/**
+ * Build the final snap heights which includes:
+ * - the configured snap points
+ * - the total content height
+ * If any two snap heights are within the tolerance,
+ * they will be merged into a single snap height.
+ */
+function buildFinalSnapHeights(
+  configuredHeights: number[],
+  totalContentHeight: number | null,
+  availableHeight: number
+): number[] {
+  if (totalContentHeight === null) {
+    return configuredHeights.length > 0
+      ? configuredHeights
+      : [availableHeight * 0.5]
+  }
+
+  const maxHeight = Math.min(totalContentHeight, availableHeight)
+  const allowedHeights = configuredHeights.filter(
+    (h) => h <= maxHeight + SNAP_POINT_TOLERANCE
+  )
+
+  const snapSet = new Set(allowedHeights)
+  const isDuplicate = allowedHeights.some(
+    (h) => Math.abs(h - maxHeight) <= SNAP_POINT_TOLERANCE
+  )
+  if (!isDuplicate || allowedHeights.length === 0) {
+    snapSet.add(maxHeight)
+  }
+
+  return Array.from(snapSet).sort((a, b) => a - b)
+}
+
+/**
+ * Resolve the initial snap index based on the initial snap index prop,
+ * the final snap heights, and the total content height.
+ */
+function resolveInitialSnapIndex(
+  initialSnapIndex: number | undefined,
+  finalSnapHeights: number[],
+  totalContentHeight: number | null
+): number {
+  if (
+    typeof initialSnapIndex === 'number' &&
+    initialSnapIndex >= 0 &&
+    initialSnapIndex < finalSnapHeights.length
+  ) {
+    return initialSnapIndex
+  }
+
+  if (
+    totalContentHeight !== null &&
+    totalContentHeight <= finalSnapHeights[0] + SNAP_POINT_TOLERANCE
+  ) {
+    const naturalIndex = finalSnapHeights.findIndex(
+      (h) => Math.abs(h - totalContentHeight) <= SNAP_POINT_TOLERANCE
+    )
+    if (naturalIndex >= 0) {
+      return naturalIndex
+    }
+  }
+
+  return 0
+}
+
+function clampIndex(index: number, maxIndex: number): number {
+  return Math.max(0, Math.min(index, maxIndex))
+}
+
+function isAtFullScreenHeight(
+  snapHeight: number,
+  availableHeight: number
+): boolean {
+  return Math.abs(snapHeight - availableHeight) <= SNAP_POINT_TOLERANCE
+}

--- a/src/components/ActionSheetButton.tsx
+++ b/src/components/ActionSheetButton.tsx
@@ -1,5 +1,6 @@
-import { Pressable, StyleSheet, Text } from 'react-native'
-import { colors, palette } from '../styles/colors'
+import { cloneElement, isValidElement, type ReactElement } from 'react'
+import { Pressable, StyleProp, StyleSheet, Text, TextStyle } from 'react-native'
+import { palette } from '../styles/colors'
 
 export function ActionSheetButton({
   disabled,
@@ -24,6 +25,11 @@ export function ActionSheetButton({
     : variant === 'primary'
     ? styles.primaryIcon
     : styles.dangerIcon
+  const renderedIcon = isValidElement(icon)
+    ? cloneElement(icon as ReactElement<{ style?: StyleProp<TextStyle> }>, {
+        style: iconStyle,
+      })
+    : icon
   return (
     <Pressable
       disabled={disabled}
@@ -31,7 +37,7 @@ export function ActionSheetButton({
       style={styles.container}
       onPress={onPress}
     >
-      <Text style={iconStyle}>{icon}</Text>
+      <Text style={iconStyle}>{renderedIcon}</Text>
       <Text style={textStyle}>{children}</Text>
     </Pressable>
   )
@@ -46,10 +52,10 @@ const styles = StyleSheet.create({
   },
   primaryText: {
     fontSize: 16,
-    color: colors.accentPrimary,
+    color: palette.gray[100],
   },
   primaryIcon: {
-    color: colors.accentPrimary,
+    color: palette.gray[100],
   },
   dangerText: {
     fontSize: 16,

--- a/src/components/FileFilter.tsx
+++ b/src/components/FileFilter.tsx
@@ -8,7 +8,7 @@ import {
   toggleCategory,
   useLibrary,
 } from '../stores/library'
-import ActionSheet from '../components/ActionSheet'
+import { ActionSheet } from '../components/ActionSheet'
 import { closeSheet, openSheet, useSheetOpen } from '../stores/sheets'
 
 const CATEGORIES: Category[] = ['Video', 'Image', 'Audio', 'Files']

--- a/src/components/FileSorter.tsx
+++ b/src/components/FileSorter.tsx
@@ -8,7 +8,7 @@ import {
   toggleDir,
   useLibrary,
 } from '../stores/library'
-import ActionSheet from '../components/ActionSheet'
+import { ActionSheet } from '../components/ActionSheet'
 import { closeSheet, useSheetOpen } from '../stores/sheets'
 import { openSheet } from '../stores/sheets'
 

--- a/src/components/LibraryStatusSheet.tsx
+++ b/src/components/LibraryStatusSheet.tsx
@@ -1,5 +1,5 @@
 import { View, Text, StyleSheet } from 'react-native'
-import ActionSheet from './ActionSheet'
+import { ActionSheet } from './ActionSheet'
 import { InfoCard } from './InfoCard'
 import { RowGroup } from './Group'
 import { LabeledValueRow } from './LabeledValueRow'


### PR DESCRIPTION
- This was quite tedious to get right but the PR updates our action sheet. Tested on Android and iOS. I am sure we will have to continue to refine as we add more complex bottom sheets with internal inputs etc.
- Updated to support more intuitive gestures and for larger sheets snap points.
- It will stick to two preset snap points, or even the full height if the content exceeds the screen height.
- Once its in the full height mode (not shown in video, but tested with dummy content) it will add an internal scroll (scroll view).
- If content is smaller than any snap point then that snap point is not included and attempts to pull up bounce back.
- The theme is also now dark/consistent, and with better contrast.
- Updated the action buttons to style passed icons.
- [sheet.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/432e0cff-d14e-48f9-9bcf-af45c1b7c104.mp4" />](https://app.graphite.com/user-attachments/video/432e0cff-d14e-48f9-9bcf-af45c1b7c104.mp4)