### PR TITLE
feat: cache appkey for background tasks

### DIFF
--- a/src/lib/appKey.ts
+++ b/src/lib/appKey.ts
@@ -3,7 +3,16 @@ import { getRecoveryPhrase } from '../stores/settings'
 import { hexToUint8 } from './hex'
 import { APP_KEY } from '../config'
 
+// Cache the app key so that it can be accessed by background tasks.
+// Background tasks run with the suspended app state, but cannot access values in SecureStore.
+let appKey: AppKey | undefined = undefined
+
 export async function getAppKey(): Promise<AppKey> {
-  const seed = await getRecoveryPhrase()
-  return new AppKey(seed, hexToUint8(APP_KEY).buffer)
+  if (appKey) return appKey
+  const recoveryPhrase = await getRecoveryPhrase()
+  if (!recoveryPhrase) {
+    throw new Error('Recovery phrase not found')
+  }
+  appKey = new AppKey(recoveryPhrase, hexToUint8(APP_KEY).buffer)
+  return appKey
 }

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -15,7 +15,7 @@ export const settingsSwr = buildSWRHelpers('settings')
 
 export const [getRecoveryPhrase, useRecoveryPhrase] = createGetterAndSWRHook(
   settingsSwr.getKey('recoveryPhrase'),
-  async () => getSecureStoreString('recoveryPhrase', '')
+  async () => getSecureStoreString<string>('recoveryPhrase', '')
 )
 
 export async function setRecoveryPhrase(


### PR DESCRIPTION
- The primary reason background uploads are not working is because they require grabbing the recovery phrase from secure storage to generate the AppKey for sealing the new pinned object, but secure storage / keychain cannot be accessed when the app in in the background.
- This PR caches the app key in memory so that subsequent accessors do not need to pull the recovery phrase from the keychain.