### PR TITLE
fix: action sheet button disabled style

### DIFF
--- a/src/components/ActionSheetButton.tsx
+++ b/src/components/ActionSheetButton.tsx
@@ -66,9 +66,11 @@ const styles = StyleSheet.create({
   },
   disabledText: {
     fontSize: 16,
+    color: palette.gray[100],
     opacity: 0.3,
   },
   disabledIcon: {
-    opacity: 0.3,
+    color: palette.gray[100],
+    opacity: 0.7,
   },
 })


### PR DESCRIPTION
- Disabled button text and icon was defaulting to black on dark background.
- ![Screenshot 2025-11-25 at 9.21.26 AM.png](https://app.graphite.com/user-attachments/assets/f1a0cee5-8811-4ddc-aa56-7225194ef60c.png)