### PR TITLE
feat: add full screen consumption experience to FileDetailsScreen/FileViewer

### DIFF
--- a/src/components/FileDetailsImport/index.tsx
+++ b/src/components/FileDetailsImport/index.tsx
@@ -39,7 +39,6 @@ export function FileDetailsImport({
           <FileViewer
             file={file}
             isShared
-            fullscreen={false}
             customDownloader={() => {
               handleDownload(file.id, shareUrl)
             }}

--- a/src/components/FileViewer/index.tsx
+++ b/src/components/FileViewer/index.tsx
@@ -1,42 +1,52 @@
 import { StyleSheet, Text, TouchableHighlight, View } from 'react-native'
-import { useFileStatus } from '../../lib/file'
-import { CloudDownloadIcon, FileIcon } from 'lucide-react-native'
-import { ImageViewer } from '../MediaConsumers/ImageViewer'
-import { VideoPlayer } from '../MediaConsumers/VideoPlayer'
-import { AudioPlayer } from '../MediaConsumers/AudioPlayer'
-import { PDFViewer } from '../MediaConsumers/PDFViewer'
-import { TextViewer } from '../MediaConsumers/TextViewer'
-import { MarkdownViewer } from '../MediaConsumers/MarkdownViewer'
-import { JSONViewer } from '../MediaConsumers/JSONViewer'
-import { useDownload } from '../../managers/downloader'
-import { useDownloadState } from '../../stores/downloads'
-import { colors } from '../../styles/colors'
 import { useCallback, useMemo } from 'react'
-import { FileRecord } from '../../stores/files'
+import { CloudDownloadIcon, FileIcon } from 'lucide-react-native'
+
+import { useFileStatus } from '../../lib/file'
 import {
   useAutoDownload,
   detailsShouldAutoDownload,
 } from '../../hooks/useAutoDownload'
+import { useDownload } from '../../managers/downloader'
+import { useDownloadState } from '../../stores/downloads'
+import { colors } from '../../styles/colors'
+import { FileRecord } from '../../stores/files'
+import { AudioPlayer } from '../MediaConsumers/AudioPlayer'
+import { ImageViewer } from '../MediaConsumers/ImageViewer'
+import { JSONViewer } from '../MediaConsumers/JSONViewer'
+import { MarkdownViewer } from '../MediaConsumers/MarkdownViewer'
+import { PDFViewer } from '../MediaConsumers/PDFViewer'
+import { TextViewer } from '../MediaConsumers/TextViewer'
+import { VideoPlayer } from '../MediaConsumers/VideoPlayer'
+
+type FileViewerProps = {
+  file: FileRecord
+  isShared?: boolean
+  customDownloader?: () => void
+  textTopInset?: number
+  onViewerControlPress?: () => void
+}
 
 export function FileViewer({
   file,
   isShared,
-  header,
-  fullscreen = true,
   customDownloader,
-}: {
-  file: FileRecord
-  isShared?: boolean
-  header?: React.ReactNode
-  fullscreen?: boolean
-  customDownloader?: () => void
-}) {
+  textTopInset,
+  onViewerControlPress,
+}: FileViewerProps) {
   const { type, name } = file
   const status = useFileStatus(file, isShared)
   const { fileUri, isDownloaded, isDownloading } = status.data ?? {}
   useAutoDownload(file, detailsShouldAutoDownload)
   const fileDownload = useDownload(file)
   const fileDownloadState = useDownloadState(file.id)
+
+  const baseMediaStyle = styles.media
+  const textMediaStyle = textTopInset
+    ? StyleSheet.flatten([baseMediaStyle, { paddingTop: textTopInset }])
+    : baseMediaStyle
+  const textInsetValue =
+    textTopInset && textTopInset > 0 ? textTopInset : undefined
 
   const onDownloadPress = useCallback(() => {
     if (isDownloading) return
@@ -50,7 +60,7 @@ export function FileViewer({
     return (
       <View
         style={[
-          fullscreen ? styles.mediaWithPadding : styles.media,
+          baseMediaStyle,
           { justifyContent: 'center', alignItems: 'center', gap: 20 },
         ]}
       >
@@ -70,45 +80,51 @@ export function FileViewer({
         ) : null}
       </View>
     )
-  }, [fullscreen, onDownloadPress, isDownloading, fileDownloadState?.progress])
+  }, [
+    baseMediaStyle,
+    isDownloading,
+    onDownloadPress,
+    fileDownloadState?.progress,
+  ])
 
-  const MediaDisplayElement = useMemo(() => {
+  const mediaContent = useMemo(() => {
     if (!isDownloaded || !fileUri) return DownloadPanel
 
-    if (type?.includes('image')) {
-      return (
-        <ImageViewer
-          uri={fileUri}
-          style={fullscreen ? styles.mediaWithPadding : styles.media}
-        />
-      )
-    }
-    if (type?.includes('video')) {
+    if (type?.includes('image'))
+      return <ImageViewer uri={fileUri} style={baseMediaStyle} />
+    if (type?.includes('video'))
       return (
         <VideoPlayer
           source={fileUri}
-          style={fullscreen ? styles.mediaWithPadding : styles.media}
+          style={baseMediaStyle}
+          onViewerControlPress={onViewerControlPress}
         />
       )
-    }
     if (type?.includes('audio')) {
       return (
         <AudioPlayer
           source={fileUri}
           filename={name}
-          style={fullscreen ? styles.mediaWithPadding : styles.media}
+          style={baseMediaStyle}
+          onViewerControlPress={onViewerControlPress}
         />
       )
     }
     if (type?.includes('pdf') || lowerCasedFileName.endsWith('.pdf')) {
-      return <PDFViewer source={fileUri} style={styles.media} />
+      return <PDFViewer source={fileUri} style={baseMediaStyle} />
     }
+
     if (
       type?.includes('application/json') ||
       lowerCasedFileName.endsWith('.json')
     ) {
       return (
-        <JSONViewer uri={fileUri} fileSize={file.size} style={styles.media} />
+        <JSONViewer
+          uri={fileUri}
+          fileSize={file.size}
+          style={baseMediaStyle}
+          topInset={textInsetValue}
+        />
       )
     }
     if (
@@ -116,18 +132,29 @@ export function FileViewer({
       lowerCasedFileName.endsWith('.md') ||
       lowerCasedFileName.endsWith('.markdown')
     ) {
-      return <MarkdownViewer uri={fileUri} style={styles.media} />
+      return (
+        <MarkdownViewer
+          uri={fileUri}
+          style={textMediaStyle}
+          onViewerControlPress={onViewerControlPress}
+        />
+      )
     }
     if (type?.includes('text/plain') || lowerCasedFileName.endsWith('.txt')) {
       return (
-        <TextViewer uri={fileUri} fileSize={file.size} style={styles.media} />
+        <TextViewer
+          uri={fileUri}
+          fileSize={file.size}
+          style={baseMediaStyle}
+          topInset={textInsetValue}
+        />
       )
     }
 
     return (
       <View
         style={[
-          fullscreen ? styles.mediaWithPadding : styles.media,
+          baseMediaStyle,
           { justifyContent: 'center', alignItems: 'center', gap: 20 },
         ]}
       >
@@ -136,26 +163,23 @@ export function FileViewer({
       </View>
     )
   }, [
+    DownloadPanel,
+    baseMediaStyle,
     fileUri,
     isDownloaded,
-    type,
     lowerCasedFileName,
-    fullscreen,
     name,
+    textInsetValue,
+    textMediaStyle,
+    type,
     file.size,
-    DownloadPanel,
+    onViewerControlPress,
   ])
 
-  return (
-    <View style={styles.container}>
-      {header}
-      {MediaDisplayElement}
-    </View>
-  )
+  return <View style={styles.container}>{mediaContent}</View>
 }
 
 const styles = StyleSheet.create({
   container: { flex: 1, flexDirection: 'column' },
-  mediaWithPadding: { flex: 1, marginBottom: 120 },
   media: { flex: 1 },
 })

--- a/src/components/MediaConsumers/AudioPlayer.tsx
+++ b/src/components/MediaConsumers/AudioPlayer.tsx
@@ -20,10 +20,12 @@ export function AudioPlayer({
   source,
   filename,
   style,
+  onViewerControlPress,
 }: {
   source: string
   filename: string | null
   style?: ViewStyle
+  onViewerControlPress?: () => void
 }) {
   const audioPlayer = useAudioPlayer(source)
   const { isLoaded, isBuffering, playing, duration, currentTime } =
@@ -46,23 +48,37 @@ export function AudioPlayer({
             <PauseIcon
               color="white"
               size={20}
-              onPress={() => audioPlayer.pause()}
+              onPress={() => {
+                onViewerControlPress?.()
+                audioPlayer.pause()
+              }}
             />
           ) : (
             <PlayIcon
               color="white"
               size={20}
               onPress={() => {
+                onViewerControlPress?.()
                 if (isReadyToPlay) audioPlayer.play()
               }}
             />
           )}
-          <Undo2Icon color="white" onPress={() => audioPlayer.seekTo(0)} />
+          <Undo2Icon
+            color="white"
+            onPress={() => {
+              onViewerControlPress?.()
+              audioPlayer.seekTo(0)
+            }}
+          />
           <Text style={{ color: 'white' }}>
             {currentLabel} / {durationLabel}
           </Text>
         </View>
-        {statusLabel && <Text style={{ color: 'white' }}>{statusLabel}</Text>}
+        <View style={styles.statusPlaceholder}>
+          {statusLabel ? (
+            <Text style={{ color: 'white' }}>{statusLabel}</Text>
+          ) : null}
+        </View>
       </View>
     </View>
   )
@@ -78,4 +94,8 @@ const styles = StyleSheet.create({
   audioInfo: { gap: 10, alignItems: 'center' },
   audioControlsRow: { alignItems: 'center', gap: 10 },
   audioControls: { flexDirection: 'row', alignItems: 'center', gap: 10 },
+  statusPlaceholder: {
+    minHeight: 18,
+    justifyContent: 'center',
+  },
 })

--- a/src/components/MediaConsumers/JSONViewer.tsx
+++ b/src/components/MediaConsumers/JSONViewer.tsx
@@ -3,15 +3,14 @@ import { ScrollView, Text, StyleSheet, ViewStyle, Platform } from 'react-native'
 import { WebView } from 'react-native-webview'
 import { readFileAsText } from '../../lib/readFileAsText'
 
-export function JSONViewer({
-  uri,
-  style,
-  fileSize,
-}: {
+type Props = {
   uri: string
   style?: ViewStyle
   fileSize?: number | null
-}) {
+  topInset?: number
+}
+
+export function JSONViewer({ uri, style, fileSize, topInset }: Props) {
   const [text, setText] = useState('')
   const [note, setNote] = useState<string | null>(null)
 
@@ -57,7 +56,15 @@ export function JSONViewer({
     }
   }, [uri, shouldUseWebView])
 
-  const html = useMemo(() => buildPreHtml(text), [text])
+  const html = useMemo(() => buildPreHtml(text, topInset), [text, topInset])
+
+  const insetProps = topInset
+    ? {
+        contentInset: { top: topInset },
+        contentOffset: { x: 0, y: -topInset },
+        scrollIndicatorInsets: { top: topInset },
+      }
+    : null
 
   if (shouldUseWebView) {
     return (
@@ -71,7 +78,11 @@ export function JSONViewer({
   }
 
   return (
-    <ScrollView style={style} contentContainerStyle={styles.content}>
+    <ScrollView
+      style={style}
+      contentContainerStyle={styles.content}
+      {...(insetProps ?? {})}
+    >
       {note ? (
         <Text style={styles.note}>
           {note}
@@ -99,15 +110,19 @@ const styles = StyleSheet.create({
   note: { color: 'orange', marginBottom: 8, fontSize: 12 },
 })
 
-function buildPreHtml(s: string) {
+function buildPreHtml(s: string, topInset?: number) {
+  const inset = topInset ?? 0
+  const paddingTop = inset ? `padding-top:${inset}px;` : ''
+
   return `<!doctype html>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style>
   html,body{margin:0;padding:0;background:#000;color:#fff;font:14px/1.6 -apple-system,system-ui,Segoe UI,Roboto,Ubuntu}
+  .wrap{padding:16px;${paddingTop}}
   pre{white-space:pre-wrap;word-wrap:break-word;margin:0;padding:16px}
   code,pre,tt{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,"Liberation Mono",monospace}
 </style>
-<pre>${escapeHtml(s ?? '')}</pre>`
+<div class="wrap"><pre>${escapeHtml(s ?? '')}</pre></div>`
 }
 
 function escapeHtml(s: string) {

--- a/src/components/MediaConsumers/MarkdownViewer.tsx
+++ b/src/components/MediaConsumers/MarkdownViewer.tsx
@@ -17,9 +17,11 @@ type Mode = 'preview' | 'raw'
 export function MarkdownViewer({
   uri,
   style,
+  onViewerControlPress,
 }: {
   uri: string
   style?: ViewStyle
+  onViewerControlPress?: () => void
 }) {
   const [md, setMd] = useState('')
   const [mode, setMode] = useState<Mode>('preview')
@@ -69,18 +71,26 @@ export function MarkdownViewer({
     []
   )
 
+  const setModeWithBlock = useCallback(
+    (nextMode: Mode) => {
+      onViewerControlPress?.()
+      setMode(nextMode)
+    },
+    [onViewerControlPress]
+  )
+
   return (
     <View style={[styles.container, style]}>
       <View style={styles.toolbar}>
         <Segment
           label="Preview"
           active={mode === 'preview'}
-          onPress={() => setMode('preview')}
+          onPress={() => setModeWithBlock('preview')}
         />
         <Segment
           label="Raw"
           active={mode === 'raw'}
-          onPress={() => setMode('raw')}
+          onPress={() => setModeWithBlock('raw')}
         />
       </View>
 

--- a/src/components/MediaConsumers/TextViewer.tsx
+++ b/src/components/MediaConsumers/TextViewer.tsx
@@ -3,15 +3,14 @@ import { ScrollView, Text, StyleSheet, ViewStyle, Platform } from 'react-native'
 import { WebView } from 'react-native-webview'
 import { readFileAsText } from '../../lib/readFileAsText'
 
-export function TextViewer({
-  uri,
-  style,
-  fileSize,
-}: {
+type Props = {
   uri: string
   style?: ViewStyle
   fileSize?: number | null
-}) {
+  topInset?: number
+}
+
+export function TextViewer({ uri, style, fileSize, topInset }: Props) {
   const [text, setText] = useState('')
 
   const shouldUseWebView = fileSize == null ? true : fileSize > 256 * 1024 // ~256kb
@@ -32,7 +31,15 @@ export function TextViewer({
     }
   }, [uri])
 
-  const html = useMemo(() => buildPreHtml(text), [text])
+  const html = useMemo(() => buildPreHtml(text, topInset), [text, topInset])
+
+  const insetProps = topInset
+    ? {
+        contentInset: { top: topInset },
+        contentOffset: { x: 0, y: -topInset },
+        scrollIndicatorInsets: { top: topInset },
+      }
+    : null
 
   if (shouldUseWebView) {
     return (
@@ -46,7 +53,11 @@ export function TextViewer({
   }
 
   return (
-    <ScrollView style={style} contentContainerStyle={styles.content}>
+    <ScrollView
+      style={style}
+      contentContainerStyle={styles.content}
+      {...(insetProps ?? {})}
+    >
       <Text selectable style={styles.mono}>
         {text}
       </Text>
@@ -67,15 +78,19 @@ const styles = StyleSheet.create({
   },
 })
 
-function buildPreHtml(s: string) {
+function buildPreHtml(s: string, topInset?: number) {
+  const inset = topInset ?? 0
+  const paddingTop = inset ? `padding-top:${inset}px;` : ''
+
   return `<!doctype html>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style>
   html,body{margin:0;padding:0;background:#000;color:#fff;font:14px/1.6 -apple-system,system-ui,Segoe UI,Roboto,Ubuntu}
-  pre{white-space:pre-wrap;word-wrap:break-word;margin:0;padding:16px}
+  .wrap{padding:16px;${paddingTop}}
+  pre{white-space:pre-wrap;word-wrap:break-word;margin:0;}
   code,pre,tt{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,"Liberation Mono",monospace}
 </style>
-<pre>${escapeHtml(s ?? '')}</pre>`
+<div class="wrap"><pre>${escapeHtml(s ?? '')}</pre></div>`
 }
 
 function escapeHtml(s: string) {

--- a/src/components/MediaConsumers/VideoPlayer.tsx
+++ b/src/components/MediaConsumers/VideoPlayer.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { Pressable, StyleSheet, View, ViewStyle } from 'react-native'
 import { useVideoPlayer, VideoView } from 'expo-video'
 import { PlayIcon } from 'lucide-react-native'
@@ -8,16 +8,18 @@ import { logger } from '../../lib/logger'
 export function VideoPlayer({
   source,
   style,
+  onViewerControlPress,
 }: {
   source: string
   style?: ViewStyle
+  onViewerControlPress?: () => void
 }) {
   const player = useVideoPlayer(source)
   const videoRef = useRef<VideoView>(null)
   const [showNativeControls, setShowNativeControls] = useState(false)
   const [isPlaying, setIsPlaying] = useState(false)
 
-  const onPlayPress = async () => {
+  const onPlayPress = useCallback(async () => {
     setIsPlaying(true)
     player.play()
     try {
@@ -25,7 +27,11 @@ export function VideoPlayer({
     } catch (error) {
       logger.log('[VideoPlayer] Failed to enter fullscreen:', error)
     }
-  }
+  }, [onViewerControlPress, player])
+
+  const handlePressIn = useCallback(() => {
+    onViewerControlPress?.()
+  }, [onViewerControlPress])
 
   return (
     <View style={[styles.container, style]}>
@@ -48,6 +54,7 @@ export function VideoPlayer({
         <View style={styles.playIconContainer} pointerEvents="box-none">
           <Pressable
             style={styles.playButton}
+            onPressIn={handlePressIn}
             onPress={onPlayPress}
             hitSlop={12}
             accessibilityRole="button"

--- a/src/screens/FileDetailScreen.tsx
+++ b/src/screens/FileDetailScreen.tsx
@@ -1,33 +1,73 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { View, StyleSheet, FlatList, useWindowDimensions } from 'react-native'
-import { FileDetails } from '../components/FileDetails'
+import {
+  View,
+  StyleSheet,
+  FlatList,
+  useWindowDimensions,
+  type GestureResponderEvent,
+  type NativeTouchEvent,
+  AccessibilityInfo,
+  Pressable,
+} from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { type NativeStackScreenProps } from '@react-navigation/native-stack'
-import { type MainStackParamList } from '../stacks/types'
-import { FileActionsSheet } from '../components/FileActionsSheet'
-import { palette } from '../styles/colors'
+
+import { FileDetails } from '../components/FileDetails'
+import { FileDetailsControlBar } from '../components/FileDetailsControlBar'
 import { FileDetailScreenHeader } from '../components/FileDetailScreenHeader'
 import { FileViewer } from '../components/FileViewer'
-import { FileDetailsControlBar } from '../components/FileDetailsControlBar'
+import { FileActionsSheet } from '../components/FileActionsSheet'
+import { palette } from '../styles/colors'
 import { type FileRecord } from '../stores/files'
 import { useFileList } from '../stores/library'
 import { useFlatListControls } from '../hooks/useFlatListControls'
+import { type MainStackParamList } from '../stacks/types'
 
 type Props = NativeStackScreenProps<MainStackParamList, 'FileDetail'>
+
+type TapState = {
+  id: string
+  startX: number
+  startY: number
+  startedAt: number
+  moved: boolean
+}
 
 export function FileDetailScreen({ route, navigation }: Props) {
   const [viewStyle, setViewStyle] = useState<'consume' | 'detail'>('consume')
   const [activeFileID, setActiveFileID] = useState(route.params.id)
+  const [areControlsVisible, setAreControlsVisible] = useState(false)
+  const [isScreenReaderEnabled, setIsScreenReaderEnabled] = useState(false)
+  const { top: topInset } = useSafeAreaInsets()
+  const tapStateRef = useRef<TapState | null>(null)
+  const shouldIgnoreNextToggleRef = useRef(false)
+
+  const blockNextControlToggle = useCallback(() => {
+    shouldIgnoreNextToggleRef.current = true
+  }, [])
+
+  const toggleControlsVisibility = useCallback(() => {
+    setAreControlsVisible((curr) => !curr)
+  }, [])
+
   const { data: fileList, size, setSize, isValidating, hasMore } = useFileList()
-  const files = useMemo(() => fileList ?? [], [fileList])
   const { width } = useWindowDimensions()
+  const files = useMemo(() => fileList ?? [], [fileList])
+  const file = useMemo(
+    () => files.find((item) => item.id === activeFileID),
+    [files, activeFileID]
+  )
+
   const flatListRef = useRef<FlatList<FileRecord>>(null)
+  const hasAlignedInitialIndex = useRef(false)
+
   const initialTargetIndex = useMemo(
     () => files.findIndex((item) => item.id === route.params.id),
     [files, route.params.id]
   )
   const canPage = files.length > 0 && initialTargetIndex !== -1
   const initialIndex = initialTargetIndex === -1 ? 0 : initialTargetIndex
-  const hasAlignedInitialIndex = useRef(false)
+
   const { handleEndReached } = useFlatListControls({
     data: fileList,
     size,
@@ -35,11 +75,6 @@ export function FileDetailScreen({ route, navigation }: Props) {
     isValidating,
     hasMore,
   })
-
-  const file = useMemo(
-    () => files.find((item) => item.id === activeFileID),
-    [files, activeFileID]
-  )
 
   useEffect(() => {
     setActiveFileID(route.params.id)
@@ -58,6 +93,17 @@ export function FileDetailScreen({ route, navigation }: Props) {
     })
     hasAlignedInitialIndex.current = true
   }, [canPage, initialIndex, route.params.id])
+
+  useEffect(() => {
+    AccessibilityInfo.isScreenReaderEnabled().then(setIsScreenReaderEnabled)
+    const sub = AccessibilityInfo.addEventListener(
+      'screenReaderChanged',
+      setIsScreenReaderEnabled
+    )
+    return () => {
+      sub.remove()
+    }
+  }, [])
 
   const handleSetViewStyle = useCallback(
     (next: 'consume' | 'detail') => {
@@ -79,27 +125,116 @@ export function FileDetailScreen({ route, navigation }: Props) {
     [files, width, activeFileID]
   )
 
+  const handleTouchStart = useCallback((event: GestureResponderEvent) => {
+    const touches = event.nativeEvent.touches
+    if (touches.length !== 1) {
+      tapStateRef.current = null
+      return
+    }
+    const touch = touches[0]
+    const id = normalizeIdentifier(touch)
+    tapStateRef.current = {
+      id,
+      startX: touch.pageX,
+      startY: touch.pageY,
+      startedAt: Date.now(),
+      moved: false,
+    }
+  }, [])
+
+  const handleTouchMove = useCallback((event: GestureResponderEvent) => {
+    const state = tapStateRef.current
+    if (!state) return
+    const touches = event.nativeEvent.touches
+    const target = touches.find((t) => normalizeIdentifier(t) === state.id)
+    if (!target) {
+      tapStateRef.current = null
+      return
+    }
+    if (!state.moved) {
+      const dx = target.pageX - state.startX
+      const dy = target.pageY - state.startY
+      if (Math.hypot(dx, dy) > 10) state.moved = true
+    }
+  }, [])
+
+  const handleTouchEnd = useCallback(
+    (event: GestureResponderEvent) => {
+      const state = tapStateRef.current
+      if (!state) return
+      const changedTouch = event.nativeEvent.changedTouches.find(
+        (t) => normalizeIdentifier(t) === state.id
+      )
+      if (!changedTouch) return
+      const duration = Date.now() - state.startedAt
+      if (
+        !state.moved &&
+        duration < 250 &&
+        event.nativeEvent.touches.length === 0
+      ) {
+        if (shouldIgnoreNextToggleRef.current) {
+          shouldIgnoreNextToggleRef.current = false
+          tapStateRef.current = null
+          return
+        }
+        toggleControlsVisibility()
+      }
+      tapStateRef.current = null
+    },
+    [toggleControlsVisibility]
+  )
+
+  const renderConsumeView = useCallback(
+    (fileRecord: FileRecord) => (
+      <View
+        style={styles.consumeContainer}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+      >
+        <FileViewer
+          file={fileRecord}
+          textTopInset={topInset}
+          onViewerControlPress={blockNextControlToggle}
+        />
+      </View>
+    ),
+    [
+      blockNextControlToggle,
+      handleTouchEnd,
+      handleTouchMove,
+      handleTouchStart,
+      topInset,
+    ]
+  )
+
   const renderFileItem = useCallback(
     ({ item }: { item: FileRecord }) => {
-      const headerTitle = viewStyle === 'consume' ? 'View' : 'Details'
-      const header = (
-        <FileDetailScreenHeader
-          file={item}
-          title={item?.name ?? headerTitle}
-          navigation={navigation}
-        />
-      )
       return (
         <View style={[styles.swipePage, { width }]}>
           {viewStyle === 'consume' ? (
-            <FileViewer file={item} header={header} />
+            renderConsumeView(item)
           ) : (
-            <FileDetails file={item} header={header} />
+            <FileDetails
+              file={item}
+              header={
+                <FileDetailScreenHeader
+                  file={item}
+                  title={item?.name ?? 'Details'}
+                  navigation={navigation}
+                />
+              }
+            />
           )}
         </View>
       )
     },
-    [navigation, viewStyle, width]
+    [navigation, renderConsumeView, viewStyle, width]
+  )
+
+  const flatListExtraData = useMemo(
+    () => ({ viewStyle, areControlsVisible }),
+    [areControlsVisible, viewStyle]
   )
 
   return (
@@ -123,21 +258,12 @@ export function FileDetailScreen({ route, navigation }: Props) {
           onEndReached={handleEndReached}
           onEndReachedThreshold={0.7}
           windowSize={3}
-          extraData={viewStyle}
+          extraData={flatListExtraData}
         />
       ) : (
         file &&
         (viewStyle === 'consume' ? (
-          <FileViewer
-            file={file}
-            header={
-              <FileDetailScreenHeader
-                file={file}
-                title={file.name ?? 'View'}
-                navigation={navigation}
-              />
-            }
-          />
+          renderConsumeView(file)
         ) : (
           <FileDetails
             file={file}
@@ -151,14 +277,49 @@ export function FileDetailScreen({ route, navigation }: Props) {
           />
         ))
       )}
+
+      {file && viewStyle === 'consume' ? (
+        <View
+          style={styles.headerOverlay}
+          pointerEvents={areControlsVisible ? 'box-none' : 'none'}
+        >
+          {areControlsVisible ? (
+            <FileDetailScreenHeader
+              file={file}
+              title={file?.name ?? 'View'}
+              navigation={navigation}
+            />
+          ) : null}
+        </View>
+      ) : null}
+
+      {areControlsVisible ? (
+        <FileDetailsControlBar
+          viewStyle={viewStyle}
+          setViewStyle={handleSetViewStyle}
+          fileID={activeFileID}
+        />
+      ) : null}
+
+      {isScreenReaderEnabled ? (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={
+            areControlsVisible ? 'Hide controls' : 'Show controls'
+          }
+          accessibilityHint="Toggles navigation and actions"
+          style={styles.accessibilityToggle}
+          onPress={toggleControlsVisibility}
+        >
+          <View style={styles.accessibilityToggleInner}>
+            <View style={styles.accessibilityToggleDot} />
+          </View>
+        </Pressable>
+      ) : null}
+
       <FileActionsSheet
         navigation={navigation}
         sheetName="fileActions"
-        fileID={activeFileID}
-      />
-      <FileDetailsControlBar
-        viewStyle={viewStyle}
-        setViewStyle={handleSetViewStyle}
         fileID={activeFileID}
       />
     </View>
@@ -168,4 +329,37 @@ export function FileDetailScreen({ route, navigation }: Props) {
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: palette.gray[950], zIndex: 1 },
   swipePage: { flex: 1 },
+  consumeContainer: { flex: 1 },
+  headerOverlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+  },
+  accessibilityToggle: {
+    position: 'absolute',
+    right: 12,
+    top: '50%',
+    marginTop: -16,
+    zIndex: 3,
+  },
+  accessibilityToggleInner: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: palette.gray[800],
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  accessibilityToggleDot: {
+    width: 12,
+    height: 12,
+    borderRadius: 6,
+    backgroundColor: palette.gray[50],
+  },
 })
+
+const normalizeIdentifier = (touch: NativeTouchEvent) =>
+  touch.identifier != null
+    ? String(touch.identifier)
+    : `${touch.pageX}-${touch.pageY}`


### PR DESCRIPTION
[Screen Recording 2025-11-21 at 3.03.56 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/cd762718-49e9-4355-b224-198e972dacd9.mov" />](https://app.graphite.com/user-attachments/video/cd762718-49e9-4355-b224-198e972dacd9.mov)

This includes a couple of different things:

* We now float the header and file action bar and allow media to generally take up the full vertical width of the screen. 
* The header and bar are functionally hidden by default and a single tap anywhere that's not a Media control brings them up.
* There's some trickiness that I had to employ here around allowing media consumer (VideoPlayer, MarkdownViewer, etc) controls to function and having an overlay that captures single tap as well, but I played around with different patterns and settled on passing down to FileViewer a function that tells FileDetailsScreen to ignore the next tap in terms of bringing up the header/bar. This allows, for example, the play button on videos to be pressed and not have a flash of header/bar before we fullscreen.
* For accessibility, I've added a small tap point in the middle right where control visibility can be toggled.

While I've tested this quite a bit, there is a high likelihood that we will find edge cases to fix around this new functionality, particularly around certain aspect ratios or text file sizes and scrolling positions. In short: this feature needs to be out in the world and tested thoroughly by real users and real files.

Only partially gets at https://github.com/SiaFoundation/sia-mobile/issues/38 because that also includes landscape orientation, which will be a next focus. But this is probably 80-90% of that work.