### PR TITLE
feat: add useFileViewerWindow hook

### DIFF
--- a/src/stores/fileCarousel.test.ts
+++ b/src/stores/fileCarousel.test.ts
@@ -1,0 +1,390 @@
+import { initializeDB, resetDb } from '../db'
+import { createFileRecord } from './files'
+import { fetchFileCarouselWindow } from './fileCarousel'
+
+jest.mock('./library', () => {
+  const actual = jest.requireActual('./library')
+  return {
+    ...actual,
+    librarySwr: {
+      triggerChange: jest.fn(),
+      addChangeCallback: jest.fn(),
+      getKey: jest.fn((key: string) => key),
+    },
+  }
+})
+
+describe('fetchFileCarouselWindow', () => {
+  const base = 1_000
+
+  beforeEach(async () => {
+    await initializeDB()
+  })
+
+  afterEach(async () => {
+    await resetDb()
+    jest.clearAllMocks()
+  })
+
+  async function createRecord(params: {
+    id: string
+    name: string | null
+    createdAt: number
+    type?: string
+  }) {
+    await createFileRecord({
+      id: params.id,
+      name: params.name ?? `${params.id}.jpg`,
+      type: params.type ?? 'image/jpeg',
+      size: 100,
+      hash: `hash-${params.id}`,
+      createdAt: params.createdAt,
+      updatedAt: params.createdAt,
+      localId: null,
+      addedAt: params.createdAt,
+    })
+  }
+
+  async function seedDateRecords() {
+    await createRecord({ id: 'file-a', name: 'a.jpg', createdAt: base })
+    await createRecord({ id: 'file-b', name: 'b.jpg', createdAt: base + 10 })
+    await createRecord({ id: 'file-c', name: 'c.jpg', createdAt: base + 20 })
+    await createRecord({ id: 'file-d', name: 'd.jpg', createdAt: base + 30 })
+    await createRecord({ id: 'file-e', name: 'e.jpg', createdAt: base + 40 })
+  }
+
+  async function seedNameRecords() {
+    await createRecord({ id: 'id-3', name: 'a.jpg', createdAt: base })
+    await createRecord({ id: 'id-1', name: 'b.jpg', createdAt: base + 10 })
+    await createRecord({ id: 'id-5', name: 'c.jpg', createdAt: base + 20 })
+    await createRecord({ id: 'id-2', name: 'd.jpg', createdAt: base + 30 })
+    await createRecord({ id: 'id-4', name: 'e.jpg', createdAt: base + 40 })
+  }
+
+  describe('DATE sorting (DESC)', () => {
+    test('returns window centered on anchor with neighbors', async () => {
+      await seedDateRecords()
+
+      const result = await fetchFileCarouselWindow({
+        initialId: 'file-c',
+        neighborsPerSide: 2,
+        sortBy: 'DATE',
+        sortDir: 'DESC',
+        categories: [],
+        searchQuery: '',
+      })
+
+      expect(result.files.map((f) => f.id)).toEqual([
+        'file-e',
+        'file-d',
+        'file-c',
+        'file-b',
+        'file-a',
+      ])
+      expect(result.hasPrevious).toBe(true)
+      expect(result.hasNext).toBe(true)
+      expect(result.anchorId).toBe('file-c')
+    })
+
+    test('returns hasPrevious=false when anchor is at start', async () => {
+      await seedDateRecords()
+
+      const result = await fetchFileCarouselWindow({
+        initialId: 'file-e',
+        neighborsPerSide: 2,
+        sortBy: 'DATE',
+        sortDir: 'DESC',
+        categories: [],
+        searchQuery: '',
+      })
+
+      expect(result.files.map((f) => f.id)).toEqual([
+        'file-e',
+        'file-d',
+        'file-c',
+      ])
+      expect(result.hasPrevious).toBe(false)
+      expect(result.hasNext).toBe(true)
+      expect(result.anchorId).toBe('file-e')
+    })
+
+    test('returns hasNext=false when anchor is at end', async () => {
+      await seedDateRecords()
+
+      const result = await fetchFileCarouselWindow({
+        initialId: 'file-a',
+        neighborsPerSide: 2,
+        sortBy: 'DATE',
+        sortDir: 'DESC',
+        categories: [],
+        searchQuery: '',
+      })
+
+      expect(result.files.map((f) => f.id)).toEqual([
+        'file-c',
+        'file-b',
+        'file-a',
+      ])
+      expect(result.hasPrevious).toBe(true)
+      expect(result.hasNext).toBe(false)
+      expect(result.anchorId).toBe('file-a')
+    })
+  })
+
+  describe('DATE sorting (ASC)', () => {
+    test('returns window in ascending order', async () => {
+      await seedDateRecords()
+
+      const result = await fetchFileCarouselWindow({
+        initialId: 'file-c',
+        neighborsPerSide: 2,
+        sortBy: 'DATE',
+        sortDir: 'ASC',
+        categories: [],
+        searchQuery: '',
+      })
+
+      expect(result.files.map((f) => f.id)).toEqual([
+        'file-a',
+        'file-b',
+        'file-c',
+        'file-d',
+        'file-e',
+      ])
+      expect(result.hasPrevious).toBe(true)
+      expect(result.hasNext).toBe(true)
+    })
+  })
+
+  describe('NAME sorting (ASC)', () => {
+    test('returns window in alphabetical order', async () => {
+      await seedNameRecords()
+
+      const result = await fetchFileCarouselWindow({
+        initialId: 'id-5',
+        neighborsPerSide: 2,
+        sortBy: 'NAME',
+        sortDir: 'ASC',
+        categories: [],
+        searchQuery: '',
+      })
+
+      expect(result.files.map((f) => f.id)).toEqual([
+        'id-3',
+        'id-1',
+        'id-5',
+        'id-2',
+        'id-4',
+      ])
+      expect(result.hasPrevious).toBe(true)
+      expect(result.hasNext).toBe(true)
+    })
+
+    test('returns hasPrevious=false at start of alphabetical list', async () => {
+      await seedNameRecords()
+
+      const result = await fetchFileCarouselWindow({
+        initialId: 'id-3',
+        neighborsPerSide: 2,
+        sortBy: 'NAME',
+        sortDir: 'ASC',
+        categories: [],
+        searchQuery: '',
+      })
+
+      expect(result.files.map((f) => f.id)).toEqual(['id-3', 'id-1', 'id-5'])
+      expect(result.hasPrevious).toBe(false)
+      expect(result.hasNext).toBe(true)
+    })
+  })
+
+  describe('NAME sorting (DESC)', () => {
+    test('returns window in reverse alphabetical order', async () => {
+      await seedNameRecords()
+
+      const result = await fetchFileCarouselWindow({
+        initialId: 'id-5',
+        neighborsPerSide: 2,
+        sortBy: 'NAME',
+        sortDir: 'DESC',
+        categories: [],
+        searchQuery: '',
+      })
+
+      expect(result.files.map((f) => f.id)).toEqual([
+        'id-4',
+        'id-2',
+        'id-5',
+        'id-1',
+        'id-3',
+      ])
+    })
+  })
+
+  describe('tie-breaking by ID', () => {
+    test('breaks DATE ties using ID', async () => {
+      await createRecord({ id: 'file-c', name: 'c.jpg', createdAt: base })
+      await createRecord({ id: 'file-a', name: 'a.jpg', createdAt: base })
+      await createRecord({ id: 'file-b', name: 'b.jpg', createdAt: base })
+
+      const result = await fetchFileCarouselWindow({
+        initialId: 'file-b',
+        neighborsPerSide: 2,
+        sortBy: 'DATE',
+        sortDir: 'DESC',
+        categories: [],
+        searchQuery: '',
+      })
+
+      expect(result.files.map((f) => f.id)).toEqual([
+        'file-c',
+        'file-b',
+        'file-a',
+      ])
+    })
+
+    test('breaks NAME ties using ID', async () => {
+      await createRecord({ id: 'file-c', name: 'same.jpg', createdAt: base })
+      await createRecord({ id: 'file-a', name: 'same.jpg', createdAt: base + 10 })
+      await createRecord({ id: 'file-b', name: 'same.jpg', createdAt: base + 20 })
+
+      const result = await fetchFileCarouselWindow({
+        initialId: 'file-b',
+        neighborsPerSide: 2,
+        sortBy: 'NAME',
+        sortDir: 'ASC',
+        categories: [],
+        searchQuery: '',
+      })
+
+      expect(result.files.map((f) => f.id)).toEqual([
+        'file-a',
+        'file-b',
+        'file-c',
+      ])
+    })
+  })
+
+  describe('category filtering', () => {
+    test('filters by category and returns correct window', async () => {
+      await createRecord({
+        id: 'img-1',
+        name: 'photo1.jpg',
+        createdAt: base,
+        type: 'image/jpeg',
+      })
+      await createRecord({
+        id: 'vid-1',
+        name: 'video1.mp4',
+        createdAt: base + 10,
+        type: 'video/mp4',
+      })
+      await createRecord({
+        id: 'img-2',
+        name: 'photo2.jpg',
+        createdAt: base + 20,
+        type: 'image/jpeg',
+      })
+      await createRecord({
+        id: 'vid-2',
+        name: 'video2.mp4',
+        createdAt: base + 30,
+        type: 'video/mp4',
+      })
+      await createRecord({
+        id: 'img-3',
+        name: 'photo3.jpg',
+        createdAt: base + 40,
+        type: 'image/jpeg',
+      })
+
+      const result = await fetchFileCarouselWindow({
+        initialId: 'img-2',
+        neighborsPerSide: 2,
+        sortBy: 'DATE',
+        sortDir: 'DESC',
+        categories: ['Image'],
+        searchQuery: '',
+      })
+
+      expect(result.files.map((f) => f.id)).toEqual(['img-3', 'img-2', 'img-1'])
+      expect(result.hasPrevious).toBe(false)
+      expect(result.hasNext).toBe(false)
+    })
+  })
+
+  describe('edge cases', () => {
+    test('returns empty result when anchor not found', async () => {
+      await seedDateRecords()
+
+      const result = await fetchFileCarouselWindow({
+        initialId: 'nonexistent',
+        neighborsPerSide: 2,
+        sortBy: 'DATE',
+        sortDir: 'DESC',
+        categories: [],
+        searchQuery: '',
+      })
+
+      expect(result.files).toEqual([])
+      expect(result.hasPrevious).toBe(false)
+      expect(result.hasNext).toBe(false)
+      expect(result.anchorId).toBeNull()
+    })
+
+    test('returns empty when anchor filtered out by category', async () => {
+      await createRecord({
+        id: 'img-1',
+        name: 'photo.jpg',
+        createdAt: base,
+        type: 'image/jpeg',
+      })
+
+      const result = await fetchFileCarouselWindow({
+        initialId: 'img-1',
+        neighborsPerSide: 2,
+        sortBy: 'DATE',
+        sortDir: 'DESC',
+        categories: ['Video'],
+        searchQuery: '',
+      })
+
+      expect(result.files).toEqual([])
+      expect(result.anchorId).toBeNull()
+    })
+
+    test('handles single file', async () => {
+      await createRecord({ id: 'only-file', name: 'solo.jpg', createdAt: base })
+
+      const result = await fetchFileCarouselWindow({
+        initialId: 'only-file',
+        neighborsPerSide: 2,
+        sortBy: 'DATE',
+        sortDir: 'DESC',
+        categories: [],
+        searchQuery: '',
+      })
+
+      expect(result.files.map((f) => f.id)).toEqual(['only-file'])
+      expect(result.hasPrevious).toBe(false)
+      expect(result.hasNext).toBe(false)
+    })
+
+    test('respects neighborsPerSide of 1', async () => {
+      await seedDateRecords()
+
+      const result = await fetchFileCarouselWindow({
+        initialId: 'file-c',
+        neighborsPerSide: 1,
+        sortBy: 'DATE',
+        sortDir: 'DESC',
+        categories: [],
+        searchQuery: '',
+      })
+
+      expect(result.files.map((f) => f.id)).toEqual(['file-d', 'file-c', 'file-b'])
+      expect(result.hasPrevious).toBe(true)
+      expect(result.hasNext).toBe(true)
+    })
+  })
+})

--- a/src/stores/fileCarousel.ts
+++ b/src/stores/fileCarousel.ts
@@ -1,0 +1,346 @@
+import { useMemo, useState, useEffect } from 'react'
+import useSWR from 'swr'
+
+import { db } from '../db'
+import { FileRecord, FileRecordRow, transformRow } from './files'
+import { readLocalObjectsForFiles } from './localObjects'
+import {
+  SortBy,
+  SortDir,
+  Category,
+  useLibrary,
+  buildLibraryQueryParts,
+} from './library'
+import { logger } from '../lib/logger'
+
+export type WindowResult = {
+  files: FileRecord[]
+  hasPrevious: boolean
+  hasNext: boolean
+  anchorId: string | null
+}
+
+export type FetchFileCarouselWindowParams = {
+  initialId: string
+  neighborsPerSide: number
+  sortBy: SortBy
+  sortDir: SortDir
+  categories: Category[]
+  searchQuery: string
+}
+
+const FILE_COLUMNS =
+  'f.id, f.name, f.size, f.createdAt, f.updatedAt, f.addedAt, f.type, f.localId, f.hash, f.thumbForHash, f.thumbSize'
+
+function buildDateCursorClause(
+  dir: SortDir,
+  direction: 'before' | 'after',
+  alias: string,
+  anchorValue: number,
+  anchorId: string
+) {
+  const isBefore = direction === 'before'
+  const op = dir === 'ASC' ? (isBefore ? '<' : '>') : isBefore ? '>' : '<'
+  const orderDirection = isBefore ? (dir === 'ASC' ? 'DESC' : 'ASC') : dir
+  return {
+    clause: `(${alias}.createdAt ${op} ?) OR (${alias}.createdAt = ? AND ${alias}.id ${op} ?)`,
+    params: [anchorValue, anchorValue, anchorId],
+    orderDirection,
+  }
+}
+
+function buildNameCursorClause(
+  dir: SortDir,
+  direction: 'before' | 'after',
+  alias: string,
+  anchorName: string | null,
+  anchorId: string
+) {
+  const nullExpr = `${alias}.name IS NULL`
+  const nameExpr = `${alias}.name COLLATE NOCASE`
+  const anchorNull = anchorName === null ? 1 : 0
+  const isBefore = direction === 'before'
+
+  const nameOp = dir === 'ASC' ? '<' : '>'
+  const afterNameOp = dir === 'ASC' ? '>' : '<'
+  const idOpBefore = dir === 'ASC' ? '<' : '>'
+  const idOpAfter = dir === 'ASC' ? '>' : '<'
+  const orderDirection = isBefore ? (dir === 'ASC' ? 'DESC' : 'ASC') : dir
+
+  if (anchorName === null) {
+    return {
+      clause: `(${nullExpr} ${
+        isBefore ? '<' : '>'
+      } ?) OR (${nullExpr} = ? AND ${alias}.id ${
+        isBefore ? idOpBefore : idOpAfter
+      } ?)`,
+      params: [anchorNull, anchorNull, anchorId],
+      orderDirection,
+    }
+  }
+
+  if (isBefore) {
+    return {
+      clause: `(${nullExpr} < ?) OR (${nullExpr} = ? AND (${nameExpr} ${nameOp} ? OR (${nameExpr} = ? AND ${alias}.id ${idOpBefore} ?)))`,
+      params: [anchorNull, anchorNull, anchorName, anchorName, anchorId],
+      orderDirection,
+    }
+  }
+
+  return {
+    clause: `(${nullExpr} > ?) OR (${nullExpr} = ? AND (${nameExpr} ${afterNameOp} ? OR (${nameExpr} = ? AND ${alias}.id ${idOpAfter} ?)))`,
+    params: [anchorNull, anchorNull, anchorName, anchorName, anchorId],
+    orderDirection,
+  }
+}
+
+async function hydrateRows(rows: FileRecordRow[]): Promise<FileRecord[]> {
+  if (!rows.length) return []
+  const ids = rows.map((r) => r.id)
+  const objectsById = await readLocalObjectsForFiles(ids)
+  return rows.map((row) => transformRow(row, objectsById[row.id]))
+}
+
+export async function fetchFileCarouselWindow(
+  params: FetchFileCarouselWindowParams
+): Promise<WindowResult> {
+  const {
+    initialId,
+    neighborsPerSide,
+    sortBy,
+    sortDir: sortingDir,
+    categories,
+    searchQuery,
+  } = params
+
+  const { where, params: queryParams } = buildLibraryQueryParts({
+    sortBy,
+    sortDir: sortingDir,
+    categories,
+    query: searchQuery,
+    tableAlias: 'f',
+  })
+
+  const anchorRow = await db().getFirstAsync<FileRecordRow>(
+    `SELECT ${FILE_COLUMNS}
+     FROM files f
+     ${where ? `${where} AND f.id = ?` : 'WHERE f.id = ?'}
+     LIMIT 1`,
+    ...queryParams,
+    initialId
+  )
+
+  if (!anchorRow) {
+    return { files: [], hasPrevious: false, hasNext: false, anchorId: null }
+  }
+
+  const buildOrderExpr = (dir: SortDir) =>
+    sortBy === 'NAME'
+      ? `(f.name IS NULL) ASC, f.name COLLATE NOCASE ${dir}, f.id ${dir}`
+      : `f.createdAt ${dir}, f.id ${dir}`
+
+  const beforeCursor =
+    sortBy === 'NAME'
+      ? buildNameCursorClause(
+          sortingDir,
+          'before',
+          'f',
+          anchorRow.name ?? null,
+          anchorRow.id
+        )
+      : buildDateCursorClause(
+          sortingDir,
+          'before',
+          'f',
+          anchorRow.createdAt,
+          anchorRow.id
+        )
+
+  const afterCursor =
+    sortBy === 'NAME'
+      ? buildNameCursorClause(
+          sortingDir,
+          'after',
+          'f',
+          anchorRow.name ?? null,
+          anchorRow.id
+        )
+      : buildDateCursorClause(
+          sortingDir,
+          'after',
+          'f',
+          anchorRow.createdAt,
+          anchorRow.id
+        )
+
+  const beforeRows = await db().getAllAsync<FileRecordRow>(
+    `SELECT ${FILE_COLUMNS}
+     FROM files f
+     ${
+       where
+         ? `${where} AND (${beforeCursor.clause})`
+         : `WHERE ${beforeCursor.clause}`
+     }
+     ORDER BY ${buildOrderExpr(beforeCursor.orderDirection)}
+     LIMIT ${neighborsPerSide | 0}`,
+    ...queryParams,
+    ...beforeCursor.params
+  )
+
+  const afterRows = await db().getAllAsync<FileRecordRow>(
+    `SELECT ${FILE_COLUMNS}
+     FROM files f
+     ${
+       where
+         ? `${where} AND (${afterCursor.clause})`
+         : `WHERE ${afterCursor.clause}`
+     }
+     ORDER BY ${buildOrderExpr(afterCursor.orderDirection)}
+     LIMIT ${neighborsPerSide | 0}`,
+    ...queryParams,
+    ...afterCursor.params
+  )
+
+  const orderedBeforeRows = [...beforeRows].reverse()
+  const allRows = [...orderedBeforeRows, anchorRow, ...afterRows]
+  const records = await hydrateRows(allRows)
+
+  return {
+    files: records,
+    hasPrevious: beforeRows.length === neighborsPerSide,
+    hasNext: afterRows.length === neighborsPerSide,
+    anchorId: anchorRow.id,
+  }
+}
+
+type UseFileCarouselWindowParams = {
+  initialId: string
+  initialFile?: FileRecord
+  windowSize: number
+}
+
+type UseFileCarouselWindowReturn = {
+  currentFile: FileRecord | null
+  prevFile: FileRecord | undefined
+  nextFile: FileRecord | undefined
+  setCurrentFile: (file: FileRecord) => void
+  isValidating: boolean
+}
+
+/**
+ * Hook for managing the file carousel window (current file + neighbors).
+ * Handles fetching the file list window, managing current file state,
+ * and extracting prev/next files for navigation.
+ */
+export function useFileCarouselWindow({
+  initialId,
+  initialFile,
+  windowSize,
+}: UseFileCarouselWindowParams): UseFileCarouselWindowReturn {
+  const { sortBy, sortDir, selectedCategories, searchQuery } = useLibrary()
+  const sortingDir: SortDir = sortDir ?? (sortBy === 'NAME' ? 'ASC' : 'DESC')
+
+  const [currentFile, setCurrentFile] = useState<FileRecord | null>(
+    initialFile ?? null
+  )
+
+  // Build SWR key based on current file ID and library filters
+  const swrKey = useMemo(() => {
+    const fileId = currentFile?.id ?? initialId
+    const cats = Array.from(selectedCategories ?? new Set())
+      .slice()
+      .sort()
+      .join(',')
+    return `viewer:${sortBy}:${sortingDir}:${cats}:${
+      searchQuery ?? ''
+    }:${fileId}:${windowSize}`
+  }, [
+    selectedCategories,
+    sortBy,
+    sortingDir,
+    searchQuery,
+    currentFile?.id,
+    initialId,
+    windowSize,
+  ])
+
+  // Fetch the windowed file list centered around the current file
+  const { data, isValidating } = useSWR<WindowResult>(
+    swrKey,
+    () => {
+      const fileId = currentFile?.id ?? initialId
+      logger.debug('useFileCarouselWindow', `Fetching window for ${fileId}`)
+      return fetchFileCarouselWindow({
+        initialId: fileId,
+        neighborsPerSide: windowSize,
+        sortBy,
+        sortDir: sortingDir,
+        categories: Array.from(selectedCategories ?? new Set()),
+        searchQuery: searchQuery ?? '',
+      })
+    },
+    {
+      revalidateOnFocus: false,
+      keepPreviousData: true,
+    }
+  )
+
+  // Initialize and update currentFile state based on data changes
+  useEffect(() => {
+    if (!data?.files?.length) return
+
+    // If no current file, initialize with the target file or first in list
+    if (!currentFile) {
+      const initial =
+        data.files.find((f) => f.id === initialId) ?? data.files[0]
+      logger.debug(
+        'useFileCarouselWindow',
+        `Initializing with file ${initial.id}`
+      )
+      setCurrentFile(initial)
+      return
+    }
+
+    // Update current file if it exists in the new data and has changed
+    const updatedFile = data.files.find((f) => f.id === currentFile.id)
+    if (!updatedFile) return
+
+    // Only update if the file has actually changed (by updatedAt timestamp)
+    if (updatedFile.updatedAt === currentFile.updatedAt) return
+
+    logger.debug(
+      'useFileCarouselWindow',
+      `Updating file ${currentFile.id} (updatedAt changed)`
+    )
+    setCurrentFile(updatedFile)
+  }, [data, initialId, currentFile])
+
+  // Extract prev and next files from the window
+  const { prevFile, nextFile } = useMemo(() => {
+    if (!data?.files?.length || !currentFile) {
+      return { prevFile: undefined, nextFile: undefined }
+    }
+
+    const idx = data.files.findIndex((f) => f.id === currentFile.id)
+    if (idx === -1) {
+      return { prevFile: undefined, nextFile: undefined }
+    }
+
+    const previousFile =
+      idx > 0 && data.hasPrevious ? data.files[idx - 1] : undefined
+    const nextFileItem =
+      idx < data.files.length - 1 && data.hasNext
+        ? data.files[idx + 1]
+        : undefined
+
+    return { prevFile: previousFile, nextFile: nextFileItem }
+  }, [data, currentFile])
+
+  return {
+    currentFile,
+    prevFile,
+    nextFile,
+    setCurrentFile,
+    isValidating,
+  }
+}

--- a/src/stores/library.ts
+++ b/src/stores/library.ts
@@ -37,29 +37,13 @@ async function readOrderedFileRecords(
   } = opts ?? {}
   const dir: SortDir = sortDir ?? (sortBy === 'NAME' ? 'ASC' : 'DESC')
 
-  const prefixes = categories.map((c) => CATEGORY_TO_PREFIX[c])
-  const hasCategories = prefixes.length > 0
-  const hasQuery = typeof query === 'string' && query.trim().length > 0
-
-  const whereParts: string[] = []
-  const params: (string | number | null)[] = []
-  // Exclude thumbnails from library lists.
-  whereParts.push('thumbForHash IS NULL')
-  if (hasCategories) {
-    whereParts.push(prefixes.map(() => 'type LIKE ?').join(' OR '))
-    params.push(...prefixes.map((p) => `${p}%`))
-  }
-  if (hasQuery) {
-    whereParts.push('name LIKE ? COLLATE NOCASE ESCAPE "\\"')
-    const escaped = (query ?? '').replace(/[%_\\]/g, (m) => `\\${m}`)
-    params.push(`%${escaped}%`)
-  }
-  const where = whereParts.length ? `WHERE ${whereParts.join(' AND ')}` : ''
-
-  const orderExpr =
-    sortBy === 'NAME'
-      ? `(name IS NULL) ASC, name COLLATE NOCASE ${dir}, id ${dir}`
-      : `createdAt ${dir}, id ${dir}`
+  const { where, params, orderExpr } = buildLibraryQueryParts({
+    sortBy,
+    sortDir: dir,
+    categories,
+    query,
+    tableAlias: 'files',
+  })
 
   let pageClause = ''
   if (limit != null && offset != null) {
@@ -147,6 +131,59 @@ export type SortBy = 'NAME' | 'DATE'
 export type SortDir = 'ASC' | 'DESC'
 export type Category = 'Video' | 'Image' | 'Audio' | 'Files'
 export const categories = ['Video', 'Image', 'Audio', 'Files'] as const
+
+export function buildLibraryQueryParts(
+  opts: {
+    sortBy?: SortBy
+    sortDir?: SortDir
+    categories?: Category[]
+    query?: string
+    tableAlias?: string
+  } = {}
+): {
+  where: string
+  params: (string | number)[]
+  orderExpr: string
+} {
+  const {
+    sortBy = 'DATE',
+    sortDir,
+    categories = [],
+    query,
+    tableAlias = 'files',
+  } = opts
+  const dir: SortDir = sortDir ?? (sortBy === 'NAME' ? 'ASC' : 'DESC')
+
+  const prefixes = categories.map((c) => CATEGORY_TO_PREFIX[c])
+  const hasCategories = prefixes.length > 0
+  const hasQuery = typeof query === 'string' && query.trim().length > 0
+
+  const whereParts: string[] = []
+  const params: (string | number)[] = []
+  // Exclude thumbnails from library lists.
+  whereParts.push(`${tableAlias}.thumbForHash IS NULL`)
+  if (hasCategories) {
+    whereParts.push(
+      prefixes.map(() => `${tableAlias}.type LIKE ?`).join(' OR ')
+    )
+    params.push(...prefixes.map((p) => `${p}%`))
+  }
+  if (hasQuery) {
+    whereParts.push(
+      `${tableAlias}.name LIKE ? COLLATE NOCASE ESCAPE "\\"`
+    )
+    const escaped = (query ?? '').replace(/[%_\\]/g, (m) => `\\${m}`)
+    params.push(`%${escaped}%`)
+  }
+  const where = whereParts.length ? `WHERE ${whereParts.join(' AND ')}` : ''
+
+  const orderExpr =
+    sortBy === 'NAME'
+      ? `(${tableAlias}.name IS NULL) ASC, ${tableAlias}.name COLLATE NOCASE ${dir}, ${tableAlias}.id ${dir}`
+      : `${tableAlias}.createdAt ${dir}, ${tableAlias}.id ${dir}`
+
+  return { where, params, orderExpr }
+}
 
 type LibraryState = {
   sortBy: SortBy


### PR DESCRIPTION
This is not plugged in anywhere and shouldn't affect the app at all. I have a new fileviewer MVP I've been using to test it and I think I'm happy with this. Was able to rectify rendering issues I had discussed via DM. It was actually just a bug in here about ordering, but it is now resolved. Essentially, for the item(s) "back" from the currently active, the tiebreaker was in the wrong direction.