### PR TITLE
refactor: use non-deprecated VideoView fullscreen props

### DIFF
--- a/src/components/MediaConsumers/VideoPlayer.tsx
+++ b/src/components/MediaConsumers/VideoPlayer.tsx
@@ -39,7 +39,11 @@ export function VideoPlayer({
         ref={videoRef}
         style={StyleSheet.absoluteFill}
         player={player}
-        allowsFullscreen
+        fullscreenOptions={{
+          enable: true,
+          orientation: 'default',
+          autoExitOnRotate: false,
+        }}
         allowsPictureInPicture
         contentFit="contain"
         nativeControls={showNativeControls}


### PR DESCRIPTION
This is very minor but we were using the `allowFullscreen` prop in `VideoPlayer`, and that prop will be deprecated at some point. I've switched it out for the dev's preferred prop and set explicit values (that are the defaults) just to keep this behavior up to date and more resilient to any changes should we update, etc. Tested on iOS and Android and seems to have no behavior change, which is the desired result.