### PR TITLE
feat: add and implement serviceLog function and allow toggling in dev

### DIFF
--- a/jest.setup.cjs
+++ b/jest.setup.cjs
@@ -1,4 +1,8 @@
-jest.mock('./src/lib/logger', () => ({ logger: { log: jest.fn() } }))
+jest.mock('./src/lib/logger', () => ({
+  LOG_SERVICES: true,
+  logger: { log: jest.fn(), sdk: jest.fn(), clear: jest.fn() },
+  serviceLog: jest.fn(),
+}))
 
 // Ensure expo-constants is available for transitive expo modules (expo-asset/SQLite).
 jest.mock('expo-constants', () => ({ EXDevLauncher: undefined }))

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -14,6 +14,10 @@ export const rustLogger = {
   },
 }
 
+// Flip this to false locally to silence service logs in dev.
+// Saving this file likely crashes your dev app.
+const logServices = true
+
 export const logger = {
   log: (...args: any[]) => {
     console.log(...args)
@@ -22,4 +26,15 @@ export const logger = {
     console.log(...args)
   },
   clear: () => {},
+}
+
+/**
+ * Logs messages from background services and periodic tasks.
+ * In development mode, logging can be toggled using the `logServices` flag.
+ * In production, all service logs are always output.
+ */
+export const serviceLog = (...args: any[]) => {
+  if (!__DEV__ || logServices) {
+    logger.log(...args)
+  }
 }

--- a/src/lib/serviceInterval.ts
+++ b/src/lib/serviceInterval.ts
@@ -1,4 +1,4 @@
-import { logger } from './logger'
+import { serviceLog } from './logger'
 
 // Scheduler state for a service: the latest token and its timeout handle.
 type SchedulerState = {
@@ -25,7 +25,7 @@ export function createServiceInterval({
       clearTimeout(existing.timeoutId)
     }
 
-    logger.log(`[${name}] initializing`)
+    serviceLog(`[${name}] initializing`)
 
     // Increment the token to invalidate any previously scheduled or in-flight ticks.
     const token = (existing?.token ?? 0) + 1

--- a/src/managers/backgroundTasks.ts
+++ b/src/managers/backgroundTasks.ts
@@ -1,4 +1,4 @@
-import { logger } from '../lib/logger'
+import { serviceLog } from '../lib/logger'
 import BackgroundFetch, {
   BackgroundFetchConfig,
 } from 'react-native-background-fetch'
@@ -79,7 +79,7 @@ const taskStates: Record<TaskId, TaskState> = {
 }
 
 export async function initBackgroundTasks() {
-  logger.log(`[backgroundTask] init`)
+  serviceLog(`[backgroundTask] init`)
 
   const status = await BackgroundFetch.configure(
     {
@@ -90,7 +90,7 @@ export async function initBackgroundTasks() {
       const config = taskConfigs[taskId as TaskId]
       const state = taskStates[taskId as TaskId]
       if (!config) {
-        logger.log(`[backgroundTask] unknown task id: ${taskId}`)
+        serviceLog(`[backgroundTask] unknown task id: ${taskId}`)
         BackgroundFetch.finish(taskId)
         return
       }
@@ -104,7 +104,7 @@ export async function initBackgroundTasks() {
       const state = taskStates[taskId as TaskId]
       transitionTaskState(state, 'finished')
       if (!config) {
-        logger.log(`[backgroundTask] unknown task id: ${taskId}`)
+        serviceLog(`[backgroundTask] unknown task id: ${taskId}`)
         BackgroundFetch.finish(taskId)
         return
       }
@@ -117,7 +117,7 @@ export async function initBackgroundTasks() {
     }
   )
 
-  logger.log('[backgroundTask] configure status: ', status)
+  serviceLog('[backgroundTask] configure status: ', status)
 
   // Schedule custom background processing task on iOS.
   if (Platform.OS === 'ios') {
@@ -129,11 +129,11 @@ export async function initBackgroundTasks() {
         delay: secondsInMs(5),
         ...sharedConfig,
       })
-      logger.log(
+      serviceLog(
         `[backgroundTask] scheduleTask status for ${bgProcessingTaskConfig.id}: ${scheduled}`
       )
     } catch (error) {
-      logger.log(
+      serviceLog(
         `[backgroundTask] scheduleTask failed for ${bgProcessingTaskConfig.id}:`,
         error
       )
@@ -194,7 +194,7 @@ function delay(ms: number) {
 
 function logTask(config: TaskConfig) {
   return (message: string) => {
-    logger.log(
+    serviceLog(
       `[${new Date().toISOString()}][${config.type}][${config.id}] ${message}`
     )
   }

--- a/src/managers/fsEvictionScanner.ts
+++ b/src/managers/fsEvictionScanner.ts
@@ -4,7 +4,7 @@ import {
   FS_EVICTABLE_MIN_AGE,
 } from '../config'
 import { db } from '../db'
-import { logger } from '../lib/logger'
+import { serviceLog } from '../lib/logger'
 import { createServiceInterval } from '../lib/serviceInterval'
 import {
   calcFsFilesMetadataTotalSize,
@@ -43,7 +43,7 @@ export async function runFsEvictionScanner(): Promise<
     }
 
     let currentSize = totalSize
-    logger.log('[fsEvictionScanner] total size over limit', { totalSize })
+    serviceLog('[fsEvictionScanner] total size over limit', { totalSize })
 
     let processedRows = 0
     let evicted = 0
@@ -69,7 +69,7 @@ export async function runFsEvictionScanner(): Promise<
           currentSize -= row.size
           evicted += 1
         } catch (error) {
-          logger.log('[fsEvictionScanner] failed to remove file', {
+          serviceLog('[fsEvictionScanner] failed to remove file', {
             fileId: row.fileId,
             error,
           })
@@ -88,12 +88,12 @@ export async function runFsEvictionScanner(): Promise<
       evicted,
       currentSize,
     }
-    logger.log(
+    serviceLog(
       `[fsEvictionScanner] summary processedRows=${processedRows} evicted=${evicted} currentSize=${currentSize}`
     )
     return results
   } catch (error) {
-    logger.log('[fsEvictionScanner] error during scan', error)
+    serviceLog('[fsEvictionScanner] error during scan', error)
   } finally {
     await setFsEvictionLastRun()
   }

--- a/src/managers/fsOrphanScanner.ts
+++ b/src/managers/fsOrphanScanner.ts
@@ -1,6 +1,6 @@
 import { FS_ORPHAN_FREQUENCY } from '../config'
 import { db } from '../db'
-import { logger } from '../lib/logger'
+import { serviceLog } from '../lib/logger'
 import { createServiceInterval } from '../lib/serviceInterval'
 import {
   deleteFsFileMetadata,
@@ -49,22 +49,22 @@ export async function runFsOrphanScanner(): Promise<
         removed += 1
         await deleteFsFileMetadata(fileId)
         await fsTriggerRefresh(fileId)
-        logger.log(
+        serviceLog(
           `[fsOrphanScanner] removed unindexed file fileId=${fileId} uri=${file.uri}`
         )
       } catch (error) {
-        logger.log(
+        serviceLog(
           `[fsOrphanScanner] failed to delete file fileId=${fileId} uri=${file.uri} error=${error}`
         )
       }
     }
 
     if (removed > 0) {
-      logger.log(`[fsOrphanScanner] summary removed=${removed}`)
+      serviceLog(`[fsOrphanScanner] summary removed=${removed}`)
     }
     return { removed }
   } catch (error) {
-    logger.log('[fsOrphanScanner] error during scan', error)
+    serviceLog('[fsOrphanScanner] error during scan', error)
   } finally {
     await setFsOrphanLastRun()
   }

--- a/src/managers/syncDownEvents.ts
+++ b/src/managers/syncDownEvents.ts
@@ -1,4 +1,4 @@
-import { logger } from '../lib/logger'
+import { serviceLog } from '../lib/logger'
 import { SYNC_EVENTS_INTERVAL } from '../config'
 import { getIsConnected, getSdk } from '../stores/sdk'
 import { getAutoSyncDownEvents, getIndexerURL } from '../stores/settings'
@@ -49,12 +49,12 @@ type Counts = {
 export async function syncDownEvents(): Promise<void> {
   const isConnected = getIsConnected()
   if (!isConnected) {
-    logger.log('[syncDownEvents] not connected to indexer, skipping sync')
+    serviceLog('[syncDownEvents] not connected to indexer, skipping sync')
     return
   }
   const sdk = getSdk()
   if (!sdk) {
-    logger.log('[syncDownEvents] no sdk, skipping sync')
+    serviceLog('[syncDownEvents] no sdk, skipping sync')
     return
   }
 
@@ -67,7 +67,7 @@ export async function syncDownEvents(): Promise<void> {
   while (true) {
     try {
       const cursor = await getSyncDownCursor()
-      logger.log(
+      serviceLog(
         `[syncDownEvents] syncing from id=${cursor?.key} after=${cursor?.after}`
       )
 
@@ -75,11 +75,11 @@ export async function syncDownEvents(): Promise<void> {
 
       // If the batch size is 1, we are probably synced and repeatedly polling the last event.
       if (events.length === 1) {
-        logger.log(
+        serviceLog(
           `[syncDownEvents] batch size=${events.length}, no new events found`
         )
       } else {
-        logger.log(`[syncDownEvents] batch size=${events.length}`)
+        serviceLog(`[syncDownEvents] batch size=${events.length}`)
       }
 
       await processBatch(events, counts)
@@ -99,12 +99,12 @@ export async function syncDownEvents(): Promise<void> {
         break
       }
     } catch (e) {
-      logger.log('[syncDownEvents] sync error', e)
+      serviceLog('[syncDownEvents] sync error', e)
       break
     }
   }
 
-  logger.log(
+  serviceLog(
     `[syncDownEvents] synced, existingCount=${counts.existing}, addedCount=${counts.added}, deletedCount=${counts.deleted}`
   )
 }
@@ -127,7 +127,7 @@ async function handleDeleteEvent(id: string, counts: Counts): Promise<void> {
   try {
     const existingFileRecord = await readFileRecordByObjectId(id)
     if (existingFileRecord) {
-      logger.log(`[syncDownEvents] deleting file id=${existingFileRecord.id}`)
+      serviceLog(`[syncDownEvents] deleting file id=${existingFileRecord.id}`)
       await Promise.all([
         // Remove the file from the file system.
         removeFsFile(existingFileRecord),
@@ -138,12 +138,12 @@ async function handleDeleteEvent(id: string, counts: Counts): Promise<void> {
       ])
       counts.deleted++
     } else {
-      logger.log(
+      serviceLog(
         `[syncDownEvents] no file record found for object id=${id}, skipping delete`
       )
     }
   } catch (e) {
-    logger.log(`[syncDownEvents] error handling delete for id=${id}`, e)
+    serviceLog(`[syncDownEvents] error handling delete for id=${id}`, e)
     throw e
   }
 }
@@ -183,9 +183,9 @@ async function handleUpdateEvent(
       )
       return
     }
-    logger.log(`[syncDownEvents] incomplete metadata, skipping update`)
+    serviceLog(`[syncDownEvents] incomplete metadata, skipping update`)
   } catch (e) {
-    logger.log(`[syncDownEvents] error handling update for id=${id}`, e)
+    serviceLog(`[syncDownEvents] error handling update for id=${id}`, e)
     throw e
   }
 }
@@ -200,9 +200,9 @@ async function handleFileRecord(
 ) {
   if (existingFile) {
     if (type === 'file') {
-      logger.log(`[syncDownEvents] updating file hash=${existingFile.hash}`)
+      serviceLog(`[syncDownEvents] updating file hash=${existingFile.hash}`)
     } else {
-      logger.log(
+      serviceLog(
         `[syncDownEvents] updating thumbnail thumbForHash=${existingFile.thumbForHash}`
       )
     }
@@ -224,9 +224,9 @@ async function handleFileRecord(
     counts.existing++
   } else {
     if (type === 'file') {
-      logger.log(`[syncDownEvents] creating file hash=${metadata.hash}`)
+      serviceLog(`[syncDownEvents] creating file hash=${metadata.hash}`)
     } else {
-      logger.log(
+      serviceLog(
         `[syncDownEvents] creating thumbnail thumbForHash=${metadata.thumbForHash}`
       )
     }
@@ -292,6 +292,6 @@ export async function setSyncDownCursor(value: ObjectsCursor | undefined) {
 }
 
 export async function resetSyncDownCursor() {
-  logger.log('[syncDownEvents] resetting sync down cursor')
+  serviceLog('[syncDownEvents] resetting sync down cursor')
   await setSyncDownCursor(undefined)
 }

--- a/src/managers/syncNewPhotos.ts
+++ b/src/managers/syncNewPhotos.ts
@@ -1,5 +1,5 @@
 import * as MediaLibrary from 'expo-media-library'
-import { logger } from '../lib/logger'
+import { serviceLog } from '../lib/logger'
 import { createServiceInterval } from '../lib/serviceInterval'
 import { settingsSwr } from '../stores/settings'
 import { processAssets } from '../lib/processAssets'
@@ -35,10 +35,10 @@ async function workForward(): Promise<void> {
       resolveWithFullInfo: true,
     })
     if (page.assets.length === 0) {
-      logger.log('[syncNewPhotos] no new photos found')
+      serviceLog('[syncNewPhotos] no new photos found')
       return
     }
-    logger.log('[syncNewPhotos] batch size', page.assets.length)
+    serviceLog('[syncNewPhotos] batch size', page.assets.length)
     const lastAssetCreationTime =
       page.assets[page.assets.length - 1].creationTime
     const nextTimestamp = lastAssetCreationTime ? lastAssetCreationTime + 1 : 0
@@ -55,7 +55,7 @@ async function workForward(): Promise<void> {
     )
     if (files.length > 0) await librarySwr.triggerChange()
   } catch (e) {
-    logger.log('[syncNewPhotos] batch error', e)
+    serviceLog('[syncNewPhotos] batch error', e)
   }
 }
 
@@ -101,6 +101,6 @@ export async function setPhotosNewCursor(value: number) {
 }
 
 export async function resetPhotosNewCursor() {
-  logger.log('[syncNewPhotos] resetting photos new sync cursor')
+  serviceLog('[syncNewPhotos] resetting photos new sync cursor')
   await setPhotosNewCursor(defaultValue)
 }

--- a/src/managers/syncPhotosArchive.ts
+++ b/src/managers/syncPhotosArchive.ts
@@ -1,5 +1,5 @@
 import * as MediaLibrary from 'expo-media-library'
-import { logger } from '../lib/logger'
+import { serviceLog } from '../lib/logger'
 import { settingsSwr } from '../stores/settings'
 import { processAssets } from '../lib/processAssets'
 import { librarySwr } from '../stores/library'
@@ -35,11 +35,11 @@ export async function workBackward() {
       resolveWithFullInfo: true,
     })
     if (page.assets.length === 0) {
-      logger.log('[syncPhotosArchive] archive is fully synced')
+      serviceLog('[syncPhotosArchive] archive is fully synced')
       await setPhotosArchiveCursor(0)
       return
     }
-    logger.log('[syncPhotosArchive] batch size', page.assets.length)
+    serviceLog('[syncPhotosArchive] batch size', page.assets.length)
     const lastAssetCreationTime =
       page.assets[page.assets.length - 1].creationTime ?? 0
     const nextTimestamp = lastAssetCreationTime ? lastAssetCreationTime - 1 : 0
@@ -61,7 +61,7 @@ export async function workBackward() {
       return 0
     }
   } catch (e) {
-    logger.log('[syncPhotosArchive] batch error', e)
+    serviceLog('[syncPhotosArchive] batch error', e)
   }
 }
 
@@ -105,11 +105,11 @@ export async function setPhotosArchiveCursor(value: number) {
 }
 
 export async function restartPhotosArchiveCursor() {
-  logger.log('[syncPhotosArchive] restarting photos archive sync cursor')
+  serviceLog('[syncPhotosArchive] restarting photos archive sync cursor')
   await setPhotosArchiveCursor(Date.now())
 }
 
 export async function resetPhotosArchiveCursor() {
-  logger.log('[syncPhotosArchive] disabling photos archive sync cursor')
+  serviceLog('[syncPhotosArchive] disabling photos archive sync cursor')
   await setPhotosArchiveCursor(defaultValue)
 }

--- a/src/managers/syncUpMetadata.ts
+++ b/src/managers/syncUpMetadata.ts
@@ -1,4 +1,4 @@
-import { logger } from '../lib/logger'
+import { serviceLog } from '../lib/logger'
 import {
   fileMetadataKeys,
   readAllFileRecords,
@@ -147,12 +147,12 @@ export async function setSyncUpCursor(
  */
 export async function runSyncUpMetadata(batchSize: number): Promise<void> {
   if (!getIsConnected()) {
-    logger.log('[syncUpMetadata] not connected to indexer, skipping')
+    serviceLog('[syncUpMetadata] not connected to indexer, skipping')
     return
   }
   const indexerURL = await getIndexerURL()
   const after = await getSyncUpCursor()
-  logger.log(
+  serviceLog(
     `[syncUpMetadata] service tick: from ${after?.id ?? 'begin'} after=${
       after?.updatedAt
     }`
@@ -170,7 +170,7 @@ export async function runSyncUpMetadata(batchSize: number): Promise<void> {
       : undefined,
   })
   if (batch.length === 0) {
-    logger.log('[syncUpMetadata] no new updates')
+    serviceLog('[syncUpMetadata] no new updates')
     return
   }
   for (const f of batch) {
@@ -182,7 +182,7 @@ export async function runSyncUpMetadata(batchSize: number): Promise<void> {
       const diffs = diffFileMetadata(f, remoteMeta)
       if (Object.keys(diffs).length === 0) continue
       const isLocalNewer = (f.updatedAt || 0) >= (remoteMeta.updatedAt || 0)
-      logger.log(
+      serviceLog(
         formatDiff({
           fileId: f.id,
           objectId: obj.id,
@@ -196,7 +196,7 @@ export async function runSyncUpMetadata(batchSize: number): Promise<void> {
         await updateMetadata(remote, encodeFileMetadata(f))
       }
     } catch (e) {
-      logger.log('[syncUpMetadata] error', e)
+      serviceLog('[syncUpMetadata] error', e)
     }
   }
   const last = batch[batch.length - 1]
@@ -205,7 +205,7 @@ export async function runSyncUpMetadata(batchSize: number): Promise<void> {
       updatedAt: last.updatedAt + 1,
       id: last.id,
     })
-    logger.log('[syncUpMetadata] end reached')
+    serviceLog('[syncUpMetadata] end reached')
   } else {
     await setSyncUpCursor({
       updatedAt: last.updatedAt,

--- a/src/managers/thumbnailScanner.ts
+++ b/src/managers/thumbnailScanner.ts
@@ -1,4 +1,4 @@
-import { logger } from '../lib/logger'
+import { serviceLog } from '../lib/logger'
 import { createServiceInterval } from '../lib/serviceInterval'
 import { db } from '../db'
 import { type ThumbSize, ThumbSizes } from '../stores/files'
@@ -52,13 +52,13 @@ async function logOverallProgress() {
     const targetThumbs = originals * ThumbSizes.length
     const remaining = Math.max(targetThumbs - thumbs, 0)
     const percent = targetThumbs > 0 ? Math.min(1, thumbs / targetThumbs) : 1
-    logger.log(
+    serviceLog(
       `[thumbnailScanner] overall originals=${originals} thumbs=${thumbs}/${targetThumbs} remaining=${remaining} percent=${Math.round(
         percent * 100
       )}%`
     )
   } catch (e) {
-    logger.log('[thumbnailScanner] progress error', e)
+    serviceLog('[thumbnailScanner] progress error', e)
   }
 }
 
@@ -145,7 +145,7 @@ export async function runThumbnailScanner(): Promise<ThumbnailScannerResult> {
   }
   let producedCount = 0
   try {
-    logger.log('[thumbnailScanner] scanning...')
+    serviceLog('[thumbnailScanner] scanning...')
     const skippedNoSourceUri = new Set<string>()
     const processedThisRun = new Set<string>()
 
@@ -182,7 +182,7 @@ export async function runThumbnailScanner(): Promise<ThumbnailScannerResult> {
           continue
         }
 
-        logger.log('[thumbnailScanner] candidate', {
+        serviceLog('[thumbnailScanner] candidate', {
           id: c.id,
           hash: c.hash,
           existingSizes,
@@ -191,7 +191,7 @@ export async function runThumbnailScanner(): Promise<ThumbnailScannerResult> {
 
         for (const size of missingSizes) {
           if (producedCount >= MAX_THUMBS_PER_TICK) break
-          logger.log('[thumbnailScanner] attempt size', { id: c.id, size })
+          serviceLog('[thumbnailScanner] attempt size', { id: c.id, size })
           summary.attempts.push({
             originalId: c.id,
             originalHash: c.hash,
@@ -213,7 +213,7 @@ export async function runThumbnailScanner(): Promise<ThumbnailScannerResult> {
               size,
               thumbId: outcome.thumbId,
             })
-            logger.log('[thumbnailScanner] produced', { id: c.id, size })
+            serviceLog('[thumbnailScanner] produced', { id: c.id, size })
           } else if (outcome.status === 'duplicate') {
             summary.deduplicated.push({
               originalId: c.id,
@@ -232,7 +232,7 @@ export async function runThumbnailScanner(): Promise<ThumbnailScannerResult> {
         }
       }
     }
-    logger.log(
+    serviceLog(
       `[thumbnailScanner] batch produced=${summary.produced.length}/${summary.processedCandidates}` +
         ` skippedNoSource=${summary.skippedNoSource.length}/${summary.processedCandidates}` +
         ` skippedFullyCovered=${summary.skippedFullyCovered.length}/${summary.processedCandidates}` +
@@ -241,7 +241,7 @@ export async function runThumbnailScanner(): Promise<ThumbnailScannerResult> {
     )
     await logOverallProgress()
   } catch (e) {
-    logger.log('[thumbnailScanner] scan error', e)
+    serviceLog('[thumbnailScanner] scan error', e)
   }
   return summary
 }

--- a/src/managers/uploadScanner.ts
+++ b/src/managers/uploadScanner.ts
@@ -1,4 +1,4 @@
-import { logger } from '../lib/logger'
+import { serviceLog } from '../lib/logger'
 import { getActiveUploads, useActiveUploads } from '../stores/uploads'
 import {
   getFilesLocalOnly,
@@ -21,10 +21,10 @@ import { humanUploadPercent } from '../lib/uploadPercent'
 async function startUploadScanner(): Promise<void> {
   const isConnected = getIsConnected()
   if (!isConnected) {
-    logger.log('[uploadScanner] not connected to indexer, skipping scan')
+    serviceLog('[uploadScanner] not connected to indexer, skipping scan')
     return
   }
-  logger.log('[uploadScanner] scanning...')
+  serviceLog('[uploadScanner] scanning...')
   try {
     const maxUploads = await getMaxUploads()
     const maxTotalUploads = SCANNER_MAX_TOTAL_UPLOADS_FACTOR * maxUploads
@@ -34,14 +34,14 @@ async function startUploadScanner(): Promise<void> {
     }
     const files = await getNextUploads(maxToAdd)
     if (files.length > 0) {
-      logger.log(
+      serviceLog(
         `[uploadScanner] queuing ${files.length} uploads`,
         files.map((f) => f.id).join(', ')
       )
       files.forEach((f) => queueUploadForFileId(f.id))
     }
   } catch (e) {
-    logger.log('[uploadScanner] scan error', e)
+    serviceLog('[uploadScanner] scan error', e)
   }
 }
 


### PR DESCRIPTION
This is likely not as sophisticated a solution as we'll end up with but, for now, this allows service logs to be shut off in dev. In prod, the boolean variable has no effect. It does add the a needed usage of `serviceLog` where applicable.