### PR TITLE
fix: reconnect to indexer

### DIFF
--- a/src/hooks/useIsOnline.ts
+++ b/src/hooks/useIsOnline.ts
@@ -3,7 +3,10 @@ import NetInfo, { type NetInfoState } from '@react-native-community/netinfo'
 import { logger } from '../lib/logger'
 import useSWR from 'swr'
 
-export function getIsOnline(state: NetInfoState): boolean {
+export async function getIsOnline(
+  customState?: NetInfoState
+): Promise<boolean> {
+  const state = customState || (await NetInfo.fetch())
   const reachable = state.isInternetReachable
   if (reachable !== null) return Boolean(reachable)
   return Boolean(state.isConnected)
@@ -11,8 +14,7 @@ export function getIsOnline(state: NetInfoState): boolean {
 
 export function useIsOnline() {
   const isOnline = useSWR('onlineStatus', async () => {
-    const state = await NetInfo.fetch()
-    return getIsOnline(state)
+    return getIsOnline()
   })
 
   useEffect(() => {

--- a/src/hooks/useReconnectIndexer.ts
+++ b/src/hooks/useReconnectIndexer.ts
@@ -1,32 +1,48 @@
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
 import NetInfo from '@react-native-community/netinfo'
-import { reconnect, useIsConnected } from '../stores/sdk'
+import { reconnect, getIsConnected, useIsConnected } from '../stores/sdk'
 import { logger } from '../lib/logger'
-import { getIsOnline } from './useIsOnline'
-import { useIsInitializing } from '../stores/app'
+import { getIsOnline, useIsOnline } from './useIsOnline'
+import { getIsInitializing, useIsInitializing } from '../stores/app'
 
 export function useReconnectIndexer() {
-  const reconnectingRef = useRef(false)
-  const isIndexerConnected = useIsConnected()
-  const isInitializing = useIsInitializing()
-
+  // Try to reconnect to the indexer when the app reconnects to the internet.
   useEffect(() => {
-    const unsubscribe = NetInfo.addEventListener((state) => {
-      const isOnline = getIsOnline(state)
+    const unsubscribe = NetInfo.addEventListener(async (state) => {
+      const isOnline = await getIsOnline(state)
+      const isIndexerConnected = getIsConnected()
+      const isInitializing = getIsInitializing()
 
-      if (
-        !isInitializing &&
-        !isIndexerConnected &&
-        isOnline &&
-        !reconnectingRef.current
-      ) {
-        reconnectingRef.current = true
+      if (!isInitializing && !isIndexerConnected && isOnline) {
         logger.log('[netinfo] app is now online, reconnecting...')
-        void reconnect().finally(() => {
-          reconnectingRef.current = false
-        })
+        await reconnect()
       }
     })
     return () => unsubscribe()
   }, [])
+
+  // Try to reconnect to the indexer when the app is online but not connected to the indexer.
+  const isInitializing = useIsInitializing()
+  const isOnline = useIsOnline()
+  const isIndexerConnected = useIsConnected()
+  useEffect(() => {
+    let interval: NodeJS.Timeout | null = null
+    if (!isInitializing && isOnline && !isIndexerConnected) {
+      interval = setInterval(async () => {
+        const isOnline = await getIsOnline()
+        const isIndexerConnected = getIsConnected()
+        if (isOnline && !isIndexerConnected) {
+          logger.log(
+            '[netinfo] app is online but not connected to indexer, reconnecting...'
+          )
+          reconnect()
+        }
+      }, 5_000)
+    }
+    return () => {
+      if (interval) {
+        clearInterval(interval)
+      }
+    }
+  }, [isOnline, isIndexerConnected])
 }

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -195,9 +195,10 @@ export const [getCurrentInitStep, useCurrentInitStep] = createGetterAndSelector(
 export const [getInitializationError, useInitializationError] =
   createGetterAndSelector(useAppInitStore, (state) => state.initializationError)
 
-export function useIsInitializing(): boolean {
-  return useAppInitStore((s) => s.isInitializing)
-}
+export const [getIsInitializing, useIsInitializing] = createGetterAndSelector(
+  useAppInitStore,
+  (s) => s.isInitializing
+)
 
 export const [getShowSplash, useShowSplash] = createGetterAndSelector(
   useAppInitStore,

--- a/src/stores/sdk.ts
+++ b/src/stores/sdk.ts
@@ -11,6 +11,7 @@ export type SdkState = {
   isConnected: boolean
   connectionError: string | null
   isAuthing: boolean
+  isReconnecting: boolean
 }
 
 const useSdkStore = create<SdkState>(() => {
@@ -19,15 +20,23 @@ const useSdkStore = create<SdkState>(() => {
     isConnected: false,
     connectionError: null,
     isAuthing: false,
+    isReconnecting: false,
   }
 })
 
 const { getState, setState } = useSdkStore
 
-export async function reconnect() {
-  logger.log('Reconnecting...')
+export async function reconnect(): Promise<boolean> {
+  if (getState().isReconnecting) {
+    logger.log('[sdk] already reconnecting, skipping')
+    return false
+  }
+  setState({ isReconnecting: true })
+
+  logger.log('[sdk] reconnecting...')
   const isAuthing = getState().isAuthing
   if (isAuthing) {
+    logger.log('[sdk] already authing, skipping')
     return false
   }
   const sdk = getState().sdk || (await initSdk())
@@ -54,6 +63,8 @@ export async function reconnect() {
       connectionError: 'Failed to connect to indexer',
     })
     return false
+  } finally {
+    setState({ isReconnecting: false })
   }
 }
 


### PR DESCRIPTION
- Noticed that sometimes when the indexer is disconnected it does not reconnect until restarting the app.
- This PR adds polling that tries to reconnect if the app is online but not connected.
- Also fixes the event listener that fires when the internet connection status changes, we were stale values in the closure.