### PR TITLE
refactor: timeout, result, embedded browser utils

### DIFF
--- a/src/lib/inAppBrowser.ts
+++ b/src/lib/inAppBrowser.ts
@@ -1,15 +1,30 @@
-import { Linking } from 'react-native'
+import { Linking, Platform } from 'react-native'
 import InAppBrowser from 'react-native-inappbrowser-reborn'
 import { palette } from '../styles/colors'
 
-export default async function authApp(url: string): Promise<boolean> {
+export type InAppBrowserOptions<T = boolean> = {
+  onResponseURL?: (url: string) => T
+}
+
+/**
+ * Opens a URL in the in-app browser.
+ * @param url - The URL to open.
+ * @param options - Optional configuration for completion handling.
+ * @returns Promise that resolves with the result of onResponseURL if a URL was received.
+ */
+export async function openInAppBrowser<T = boolean>(
+  url: string,
+  options?: InAppBrowserOptions<T>
+): Promise<T | null> {
   if (await InAppBrowser.isAvailable()) {
-    let completed = false
+    const { onResponseURL } = options || {}
+    let result: T | null = null
+
     const subscription = Linking.addEventListener(
       'url',
       ({ url: received }) => {
-        if (received.startsWith('sia://')) {
-          completed = true
+        if (onResponseURL) {
+          result = onResponseURL(received)
           InAppBrowser.close()
         }
       }
@@ -41,12 +56,19 @@ export default async function authApp(url: string): Promise<boolean> {
           endExit: 'slide_out_right',
         },
       })
-      return completed
+
+      // On Android, add a small delay to ensure Linking event is processed before returning.
+      // This prevents a race condition where the browser closes before the listener fires.
+      if (Platform.OS === 'android') {
+        await new Promise((resolve) => setTimeout(resolve, 100))
+      }
+
+      return result
     } finally {
       subscription.remove()
     }
   } else {
     await Linking.openURL(url)
-    return true
+    return null
   }
 }

--- a/src/lib/openAuthUrl.ts
+++ b/src/lib/openAuthUrl.ts
@@ -1,0 +1,14 @@
+import { openInAppBrowser } from './inAppBrowser'
+
+/**
+ * Opens the auth URL in the in-app browser.
+ * Waits for the user to complete authentication via the sia:// callback URL.
+ * @param authURL - The auth URL to open.
+ * @returns True if the auth URL was opened and the sia:// callback was received, false otherwise.
+ */
+export async function openAuthURL(authURL: string): Promise<boolean> {
+  const result = await openInAppBrowser(authURL, {
+    onResponseURL: (url) => url.startsWith('sia://'),
+  })
+  return result ?? false
+}

--- a/src/lib/result.ts
+++ b/src/lib/result.ts
@@ -1,0 +1,53 @@
+/**
+ * Result type for operations that can succeed or fail.
+ */
+
+/** Tuple-based result for simple success/error cases. */
+export type Result<T, E = Error> = [T, null] | [null, E]
+
+/** Helper to create success result. */
+export function ok<T>(value: T): [T, null] {
+  return [value, null]
+}
+
+/** Helper to create error result. */
+export function err<E = Error>(error: E): [null, E] {
+  return [null, error]
+}
+
+/** Type guard to check if result is success. */
+export function isOk<T, E>(result: Result<T, E>): result is [T, null] {
+  return result[1] === null
+}
+
+/** Type guard to check if result is error. */
+export function isErr<T, E>(result: Result<T, E>): result is [null, E] {
+  return result[1] !== null
+}
+
+/** Unwrap a result, throwing if it's an error. */
+export function unwrap<T, E>(result: Result<T, E>): T {
+  if (isErr(result)) {
+    throw result[1]
+  }
+  return result[0]
+}
+
+/** Unwrap a result with a default value. */
+export function unwrapOr<T, E>(result: Result<T, E>, defaultValue: T): T {
+  if (isErr(result)) {
+    return defaultValue
+  }
+  return result[0]
+}
+
+/** Wrap an async function in try-catch and return a Result. */
+export async function tryCatch<T>(
+  fn: () => Promise<T>
+): Promise<Result<T, Error>> {
+  try {
+    return ok(await fn())
+  } catch (e) {
+    return err(e instanceof Error ? e : new Error(String(e)))
+  }
+}

--- a/src/lib/timeout.ts
+++ b/src/lib/timeout.ts
@@ -1,0 +1,25 @@
+export class TimeoutError extends Error {
+  constructor(message = 'Connection timed out') {
+    super(message)
+    this.name = 'TimeoutError'
+  }
+}
+
+/**
+ * Wraps a promise with a timeout. Rejects with TimeoutError if not resolved in time.
+ */
+export function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new TimeoutError()), ms)
+    promise.then(
+      (value) => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      (err) => {
+        clearTimeout(timer)
+        reject(err)
+      }
+    )
+  })
+}


### PR DESCRIPTION
- This PR adds two utils that will be used in the new auth flow:
    - Adds withTimeout util for use in the auth flows.
    - Adds result type utils for making control flow with many different potential errors easier to write and follow.
- Also extracts a generic inAppBrowser util so the openAuthUrl logic is more clear.