### PR TITLE
refactor: move settings to async storage

### DIFF
--- a/__mocks__/@react-native-async-storage/async-storage.ts
+++ b/__mocks__/@react-native-async-storage/async-storage.ts
@@ -1,0 +1,9 @@
+const store = new Map()
+export default {
+  setItem: jest.fn(async (key: string, value: string) => {
+    store.set(key, value)
+  }),
+  getItem: jest.fn(async (key: string) => {
+    return store.has(key) ? store.get(key) : null
+  }),
+}

--- a/__mocks__/expo-secure-storage/index.ts
+++ b/__mocks__/expo-secure-storage/index.ts
@@ -1,0 +1,9 @@
+const store = new Map()
+export default {
+  setItem: jest.fn(async (key: string, value: string) => {
+    store.set(key, value)
+  }),
+  getItem: jest.fn(async (key: string) => {
+    return store.has(key) ? store.get(key) : null
+  }),
+}

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
         "@azure/core-asynciterator-polyfill": "^1.0.2",
         "@bacons/text-decoder": "^0.0.0",
         "@gorhom/bottom-sheet": "^5.2.6",
+        "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-clipboard/clipboard": "^1.16.3",
         "@react-native-community/netinfo": "^11.4.1",
         "@react-native/new-app-screen": "0.81.0",
@@ -382,6 +383,8 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@react-native-async-storage/async-storage": ["@react-native-async-storage/async-storage@2.2.0", "", { "dependencies": { "merge-options": "^3.0.4" }, "peerDependencies": { "react-native": "^0.0.0-0 || >=0.65 <1.0" } }, "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw=="],
 
     "@react-native-clipboard/clipboard": ["@react-native-clipboard/clipboard@1.16.3", "", { "peerDependencies": { "react": ">= 16.9.0", "react-native": ">= 0.61.5", "react-native-macos": ">= 0.61.0", "react-native-windows": ">= 0.61.0" }, "optionalPeers": ["react-native-macos", "react-native-windows"] }, "sha512-cMIcvoZKIrShzJHEaHbTAp458R9WOv0fB6UyC7Ek4Qk561Ow/DrzmmJmH/rAZg21Z6ixJ4YSdFDC14crqIBmCQ=="],
 
@@ -1051,6 +1054,8 @@
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
+    "is-plain-obj": ["is-plain-obj@2.1.0", "", {}, "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="],
+
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
 
     "is-regex": ["is-regex@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g=="],
@@ -1222,6 +1227,8 @@
     "mdurl": ["mdurl@2.0.0", "", {}, "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="],
 
     "memoize-one": ["memoize-one@5.2.1", "", {}, "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="],
+
+    "merge-options": ["merge-options@3.0.4", "", { "dependencies": { "is-plain-obj": "^2.1.0" } }, "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ=="],
 
     "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
 

--- a/jest.setup.cjs
+++ b/jest.setup.cjs
@@ -73,50 +73,6 @@ jest.mock('./src/lib/uniqueId', () => {
   return { uniqueId: () => `uid-${++c}` }
 })
 
-// In-memory SecureStore for tests.
-jest.mock('./src/stores/secureStore', () => {
-  const numStore = new Map()
-  const boolStore = new Map()
-  const strStore = new Map()
-  return {
-    __esModule: true,
-    setSecureStoreNumber: jest.fn(async (key, value) => {
-      numStore.set(key, value)
-    }),
-    getSecureStoreNumber: jest.fn(async (key, fallback = 0) => {
-      return numStore.has(key) ? numStore.get(key) : fallback
-    }),
-    setSecureStoreBoolean: jest.fn(async (key, value) => {
-      boolStore.set(key, value)
-    }),
-    getSecureStoreBoolean: jest.fn(async (key, fallback = false) => {
-      return boolStore.has(key) ? boolStore.get(key) : fallback
-    }),
-    setSecureStoreString: jest.fn(async (key, value) => {
-      strStore.set(key, value)
-    }),
-    getSecureStoreString: jest.fn(async (key, fallback) => {
-      return strStore.has(key) ? strStore.get(key) : fallback
-    }),
-    setSecureStoreJSON: jest.fn(async (key, value) => {
-      if (value == null) {
-        strStore.set(key, '')
-      } else {
-        strStore.set(key, JSON.stringify(value))
-      }
-    }),
-    getSecureStoreJSON: jest.fn(async (key, _codec, fallback) => {
-      const v = strStore.get(key)
-      if (typeof v !== 'string' || v.trim() === '') return fallback
-      try {
-        return JSON.parse(v)
-      } catch {
-        return fallback
-      }
-    }),
-  }
-})
-
 // These warnings are produced when Jest loads Expo modules without native bindings.
 // In the test environment we intentionally replace those bindings with mocks, so
 // the messages are expected noise and safe to ignore.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@azure/core-asynciterator-polyfill": "^1.0.2",
     "@bacons/text-decoder": "^0.0.0",
     "@gorhom/bottom-sheet": "^5.2.6",
+    "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-clipboard/clipboard": "^1.16.3",
     "@react-native-community/netinfo": "^11.4.1",
     "@react-native/new-app-screen": "0.81.0",

--- a/src/db/migrations/0005_migrate_settings_to_async.ts
+++ b/src/db/migrations/0005_migrate_settings_to_async.ts
@@ -1,0 +1,72 @@
+import * as SQLite from 'expo-sqlite'
+import * as SecureStore from 'expo-secure-store'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { type Migration } from './types'
+import { logger } from '../../lib/logger'
+
+const MIGRATION_ID = '0005_migrate_settings_to_async'
+
+// Migrates all settings from secure storage to async storage except 'recoveryPhrase'.
+async function up(db: SQLite.SQLiteDatabase): Promise<void> {
+  const keysToMigrate = [
+    'indexerURL',
+    'libraryViewMode',
+    'maxUploads',
+    'maxDownloads',
+    'hasOnboarded',
+    'showAdvanced',
+    'autoScanUploads',
+    'autoSyncDownEvents',
+    'autoSyncPhotosArchive',
+    'autoSyncNewPhotos',
+    'photosArchiveCursor',
+    'photosNewCursor',
+    'fsEvictionLastRun',
+    'fsOrphanLastRun',
+    'syncDownCursor',
+    'syncUpCursor',
+    'enableSdkLogs',
+  ]
+
+  let migratedCount = 0
+  let skippedCount = 0
+
+  for (const key of keysToMigrate) {
+    try {
+      // Check if value exists in secure storage.
+      const secureValue = await SecureStore.getItemAsync(key)
+
+      if (secureValue !== null) {
+        // Check if value already exists in async storage.
+        const asyncValue = await AsyncStorage.getItem(key)
+
+        // Only migrate if async storage doesn't have a value yet.
+        if (asyncValue === null) {
+          await AsyncStorage.setItem(key, secureValue)
+          migratedCount++
+          logger.log(
+            `[db] migrated ${key} from secure storage to async storage`
+          )
+        } else {
+          skippedCount++
+        }
+      } else {
+        skippedCount++
+      }
+    } catch (error) {
+      logger.log(`[db] failed to migrate ${key}:`, error)
+      skippedCount++
+    }
+  }
+
+  logger.log(
+    '[db] settings migration complete',
+    JSON.stringify({ migratedCount, skippedCount })
+  )
+}
+
+export const migration_0005_migrate_settings_to_async: Migration = {
+  id: MIGRATION_ID,
+  description: 'Migrate settings from secure storage to async storage.',
+  up,
+}

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -23,12 +23,14 @@ import { migration_0001_init_schema } from './0001_init_schema'
 import { migration_0002_add_thumbnail_columns } from './0002_add_thumbnail_columns'
 import { migration_0003_add_updated_at_index } from './0003_add_updated_at_index'
 import { migration_0004_add_fs_table } from './0004_add_fs_table'
+import { migration_0005_migrate_settings_to_async } from './0005_migrate_settings_to_async'
 
 const migrations: Migration[] = [
   migration_0001_init_schema,
   migration_0002_add_thumbnail_columns,
   migration_0003_add_updated_at_index,
   migration_0004_add_fs_table,
+  migration_0005_migrate_settings_to_async,
 ]
 
 export async function runMigrations(

--- a/src/managers/downloadsPool.ts
+++ b/src/managers/downloadsPool.ts
@@ -1,10 +1,10 @@
 import { SlotPool } from '../lib/slotPool'
-import { getKey, triggerChange } from '../stores/settings'
+import { settingsSwr } from '../stores/settings'
 import { SingleInit } from '../lib/singleflight'
 import {
-  setSecureStoreNumber,
-  getSecureStoreNumber,
-} from '../stores/secureStore'
+  setAsyncStorageNumber,
+  getAsyncStorageNumber,
+} from '../stores/asyncStore'
 import { createGetterAndSWRHook } from '../lib/selectors'
 import { logger } from '../lib/logger'
 import { DEFAULT_MAX_DOWNLOADS } from '../config'
@@ -40,12 +40,12 @@ export async function setMaxDownloads(value: number) {
     logger.log('[settings] setMaxDownloads: value must be 1 or greater')
   }
   const clamped = Math.max(1, Math.floor(Number(value) || 1))
-  await setSecureStoreNumber('maxDownloads', clamped)
+  await setAsyncStorageNumber('maxDownloads', clamped)
   setDownloadMaxSlots(clamped)
-  triggerChange('maxDownloads')
+  settingsSwr.triggerChange('maxDownloads')
 }
 
 export const [getMaxDownloads, useMaxDownloads] = createGetterAndSWRHook(
-  getKey('maxDownloads'),
-  () => getSecureStoreNumber('maxDownloads', DEFAULT_MAX_DOWNLOADS)
+  settingsSwr.getKey('maxDownloads'),
+  () => getAsyncStorageNumber('maxDownloads', DEFAULT_MAX_DOWNLOADS)
 )

--- a/src/managers/fsEvictionScanner.test.ts
+++ b/src/managers/fsEvictionScanner.test.ts
@@ -9,9 +9,9 @@ import {
 import { type LocalObject } from '../encoding/localObject'
 import { readFsFileMetadata, upsertFsFileMetadata } from '../stores/fs'
 import {
-  getSecureStoreNumber,
-  setSecureStoreNumber,
-} from '../stores/secureStore'
+  getAsyncStorageNumber,
+  setAsyncStorageNumber,
+} from '../stores/asyncStore'
 
 jest.mock('../config', () => {
   const daysInMs = jest.requireActual('../lib/time').daysInMs
@@ -31,7 +31,7 @@ describe('fsEvictionScanner', () => {
   beforeEach(async () => {
     jest.spyOn(Date, 'now').mockReturnValue(now)
     await initializeDB()
-    await setSecureStoreNumber('fsEvictionLastRun', 0)
+    await setAsyncStorageNumber('fsEvictionLastRun', 0)
   })
 
   afterEach(async () => {
@@ -48,7 +48,7 @@ describe('fsEvictionScanner', () => {
     const result = await runFsEvictionScanner()
 
     expect(await readFsFileMetadata('file-1')).toBeDefined()
-    expect(await getSecureStoreNumber('fsEvictionLastRun', now)).toBe(now)
+    expect(await getAsyncStorageNumber('fsEvictionLastRun', now)).toBe(now)
     expect(result).toBeUndefined()
   })
 
@@ -67,7 +67,7 @@ describe('fsEvictionScanner', () => {
 
     expect(await readFsFileMetadata('file-2')).toBeDefined()
     expect(await readFsFileMetadata('file-3')).toBeDefined()
-    expect(await getSecureStoreNumber('fsEvictionLastRun', now)).toBe(now)
+    expect(await getAsyncStorageNumber('fsEvictionLastRun', now)).toBe(now)
     expect(result).toBeUndefined()
   })
 
@@ -115,7 +115,7 @@ describe('fsEvictionScanner', () => {
     expect(await readFsFileMetadata('file-3')).toBeDefined()
     expect(await readFsFileMetadata('file-4')).toBeNull()
     expect(await readFsFileMetadata('file-5')).toBeDefined()
-    expect(await getSecureStoreNumber('fsEvictionLastRun', 0)).toBe(now)
+    expect(await getAsyncStorageNumber('fsEvictionLastRun', 0)).toBe(now)
   })
 })
 

--- a/src/managers/fsEvictionScanner.ts
+++ b/src/managers/fsEvictionScanner.ts
@@ -13,9 +13,9 @@ import {
   FsMetaRow,
 } from '../stores/fs'
 import {
-  getSecureStoreNumber,
-  setSecureStoreNumber,
-} from '../stores/secureStore'
+  getAsyncStorageNumber,
+  setAsyncStorageNumber,
+} from '../stores/asyncStore'
 
 /**
  * fsEvictionScanner evicts stale files from the file system under the following rules:
@@ -142,9 +142,9 @@ export const initFsEvictionScanner = createServiceInterval({
 })
 
 export async function setFsEvictionLastRun(): Promise<void> {
-  await setSecureStoreNumber('fsEvictionLastRun', Date.now())
+  await setAsyncStorageNumber('fsEvictionLastRun', Date.now())
 }
 
 export async function getFsEvictionLastRun(): Promise<number> {
-  return await getSecureStoreNumber('fsEvictionLastRun', 0)
+  return await getAsyncStorageNumber('fsEvictionLastRun', 0)
 }

--- a/src/managers/fsOrphanScanner.test.ts
+++ b/src/managers/fsOrphanScanner.test.ts
@@ -8,9 +8,9 @@ import {
 } from '../stores/fs'
 import { createFileRecord } from '../stores/files'
 import {
-  getSecureStoreNumber,
-  setSecureStoreNumber,
-} from '../stores/secureStore'
+  getAsyncStorageNumber,
+  setAsyncStorageNumber,
+} from '../stores/asyncStore'
 import { File } from 'expo-file-system'
 
 const listFilesInFsStorageDirectoryMock = jest.mocked(
@@ -32,7 +32,7 @@ describe('fsOrphanScanner', () => {
     jest.spyOn(Date, 'now').mockReturnValue(now)
     listFilesInFsStorageDirectoryMock.mockImplementation(() => [])
     await initializeDB()
-    await setSecureStoreNumber('fsOrphanLastRun', 0)
+    await setAsyncStorageNumber('fsOrphanLastRun', 0)
   })
 
   afterEach(async () => {
@@ -42,12 +42,15 @@ describe('fsOrphanScanner', () => {
   })
 
   it('skips run when last run was recent', async () => {
-    await setSecureStoreNumber('fsOrphanLastRun', now - FS_ORPHAN_FREQUENCY / 2)
+    await setAsyncStorageNumber(
+      'fsOrphanLastRun',
+      now - FS_ORPHAN_FREQUENCY / 2
+    )
 
     const result = await runFsOrphanScanner()
 
     expect(listFilesInFsStorageDirectoryMock).not.toHaveBeenCalled()
-    expect(await getSecureStoreNumber('fsOrphanLastRun', 0)).toBe(
+    expect(await getAsyncStorageNumber('fsOrphanLastRun', 0)).toBe(
       now - FS_ORPHAN_FREQUENCY / 2
     )
     expect(result).toBeUndefined()
@@ -56,7 +59,7 @@ describe('fsOrphanScanner', () => {
   it('records timestamp even when there are no files', async () => {
     const result = await runFsOrphanScanner()
 
-    expect(await getSecureStoreNumber('fsOrphanLastRun', 0)).toBe(now)
+    expect(await getAsyncStorageNumber('fsOrphanLastRun', 0)).toBe(now)
     expect(result).toBeUndefined()
   })
 
@@ -68,7 +71,7 @@ describe('fsOrphanScanner', () => {
 
     expect(file.delete).toHaveBeenCalledTimes(1)
     expect(await readFsFileMetadata('file-1')).toBeNull()
-    expect(await getSecureStoreNumber('fsOrphanLastRun', 0)).toBe(now)
+    expect(await getAsyncStorageNumber('fsOrphanLastRun', 0)).toBe(now)
     expect(result).toEqual({ removed: 1 })
   })
 
@@ -97,7 +100,7 @@ describe('fsOrphanScanner', () => {
 
     expect(file.delete).not.toHaveBeenCalled()
     expect((await readFsFileMetadata('file-2'))?.fileId).toBe('file-2')
-    expect(await getSecureStoreNumber('fsOrphanLastRun', 0)).toBe(now)
+    expect(await getAsyncStorageNumber('fsOrphanLastRun', 0)).toBe(now)
     expect(result).toEqual({ removed: 0 })
   })
   it('deletes files that have no associated files table row', async () => {

--- a/src/managers/fsOrphanScanner.ts
+++ b/src/managers/fsOrphanScanner.ts
@@ -8,9 +8,9 @@ import {
   listFilesInFsStorageDirectory,
 } from '../stores/fs'
 import {
-  getSecureStoreNumber,
-  setSecureStoreNumber,
-} from '../stores/secureStore'
+  getAsyncStorageNumber,
+  setAsyncStorageNumber,
+} from '../stores/asyncStore'
 
 function extractFileIdFromName(name: string): string | null {
   const dotIndex = name.lastIndexOf('.')
@@ -96,9 +96,9 @@ export const initFsOrphanScanner = createServiceInterval({
 })
 
 export async function setFsOrphanLastRun(): Promise<void> {
-  await setSecureStoreNumber('fsOrphanLastRun', Date.now())
+  await setAsyncStorageNumber('fsOrphanLastRun', Date.now())
 }
 
 export async function getFsOrphanLastRun(): Promise<number> {
-  return await getSecureStoreNumber('fsOrphanLastRun', 0)
+  return await getAsyncStorageNumber('fsOrphanLastRun', 0)
 }

--- a/src/managers/syncDownEvents.ts
+++ b/src/managers/syncDownEvents.ts
@@ -23,7 +23,7 @@ import {
 } from 'react-native-sia'
 import { createServiceInterval } from '../lib/serviceInterval'
 import { z } from 'zod'
-import { getSecureStoreJSON, setSecureStoreJSON } from '../stores/secureStore'
+import { getAsyncStorageJSON, setAsyncStorageJSON } from '../stores/asyncStore'
 import { isoToEpochCodec } from '../encoding/date'
 import { pinnedObjectToLocalObject } from '../lib/localObjects'
 import { removeFsFile } from '../stores/fs'
@@ -275,12 +275,15 @@ const objectsCursorCodec = z.codec(
 )
 
 async function getSyncDownCursor(): Promise<ObjectsCursor | undefined> {
-  const decoded = await getSecureStoreJSON('syncDownCursor', objectsCursorCodec)
+  const decoded = await getAsyncStorageJSON(
+    'syncDownCursor',
+    objectsCursorCodec
+  )
   return decoded == null ? undefined : (decoded as unknown as ObjectsCursor)
 }
 
 export async function setSyncDownCursor(value: ObjectsCursor | undefined) {
-  await setSecureStoreJSON('syncDownCursor', value, objectsCursorCodec)
+  await setAsyncStorageJSON('syncDownCursor', value, objectsCursorCodec)
 }
 
 export async function resetSyncDownCursor() {

--- a/src/managers/syncNewPhotos.ts
+++ b/src/managers/syncNewPhotos.ts
@@ -1,17 +1,17 @@
 import * as MediaLibrary from 'expo-media-library'
 import { logger } from '../lib/logger'
 import { createServiceInterval } from '../lib/serviceInterval'
-import { getKey, triggerChange } from '../stores/settings'
+import { settingsSwr } from '../stores/settings'
 import { processAssets } from '../lib/processAssets'
 import { librarySwr } from '../stores/library'
 import { SYNC_NEW_PHOTOS_INTERVAL } from '../config'
 import { createGetterAndSWRHook } from '../lib/selectors'
 import {
-  getSecureStoreBoolean,
-  getSecureStoreNumber,
-  setSecureStoreBoolean,
-  setSecureStoreNumber,
-} from '../stores/secureStore'
+  getAsyncStorageBoolean,
+  getAsyncStorageNumber,
+  setAsyncStorageBoolean,
+  setAsyncStorageNumber,
+} from '../stores/asyncStore'
 import {
   ensureMediaLibraryPermission,
   getMediaLibraryPermissions,
@@ -69,13 +69,13 @@ export const initSyncNewPhotos = createServiceInterval({
 // Photos sync - new photos forward cursor and toggle.
 
 export const [getAutoSyncNewPhotos, useAutoSyncNewPhotos] =
-  createGetterAndSWRHook(getKey('autoSyncNewPhotos'), () =>
-    getSecureStoreBoolean('autoSyncNewPhotos', false)
+  createGetterAndSWRHook(settingsSwr.getKey('autoSyncNewPhotos'), () =>
+    getAsyncStorageBoolean('autoSyncNewPhotos', false)
   )
 
 export async function setAutoSyncNewPhotos(value: boolean) {
-  await setSecureStoreBoolean('autoSyncNewPhotos', value)
-  triggerChange('autoSyncNewPhotos')
+  await setAsyncStorageBoolean('autoSyncNewPhotos', value)
+  settingsSwr.triggerChange('autoSyncNewPhotos')
   if (value) {
     ensureMediaLibraryPermission()
   }
@@ -91,13 +91,13 @@ export async function toggleAutoSyncNewPhotos() {
 const defaultValue = new Date().getTime()
 
 export const [getPhotosNewCursor, usePhotosNewCursor] = createGetterAndSWRHook(
-  getKey('photosNewCursor'),
-  () => getSecureStoreNumber('photosNewCursor', defaultValue)
+  settingsSwr.getKey('photosNewCursor'),
+  () => getAsyncStorageNumber('photosNewCursor', defaultValue)
 )
 
 export async function setPhotosNewCursor(value: number) {
-  await setSecureStoreNumber('photosNewCursor', value)
-  triggerChange('photosNewCursor')
+  await setAsyncStorageNumber('photosNewCursor', value)
+  settingsSwr.triggerChange('photosNewCursor')
 }
 
 export async function resetPhotosNewCursor() {

--- a/src/managers/syncPhotosArchive.ts
+++ b/src/managers/syncPhotosArchive.ts
@@ -1,15 +1,15 @@
 import * as MediaLibrary from 'expo-media-library'
 import { logger } from '../lib/logger'
-import { getKey, triggerChange } from '../stores/settings'
+import { settingsSwr } from '../stores/settings'
 import { processAssets } from '../lib/processAssets'
 import { librarySwr } from '../stores/library'
 import { createGetterAndSWRHook } from '../lib/selectors'
 import {
-  getSecureStoreNumber,
-  setSecureStoreNumber,
-  getSecureStoreBoolean,
-  setSecureStoreBoolean,
-} from '../stores/secureStore'
+  getAsyncStorageNumber,
+  setAsyncStorageNumber,
+  getAsyncStorageBoolean,
+  setAsyncStorageBoolean,
+} from '../stores/asyncStore'
 import { createServiceInterval } from '../lib/serviceInterval'
 import { SYNC_PHOTOS_ARCHIVE_INTERVAL } from '../config'
 import {
@@ -75,13 +75,13 @@ export const initSyncPhotosArchive = createServiceInterval({
 const defaultValue = 0
 
 export const [getAutoSyncPhotosArchive, useAutoSyncPhotosArchive] =
-  createGetterAndSWRHook(getKey('autoSyncPhotosArchive'), () =>
-    getSecureStoreBoolean('autoSyncPhotosArchive', false)
+  createGetterAndSWRHook(settingsSwr.getKey('autoSyncPhotosArchive'), () =>
+    getAsyncStorageBoolean('autoSyncPhotosArchive', false)
   )
 
 export async function setAutoSyncPhotosArchive(value: boolean) {
-  await setSecureStoreBoolean('autoSyncPhotosArchive', value)
-  triggerChange('autoSyncPhotosArchive')
+  await setAsyncStorageBoolean('autoSyncPhotosArchive', value)
+  settingsSwr.triggerChange('autoSyncPhotosArchive')
   if (value) {
     ensureMediaLibraryPermission()
   }
@@ -95,13 +95,13 @@ export async function toggleAutoSyncPhotosArchive() {
 }
 
 export const [getPhotosArchiveCursor, usePhotosArchiveCursor] =
-  createGetterAndSWRHook(getKey('photosArchiveCursor'), () =>
-    getSecureStoreNumber('photosArchiveCursor', defaultValue)
+  createGetterAndSWRHook(settingsSwr.getKey('photosArchiveCursor'), () =>
+    getAsyncStorageNumber('photosArchiveCursor', defaultValue)
   )
 
 export async function setPhotosArchiveCursor(value: number) {
-  await setSecureStoreNumber('photosArchiveCursor', value)
-  triggerChange('photosArchiveCursor')
+  await setAsyncStorageNumber('photosArchiveCursor', value)
+  settingsSwr.triggerChange('photosArchiveCursor')
 }
 
 export async function restartPhotosArchiveCursor() {

--- a/src/managers/syncUpMetadata.ts
+++ b/src/managers/syncUpMetadata.ts
@@ -7,7 +7,7 @@ import {
 import { getIndexerURL } from '../stores/settings'
 import { getIsConnected, getPinnedObject, updateMetadata } from '../stores/sdk'
 import { createServiceInterval } from '../lib/serviceInterval'
-import { getSecureStoreJSON, setSecureStoreJSON } from '../stores/secureStore'
+import { getAsyncStorageJSON, setAsyncStorageJSON } from '../stores/asyncStore'
 import { z } from 'zod'
 import {
   SYNC_UP_METADATA_INTERVAL,
@@ -130,13 +130,13 @@ type SyncUpCursor = {
 }
 
 export async function getSyncUpCursor(): Promise<SyncUpCursor | undefined> {
-  return getSecureStoreJSON('syncUpCursor', syncUpCursorCodec)
+  return getAsyncStorageJSON('syncUpCursor', syncUpCursorCodec)
 }
 
 export async function setSyncUpCursor(
   value: SyncUpCursor | undefined
 ): Promise<void> {
-  await setSecureStoreJSON('syncUpCursor', value, syncUpCursorCodec)
+  await setAsyncStorageJSON('syncUpCursor', value, syncUpCursorCodec)
 }
 
 /**

--- a/src/managers/uploadsPool.ts
+++ b/src/managers/uploadsPool.ts
@@ -1,11 +1,11 @@
 import { SlotPool } from '../lib/slotPool'
-import { getKey, triggerChange } from '../stores/settings'
+import { settingsSwr } from '../stores/settings'
 import { SingleInit } from '../lib/singleflight'
 import { logger } from '../lib/logger'
 import {
-  getSecureStoreNumber,
-  setSecureStoreNumber,
-} from '../stores/secureStore'
+  getAsyncStorageNumber,
+  setAsyncStorageNumber,
+} from '../stores/asyncStore'
 import { createGetterAndSWRHook } from '../lib/selectors'
 import { DEFAULT_MAX_UPLOADS } from '../config'
 
@@ -40,12 +40,12 @@ export async function setMaxUploads(value: number) {
     logger.log('[settings] setMaxUploads: value must be 1 or greater')
   }
   const clamped = Math.max(1, Math.floor(Number(value) || 1))
-  await setSecureStoreNumber('maxUploads', clamped)
+  await setAsyncStorageNumber('maxUploads', clamped)
   setUploadMaxSlots(clamped)
-  triggerChange('maxUploads')
+  settingsSwr.triggerChange('maxUploads')
 }
 
 export const [getMaxUploads, useMaxUploads] = createGetterAndSWRHook(
-  getKey('maxUploads'),
-  () => getSecureStoreNumber('maxUploads', DEFAULT_MAX_UPLOADS)
+  settingsSwr.getKey('maxUploads'),
+  () => getAsyncStorageNumber('maxUploads', DEFAULT_MAX_UPLOADS)
 )

--- a/src/stores/asyncStore.ts
+++ b/src/stores/asyncStore.ts
@@ -1,0 +1,119 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { retry } from '../lib/retry'
+
+export async function setAsyncStorageBoolean(key: string, value: boolean) {
+  validateKey(key)
+  return AsyncStorage.setItem(key, value ? 'true' : 'false')
+}
+
+export async function getAsyncStorageBoolean(
+  key: string,
+  initialValue = false
+) {
+  return retry('getAsyncStorageBoolean', async () => {
+    const found = await AsyncStorage.getItem(key)
+    if (typeof found === 'string') {
+      if (found === 'true') {
+        return true
+      } else {
+        return false
+      }
+    }
+    await setAsyncStorageBoolean(key, initialValue)
+    return initialValue
+  })
+}
+
+export async function setAsyncStorageNumber(key: string, value: number) {
+  validateKey(key)
+  const str = Number.isFinite(value) ? String(Math.floor(value)) : '0'
+  return AsyncStorage.setItem(key, str)
+}
+
+export async function getAsyncStorageNumber(key: string, initialValue = 0) {
+  return retry('getAsyncStorageNumber', async () => {
+    const found = await AsyncStorage.getItem(key)
+    if (typeof found === 'string' && found.trim().length > 0) {
+      const n = Number(found)
+      if (Number.isFinite(n)) {
+        return n
+      }
+      await setAsyncStorageNumber(key, initialValue)
+    }
+    return initialValue
+  })
+}
+
+export async function setAsyncStorageString<T extends string>(
+  key: string,
+  value: T
+) {
+  validateKey(key)
+  return AsyncStorage.setItem(key, value)
+}
+
+export async function getAsyncStorageString<T extends string>(
+  key: string,
+  initialValue: T
+): Promise<T> {
+  return retry('getAsyncStorageString', async () => {
+    const found = await AsyncStorage.getItem(key)
+    if (typeof found === 'string' && found.trim().length > 0) {
+      return found as T
+    }
+    await setAsyncStorageString(key, initialValue)
+    return initialValue
+  })
+}
+
+export type JsonCodec<TStorage, TDomain> = {
+  encode: (domain: TDomain) => TStorage
+  decode: (storage: TStorage) => TDomain
+}
+
+export async function setAsyncStorageJSON<TStorage, TDomain>(
+  key: string,
+  value: TDomain | undefined,
+  codec: JsonCodec<TStorage, TDomain>
+) {
+  validateKey(key)
+  if (value == null) {
+    return AsyncStorage.setItem(key, '')
+  }
+  try {
+    const encoded = codec.encode(value)
+    const json = JSON.stringify(encoded)
+    return AsyncStorage.setItem(key, json)
+  } catch {
+    return AsyncStorage.setItem(key, '')
+  }
+}
+
+export async function getAsyncStorageJSON<TStorage, TDomain>(
+  key: string,
+  codec: JsonCodec<TStorage, TDomain>,
+  initialValue?: TDomain
+): Promise<TDomain | undefined> {
+  const storedValue = await retry('getAsyncStorageJSON', async () => {
+    const found = await AsyncStorage.getItem(key)
+    if (typeof found !== 'string' || found.trim().length === 0) {
+      return undefined
+    }
+    return found
+  })
+  if (storedValue) {
+    const parsed = JSON.parse(storedValue) as TStorage
+    return codec.decode(parsed)
+  } else {
+    await setAsyncStorageJSON(key, initialValue, codec)
+    return initialValue
+  }
+}
+
+export function validateKey(key: string) {
+  if (!/^[a-zA-Z0-9._-]+$/.test(key)) {
+    throw new Error(
+      'AsyncStore key must contain only alphanumeric characters, dots, hyphens, and underscores'
+    )
+  }
+}

--- a/src/stores/logs.ts
+++ b/src/stores/logs.ts
@@ -1,8 +1,8 @@
 import { create } from 'zustand'
 import { useShallow } from 'zustand/react/shallow'
 import { logger } from '../lib/logger'
-import { getSecureStoreBoolean, setSecureStoreBoolean } from './secureStore'
 import { createGetterAndSelector } from '../lib/selectors'
+import { getAsyncStorageBoolean, setAsyncStorageBoolean } from './asyncStore'
 
 export type LogsState = {
   logs: string[]
@@ -43,7 +43,7 @@ export async function initLogger(): Promise<void> {
 
   // Init state with secure store value so that we can use an in memory value
   // in the logger callbacks.
-  const enableSdkLogs = await getSecureStorageEnableSdkLogs()
+  const enableSdkLogs = await getEnableSdkLogs()
   setState((state) => {
     return { ...state, enableSdkLogs }
   })
@@ -79,13 +79,13 @@ export const [getSDKLogsEnabled, useSDKLogsEnabled] = createGetterAndSelector(
 )
 
 // Get the enable SDK logs flag from the secure store.
-async function getSecureStorageEnableSdkLogs(): Promise<boolean> {
-  return getSecureStoreBoolean('enableSdkLogs', false)
+export async function getEnableSdkLogs(): Promise<boolean> {
+  return getAsyncStorageBoolean('enableSdkLogs', false)
 }
 
-// Set the enable SDK logs flag in both the secure store and the store state.
+// Set the enable SDK logs flag in both the async store and the store state.
 export async function setEnableSdkLogs(value: boolean): Promise<void> {
-  await setSecureStoreBoolean('enableSdkLogs', value)
+  await setAsyncStorageBoolean('enableSdkLogs', value)
   setState((state) => {
     return { ...state, enableSdkLogs: value }
   })

--- a/src/stores/secureStore.ts
+++ b/src/stores/secureStore.ts
@@ -2,11 +2,7 @@ import * as SecureStore from 'expo-secure-store'
 import { retry } from '../lib/retry'
 
 export async function setSecureStoreBoolean(key: string, value: boolean) {
-  if (!/^[a-zA-Z0-9._-]+$/.test(key)) {
-    throw new Error(
-      'SecureStore key must contain only alphanumeric characters, dots, hyphens, and underscores'
-    )
-  }
+  validateKey(key)
   return SecureStore.setItemAsync(key, value ? 'true' : 'false')
 }
 
@@ -26,11 +22,7 @@ export async function getSecureStoreBoolean(key: string, initialValue = false) {
 }
 
 export async function setSecureStoreNumber(key: string, value: number) {
-  if (!/^[a-zA-Z0-9._-]+$/.test(key)) {
-    throw new Error(
-      'SecureStore key must contain only alphanumeric characters, dots, hyphens, and underscores'
-    )
-  }
+  validateKey(key)
   const str = Number.isFinite(value) ? String(Math.floor(value)) : '0'
   return SecureStore.setItemAsync(key, str)
 }
@@ -53,11 +45,7 @@ export async function setSecureStoreString<T extends string>(
   key: string,
   value: T
 ) {
-  if (!/^[a-zA-Z0-9._-]+$/.test(key)) {
-    throw new Error(
-      'SecureStore key must contain only alphanumeric characters, dots, hyphens, and underscores'
-    )
-  }
+  validateKey(key)
   return SecureStore.setItemAsync(key, value)
 }
 
@@ -85,11 +73,7 @@ export async function setSecureStoreJSON<TStorage, TDomain>(
   value: TDomain | undefined,
   codec: JsonCodec<TStorage, TDomain>
 ) {
-  if (!/^[a-zA-Z0-9._-]+$/.test(key)) {
-    throw new Error(
-      'SecureStore key must contain only alphanumeric characters, dots, hyphens, and underscores'
-    )
-  }
+  validateKey(key)
   if (value == null) {
     return SecureStore.setItemAsync(key, '')
   }
@@ -120,5 +104,13 @@ export async function getSecureStoreJSON<TStorage, TDomain>(
   } else {
     await setSecureStoreJSON(key, initialValue, codec)
     return initialValue
+  }
+}
+
+export function validateKey(key: string) {
+  if (!/^[a-zA-Z0-9._-]+$/.test(key)) {
+    throw new Error(
+      'SecureStore key must contain only alphanumeric characters, dots, hyphens, and underscores'
+    )
   }
 }

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -1,19 +1,20 @@
+import { setSecureStoreString, getSecureStoreString } from './secureStore'
 import {
-  setSecureStoreBoolean,
-  getSecureStoreBoolean,
-  setSecureStoreString,
-  getSecureStoreString,
-} from './secureStore'
+  setAsyncStorageBoolean,
+  getAsyncStorageBoolean,
+  setAsyncStorageString,
+  getAsyncStorageString,
+} from './asyncStore'
 import { createGetterAndSWRHook } from '../lib/selectors'
 import { buildSWRHelpers } from '../lib/swr'
 import { DEFAULT_INDEXER_URL } from '../config'
 
-export const { getKey, triggerChange } = buildSWRHelpers('secureStore')
+export const settingsSwr = buildSWRHelpers('settings')
 
 // Recovery Phrase
 
 export const [getRecoveryPhrase, useRecoveryPhrase] = createGetterAndSWRHook(
-  getKey('recoveryPhrase'),
+  settingsSwr.getKey('recoveryPhrase'),
   async () => getSecureStoreString('recoveryPhrase', '')
 )
 
@@ -22,7 +23,7 @@ export async function setRecoveryPhrase(
 ): Promise<boolean> {
   try {
     await setSecureStoreString('recoveryPhrase', recoveryPhrase)
-    triggerChange('recoveryPhrase')
+    settingsSwr.triggerChange('recoveryPhrase')
     return true
   } catch {
     return false
@@ -32,49 +33,49 @@ export async function setRecoveryPhrase(
 // Indexer
 
 export const [getIndexerURL, useIndexerURL] = createGetterAndSWRHook(
-  getKey('indexerURL'),
-  () => getSecureStoreString<string>('indexerURL', DEFAULT_INDEXER_URL)
+  settingsSwr.getKey('indexerURL'),
+  () => getAsyncStorageString<string>('indexerURL', DEFAULT_INDEXER_URL)
 )
 
 export async function setIndexerURL(value: string) {
-  await setSecureStoreString('indexerURL', value)
-  triggerChange('indexerURL')
+  await setAsyncStorageString('indexerURL', value)
+  settingsSwr.triggerChange('indexerURL')
 }
 
 // Has Onboarded
 
 export const [getHasOnboarded, useHasOnboarded] = createGetterAndSWRHook(
-  getKey('hasOnboarded'),
-  () => getSecureStoreBoolean('hasOnboarded')
+  settingsSwr.getKey('hasOnboarded'),
+  () => getAsyncStorageBoolean('hasOnboarded')
 )
 
 export async function setHasOnboarded(value: boolean) {
-  await setSecureStoreBoolean('hasOnboarded', value)
-  triggerChange('hasOnboarded')
+  await setAsyncStorageBoolean('hasOnboarded', value)
+  settingsSwr.triggerChange('hasOnboarded')
 }
 
 // Show Advanced
 
 export async function setShowAdvanced(value: boolean) {
-  await setSecureStoreBoolean('showAdvanced', value)
-  triggerChange('showAdvanced')
+  await setAsyncStorageBoolean('showAdvanced', value)
+  settingsSwr.triggerChange('showAdvanced')
 }
 
 export const [getShowAdvanced, useShowAdvanced] = createGetterAndSWRHook(
-  getKey('showAdvanced'),
-  () => getSecureStoreBoolean('showAdvanced')
+  settingsSwr.getKey('showAdvanced'),
+  () => getAsyncStorageBoolean('showAdvanced')
 )
 
 // Auto Scan Uploads
 
 export const [getAutoScanUploads, useAutoScanUploads] = createGetterAndSWRHook(
-  getKey('autoScanUploads'),
-  () => getSecureStoreBoolean('autoScanUploads', true)
+  settingsSwr.getKey('autoScanUploads'),
+  () => getAsyncStorageBoolean('autoScanUploads', true)
 )
 
 export async function setAutoScanUploads(value: boolean) {
-  await setSecureStoreBoolean('autoScanUploads', value)
-  triggerChange('autoScanUploads')
+  await setAsyncStorageBoolean('autoScanUploads', value)
+  settingsSwr.triggerChange('autoScanUploads')
 }
 
 export async function toggleAutoScanUploads() {
@@ -86,13 +87,13 @@ export async function toggleAutoScanUploads() {
 // Auto Sync Down Events
 
 export const [getAutoSyncDownEvents, useAutoSyncDownEvents] =
-  createGetterAndSWRHook(getKey('autoSyncDownEvents'), () =>
-    getSecureStoreBoolean('autoSyncDownEvents', true)
+  createGetterAndSWRHook(settingsSwr.getKey('autoSyncDownEvents'), () =>
+    getAsyncStorageBoolean('autoSyncDownEvents', true)
   )
 
 export async function setAutoSyncDownEvents(value: boolean) {
-  await setSecureStoreBoolean('autoSyncDownEvents', value)
-  triggerChange('autoSyncDownEvents')
+  await setAsyncStorageBoolean('autoSyncDownEvents', value)
+  settingsSwr.triggerChange('autoSyncDownEvents')
 }
 
 export async function toggleAutoSyncDownEvents() {
@@ -106,13 +107,13 @@ export async function toggleAutoSyncDownEvents() {
 export type LibraryViewMode = 'gallery' | 'list'
 
 export const [getLibraryViewMode, useLibraryViewMode] = createGetterAndSWRHook(
-  getKey('libraryViewMode'),
-  () => getSecureStoreString<LibraryViewMode>('libraryViewMode', 'gallery')
+  settingsSwr.getKey('libraryViewMode'),
+  () => getAsyncStorageString<LibraryViewMode>('libraryViewMode', 'gallery')
 )
 
 export async function setLibraryViewMode(value: LibraryViewMode) {
-  await setSecureStoreString<LibraryViewMode>('libraryViewMode', value)
-  triggerChange('libraryViewMode')
+  await setAsyncStorageString<LibraryViewMode>('libraryViewMode', value)
+  settingsSwr.triggerChange('libraryViewMode')
 }
 
 export async function toggleLibraryViewMode() {


### PR DESCRIPTION
- We have been storing all settings in secure storage which is encrypted and in the keychain, this is the right place for sensitive metadata such as the recovery phrase, but unnecessary for everything else.
- This PR moves all other settings to async storage which is not encrypted, is faster to read and write, and most importantly supports larger values. Secure storage appears to have a limit of 2KB on some devices. All values are small at the moment but if we every wanted to store say recent searches or other larger JSON, this could become an issue.
- Closes #240