### PR TITLE
refactor: switch hash algorithm separator

### DIFF
--- a/src/lib/__snapshots__/contentHash.test.ts.snap
+++ b/src/lib/__snapshots__/contentHash.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`calculateContentHash falls back to QuickCrypto when RNFS.hash fails 1`] = `"sha256|c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2"`;
+exports[`calculateContentHash falls back to QuickCrypto when RNFS.hash fails 1`] = `"sha256:c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2"`;
 
-exports[`calculateContentHash handles binary data with null bytes via fallback 1`] = `"sha256|7f07808cb0745837d54ca4174b39ceed57db3bddc520b1402ed0c14ccc2cce76"`;
+exports[`calculateContentHash handles binary data with null bytes via fallback 1`] = `"sha256:7f07808cb0745837d54ca4174b39ceed57db3bddc520b1402ed0c14ccc2cce76"`;
 
-exports[`calculateContentHash handles empty files via fallback 1`] = `"sha256|e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"`;
+exports[`calculateContentHash handles empty files via fallback 1`] = `"sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"`;

--- a/src/lib/contentHash.test.ts
+++ b/src/lib/contentHash.test.ts
@@ -28,7 +28,7 @@ describe('calculateContentHash', () => {
     rnfs.rnfsHash.mockResolvedValueOnce(expectedHash)
 
     const res = await calculateContentHash('file:///test.txt')
-    expect(res).toBe(`sha256|${expectedHash}`)
+    expect(res).toBe(`sha256:${expectedHash}`)
   })
 
   it('falls back to QuickCrypto when RNFS.hash fails', async () => {

--- a/src/lib/contentHash.ts
+++ b/src/lib/contentHash.ts
@@ -2,7 +2,7 @@ import RNFS from 'react-native-fs'
 import QuickCrypto from 'react-native-quick-crypto'
 import { Buffer } from 'buffer'
 
-export type HashResult = `sha256|${string}`
+export type HashResult = `sha256:${string}`
 
 /**
  * Calculate a content hash for a file.
@@ -15,7 +15,7 @@ export async function calculateContentHash(
     return null
   }
   const hex = await sha256File(uri)
-  return `sha256|${hex}`
+  return `sha256:${hex}`
 }
 
 /** SHA-256. Try streamed native RNFS.hash first, otherwise fallback to QuickCrypto. */

--- a/src/lib/processAssets.test.ts
+++ b/src/lib/processAssets.test.ts
@@ -18,7 +18,7 @@ jest.mock('./mediaLibrary', () => ({
   getMediaLibraryUri: jest.fn(),
 }))
 jest.mock('./contentHash', () => ({
-  calculateContentHash: jest.fn(async (uri: string) => `sha256|hash:${uri}`),
+  calculateContentHash: jest.fn(async (uri: string) => `sha256:hash:${uri}`),
 }))
 jest.mock('../managers/thumbnailer', () => ({
   generateThumbnails: jest.fn(),
@@ -119,7 +119,7 @@ describe('processAssets', () => {
         createdAt: 1,
         updatedAt: 1,
         type: 'image/jpeg',
-        hash: 'sha256|existing-hash',
+        hash: 'sha256:existing-hash',
         localId: null,
         addedAt: 1,
       },
@@ -128,7 +128,7 @@ describe('processAssets', () => {
 
     jest
       .mocked(calculateContentHash)
-      .mockImplementation(async () => 'sha256|existing-hash')
+      .mockImplementation(async () => 'sha256:existing-hash')
     const assets = [
       {
         id: 'same-hash',
@@ -159,7 +159,7 @@ describe('processAssets', () => {
     })
     jest
       .mocked(calculateContentHash)
-      .mockImplementation(async () => 'sha256|same-for-all')
+      .mockImplementation(async () => 'sha256:same-for-all')
     const assets = [
       {
         id: undefined,

--- a/src/managers/thumbnailScanner.test.ts
+++ b/src/managers/thumbnailScanner.test.ts
@@ -37,7 +37,7 @@ beforeEach(async () => {
   getFsFileUriMock.mockResolvedValue('file://source.jpg')
   let hashCounter = 0
   calculateContentHashMock.mockImplementation(
-    async () => `sha256|thumb-hash-${++hashCounter}`
+    async () => `sha256:thumb-hash-${++hashCounter}`
   )
 
   imageGetSizeMock.mockImplementation((_, ok) => {
@@ -161,7 +161,7 @@ describe('thumbnailScanner', () => {
       })
     }
     getFsFileUriMock.mockResolvedValue('file://test.jpg')
-    calculateContentHashMock.mockResolvedValue('sha256|thumb-64')
+    calculateContentHashMock.mockResolvedValue('sha256:thumb-64')
     const result = await runThumbnailScanner()
     const producedSizes = result.produced
       .filter((p) => p.originalId === 'file1')
@@ -303,7 +303,7 @@ describe('thumbnailScanner', () => {
       name: 'thumbnail.webp',
       type: 'image/webp',
       size: 100,
-      hash: 'sha256|duplicate-thumb-hash',
+      hash: 'sha256:duplicate-thumb-hash',
       createdAt: now,
       updatedAt: now,
       addedAt: now,
@@ -312,7 +312,7 @@ describe('thumbnailScanner', () => {
       thumbSize: 64,
     })
     getFsFileUriMock.mockResolvedValue('file://test.jpg')
-    calculateContentHashMock.mockResolvedValue('sha256|duplicate-thumb-hash')
+    calculateContentHashMock.mockResolvedValue('sha256:duplicate-thumb-hash')
     const result = await runThumbnailScanner()
     expect(result.deduplicated.length).toBeGreaterThanOrEqual(1)
     expect(result.deduplicated).toEqual(
@@ -345,7 +345,7 @@ describe('thumbnailScanner', () => {
     })
     let counter = 0
     calculateContentHashMock.mockImplementation(
-      async () => `sha256|video-thumb-${++counter}`
+      async () => `sha256:video-thumb-${++counter}`
     )
 
     const result = await runThumbnailScanner()
@@ -378,7 +378,7 @@ describe('thumbnailScanner', () => {
     getFsFileUriMock.mockResolvedValue('file://test.jpg')
     let counter = 0
     calculateContentHashMock.mockImplementation(
-      async () => `sha256|thumb-hash-${++counter}`
+      async () => `sha256:thumb-hash-${++counter}`
     )
     const result = await runThumbnailScanner()
     expect(result.produced).toHaveLength(10)
@@ -415,7 +415,7 @@ describe('thumbnailScanner', () => {
     imageManipulatorMock.mockReturnValue(
       ctx as unknown as ImageManipulatorContext
     )
-    calculateContentHashMock.mockResolvedValue('sha256|thumb-hash')
+    calculateContentHashMock.mockResolvedValue('sha256:thumb-hash')
     await runThumbnailScanner()
     expect(ctx.resize).toHaveBeenCalledWith({ width: 64, height: undefined })
   })


### PR DESCRIPTION
- The colon separator makes more sense, adding this breaking change before testflight.