### PR TITLE
ci: configure fastlane build and release automation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,18 @@
+# Android Release Signing
 SIA_RELEASE_STORE_FILE=android-release.keystore
 SIA_RELEASE_KEY_ALIAS=siaReleaseKey
 SIA_RELEASE_STORE_PASSWORD=password
 SIA_RELEASE_KEY_PASSWORD=password
+
+# Google Maps API
 GOOGLE_MAPS_API_KEY=apikey
+
+# Apple Developer
+APPLE_ID=foo@email.com
+APPLE_TEAM_ID=43LR9F6BNP
+
+# App Store Connect API Key (must be a JSON string, not a file path)
+APP_STORE_CONNECT_API_KEY_JSON={"key_id":"","issuer_id":"","key_content":""}
+
+# Google Play Service Account Key (must be a JSON string, not a file path)
+GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_JSON={"type":"service_account","project_id":"","private_key_id":"","private_key":"","client_email":"","client_id":"","auth_uri":"","token_uri":"","auth_provider_x509_cert_url":"","client_x509_cert_url":""}

--- a/app.config.js
+++ b/app.config.js
@@ -1,13 +1,15 @@
-const PROD = process.env.PROD === 'true'
+const RELEASE = process.env.RELEASE === 'true'
 
 export default {
   expo: {
-    name: PROD ? 'Sia Storage' : 'Sia Storage Dev',
-    slug: PROD ? 'siastorage' : 'siastoragedev',
+    name: RELEASE ? 'Sia Storage' : 'Sia Storage Dev',
+    slug: RELEASE ? 'siastorage' : 'siastoragedev',
     scheme: 'sia',
     version: '1.0.0',
     orientation: 'default',
-    icon: PROD ? './assets/app-icon-ios.png' : './assets/app-icon-ios-dev.png',
+    icon: RELEASE
+      ? './assets/app-icon-ios.png'
+      : './assets/app-icon-ios-dev.png',
     userInterfaceStyle: 'dark',
     newArchEnabled: true,
     splash: {
@@ -17,7 +19,7 @@ export default {
     },
     ios: {
       supportsTablet: true,
-      bundleIdentifier: PROD ? 'sia.storage' : 'sia.storage.dev',
+      bundleIdentifier: RELEASE ? 'sia.storage' : 'sia.storage.dev',
       infoPlist: {
         ITSAppUsesNonExemptEncryption: false,
         NSPhotoLibraryUsageDescription:
@@ -34,14 +36,15 @@ export default {
       },
     },
     android: {
+      versionCode: 2,
       adaptiveIcon: {
-        foregroundImage: PROD
+        foregroundImage: RELEASE
           ? './assets/app-icon-android.png'
           : './assets/app-icon-android-dev.png',
         backgroundColor: '#ffffff',
       },
       edgeToEdgeEnabled: true,
-      package: PROD ? 'sia.storage' : 'sia.storage.dev',
+      package: RELEASE ? 'sia.storage' : 'sia.storage.dev',
       permissions: [
         'android.permission.READ_EXTERNAL_STORAGE',
         'android.permission.READ_MEDIA_IMAGES',
@@ -109,7 +112,7 @@ export default {
       policy: 'appVersion',
     },
     extra: {
-      prod: PROD,
+      prod: RELEASE,
     },
   },
 }

--- a/fastlane/.gitignore
+++ b/fastlane/.gitignore
@@ -1,0 +1,8 @@
+# Fastlane specific
+report.xml
+*.html
+*.zip
+Preview.html
+screenshots
+metadata
+

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,0 +1,10 @@
+# Appfile for iOS and Android app configuration
+
+# iOS App Store Connect
+app_identifier("sia.storage")
+apple_id(ENV["APPLE_ID"] || "")
+team_id(ENV["APPLE_TEAM_ID"] || "")
+
+# Android Google Play
+package_name("sia.storage")
+

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,179 @@
+# Fastfile for iOS and Android app distribution
+
+default_platform(:ios)
+
+# Path to the iOS workspace
+IOS_WORKSPACE_PATH = File.expand_path("../ios/SiaStorage.xcworkspace", __dir__)
+
+# iOS IPA names
+IOS_RELEASE_IPA_NAME = "SiaStorage.ipa"
+IOS_DEV_IPA_NAME = "SiaStorageDev.ipa"
+IOS_RELEASE_IPA_PATH = File.expand_path("../ios/build/#{IOS_RELEASE_IPA_NAME}", __dir__)
+IOS_DEV_IPA_PATH = File.expand_path("../ios/build/#{IOS_DEV_IPA_NAME}", __dir__)
+
+# Path to the Android AAB file
+ANDROID_AAB_PATH = File.expand_path("../android/app/build/outputs/bundle/release/app-release.aab", __dir__)
+
+# Get App Store Connect API key from environment variable
+# APP_STORE_CONNECT_API_KEY_JSON must be a JSON string with key_id, issuer_id, and key_filepath or key_content
+def app_store_connect_api_key
+  api_key_env = ENV["APP_STORE_CONNECT_API_KEY_JSON"]
+  
+  if api_key_env.nil? || api_key_env.empty?
+    UI.user_error!("APP_STORE_CONNECT_API_KEY_JSON environment variable is required")
+  end
+  
+  # Parse as JSON string
+  begin
+    JSON.parse(api_key_env)
+  rescue JSON::ParserError
+    UI.user_error!("APP_STORE_CONNECT_API_KEY_JSON must be a valid JSON string")
+  end
+end
+
+platform :ios do
+  desc "Build and install dev build on connected iOS device"
+  lane :dev_device do
+    # Builds a development build and installs it on the connected physical device
+    # This automates: expo run:ios -> Xcode -> configure signing -> run
+    
+    team_id = ENV["APPLE_TEAM_ID"]
+    if team_id.nil? || team_id.empty?
+      UI.user_error!("APPLE_TEAM_ID environment variable is required")
+    end
+    
+    # Dev builds use SiaStorageDev workspace (when RELEASE != true)
+    dev_workspace = File.expand_path("../ios/SiaStorageDev.xcworkspace", __dir__)
+    if !File.exist?(dev_workspace)
+      UI.user_error!("Dev workspace not found at #{dev_workspace}. Run 'expo prebuild' first.")
+    end
+    
+    # Build the app for development
+    build_app(
+      workspace: dev_workspace,
+      scheme: "SiaStorageDev",
+      configuration: "Debug", # Use Debug for dev builds
+      export_method: "development", # Development signing for physical devices
+      output_directory: File.expand_path("../ios/build", __dir__),
+      output_name: "SiaStorageDev.ipa",
+      # Set DEVELOPMENT_TEAM during build phase (expo prebuild regenerates the project)
+      xcargs: "DEVELOPMENT_TEAM=#{team_id}",
+      export_options: {
+        method: "development",
+        signingStyle: "automatic"
+      }
+    )
+    
+    # Install the generated IPA on the connected device
+    if !File.exist?(IOS_DEV_IPA_PATH)
+      UI.user_error!("Could not find generated IPA file at #{IOS_DEV_IPA_PATH}")
+    end
+    
+    install_on_device(
+      ipa: IOS_DEV_IPA_PATH
+    )
+  end
+
+  desc "Build and export iOS IPA for App Store"
+  lane :build_ipa do
+    # This does the same as:
+    # 1. Product > Archive (builds both SiaStorage and ShareExtension)
+    # 2. Export > App Store Connect (creates signed IPA)
+    
+    team_id = ENV["APPLE_TEAM_ID"]
+    if team_id.nil? || team_id.empty?
+      UI.user_error!("APPLE_TEAM_ID environment variable is required")
+    end
+    
+    build_app(
+      workspace: IOS_WORKSPACE_PATH,
+      scheme: "SiaStorage",
+      configuration: "Release",
+      export_method: "app-store",
+      output_directory: File.expand_path("../ios/build", __dir__),
+      output_name: "SiaStorage.ipa",
+      export_team_id: team_id,
+      # Set DEVELOPMENT_TEAM during build phase (export_team_id only applies during export).
+      # expo prebuild regenerates the project, so the team isn't saved in the Xcode project file.
+      # Alternative: create an Expo config plugin to set the team during prebuild.
+      xcargs: "DEVELOPMENT_TEAM=#{team_id}",
+      export_options: {
+        method: "app-store",
+        signingStyle: "automatic"
+      },
+      include_bitcode: false,
+      include_symbols: true,
+    )
+  end
+
+  desc "Upload iOS app to App Store Connect"
+  lane :distribute_app_store do
+    # Build IPA if it doesn't exist
+    build_ipa unless File.exist?(IOS_RELEASE_IPA_PATH)
+    
+    upload_to_app_store(
+      api_key: app_store_connect_api_key,
+      ipa: IOS_RELEASE_IPA_PATH,
+      skip_screenshots: true, # Don't upload screenshots - we manage them manually in App Store Connect
+      skip_metadata: true, # Don't upload metadata - we manage descriptions, keywords, etc. manually in App Store Connect
+    )
+  end
+
+  desc "Upload iOS app to TestFlight"
+  lane :distribute_testflight do
+    # Build IPA if it doesn't exist
+    build_ipa unless File.exist?(IOS_RELEASE_IPA_PATH)
+    
+    upload_to_testflight(
+      api_key: app_store_connect_api_key,
+      ipa: IOS_RELEASE_IPA_PATH,
+      skip_waiting_for_build_processing: false, # Wait for processing - ensures build is ready before command completes (takes 10-30 min)
+      distribute_external: false, # Don't auto-distribute externally - we manually manage tester groups in TestFlight
+      notify_external_testers: false # Don't notify testers - we control when to send notifications manually
+    )
+  end
+end
+
+# Get Google Play service account JSON key from environment variable
+# GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_JSON must be a JSON string with the service account key content
+def google_play_service_account_key
+  json_key = ENV["GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_JSON"]
+  
+  if json_key.nil? || json_key.empty?
+    UI.user_error!("GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_JSON environment variable is required")
+  end
+  
+  # Return JSON string - Fastlane will use json_key_data parameter
+  json_key
+end
+
+platform :android do
+  desc "Upload Android app to Google Play Store"
+  lane :distribute_play_store do
+    upload_to_play_store(
+      track: "production", # Production track - for public release
+      aab: ANDROID_AAB_PATH,
+      skip_upload_apk: true, # Don't upload APK - Google Play requires AAB format for new apps (smaller size, better optimization)
+      skip_upload_aab: false, # Upload AAB - this is the required format for Play Store distribution
+      skip_upload_metadata: true, # Don't upload metadata - we manage descriptions, changelogs, etc. manually in Play Console
+      skip_upload_images: true, # Don't upload images - we manage app icons and feature graphics manually
+      skip_upload_screenshots: true, # Don't upload screenshots - we manage them manually in Play Console
+      json_key_data: google_play_service_account_key
+    )
+  end
+
+  desc "Upload Android app to internal testing track"
+  lane :distribute_internal do
+    upload_to_play_store(
+      track: "internal", # Internal track - for testing
+      aab: ANDROID_AAB_PATH,
+      skip_upload_apk: true, # Don't upload APK - Google Play requires AAB format for new apps (smaller size, better optimization)
+      skip_upload_aab: false, # Upload AAB - this is the required format for Play Store distribution
+      skip_upload_metadata: true, # Don't upload metadata - we manage descriptions, changelogs, etc. manually in Play Console
+      skip_upload_images: true, # Don't upload images - we manage app icons and feature graphics manually
+      skip_upload_screenshots: true, # Don't upload screenshots - we manage them manually in Play Console
+      json_key_data: google_play_service_account_key
+    )
+  end
+end
+

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -1,0 +1,77 @@
+fastlane documentation
+----
+
+# Installation
+
+Make sure you have the latest version of the Xcode command line tools installed:
+
+```sh
+xcode-select --install
+```
+
+For _fastlane_ installation instructions, see [Installing _fastlane_](https://docs.fastlane.tools/#installing-fastlane)
+
+# Available Actions
+
+## iOS
+
+### ios dev_device
+
+```sh
+[bundle exec] fastlane ios dev_device
+```
+
+Build and install dev build on connected iOS device
+
+### ios build_ipa
+
+```sh
+[bundle exec] fastlane ios build_ipa
+```
+
+Build and export iOS IPA for App Store
+
+### ios distribute_app_store
+
+```sh
+[bundle exec] fastlane ios distribute_app_store
+```
+
+Upload iOS app to App Store Connect
+
+### ios distribute_testflight
+
+```sh
+[bundle exec] fastlane ios distribute_testflight
+```
+
+Upload iOS app to TestFlight
+
+----
+
+
+## Android
+
+### android distribute_play_store
+
+```sh
+[bundle exec] fastlane android distribute_play_store
+```
+
+Upload Android app to Google Play Store
+
+### android distribute_internal
+
+```sh
+[bundle exec] fastlane android distribute_internal
+```
+
+Upload Android app to internal testing track
+
+----
+
+This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.
+
+More information about _fastlane_ can be found on [fastlane.tools](https://fastlane.tools).
+
+The documentation of _fastlane_ can be found on [docs.fastlane.tools](https://docs.fastlane.tools).

--- a/package.json
+++ b/package.json
@@ -2,20 +2,34 @@
   "name": "Sia Storage",
   "main": "index.ts",
   "scripts": {
-    "build": "expo prebuild",
-    "build:clean": "expo prebuild --clean",
-    "build:prod": "PROD=true expo prebuild",
+    "fresh": "bunx rimraf .expo android ios node_modules && bun install && expo prebuild",
     "start": "expo start --dev-client",
-    "android": "expo run:android",
-    "android:prod": "PROD=true expo run:android",
-    "ios": "expo run:ios",
-    "ios:prod": "PROD=true expo run:ios",
-    "web": "expo start --web",
-    "fresh": "bunx rimraf .expo android ios node_modules && bun install && bun run build",
-    "android:signing-report": "bun scripts/androidGradleTask.ts signingReport",
-    "android:bundle-release": "bun scripts/androidGradleTask.ts bundleRelease",
+    "ios:build:sim": "bunx rimraf .expo ios && expo run:ios",
+    "ios:build:device": "bunx rimraf .expo ios && expo prebuild && fastlane ios dev_device",
+    "android:build": "bunx rimraf .expo android && expo run:android --device",
+    "fastlane:ios:build-ipa": "fastlane ios build_ipa",
+    "fastlane:android:distribute-play-store": "fastlane android distribute_play_store",
+    "fastlane:android:distribute-internal": "fastlane android distribute_internal",
+    "fastlane:ios:distribute-app-store": "fastlane ios distribute_app_store",
+    "fastlane:ios:distribute-testflight": "fastlane ios distribute_testflight",
+    "gradle:signing-report": "bun scripts/androidGradleTask.ts signingReport",
+    "gradle:bundle-release": "bun scripts/androidGradleTask.ts bundleRelease",
+    "release:android:prebuild": "bunx rimraf .expo android && RELEASE=true expo prebuild",
+    "release:android:build": "bun run gradle:bundle-release",
+    "release:ios:prebuild": "bunx rimraf .expo ios && RELEASE=true expo prebuild",
+    "release:ios:build": "bun run fastlane:ios:build-ipa",
+    "release:both:prebuild": "bunx rimraf .expo ios android && RELEASE=true expo prebuild",
+    "release:both:build": "bunx concurrently --kill-others-on-fail --names \"android,ios\" --prefix-colors \"green,blue\" \"bun run release:android:build\" \"bun run release:ios:build\"",
+    "release:build": "bun run release:both:prebuild && bun run release:both:build",
+    "release:production": "bun run release:build && bunx concurrently --kill-others-on-fail --names \"android,ios\" --prefix-colors \"green,blue\" \"bun run fastlane:android:distribute-play-store\" \"bun run fastlane:ios:distribute-app-store\"",
+    "release:internal": "bun run release:build && bunx concurrently --kill-others-on-fail --names \"android,ios\" --prefix-colors \"green,blue\" \"bun run fastlane:android:distribute-internal\" \"bun run fastlane:ios:distribute-testflight\"",
+    "release:ios:production": "bun run release:ios:prebuild && bun run release:ios:build && bun run fastlane:ios:distribute-app-store",
+    "release:ios:internal": "bun run release:ios:prebuild && bun run release:ios:build && bun run fastlane:ios:distribute-testflight",
+    "release:android:production": "bun run release:android:prebuild && bun run release:android:build && bun run fastlane:android:distribute-play-store",
+    "release:android:internal": "bun run release:android:prebuild && bun run release:android:build && bun run fastlane:android:distribute-internal",
     "test": "jest",
-    "test:run": "jest --coverage"
+    "android": "expo run:android",
+    "ios": "expo run:ios"
   },
   "dependencies": {
     "@azure/core-asynciterator-polyfill": "^1.0.2",
@@ -89,5 +103,6 @@
   "private": true,
   "trustedDependencies": [
     "better-sqlite3"
-  ]
+  ],
+  "version": "1.0.0"
 }

--- a/plugins/android-release-signing.js
+++ b/plugins/android-release-signing.js
@@ -19,8 +19,8 @@ const DEFAULTS = {
 const SIGNING_TAG = '// Added by android-release-signing plugin.'
 
 function isReleaseBuild() {
-  if (process.env.PROD) {
-    return process.env.PROD === 'true'
+  if (process.env.RELEASE) {
+    return process.env.RELEASE === 'true'
   }
 
   const easProfile = process.env.EAS_BUILD_PROFILE


### PR DESCRIPTION
- Adds fastlane for building and releasing the app on both iOS and Android.
- New dev workflow:

```
# Run the following commands to build for sim or actual device.

bun run ios:build:sim
bun run ios:build:device # no longer need to open XCode
bun run android:build # asks you which sim or device to build for

# After a successful build run:
bun run start
```