### PR TITLE
refactor: import share url

### DIFF
--- a/src/components/FileImport/DownloadPrompt.tsx
+++ b/src/components/FileImport/DownloadPrompt.tsx
@@ -1,0 +1,82 @@
+import {
+  ActivityIndicator,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native'
+import { CloudDownloadIcon } from 'lucide-react-native'
+import { colors, palette } from '../../styles/colors'
+import { useDownloadState } from '../../stores/downloads'
+
+type DownloadPromptProps = {
+  fileId: string
+  hasMissingMetadata: boolean
+  onDownloadPress: () => void
+  isDownloading: boolean
+}
+
+export function DownloadPrompt({
+  fileId,
+  hasMissingMetadata,
+  onDownloadPress,
+  isDownloading,
+}: DownloadPromptProps) {
+  const downloadState = useDownloadState(fileId)
+
+  if (isDownloading) {
+    return (
+      <View style={styles.container}>
+        <ActivityIndicator color={colors.accentPrimary} size="large" />
+        <Text style={styles.downloadText}>
+          Downloading: {((downloadState?.progress || 0) * 100).toFixed(0)}%
+        </Text>
+      </View>
+    )
+  }
+
+  return (
+    <View style={styles.container}>
+      <CloudDownloadIcon color={colors.textPrimary} size={40} />
+      <Text style={styles.downloadText}>
+        {hasMissingMetadata
+          ? 'Press to download and compute required metadata'
+          : 'Press to download'}
+      </Text>
+      <TouchableOpacity style={styles.downloadButton} onPress={onDownloadPress}>
+        <Text style={styles.downloadButtonText}>Download</Text>
+      </TouchableOpacity>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: '100%',
+    height: '100%',
+    backgroundColor: colors.bgPanel,
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 10,
+  },
+  downloadText: {
+    color: colors.textPrimary,
+    textAlign: 'center',
+    width: '80%',
+    maxWidth: 500,
+  },
+  downloadButton: {
+    height: 36,
+    paddingHorizontal: 20,
+    borderRadius: 12,
+    backgroundColor: palette.gray[100],
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 8,
+  },
+  downloadButtonText: {
+    color: palette.gray[900],
+    fontWeight: '600',
+    fontSize: 16,
+  },
+})

--- a/src/components/FileImport/FileDetailsImport.tsx
+++ b/src/components/FileImport/FileDetailsImport.tsx
@@ -4,10 +4,6 @@ import { useFileStatus } from '../../lib/file'
 import { FileMetaImport } from './FileMetaImport'
 import { FileViewer } from '../FileViewer'
 import { useDownloadFromShareURL } from '../../managers/downloader'
-import {
-  detailsShouldAutoDownload,
-  useAutoDownloadFromShareURL,
-} from '../../hooks/useAutoDownload'
 import { FileRecord } from '../../stores/files'
 
 export function FileDetailsImport({
@@ -19,11 +15,6 @@ export function FileDetailsImport({
 }) {
   const status = useFileStatus(file, true)
   const handleDownload = useDownloadFromShareURL()
-
-  // If the file is less than 4 MB, go ahead and download it to the user
-  // device. We might look at a settings toggle for this or otherwise more
-  // smartly do this depending on whether a user is on wifi, etc.
-  useAutoDownloadFromShareURL(file, detailsShouldAutoDownload, shareUrl)
 
   return (
     <View style={styles.container}>

--- a/src/components/FileImport/FileMetaImport.tsx
+++ b/src/components/FileImport/FileMetaImport.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { View, StyleSheet } from 'react-native'
+import { View, StyleSheet, Text } from 'react-native'
 import { colors } from '../../styles/colors'
 import { type FileStatus } from '../../lib/file'
 import { InfoCard } from '../InfoCard'
@@ -29,15 +29,54 @@ export function FileMetaImport({
 
   const showAdvanced = useShowAdvanced()
 
+  const hasValidSize = file.size > 0
+  const hasValidType = file.type && file.type !== 'application/octet-stream'
+  const hasValidHash = !!file.hash
+
   return (
     <View style={styles.container}>
       <RowGroup title="Details">
         <InfoCard>
           {showAdvanced.data && <LabeledValueRow label="ID" value={file.id} />}
-          <LabeledValueRow label="Size" value={humanSize ?? '—'} />
+          <LabeledValueRow
+            label="Size"
+            value={
+              hasValidSize ? (
+                humanSize ?? '—'
+              ) : (
+                <View style={styles.unknownValue}>
+                  <Text style={styles.unknownText}>unknown</Text>
+                  <View style={styles.requiredIndicator} />
+                </View>
+              )
+            }
+          />
           <LabeledValueRow
             label="Type"
-            value={file.type ?? '—'}
+            value={
+              hasValidType ? (
+                file.type
+              ) : (
+                <View style={styles.unknownValue}>
+                  <Text style={styles.unknownText}>unknown</Text>
+                  <View style={styles.requiredIndicator} />
+                </View>
+              )
+            }
+            showDividerTop
+          />
+          <LabeledValueRow
+            label="Hash"
+            value={
+              hasValidHash ? (
+                file.hash
+              ) : (
+                <View style={styles.unknownValue}>
+                  <Text style={styles.unknownText}>unknown</Text>
+                  <View style={styles.requiredIndicator} />
+                </View>
+              )
+            }
             showDividerTop
           />
           {showAdvanced.data && status.fileUri && (
@@ -83,5 +122,20 @@ const styles = StyleSheet.create({
     borderColor: colors.borderSubtle,
     borderWidth: StyleSheet.hairlineWidth,
     overflow: 'hidden',
+  },
+  unknownValue: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  unknownText: {
+    color: colors.textSecondary,
+    fontStyle: 'italic',
+  },
+  requiredIndicator: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: colors.textDanger,
   },
 })

--- a/src/components/FileImport/index.tsx
+++ b/src/components/FileImport/index.tsx
@@ -1,0 +1,373 @@
+import { type NavigationProp } from '@react-navigation/native'
+import { useCallback, useMemo, useState } from 'react'
+import useSWR from 'swr'
+import {
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native'
+import { type RootTabParamList } from '../../stacks/types'
+import { useToast } from '../../lib/toastContext'
+import { useSdk } from '../../stores/sdk'
+import {
+  FileRecord,
+  readFileRecordByContentHash,
+  createFileRecordWithLocalObject,
+} from '../../stores/files'
+import { FileViewer } from '../FileViewer'
+import { logger } from '../../lib/logger'
+import { BottomActionButton } from '../BottomActionButton'
+import { PlusIcon } from 'lucide-react-native'
+import { colors } from '../../styles/colors'
+import { File } from 'expo-file-system'
+import { getMimeType } from '../../lib/fileTypes'
+import {
+  detectMimeTypeFromBytes,
+  MAGIC_BYTES_LENGTH,
+} from '../../lib/detectMimeType'
+import {
+  useDownloadFromShareURL,
+  downloadFirstBytesFromShared,
+} from '../../managers/downloader'
+import { getIndexerURL } from '../../stores/settings'
+import { pinnedObjectToLocalObject } from '../../lib/localObjects'
+import { getFsFileUri, copyFileToFs } from '../../stores/fs'
+import { calculateContentHash } from '../../lib/contentHash'
+import { FileMetaImport } from './FileMetaImport'
+import { DownloadPrompt } from './DownloadPrompt'
+import { useFileStatus } from '../../lib/file'
+import { useDownloadState } from '../../stores/downloads'
+import { type SharedObjectInterface } from 'react-native-sia'
+import { SHARED_FILE_AUTO_DOWNLOAD_THRESHOLD } from '../../config'
+
+// Helper function to detect file type from first few bytes.
+async function detectFileType(
+  sdk: ReturnType<typeof useSdk>,
+  sharedObject: SharedObjectInterface,
+  id: string
+): Promise<string> {
+  logger.log(
+    `[FileImport] Detecting type from first ${MAGIC_BYTES_LENGTH} bytes`,
+    id
+  )
+  try {
+    if (!sdk || !sharedObject) {
+      throw new Error('Missing required data for type detection')
+    }
+
+    const bytes = await downloadFirstBytesFromShared(
+      sdk,
+      sharedObject,
+      MAGIC_BYTES_LENGTH
+    )
+
+    if (bytes.length === 0) {
+      logger.log('[FileImport] No bytes received for type detection')
+      return 'application/octet-stream'
+    }
+
+    const type = detectMimeTypeFromBytes(bytes)
+    logger.log('[FileImport] Detected type:', type)
+    return type || 'application/octet-stream'
+  } catch (e) {
+    logger.log('[FileImport] Error detecting type', e)
+    return 'application/octet-stream'
+  }
+}
+
+// Helper function to download and process the full file.
+async function downloadAndProcessFile(
+  id: string,
+  shareUrl: string,
+  downloadFromShareURL: ReturnType<typeof useDownloadFromShareURL>
+): Promise<FileRecord> {
+  logger.log('[FileImport] SWR function starting for', id)
+  try {
+    if (!shareUrl) throw new Error('Invalid share URL')
+
+    logger.log('[FileImport] downloading to temp', id, shareUrl)
+    await downloadFromShareURL(id, shareUrl)
+    logger.log('[FileImport] download complete')
+
+    const tempFsFileUri = await getFsFileUri({
+      id,
+      type: 'application/octet-stream',
+    })
+    if (!tempFsFileUri) {
+      throw new Error('File not found in cache after download')
+    }
+
+    logger.log('[FileImport] sniffing type from', tempFsFileUri)
+    let type: string
+    try {
+      type = await getMimeType({ uri: tempFsFileUri })
+      logger.log('[FileImport] detected type', type)
+    } catch (e) {
+      logger.log('[FileImport] error detecting type', e)
+      type = 'application/octet-stream'
+    }
+
+    const tempFile = new File(tempFsFileUri)
+    const fileInfo = tempFile.info()
+    const size = fileInfo.size ?? 0
+
+    const finalFsFileUri = await copyFileToFs({ id, type }, tempFile)
+    logger.log('[FileImport] copied to final location', finalFsFileUri)
+
+    if (finalFsFileUri !== tempFsFileUri) {
+      tempFile.delete()
+    }
+
+    logger.log('[FileImport] calculating hash from', finalFsFileUri)
+    const hash = await calculateContentHash(finalFsFileUri)
+    logger.log('[FileImport] hash calculated', hash)
+
+    logger.log('[FileImport] file ready', { type, size, hash })
+
+    return {
+      id,
+      localId: null,
+      addedAt: Date.now(),
+      name: 'Shared File',
+      type,
+      size,
+      hash: hash ?? '',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      objects: {},
+    } satisfies FileRecord
+  } catch (e) {
+    logger.log('[FileImport] Error preparing file', e)
+    throw e
+  }
+}
+
+export function FileImport({
+  id,
+  shareUrl,
+  navigation,
+}: {
+  id: string
+  shareUrl: string
+  navigation: NavigationProp<RootTabParamList>
+}) {
+  const toast = useToast()
+  const sdk = useSdk()
+  const downloadFromShareURL = useDownloadFromShareURL()
+  const [hasConfirmedLargeDownload, setHasConfirmedLargeDownload] =
+    useState(false)
+
+  const sharedObject = useSWR(
+    sdk ? ['sharedObject', shareUrl, id] : null,
+    async () => {
+      try {
+        if (!sdk || !shareUrl) return null
+        return sdk.sharedObject(shareUrl)
+      } catch (e) {
+        logger.log('Error getting shared object', e)
+        return null
+      }
+    }
+  )
+
+  // Check if file requires confirmation - auto-download if less than 5MB.
+  const fileSize = sharedObject.data ? Number(sharedObject.data.size()) : null
+  const shouldAutoDownload =
+    fileSize !== null && fileSize <= SHARED_FILE_AUTO_DOWNLOAD_THRESHOLD
+  const requiresConfirmation = !hasConfirmedLargeDownload && !shouldAutoDownload
+
+  // Automatically detect type by downloading only first few bytes.
+  const detectedType = useSWR(
+    sharedObject.data && shareUrl && sdk
+      ? ['detectedType', id, shareUrl]
+      : null,
+    async () => {
+      if (!sdk || !sharedObject.data) {
+        throw new Error('Missing SDK or shared object')
+      }
+      return detectFileType(sdk, sharedObject.data, id)
+    }
+  )
+
+  // Download and build file metadata. Auto-download if file is small, otherwise require confirmation.
+  const sharedFile = useSWR(
+    sharedObject.data &&
+      shareUrl &&
+      (hasConfirmedLargeDownload || shouldAutoDownload)
+      ? [
+          'sharedFile',
+          id,
+          shareUrl,
+          hasConfirmedLargeDownload,
+          shouldAutoDownload,
+        ]
+      : null,
+    () => downloadAndProcessFile(id, shareUrl, downloadFromShareURL)
+  )
+
+  // Create a preview FileRecord for the confirmation screen.
+  const previewFile = useMemo(() => {
+    if (!sharedObject.data) return null
+    // Use detected type if available, otherwise fall back to octet-stream.
+    const type = detectedType.data || 'application/octet-stream'
+    return {
+      id,
+      localId: null,
+      addedAt: Date.now(),
+      name: 'Shared File',
+      type,
+      size: fileSize ?? 0,
+      hash: '', // Placeholder until calculated.
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      objects: {},
+    } satisfies FileRecord
+  }, [sharedObject.data, id, fileSize, detectedType.data])
+
+  // Check if metadata is complete (required fields: hash, type, size).
+  const isMetadataComplete =
+    sharedFile.data &&
+    sharedFile.data.hash &&
+    sharedFile.data.type !== 'application/octet-stream' &&
+    sharedFile.data.size > 0
+
+  const displayFile = sharedFile.data || previewFile
+  const downloadState = useDownloadState(id)
+  const isDownloading =
+    downloadState?.status === 'running' || downloadState?.status === 'queued'
+
+  const hasMissingMetadata =
+    !displayFile ||
+    displayFile.size === 0 ||
+    displayFile.type === 'application/octet-stream' ||
+    !displayFile.hash
+
+  const fileStatus = useFileStatus(displayFile || undefined, true)
+
+  const [isAddingToDatabase, setIsAddingToDatabase] = useState(false)
+  const handleAddToDatabase = useCallback(async () => {
+    if (!sharedObject.data || !sdk || !sharedFile.data) {
+      toast.show('File not ready')
+      return
+    }
+
+    // Check for duplicates before setting loading state.
+    if (sharedFile.data.hash) {
+      const existingFile = await readFileRecordByContentHash(
+        sharedFile.data.hash
+      )
+      if (existingFile) {
+        toast.show('File already exists in library')
+        return
+      }
+    }
+
+    setIsAddingToDatabase(true)
+    try {
+      logger.log('[FileImport] importing file', sharedFile.data.id)
+
+      // Pin the shared object and create file record.
+      const indexerURL = await getIndexerURL()
+      const pinnedObject = await sdk.pinShared(sharedObject.data)
+      const localObject = await pinnedObjectToLocalObject(
+        sharedFile.data.id,
+        indexerURL,
+        pinnedObject
+      )
+      await createFileRecordWithLocalObject(sharedFile.data, localObject)
+
+      toast.show('File added')
+      navigation.navigate('MainTab', {
+        screen: 'FileDetail',
+        params: { id: sharedFile.data.id },
+      })
+    } catch (e) {
+      logger.log('[FileImport] Error adding file to library', e)
+      toast.show('Error adding file to library')
+    } finally {
+      setIsAddingToDatabase(false)
+    }
+  }, [sharedObject.data, sdk, sharedFile.data, toast, navigation])
+
+  return (
+    <View style={styles.container}>
+      <ScrollView
+        contentContainerStyle={styles.content}
+        showsVerticalScrollIndicator={false}
+      >
+        {sharedObject.isLoading ? (
+          <View style={styles.center}>
+            <ActivityIndicator color={colors.accentPrimary} />
+            <Text style={styles.loadingText}>Loading…</Text>
+          </View>
+        ) : sharedObject.error ? (
+          <Text style={styles.errorText}>{sharedObject.error.message}</Text>
+        ) : displayFile ? (
+          <>
+            <View style={{ height: 500 }}>
+              {sharedFile.data && shareUrl ? (
+                <FileViewer
+                  file={sharedFile.data}
+                  isShared
+                  customDownloader={() => {
+                    if (sharedFile.data) {
+                      downloadFromShareURL(sharedFile.data.id, shareUrl)
+                    }
+                  }}
+                />
+              ) : (
+                <DownloadPrompt
+                  fileId={id}
+                  hasMissingMetadata={hasMissingMetadata}
+                  onDownloadPress={() => {
+                    if (requiresConfirmation) {
+                      setHasConfirmedLargeDownload(true)
+                    }
+                  }}
+                  isDownloading={isDownloading}
+                />
+              )}
+            </View>
+            {displayFile && fileStatus.data && (
+              <FileMetaImport file={displayFile} status={fileStatus.data} />
+            )}
+          </>
+        ) : null}
+        {sharedFile.error && (
+          <View style={styles.errorContainer}>
+            <Text style={styles.errorText}>{sharedFile.error.message}</Text>
+          </View>
+        )}
+      </ScrollView>
+      <BottomActionButton
+        label={isAddingToDatabase ? 'Adding to library...' : 'Add to library'}
+        disabled={
+          isAddingToDatabase || !isMetadataComplete || requiresConfirmation
+        }
+        icon={<PlusIcon color="white" size={22} />}
+        onPress={handleAddToDatabase}
+      />
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.bgCanvas,
+  },
+  content: { padding: 0, paddingBottom: 100 },
+  center: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 24,
+  },
+  loadingText: { color: colors.textSecondary, marginTop: 8 },
+  errorText: { color: colors.textDanger },
+  errorContainer: {
+    padding: 16,
+    backgroundColor: colors.bgCanvas,
+  },
+})

--- a/src/components/FileViewer/index.tsx
+++ b/src/components/FileViewer/index.tsx
@@ -1,12 +1,7 @@
 import { StyleSheet, Text, TouchableHighlight, View } from 'react-native'
 import { useCallback, useMemo } from 'react'
 import { CloudDownloadIcon, FileIcon } from 'lucide-react-native'
-
 import { useFileStatus } from '../../lib/file'
-import {
-  useAutoDownload,
-  detailsShouldAutoDownload,
-} from '../../hooks/useAutoDownload'
 import { useDownload } from '../../managers/downloader'
 import { useDownloadState } from '../../stores/downloads'
 import { colors } from '../../styles/colors'

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -43,3 +43,5 @@ export const FS_EVICTABLE_MIN_AGE = daysInMs(7) // 7 days
 export const SYNC_UP_METADATA_INTERVAL = secondsInMs(10) // 10 seconds
 // Sync up metadata batch size.
 export const SYNC_UP_METADATA_BATCH_SIZE = 500 // 500 files
+// Auto-download threshold for shared file imports.
+export const SHARED_FILE_AUTO_DOWNLOAD_THRESHOLD = 5 * 1024 * 1024 // 5 MB

--- a/src/hooks/useCameraCapture.ts
+++ b/src/hooks/useCameraCapture.ts
@@ -46,21 +46,23 @@ export function useCameraCapture() {
       }
 
       const { files, warnings } = await processAssets(
-        result.assets?.map((a) => ({
-          id: a.id,
-          name: buildDateFileName(
-            a.timestamp,
-            getMimeType({
-              type: a.type,
-              name: a.fileName,
-              uri: a.uri,
-            })
-          ),
-          size: a.fileSize,
-          type: a.type,
-          sourceUri: a.uri,
-          timestamp: a.timestamp,
-        }))
+        await Promise.all(
+          (result.assets ?? []).map(async (a) => ({
+            id: a.id,
+            name: buildDateFileName(
+              a.timestamp,
+              await getMimeType({
+                type: a.type,
+                name: a.fileName,
+                uri: a.uri,
+              })
+            ),
+            size: a.fileSize,
+            type: a.type,
+            sourceUri: a.uri,
+            timestamp: a.timestamp,
+          }))
+        )
       )
       if (warnings.length > 0) {
         warnings.forEach((warning) => toast.show(warning))

--- a/src/lib/detectMimeType.ts
+++ b/src/lib/detectMimeType.ts
@@ -1,0 +1,185 @@
+import { type MimeType } from './fileTypes'
+import { logger } from './logger'
+import { readFileBytes } from './readFileBytes'
+
+export const MAGIC_BYTES_LENGTH = 32
+
+/**
+ * Sniff file type from magic numbers.
+ * Reads first 32 bytes from a file URI and checks against known signatures.
+ */
+export async function detectMimeType(
+  uri: string | undefined
+): Promise<MimeType | null> {
+  if (!uri) return null
+
+  try {
+    const bytes = await readFileBytes(uri, MAGIC_BYTES_LENGTH)
+    if (!bytes || bytes.length === 0) {
+      return null
+    }
+    return detectMimeTypeFromBytes(bytes)
+  } catch (e) {
+    logger.log('[detectMimeType] error:', e)
+    return null
+  }
+}
+
+/**
+ * Sniff file type from magic numbers directly from bytes.
+ */
+export function detectMimeTypeFromBytes(bytes: Uint8Array): MimeType | null {
+  if (!bytes || bytes.length === 0) {
+    return null
+  }
+
+  // Check magic numbers for supported types.
+
+  // JPEG: FF D8 FF
+  if (
+    bytes.length >= 3 &&
+    bytes[0] === 0xff &&
+    bytes[1] === 0xd8 &&
+    bytes[2] === 0xff
+  ) {
+    return 'image/jpeg'
+  }
+
+  // PNG: 89 50 4E 47 0D 0A 1A 0A
+  if (
+    bytes.length >= 8 &&
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47 &&
+    bytes[4] === 0x0d &&
+    bytes[5] === 0x0a &&
+    bytes[6] === 0x1a &&
+    bytes[7] === 0x0a
+  ) {
+    return 'image/png'
+  }
+
+  // GIF: 47 49 46 38 (GIF8)
+  if (
+    bytes.length >= 4 &&
+    bytes[0] === 0x47 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x38
+  ) {
+    return 'image/gif'
+  }
+
+  // WEBP: RIFF....WEBP
+  if (
+    bytes.length >= 12 &&
+    bytes[0] === 0x52 && // R
+    bytes[1] === 0x49 && // I
+    bytes[2] === 0x46 && // F
+    bytes[3] === 0x46 && // F
+    bytes[8] === 0x57 && // W
+    bytes[9] === 0x45 && // E
+    bytes[10] === 0x42 && // B
+    bytes[11] === 0x50 // P
+  ) {
+    return 'image/webp'
+  }
+
+  // HEIC/HEIF: Check for ftyp with heic/heix/hevc/hevx/mif1
+  if (
+    bytes.length >= 12 &&
+    bytes[4] === 0x66 &&
+    bytes[5] === 0x74 &&
+    bytes[6] === 0x79 &&
+    bytes[7] === 0x70
+  ) {
+    const brand = String.fromCharCode(bytes[8], bytes[9], bytes[10], bytes[11])
+    if (
+      brand === 'heic' ||
+      brand === 'heix' ||
+      brand === 'hevc' ||
+      brand === 'hevx' ||
+      brand === 'mif1'
+    ) {
+      return 'image/heic'
+    }
+  }
+
+  // MP4/MOV: Check for ftyp box
+  if (
+    bytes.length >= 12 &&
+    bytes[4] === 0x66 &&
+    bytes[5] === 0x74 &&
+    bytes[6] === 0x79 &&
+    bytes[7] === 0x70
+  ) {
+    const brand = String.fromCharCode(bytes[8], bytes[9], bytes[10], bytes[11])
+    if (
+      brand === 'isom' ||
+      brand === 'mp41' ||
+      brand === 'mp42' ||
+      brand.startsWith('M4V')
+    ) {
+      return 'video/mp4'
+    }
+    if (brand === 'qt  ' || brand === 'mov ') {
+      return 'video/quicktime'
+    }
+  }
+
+  // MP3: ID3 tag (49 44 33) or MPEG frame sync (FF FB or FF F3 or FF F2)
+  if (bytes.length >= 3) {
+    if (bytes[0] === 0x49 && bytes[1] === 0x44 && bytes[2] === 0x33) {
+      return 'audio/mpeg'
+    }
+    if (
+      bytes[0] === 0xff &&
+      (bytes[1] === 0xfb || bytes[1] === 0xf3 || bytes[1] === 0xf2)
+    ) {
+      return 'audio/mpeg'
+    }
+  }
+
+  // M4A: Same as MP4 but with M4A brand
+  if (
+    bytes.length >= 12 &&
+    bytes[4] === 0x66 &&
+    bytes[5] === 0x74 &&
+    bytes[6] === 0x79 &&
+    bytes[7] === 0x70
+  ) {
+    const brand = String.fromCharCode(bytes[8], bytes[9], bytes[10], bytes[11])
+    if (brand === 'M4A ' || brand === 'M4B ') {
+      return 'audio/mp4'
+    }
+  }
+
+  // WAV: RIFF....WAVE
+  if (
+    bytes.length >= 12 &&
+    bytes[0] === 0x52 && // R
+    bytes[1] === 0x49 && // I
+    bytes[2] === 0x46 && // F
+    bytes[3] === 0x46 && // F
+    bytes[8] === 0x57 && // W
+    bytes[9] === 0x41 && // A
+    bytes[10] === 0x56 && // V
+    bytes[11] === 0x45 // E
+  ) {
+    return 'audio/wav'
+  }
+
+  // PDF: %PDF
+  if (
+    bytes.length >= 4 &&
+    bytes[0] === 0x25 && // %
+    bytes[1] === 0x50 && // P
+    bytes[2] === 0x44 && // D
+    bytes[3] === 0x46 // F
+  ) {
+    return 'application/pdf'
+  }
+
+  return null
+}

--- a/src/lib/fileTypes.ts
+++ b/src/lib/fileTypes.ts
@@ -1,3 +1,5 @@
+import { detectMimeType } from './detectMimeType'
+
 export const MimeTypes = [
   // video
   'video/quicktime',
@@ -64,12 +66,15 @@ function getMimeTypeFromPath(path: string | undefined): MimeType | null {
   return map[ext] ?? null
 }
 
-/** Detect the mimeType from available fields. */
-export function getMimeType(asset: {
+/**
+ * Detect the mimeType from available fields.
+ * Uses file path, name, and magic number sniffing as fallbacks.
+ */
+export async function getMimeType(asset: {
   type?: string
   name?: string
   uri?: string
-}): MimeType {
+}): Promise<MimeType> {
   const typeFromType = isMimeType(asset.type) ? asset.type : null
   if (typeFromType) {
     return typeFromType
@@ -81,6 +86,12 @@ export function getMimeType(asset: {
   const typeFromName = getMimeTypeFromPath(asset.name)
   if (typeFromName) {
     return typeFromName
+  }
+  if (asset.uri) {
+    const typeFromData = await detectMimeType(asset.uri)
+    if (typeFromData) {
+      return typeFromData
+    }
   }
   return 'application/octet-stream'
 }

--- a/src/lib/processAssets.ts
+++ b/src/lib/processAssets.ts
@@ -62,23 +62,25 @@ export async function processAssets(
   assets: Asset[] | undefined,
   defaultFileName: string = 'file'
 ) {
-  const candidateFiles: CandidateFileRecord[] = (assets ?? []).map((a) => ({
-    id: uniqueId(),
-    localId: a.id ?? null,
-    sourceUri: a.sourceUri ?? null,
-    name: a.name ?? defaultFileName,
-    size: null,
-    createdAt: new Date(a.timestamp ?? Date.now()).getTime(),
-    updatedAt: new Date(a.timestamp ?? Date.now()).getTime(),
-    type: getMimeType({
-      type: a.type,
-      name: a.name,
-      uri: a.sourceUri,
-    }),
-    hash: null,
-    status: 'new',
-    statusDetails: null,
-  }))
+  const candidateFiles: CandidateFileRecord[] = await Promise.all(
+    (assets ?? []).map(async (a) => ({
+      id: uniqueId(),
+      localId: a.id ?? null,
+      sourceUri: a.sourceUri ?? null,
+      name: a.name ?? defaultFileName,
+      size: null,
+      createdAt: new Date(a.timestamp ?? Date.now()).getTime(),
+      updatedAt: new Date(a.timestamp ?? Date.now()).getTime(),
+      type: await getMimeType({
+        type: a.type,
+        name: a.name,
+        uri: a.sourceUri,
+      }),
+      hash: null,
+      status: 'new',
+      statusDetails: null,
+    }))
+  )
 
   // Update the status of the files that are found by localId.
   // This is quick but will only detect duplicates from the same device.

--- a/src/lib/readFileBytes.ts
+++ b/src/lib/readFileBytes.ts
@@ -1,0 +1,53 @@
+import { File } from 'expo-file-system'
+import { logger } from './logger'
+
+/**
+ * Read the first N bytes from a file.
+ * Handles variable chunk sizes by reading multiple chunks if needed.
+ */
+export async function readFileBytes(
+  uri: string,
+  byteCount: number
+): Promise<Uint8Array | null> {
+  try {
+    const file = new File(uri)
+    const readable = file.readableStream()
+    const reader = readable.getReader()
+
+    try {
+      // Read chunks until we have enough bytes (or file ends).
+      const chunks: Uint8Array[] = []
+      let totalBytes = 0
+
+      while (totalBytes < byteCount) {
+        const { value, done } = await reader.read()
+        if (done || !value) break
+
+        const chunk = new Uint8Array(value)
+        chunks.push(chunk)
+        totalBytes += chunk.length
+      }
+
+      if (totalBytes === 0) {
+        return null
+      }
+
+      // Combine chunks and take only the requested number of bytes.
+      const bytes = new Uint8Array(Math.min(totalBytes, byteCount))
+      let offset = 0
+      for (const chunk of chunks) {
+        const toCopy = Math.min(chunk.length, byteCount - offset)
+        bytes.set(chunk.slice(0, toCopy), offset)
+        offset += toCopy
+        if (offset >= byteCount) break
+      }
+
+      return bytes
+    } finally {
+      reader.releaseLock()
+    }
+  } catch (e) {
+    logger.log('[readFileBytes] error:', e)
+    return null
+  }
+}

--- a/src/managers/downloader.ts
+++ b/src/managers/downloader.ts
@@ -11,11 +11,11 @@ import { PinnedObject } from 'react-native-sia'
 import { useCallback } from 'react'
 import { getOneSealedObject } from '../lib/file'
 import { logger } from '../lib/logger'
-import { decodeFileMetadata } from '../encoding/fileMetadata'
 import { DOWNLOAD_MAX_INFLIGHT } from '../config'
 import { getAppKeyForIndexer } from '../stores/appKey'
-import { FileLocalMetadata, FileRecord } from '../stores/files'
+import { FileRecord } from '../stores/files'
 import { File } from 'expo-file-system'
+import { type SharedObjectInterface } from 'react-native-sia'
 
 export function useDownload(file?: FileRecord | null) {
   const toast = useToast()
@@ -71,28 +71,40 @@ export function useDownload(file?: FileRecord | null) {
 export function useDownloadFromShareURL() {
   const sdk = useSdk()
   return useCallback(
-    async (id: string, sharedUrl: string) =>
-      runDownloadWithSlot({
+    async (id: string, sharedUrl: string) => {
+      // Check if download is already running or queued.
+      const downloadState = getDownloadState(id)
+      if (
+        downloadState?.status === 'running' ||
+        downloadState?.status === 'queued'
+      ) {
+        logger.log('[useDownloadFromShareURL] download already in progress', id)
+        return id
+      }
+
+      return runDownloadWithSlot({
         id,
         task: async (signal) => {
           if (!sdk) throw new Error('SDK not initialized')
           const sharedObject = await sdk.sharedObject(sharedUrl)
-          const metadata = decodeFileMetadata(sharedObject.metadata())
           const downloader = await sdk.downloadShared(sharedObject, {
             maxInflight: DOWNLOAD_MAX_INFLIGHT,
             offset: BigInt(0),
             length: undefined,
           })
-          const localMetadata: FileLocalMetadata = {
+          // Create a minimal file record for downloading
+          // The actual metadata will be extracted from the downloaded file
+          const file: FileRecord = {
             id,
+            name: 'Shared File',
+            type: 'application/octet-stream',
+            size: Number(sharedObject.size()),
+            hash: '',
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
             localId: null,
             addedAt: Date.now(),
-          }
-          const file: FileRecord = {
-            ...metadata,
-            ...localMetadata,
             objects: {},
-            id,
           }
           await streamToCache({
             file,
@@ -105,7 +117,8 @@ export function useDownloadFromShareURL() {
           })
           return id
         },
-      }),
+      })
+    },
     [sdk]
   )
 }
@@ -159,4 +172,64 @@ async function streamToCache(params: {
   if (onAfterClose) {
     await onAfterClose(targetFile)
   }
+}
+
+/**
+ * Download only the first N bytes from a shared object for type detection.
+ * Returns the bytes as a Uint8Array.
+ */
+export async function downloadFirstBytesFromShared(
+  sdk: ReturnType<typeof useSdk>,
+  sharedObject: SharedObjectInterface,
+  byteCount: number
+): Promise<Uint8Array> {
+  if (!sdk) {
+    throw new Error('SDK not initialized')
+  }
+
+  logger.log(
+    `[downloadFirstBytesFromShared] Downloading first ${byteCount} bytes`
+  )
+
+  // Download only first N bytes for type detection.
+  const downloader = await sdk.downloadShared(sharedObject, {
+    maxInflight: DOWNLOAD_MAX_INFLIGHT,
+    offset: BigInt(0),
+    length: BigInt(byteCount),
+  })
+
+  // Read the bytes.
+  const chunks: Uint8Array[] = []
+  let totalBytes = 0
+  const abortController = new AbortController()
+
+  try {
+    while (totalBytes < byteCount) {
+      const chunk = await downloader.readChunk({
+        signal: abortController.signal,
+      })
+      if (!chunk || chunk.byteLength === 0) break
+
+      const buf = new Uint8Array(chunk)
+      chunks.push(buf)
+      totalBytes += buf.length
+      if (totalBytes >= byteCount) break
+    }
+  } finally {
+    // Abort the download after we have enough bytes.
+    abortController.abort()
+  }
+
+  // Combine chunks and take only the requested number of bytes.
+  const bytes = new Uint8Array(Math.min(totalBytes, byteCount))
+  let offset = 0
+  for (const chunk of chunks) {
+    const toCopy = Math.min(chunk.length, byteCount - offset)
+    bytes.set(chunk.slice(0, toCopy), offset)
+    offset += toCopy
+    if (offset >= byteCount) break
+  }
+
+  logger.log(`[downloadFirstBytesFromShared] Downloaded ${bytes.length} bytes`)
+  return bytes
 }

--- a/src/managers/thumbnailer.ts
+++ b/src/managers/thumbnailer.ts
@@ -164,7 +164,7 @@ export async function ensureThumbnailForSize(params: {
     const thumbId = uniqueId()
     const thumbFileInfo = {
       id: thumbId,
-      type: getMimeType({ type: 'image/webp', name: 'thumbnail.webp' }),
+      type: await getMimeType({ type: 'image/webp', name: 'thumbnail.webp' }),
       localId: null,
     }
     const fileUri = await copyFileToFs(thumbFileInfo, new File(result.uri))

--- a/src/screens/ImportFileScreen.tsx
+++ b/src/screens/ImportFileScreen.tsx
@@ -1,120 +1,22 @@
 import { type NativeStackScreenProps } from '@react-navigation/native-stack'
 import { useNavigation, type NavigationProp } from '@react-navigation/native'
-import React, { useCallback, useMemo, useState } from 'react'
-import useSWR from 'swr'
-import {
-  ActivityIndicator,
-  ScrollView,
-  StyleSheet,
-  Text,
-  View,
-} from 'react-native'
+import React from 'react'
+import { StyleSheet, View } from 'react-native'
 import {
   type ImportStackParamList,
   type RootTabParamList,
 } from '../stacks/types'
-import { useToast } from '../lib/toastContext'
-import { useSdk } from '../stores/sdk'
-import {
-  createFileRecordWithLocalObject,
-  FileLocalMetadata,
-  FileMetadata,
-  FileRecord,
-  readFileRecordByContentHash,
-} from '../stores/files'
-import { FileDetailsImport } from '../components/FileDetailsImport'
-import { logger } from '../lib/logger'
-import {
-  decodeFileMetadata,
-  hasCompleteFileMetadata,
-  transformFileMetadata,
-} from '../encoding/fileMetadata'
-import { getIndexerURL } from '../stores/settings'
-import { BottomActionButton } from '../components/BottomActionButton'
-import { PlusIcon } from 'lucide-react-native'
 import { FileDetailScreenHeader } from '../components/FileDetailScreenHeader'
 import { colors } from '../styles/colors'
-import { pinnedObjectToLocalObject } from '../lib/localObjects'
 import { convertSiaShareUrlToHttp } from '../lib/shareUrl'
+import { FileImport } from '../components/FileImport'
 
 type Props = NativeStackScreenProps<ImportStackParamList, 'ImportFile'>
 
 export function ImportFileScreen({ route }: Props) {
   const navigation = useNavigation<NavigationProp<RootTabParamList>>()
-  const toast = useToast()
   const id = route.params.id
   const shareUrl = convertSiaShareUrlToHttp(route.params.shareUrl)
-  const sdk = useSdk()
-  const sharedObject = useSWR(
-    sdk ? ['sharedObject', shareUrl, id] : null,
-    async () => {
-      try {
-        if (!sdk || !shareUrl) return null
-        return sdk.sharedObject(shareUrl)
-      } catch (e) {
-        logger.log('Error getting shared object', e)
-        return null
-      }
-    }
-  )
-  const sharedFile = useMemo(() => {
-    if (!sharedObject.data) return null
-    const metadata = decodeFileMetadata(sharedObject.data.metadata())
-    const fileMetadata: FileMetadata = transformFileMetadata({
-      ...metadata,
-      size: Number(sharedObject.data.size()),
-    })
-    const localMetadata: FileLocalMetadata = {
-      id,
-      localId: null,
-      addedAt: Date.now(),
-    }
-    const file: FileRecord = {
-      ...fileMetadata,
-      ...localMetadata,
-      objects: {},
-    }
-    return file
-  }, [sharedObject.data, id])
-
-  const [isAddingToDatabase, setIsAddingToDatabase] = useState(false)
-  const handleAddToDatabase = useCallback(async () => {
-    setIsAddingToDatabase(true)
-    try {
-      if (!sharedObject.data || !sdk || !sharedFile) {
-        toast.show('Error adding file to library')
-        return
-      }
-      logger.log('[ImportFileScreen] handleAddToDatabase', sharedFile.id)
-      if (!hasCompleteFileMetadata(sharedFile)) {
-        toast.show('Shared file must have complete metadata')
-        return
-      }
-      const existingFile = await readFileRecordByContentHash(sharedFile.hash)
-      if (existingFile) {
-        toast.show('File already exists in library')
-        return
-      }
-      const indexerURL = await getIndexerURL()
-      const pinnedObject = await sdk.pinShared(sharedObject.data)
-      const localObject = await pinnedObjectToLocalObject(
-        sharedFile.id,
-        indexerURL,
-        pinnedObject
-      )
-      await createFileRecordWithLocalObject(sharedFile, localObject)
-      toast.show('File added')
-      navigation.navigate('MainTab', {
-        screen: 'FileDetail',
-        params: { id: sharedFile.id },
-      })
-    } catch (e) {
-      logger.log('[ImportFileScreen] Error adding file to library', e)
-      toast.show('Error adding file to library')
-    } finally {
-      setIsAddingToDatabase(false)
-    }
-  }, [sharedFile, sdk, toast, navigation])
 
   return (
     <View style={styles.container}>
@@ -123,28 +25,14 @@ export function ImportFileScreen({ route }: Props) {
         navigation={navigation}
         icon="close"
       />
-      <ScrollView contentContainerStyle={styles.content}>
-        {sharedObject.isLoading ? (
-          <View style={styles.center}>
-            <ActivityIndicator color={colors.accentPrimary} />
-            <Text style={styles.loadingText}>Loading…</Text>
-          </View>
-        ) : sharedObject.error ? (
-          <Text style={styles.errorText}>{sharedObject.error.message}</Text>
-        ) : (
-          <>
-            {shareUrl && sharedFile && (
-              <FileDetailsImport file={sharedFile} shareUrl={shareUrl} />
-            )}
-          </>
-        )}
-      </ScrollView>
-      <BottomActionButton
-        label={isAddingToDatabase ? 'Adding to library...' : 'Add to library'}
-        disabled={isAddingToDatabase}
-        icon={<PlusIcon color="white" size={22} />}
-        onPress={handleAddToDatabase}
-      />
+      {id && shareUrl && (
+        <FileImport
+          key={`${id}-${shareUrl}`}
+          id={id}
+          shareUrl={shareUrl}
+          navigation={navigation}
+        />
+      )}
     </View>
   )
 }
@@ -154,12 +42,4 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: colors.bgCanvas,
   },
-  content: { padding: 0 },
-  center: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingVertical: 24,
-  },
-  loadingText: { color: colors.textSecondary, marginTop: 8 },
-  errorText: { color: colors.textDanger },
 })


### PR DESCRIPTION
- This PR updates the share URL import screen to work without incoming metadata.
- The flow is now:
    - Share URL metadata is downloaded, this includes the size.
    - Tries to detect the file type by downloading only 30 bytes and inferring file type.
    - If the file is less than 5mb it auto downloads and computes the SHA256 hash.
        - If the file is larger the user must initiate the download.
    - The Add to library button is disabled until all required metadata is available.
- The new flow is set up to easily support optional metadata passed in the share URL once that feature is available.
- The general getMimeType method now includes the file type detection from bytes, updated all call sites since it is now async.

![Screenshot 2025-12-22 at 12.25.20 PM.png](https://app.graphite.com/user-attachments/assets/19f2d56d-a104-419b-8f82-7aa712d2feb0.png)

![Screenshot 2025-12-22 at 12.25.09 PM.png](https://app.graphite.com/user-attachments/assets/4ce030f3-0acc-435c-913b-f868d1bdbd59.png)

