### PR TITLE
refactor: structured logs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+# Development
+EXPO_PUBLIC_LOG_LEVEL=debug
+EXPO_PUBLIC_LOG_SCOPES=backgroundTask
+
 # Android Release Signing
 SIA_RELEASE_STORE_FILE=android-release.keystore
 SIA_RELEASE_KEY_ALIAS=siaReleaseKey

--- a/index.ts
+++ b/index.ts
@@ -4,14 +4,14 @@ import { Root } from './src/Root'
 import { initSia, setLogger } from 'react-native-sia'
 import { logger, rustLogger } from './src/lib/logger'
 
-logger.log('initSia and uniffi...')
+logger.info('app', 'initSia and uniffi...')
 
 // registerRootComponent calls AppRegistry.registerComponent('main', () => App);
 // It also ensures that whether you load the app in Expo Go or in a native build,
 // the environment is set up appropriately
 initSia().then(() => {
-  logger.log('Initializing app...')
+  logger.info('app', 'Initializing app...')
   setLogger(rustLogger, 'debug')
   registerRootComponent(Root)
-  logger.log('App initialized')
+  logger.info('app', 'App initialized')
 })

--- a/jest.setup.cjs
+++ b/jest.setup.cjs
@@ -1,7 +1,19 @@
 jest.mock('./src/lib/logger', () => ({
   LOG_SERVICES: true,
-  logger: { log: jest.fn(), sdk: jest.fn(), clear: jest.fn() },
-  serviceLog: jest.fn(),
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    clear: jest.fn(),
+  },
+  rustLogger: {
+    hasInitialized: false,
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
 }))
 
 // Ensure expo-constants is available for transitive expo modules (expo-asset/SQLite).

--- a/src/components/FileActionsSheet.tsx
+++ b/src/components/FileActionsSheet.tsx
@@ -60,7 +60,7 @@ export function FileActionsSheet({
       await removeFsFile(file)
       toast.show('Removed from device')
     } catch (e) {
-      logger.log('[FileActionsSheet] failed to remove local file', e)
+      logger.error('FileActionsSheet', 'failed to remove local file', e)
       toast.show('Failed to remove from device')
     }
   }, [file?.id, file?.type, toast])
@@ -72,7 +72,7 @@ export function FileActionsSheet({
       await reupload(file.id)
       toast.show('Reuploaded file')
     } catch (e) {
-      logger.log('[FileActionsSheet] failed to reupload file', e)
+      logger.error('FileActionsSheet', 'failed to reupload file', e)
       toast.show('Failed to reupload file')
     }
   }, [file?.id, toast])
@@ -83,7 +83,7 @@ export function FileActionsSheet({
       await deleteFileFromNetwork(file)
       toast.show('Removed from network')
     } catch (e) {
-      logger.log('[FileActionsSheet] failed to remove from network', e)
+      logger.error('FileActionsSheet', 'failed to remove from network', e)
       toast.show('Failed to remove from network')
     }
   }, [file?.id, toast])
@@ -95,7 +95,7 @@ export function FileActionsSheet({
       if (navigation) navigation.goBack()
       toast.show('File deleted')
     } catch (e) {
-      logger.log('[FileActionsSheet] failed to delete file', e)
+      logger.error('FileActionsSheet', 'failed to delete file', e)
       toast.show('Failed to delete file')
     }
   }, [file, navigation, toast])

--- a/src/components/FileImport/index.tsx
+++ b/src/components/FileImport/index.tsx
@@ -48,9 +48,9 @@ async function detectFileType(
   sharedObject: SharedObjectInterface,
   id: string
 ): Promise<string> {
-  logger.log(
-    `[FileImport] Detecting type from first ${MAGIC_BYTES_LENGTH} bytes`,
-    id
+  logger.debug(
+    'FileImport',
+    `Detecting type from first ${MAGIC_BYTES_LENGTH} bytes ${id}`
   )
   try {
     if (!sdk || !sharedObject) {
@@ -64,15 +64,15 @@ async function detectFileType(
     )
 
     if (bytes.length === 0) {
-      logger.log('[FileImport] No bytes received for type detection')
+      logger.warn('FileImport', 'No bytes received for type detection')
       return 'application/octet-stream'
     }
 
     const type = detectMimeTypeFromBytes(bytes)
-    logger.log('[FileImport] Detected type:', type)
+    logger.debug('FileImport', `Detected type: ${type}`)
     return type || 'application/octet-stream'
   } catch (e) {
-    logger.log('[FileImport] Error detecting type', e)
+    logger.error('FileImport', 'Error detecting type', e)
     return 'application/octet-stream'
   }
 }
@@ -83,13 +83,13 @@ async function downloadAndProcessFile(
   shareUrl: string,
   downloadFromShareURL: ReturnType<typeof useDownloadFromShareURL>
 ): Promise<FileRecord> {
-  logger.log('[FileImport] SWR function starting for', id)
+  logger.debug('FileImport', `SWR function starting for ${id}`)
   try {
     if (!shareUrl) throw new Error('Invalid share URL')
 
-    logger.log('[FileImport] downloading to temp', id, shareUrl)
+    logger.debug('FileImport', `downloading to temp ${id} ${shareUrl}`)
     await downloadFromShareURL(id, shareUrl)
-    logger.log('[FileImport] download complete')
+    logger.debug('FileImport', 'download complete')
 
     const tempFsFileUri = await getFsFileUri({
       id,
@@ -99,13 +99,13 @@ async function downloadAndProcessFile(
       throw new Error('File not found in cache after download')
     }
 
-    logger.log('[FileImport] sniffing type from', tempFsFileUri)
+    logger.debug('FileImport', `sniffing type from ${tempFsFileUri}`)
     let type: string
     try {
       type = await getMimeType({ uri: tempFsFileUri })
-      logger.log('[FileImport] detected type', type)
+      logger.debug('FileImport', `detected type ${type}`)
     } catch (e) {
-      logger.log('[FileImport] error detecting type', e)
+      logger.error('FileImport', 'error detecting type', e)
       type = 'application/octet-stream'
     }
 
@@ -114,17 +114,20 @@ async function downloadAndProcessFile(
     const size = fileInfo.size ?? 0
 
     const finalFsFileUri = await copyFileToFs({ id, type }, tempFile)
-    logger.log('[FileImport] copied to final location', finalFsFileUri)
+    logger.debug('FileImport', `copied to final location ${finalFsFileUri}`)
 
     if (finalFsFileUri !== tempFsFileUri) {
       tempFile.delete()
     }
 
-    logger.log('[FileImport] calculating hash from', finalFsFileUri)
+    logger.debug('FileImport', `calculating hash from ${finalFsFileUri}`)
     const hash = await calculateContentHash(finalFsFileUri)
-    logger.log('[FileImport] hash calculated', hash)
+    logger.debug('FileImport', `hash calculated ${hash}`)
 
-    logger.log('[FileImport] file ready', { type, size, hash })
+    logger.info(
+      'FileImport',
+      `file ready type=${type} size=${size} hash=${hash}`
+    )
 
     return {
       id,
@@ -139,7 +142,7 @@ async function downloadAndProcessFile(
       objects: {},
     } satisfies FileRecord
   } catch (e) {
-    logger.log('[FileImport] Error preparing file', e)
+    logger.error('FileImport', 'Error preparing file', e)
     throw e
   }
 }
@@ -166,7 +169,7 @@ export function FileImport({
         if (!sdk || !shareUrl) return null
         return sdk.sharedObject(shareUrl)
       } catch (e) {
-        logger.log('Error getting shared object', e)
+        logger.error('FileImport', 'Error getting shared object', e)
         return null
       }
     }
@@ -266,7 +269,7 @@ export function FileImport({
 
     setIsAddingToDatabase(true)
     try {
-      logger.log('[FileImport] importing file', sharedFile.data.id)
+      logger.info('FileImport', `importing file ${sharedFile.data.id}`)
 
       // Pin the shared object and create file record.
       const indexerURL = await getIndexerURL()
@@ -284,7 +287,7 @@ export function FileImport({
         params: { id: sharedFile.data.id },
       })
     } catch (e) {
-      logger.log('[FileImport] Error adding file to library', e)
+      logger.error('FileImport', 'Error adding file to library', e)
       toast.show('Error adding file to library')
     } finally {
       setIsAddingToDatabase(false)

--- a/src/components/LogView.tsx
+++ b/src/components/LogView.tsx
@@ -1,45 +1,94 @@
-import { useRef } from 'react'
-import { View, Text, ScrollView, StyleSheet, Platform } from 'react-native'
+import { useRef, useCallback } from 'react'
+import {
+  View,
+  Text,
+  FlatList,
+  StyleSheet,
+  Platform,
+  ActivityIndicator,
+} from 'react-native'
 import { palette } from '../styles/colors'
+import { type LogEntry } from '../lib/logger'
+import { getScopeColorHex, getLevelColorHex } from '../lib/logColors'
+import { useLogs } from '../hooks/useLogs'
 
-export function LogView({ logs }: { logs: string[] }) {
-  const scrollRef = useRef<any>(null)
+export function LogView() {
+  const { data: logs = [], isLoading, error } = useLogs()
 
-  const handleContentSizeChange = (_w: number, _h: number) => {
-    scrollRef.current?.scrollToEnd?.({ animated: true })
+  const renderLogItem = useCallback(
+    ({ item, index }: { item: LogEntry; index: number }) => {
+      const scopeColor = getScopeColorHex(item.scope)
+      const levelColor = getLevelColorHex(item.level) ?? palette.gray[50]
+
+      return (
+        <Text
+          key={`${index}-${item.timestamp}-${item.scope}`}
+          style={styles.line}
+        >
+          <Text style={[styles.timestamp, { color: palette.gray[400] }]}>
+            {item.timestamp}{' '}
+          </Text>
+          <Text style={[styles.level, { color: levelColor }]}>
+            {item.level.toUpperCase()}{' '}
+          </Text>
+          <Text style={[styles.scope, { color: scopeColor }]}>
+            [{item.scope}]{' '}
+          </Text>
+          <Text style={styles.message}>{item.message}</Text>
+        </Text>
+      )
+    },
+    []
+  )
+
+  if (isLoading) {
+    return (
+      <View style={styles.container}>
+        <ActivityIndicator size="large" color={palette.gray[400]} />
+        <Text style={styles.loadingText}>Loading logs...</Text>
+      </View>
+    )
+  }
+
+  if (error) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.empty}>Failed to load logs</Text>
+      </View>
+    )
+  }
+
+  if (logs.length === 0) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.empty}>No logs yet.</Text>
+      </View>
+    )
   }
 
   return (
     <View style={styles.container}>
-      <ScrollView
-        ref={(node) => {
-          scrollRef.current = node
-        }}
-        style={styles.scroll}
+      <FlatList
+        data={logs}
+        renderItem={renderLogItem}
+        keyExtractor={(item, index) =>
+          `${index}-${item.timestamp}-${item.scope}-${item.level}`
+        }
+        inverted
         contentContainerStyle={styles.content}
         showsVerticalScrollIndicator
-        onContentSizeChange={handleContentSizeChange}
-      >
-        {logs.length === 0 ? (
-          <Text style={styles.empty}>No logs yet.</Text>
-        ) : (
-          logs.map((l, i) => (
-            <Text key={`${i}-${l.slice(0, 10)}`} style={styles.line}>
-              {l}
-            </Text>
-          ))
-        )}
-      </ScrollView>
+        maintainVisibleContentPosition={{
+          minIndexForVisible: 0,
+        }}
+      />
     </View>
   )
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, minHeight: 0 },
-  scroll: { flex: 1 },
+  container: { flex: 1, minHeight: 0, paddingBottom: 85 },
   content: { padding: 12 },
   line: {
-    color: palette.gray[50],
     fontFamily: Platform.select({
       ios: 'Menlo',
       android: 'monospace',
@@ -49,9 +98,24 @@ const styles = StyleSheet.create({
     lineHeight: 16,
     marginBottom: 6,
   },
+  timestamp: {},
+  level: {
+    fontWeight: '600',
+  },
+  scope: {
+    fontWeight: '600',
+  },
+  message: {
+    color: palette.gray[50],
+  },
   empty: {
     color: palette.gray[300],
     textAlign: 'center',
     marginTop: 40,
+  },
+  loadingText: {
+    color: palette.gray[400],
+    textAlign: 'center',
+    marginTop: 12,
   },
 })

--- a/src/components/MediaConsumers/VideoPlayer.tsx
+++ b/src/components/MediaConsumers/VideoPlayer.tsx
@@ -25,7 +25,7 @@ export function VideoPlayer({
     try {
       await videoRef.current?.enterFullscreen()
     } catch (error) {
-      logger.log('[VideoPlayer] Failed to enter fullscreen:', error)
+      logger.error('VideoPlayer', 'Failed to enter fullscreen:', error)
     }
   }, [onViewerControlPress, player])
 

--- a/src/components/SettingsLogsControlBar.tsx
+++ b/src/components/SettingsLogsControlBar.tsx
@@ -1,55 +1,296 @@
 import {
+  useLogLevel,
+  useLogScopes,
+  useAvailableScopes,
+  setLogLevel,
+  setLogScopes,
+  toggleLogScope,
   clearLogs,
-  toggleEnableSdkLogs,
-  useSDKLogsEnabled,
 } from '../stores/logs'
+import { exportLogs } from '../lib/exportLogs'
+import { type LogLevel } from '../lib/logger'
+import { logger } from '../lib/logger'
+import { logsSwr } from '../hooks/useLogs'
+import { Alert } from 'react-native'
 import { type NativeStackScreenProps } from '@react-navigation/native-stack'
 import { type SettingsStackParamList } from '../stacks/types'
 import { iconColors } from './BottomControlBar'
-import { EyeIcon, EyeOffIcon, TrashIcon } from 'lucide-react-native'
-import { View } from 'react-native'
+import {
+  FilterIcon,
+  DownloadIcon,
+  ChevronDownIcon,
+  RefreshCwIcon,
+  Trash2Icon,
+} from 'lucide-react-native'
+import { View, Text, Pressable, StyleSheet } from 'react-native'
 import { IconButton } from './IconButton'
 import { useToast } from '../lib/toastContext'
 import { BottomControlBar } from './BottomControlBar'
+import { ActionSheet } from './ActionSheet'
+import { closeSheet, useSheetOpen, openSheet } from '../stores/sheets'
+import { palette } from '../styles/colors'
+import { useState } from 'react'
+import { SpinnerIcon } from './SpinnerIcon'
 
-type Props = NativeStackScreenProps<SettingsStackParamList, 'Logs'>
+type Props = NativeStackScreenProps<SettingsStackParamList, 'Logs'> & {
+  onRefresh?: () => void
+}
 
-export function SettingsLogsControlBar({ navigation }: Props) {
-  const sdkLogsEnabled = useSDKLogsEnabled()
+const LOG_LEVELS: LogLevel[] = ['debug', 'info', 'warn', 'error']
+
+export function SettingsLogsControlBar({ navigation, onRefresh }: Props) {
+  const logLevel = useLogLevel()
+  const logScopes = useLogScopes()
+  const availableScopes = useAvailableScopes()
+  const levelSheetOpen = useSheetOpen('logLevel')
+  const scopeSheetOpen = useSheetOpen('logScopes')
   const toast = useToast()
+  const [isExporting, setIsExporting] = useState(false)
 
-  const handleToggleSdkLogs = () => {
-    toggleEnableSdkLogs()
-    toast.show(sdkLogsEnabled ? 'SDK logs disabled' : 'SDK logs enabled')
+  const handleExportLogs = async () => {
+    if (isExporting) {
+      return
+    }
+    setIsExporting(true)
+    try {
+      const fileId = await exportLogs()
+      if (fileId) {
+        toast.show('Logs exported to library')
+        // Navigate to the exported file.
+        const parentNav = navigation.getParent()
+        if (parentNav) {
+          parentNav.navigate('MainTab', {
+            screen: 'FileDetail',
+            params: { id: fileId },
+          })
+        }
+      } else {
+        toast.show('No logs to export')
+      }
+    } catch (error) {
+      logger.error('logs', 'Failed to export logs', error)
+      toast.show('Failed to export logs')
+    } finally {
+      setIsExporting(false)
+    }
+  }
+
+  const handleLevelSelect = async (level: LogLevel) => {
+    await setLogLevel(level)
+    closeSheet()
+    toast.show(`Log level set to ${level}`)
+  }
+
+  const handleScopeToggle = async (scope: string) => {
+    await toggleLogScope(scope)
+    const newScopes = logScopes.includes(scope)
+      ? logScopes.filter((s) => s !== scope)
+      : [...logScopes, scope]
+    toast.show(
+      newScopes.length > 0
+        ? `Showing ${newScopes.length} scope(s)`
+        : 'Showing all scopes'
+    )
+  }
+
+  const handleClearScopes = async () => {
+    await setLogScopes([])
+    closeSheet()
+    toast.show('Showing all scopes')
   }
 
   const handleClearLogs = () => {
-    clearLogs()
-    toast.show('Logs cleared')
+    Alert.alert(
+      'Clear All Logs',
+      'This will permanently delete all log entries. This cannot be undone.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Clear',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await clearLogs()
+              await logsSwr.triggerChange()
+              toast.show('Logs cleared')
+            } catch (error) {
+              logger.error('logs', 'Failed to clear logs', error)
+              toast.show('Failed to clear logs')
+            }
+          },
+        },
+      ]
+    )
   }
 
   return (
-    <BottomControlBar style={{ width: 300, maxWidth: '90%' }}>
-      <View
-        style={{
-          flex: 1,
-          flexDirection: 'row',
-          gap: 12,
-          alignItems: 'center',
-          justifyContent: 'space-between',
-        }}
-      >
-        <IconButton onPress={handleToggleSdkLogs}>
-          {sdkLogsEnabled ? (
-            <EyeIcon color={iconColors.white} />
-          ) : (
-            <EyeOffIcon color={iconColors.white} />
+    <>
+      <BottomControlBar style={{ width: 360, maxWidth: '90%' }}>
+        <View
+          style={{
+            flex: 1,
+            flexDirection: 'row',
+            gap: 12,
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <Pressable
+            onPress={() => openSheet('logLevel')}
+            style={styles.filterButton}
+          >
+            <Text style={styles.filterButtonText}>
+              {logLevel.toUpperCase()}
+            </Text>
+            <ChevronDownIcon size={16} color={iconColors.white} />
+          </Pressable>
+          <Pressable
+            onPress={() => openSheet('logScopes')}
+            style={styles.filterButton}
+          >
+            <FilterIcon size={16} color={iconColors.white} />
+            <Text style={styles.filterButtonText}>
+              {logScopes.length > 0 ? `${logScopes.length}` : 'All'}
+            </Text>
+            <ChevronDownIcon size={16} color={iconColors.white} />
+          </Pressable>
+          {onRefresh && (
+            <IconButton onPress={onRefresh}>
+              <RefreshCwIcon color={iconColors.white} />
+            </IconButton>
           )}
-        </IconButton>
-        <IconButton onPress={handleClearLogs}>
-          <TrashIcon color={iconColors.white} />
-        </IconButton>
-      </View>
-    </BottomControlBar>
+          <IconButton onPress={handleExportLogs} disabled={isExporting}>
+            {isExporting ? (
+              <SpinnerIcon size={20} color={iconColors.white} />
+            ) : (
+              <DownloadIcon color={iconColors.white} />
+            )}
+          </IconButton>
+          <IconButton onPress={handleClearLogs}>
+            <Trash2Icon color={iconColors.white} />
+          </IconButton>
+        </View>
+      </BottomControlBar>
+
+      <ActionSheet visible={levelSheetOpen} onRequestClose={closeSheet}>
+        <Text style={styles.sheetTitle}>Log Level</Text>
+        {LOG_LEVELS.map((level) => (
+          <Pressable
+            key={level}
+            style={styles.sheetRow}
+            onPress={() => handleLevelSelect(level)}
+          >
+            <Text
+              style={[
+                styles.sheetRowText,
+                logLevel === level && styles.sheetRowTextSelected,
+              ]}
+            >
+              {level.toUpperCase()}
+            </Text>
+            {logLevel === level && <Text style={styles.sheetRowCheck}>✓</Text>}
+          </Pressable>
+        ))}
+      </ActionSheet>
+
+      <ActionSheet
+        visible={scopeSheetOpen}
+        onRequestClose={closeSheet}
+        snapPoints={['70%']}
+      >
+        <View
+          style={{
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            marginBottom: 12,
+          }}
+        >
+          <Text style={styles.sheetTitle}>Scopes</Text>
+          {logScopes.length > 0 && (
+            <Pressable onPress={handleClearScopes}>
+              <Text style={styles.clearButton}>Clear</Text>
+            </Pressable>
+          )}
+        </View>
+        {availableScopes.length === 0 ? (
+          <Text style={styles.emptyText}>No scopes available yet</Text>
+        ) : (
+          availableScopes.map((scope) => {
+            const isSelected = logScopes.includes(scope)
+            return (
+              <Pressable
+                key={scope}
+                style={styles.sheetRow}
+                onPress={() => handleScopeToggle(scope)}
+              >
+                <Text
+                  style={[
+                    styles.sheetRowText,
+                    isSelected && styles.sheetRowTextSelected,
+                  ]}
+                >
+                  {scope}
+                </Text>
+                {isSelected && <Text style={styles.sheetRowCheck}>✓</Text>}
+              </Pressable>
+            )
+          })
+        )}
+      </ActionSheet>
+    </>
   )
 }
+
+const styles = StyleSheet.create({
+  filterButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    backgroundColor: palette.gray[700],
+    borderRadius: 8,
+  },
+  filterButtonText: {
+    color: palette.gray[50],
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  sheetTitle: {
+    color: palette.gray[50],
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 16,
+  },
+  sheetRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 12,
+  },
+  sheetRowText: {
+    color: palette.gray[200],
+    fontSize: 16,
+  },
+  sheetRowTextSelected: {
+    color: palette.gray[50],
+    fontWeight: '600',
+  },
+  sheetRowCheck: {
+    color: palette.blue[400],
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  clearButton: {
+    color: palette.blue[400],
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  emptyText: {
+    color: palette.gray[400],
+    fontSize: 14,
+    textAlign: 'center',
+    marginTop: 20,
+  },
+})

--- a/src/components/ShareIntentConsumer.tsx
+++ b/src/components/ShareIntentConsumer.tsx
@@ -24,7 +24,7 @@ export function ShareIntentConsumer() {
       try {
         const files = (shareIntent.files ?? []).filter((file) => file?.path)
         if (files.length === 0) {
-          logger.log('[shareIntent] no supported files in shared payload')
+          logger.debug('shareIntent', 'no supported files in shared payload')
           toast.show('No shareable files found.')
           return
         }
@@ -46,7 +46,7 @@ export function ShareIntentConsumer() {
 
         await uploader(processedFiles)
       } catch (error) {
-        logger.log('[shareIntent] failed to process shared content', error)
+        logger.error('shareIntent', 'failed to process shared content', error)
         toast.show('Failed to import shared files.')
       } finally {
         resetShareIntent()

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -10,10 +10,10 @@ const dbName = 'app.db'
 export async function initializeDB(options?: {
   onProgress?: MigrationProgressHandler
 }): Promise<void> {
-  logger.log('[db] initializing database...')
+  logger.info('db', 'initializing database...')
   database = await SQLite.openDatabaseAsync(dbName)
   await runMigrations(database, options?.onProgress)
-  logger.log('[db] database initialized')
+  logger.info('db', 'database initialized')
 }
 
 // Drop all tables and run migrations again
@@ -22,8 +22,9 @@ export async function resetDb() {
     const rows = await database.getAllAsync<{ name: string }>(
       `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'`
     )
-    logger.log(
-      '[db] dropping tables',
+    logger.debug(
+      'db',
+      'dropping tables',
       rows.map((r) => r.name)
     )
     for (let i = 0; i < rows.length; i++) {

--- a/src/db/migrations/0001_init_schema.ts
+++ b/src/db/migrations/0001_init_schema.ts
@@ -5,12 +5,6 @@ import { logger } from '../../lib/logger'
 // Initial schema migration.
 async function up(db: SQLite.SQLiteDatabase): Promise<void> {
   try {
-    const cols = await db.getAllAsync<{ name: string }>(
-      "PRAGMA table_info('files')"
-    )
-    const hasTable = cols.length > 0
-    if (hasTable) return
-
     // Create the files table.
     await db.execAsync(
       `CREATE TABLE IF NOT EXISTS files (
@@ -105,8 +99,30 @@ async function up(db: SQLite.SQLiteDatabase): Promise<void> {
     await db.execAsync(
       `CREATE INDEX IF NOT EXISTS idx_fs_usedAt ON fs(usedAt);`
     )
+
+    // Create the logs table.
+    await db.execAsync(
+      `CREATE TABLE IF NOT EXISTS logs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      timestamp TEXT NOT NULL,
+      level TEXT NOT NULL,
+      scope TEXT NOT NULL,
+      message TEXT NOT NULL,
+      createdAt INTEGER NOT NULL
+    );`
+    )
+
+    // Index for filtering by level and scope.
+    await db.execAsync(
+      `CREATE INDEX IF NOT EXISTS idx_logs_level_scope ON logs(level, scope);`
+    )
+
+    // Index for ordering by creation time.
+    await db.execAsync(
+      `CREATE INDEX IF NOT EXISTS idx_logs_createdAt ON logs(createdAt);`
+    )
   } catch (e) {
-    logger.log('[db] error running migration 0001_init_schema', e)
+    logger.error('db', 'error running migration 0001_init_schema', e)
     throw e
   }
 }

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -27,7 +27,7 @@ export async function runMigrations(
   db: SQLite.SQLiteDatabase,
   onProgress?: MigrationProgressHandler
 ): Promise<void> {
-  logger.log('[db] checking migrations...')
+  logger.debug('db', 'checking migrations...')
   await db.execAsync(
     `CREATE TABLE IF NOT EXISTS migrations (
       id TEXT PRIMARY KEY,
@@ -42,8 +42,9 @@ export async function runMigrations(
 
   const needToApply = migrations.length - applied.size
   if (needToApply > 0) {
-    logger.log(
-      '[db] need to apply',
+    logger.info(
+      'db',
+      'need to apply',
       migrations.length - applied.size,
       'migrations'
     )
@@ -52,7 +53,7 @@ export async function runMigrations(
     if (applied.has(m.id)) {
       continue
     }
-    logger.log('[db] applying migration', m.id)
+    logger.info('db', 'applying migration', m.id)
     onProgress?.({
       id: m.id,
       message: m.description,
@@ -66,5 +67,5 @@ export async function runMigrations(
       )
     })
   }
-  logger.log('[db] all migrations applied')
+  logger.info('db', 'all migrations applied')
 }

--- a/src/encoding/fileMetadata.ts
+++ b/src/encoding/fileMetadata.ts
@@ -23,7 +23,11 @@ export function decodeFileMetadata(buffer?: ArrayBuffer): FileMetadata {
   try {
     return transformFileMetadata(JSON.parse(new TextDecoder().decode(buffer)))
   } catch (e) {
-    logger.log('Error converting file metadata from buffer', e)
+    logger.error(
+      'fileMetadata',
+      'Error converting file metadata from buffer',
+      e
+    )
     return {
       name: '',
       size: 0,

--- a/src/hooks/useAccount.tsx
+++ b/src/hooks/useAccount.tsx
@@ -9,7 +9,7 @@ export function useAccount() {
       const account = await sdk.account()
       return account
     } catch (e) {
-      logger.log('[useAccount] error getting account', e)
+      logger.error('useAccount', 'error getting account', e)
       throw e
     }
   })

--- a/src/hooks/useCameraCapture.ts
+++ b/src/hooks/useCameraCapture.ts
@@ -12,12 +12,12 @@ export function useCameraCapture() {
   const isCapturingRef = useRef<boolean>(false)
   return useCallback(async (): Promise<FileRecord[]> => {
     if (isCapturingRef.current) {
-      logger.log('[cameraCapture] already capturing, ignoring new request.')
+      logger.debug('cameraCapture', 'already capturing, ignoring new request.')
       return []
     }
     isCapturingRef.current = true
     try {
-      logger.log('[cameraCapture] opening camera...')
+      logger.debug('cameraCapture', 'opening camera...')
       const result = await ImagePicker.launchCamera({
         mediaType: 'mixed',
         saveToPhotos: false,
@@ -29,12 +29,13 @@ export function useCameraCapture() {
       })
 
       if (result.didCancel) {
-        logger.log('[cameraCapture] capture canceled.')
+        logger.debug('cameraCapture', 'capture canceled.')
         return []
       }
       if (result.errorCode) {
-        logger.log(
-          `[cameraCapture] error: ${result.errorMessage ?? result.errorCode}`
+        logger.warn(
+          'cameraCapture',
+          `error: ${result.errorMessage ?? result.errorCode}`
         )
         return []
       }
@@ -70,7 +71,7 @@ export function useCameraCapture() {
 
       return files
     } catch (e) {
-      logger.log('[cameraCapture] error', e)
+      logger.error('cameraCapture', 'error', e)
       return []
     } finally {
       isCapturingRef.current = false

--- a/src/hooks/useDocumentPicker.ts
+++ b/src/hooks/useDocumentPicker.ts
@@ -11,12 +11,12 @@ export function useDocumentPicker() {
   const isPickingRef = useRef<boolean>(false)
   return useCallback(async (): Promise<FileRecord[]> => {
     if (isPickingRef.current) {
-      logger.log('[documentPicker] already picking, ignoring new request.')
+      logger.debug('documentPicker', 'already picking, ignoring new request.')
       return []
     }
     isPickingRef.current = true
     try {
-      logger.log('[documentPicker] opening document picker...')
+      logger.debug('documentPicker', 'opening document picker...')
       const result = await DocumentPicker.getDocumentAsync({
         multiple: true,
         type: '*/*',
@@ -24,7 +24,7 @@ export function useDocumentPicker() {
       })
 
       if (result.canceled) {
-        logger.log('[documentPicker] selection canceled.')
+        logger.debug('documentPicker', 'selection canceled.')
         return []
       }
 
@@ -44,7 +44,7 @@ export function useDocumentPicker() {
 
       return files
     } catch (e) {
-      logger.log('[documentPicker] error', e)
+      logger.error('documentPicker', 'error', e)
       return []
     } finally {
       isPickingRef.current = false

--- a/src/hooks/useImagePicker.ts
+++ b/src/hooks/useImagePicker.ts
@@ -11,12 +11,12 @@ export function useImagePicker() {
   const isPickingRef = useRef<boolean>(false)
   return useCallback(async (): Promise<FileRecord[]> => {
     if (isPickingRef.current) {
-      logger.log('[imagePicker] already picking, ignoring new request.')
+      logger.debug('imagePicker', 'already picking, ignoring new request.')
       return []
     }
     isPickingRef.current = true
     try {
-      logger.log('[imagePicker] opening media picker...')
+      logger.debug('imagePicker', 'opening media picker...')
       const result = await ImagePicker.launchImageLibrary({
         mediaType: 'mixed',
         // 0 => unlimited on iOS; Android uses picker default multi-select UI if available.
@@ -29,12 +29,13 @@ export function useImagePicker() {
       })
 
       if (result.didCancel) {
-        logger.log('[imagePicker] media selection canceled.')
+        logger.debug('imagePicker', 'media selection canceled.')
         return []
       }
       if (result.errorCode) {
-        logger.log(
-          `[imagePicker] error: ${result.errorMessage ?? result.errorCode}`
+        logger.warn(
+          'imagePicker',
+          `error: ${result.errorMessage ?? result.errorCode}`
         )
         return []
       }
@@ -54,7 +55,7 @@ export function useImagePicker() {
       }
       return files
     } catch (e) {
-      logger.log('[imagePicker] error', e)
+      logger.error('imagePicker', 'error', e)
       return []
     } finally {
       isPickingRef.current = false

--- a/src/hooks/useIsOnline.ts
+++ b/src/hooks/useIsOnline.ts
@@ -28,7 +28,10 @@ export function useIsOnline() {
     if (isOnline.isLoading) {
       return
     }
-    logger.log(`[netinfo] app is now ${isOnline.data ? 'online' : 'offline'}`)
+    logger.debug(
+      'netinfo',
+      `app is now ${isOnline.data ? 'online' : 'offline'}`
+    )
   }, [isOnline.data])
 
   return isOnline

--- a/src/hooks/useLogs.ts
+++ b/src/hooks/useLogs.ts
@@ -1,0 +1,19 @@
+import useSWR from 'swr'
+import { readLogs, useLogLevel, useLogScopes } from '../stores/logs'
+import { buildSWRHelpers } from '../lib/swr'
+
+export const logsSwr = buildSWRHelpers('logs')
+
+export function useLogs() {
+  const logLevel = useLogLevel()
+  const logScopes = useLogScopes()
+
+  return useSWR(
+    logsSwr.getKey(logLevel + ',' + logScopes.join(',')),
+    () => readLogs(logLevel, logScopes),
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+    }
+  )
+}

--- a/src/hooks/usePinnedObjects.tsx
+++ b/src/hooks/usePinnedObjects.tsx
@@ -14,8 +14,9 @@ export function usePinnedObjects(file: FileRecord) {
           const appKey = await getAppKeyForIndexer(indexerURL)
           if (!appKey) {
             // TODO: Figure out how to handle this situation.
-            logger.log(
-              `[usePinnedObjects] fileId=${file.id} indexerURL=${indexerURL} No AppKey found`
+            logger.warn(
+              'usePinnedObjects',
+              `fileId=${file.id} indexerURL=${indexerURL} No AppKey found`
             )
             return null
           }

--- a/src/hooks/useReconnectIndexer.ts
+++ b/src/hooks/useReconnectIndexer.ts
@@ -14,7 +14,7 @@ export function useReconnectIndexer() {
       const isInitializing = getIsInitializing()
 
       if (!isInitializing && !isIndexerConnected && isOnline) {
-        logger.log('[netinfo] app is now online, reconnecting...')
+        logger.info('netinfo', 'app is now online, reconnecting...')
         await reconnectIndexer()
       }
     })
@@ -32,8 +32,9 @@ export function useReconnectIndexer() {
         const isOnline = await getIsOnline()
         const isIndexerConnected = getIsConnected()
         if (isOnline && !isIndexerConnected) {
-          logger.log(
-            '[netinfo] app is online but not connected to indexer, reconnecting...'
+          logger.info(
+            'netinfo',
+            'app is online but not connected to indexer, reconnecting...'
           )
           reconnectIndexer()
         }

--- a/src/hooks/useRecoveryPhraseRegistration.ts
+++ b/src/hooks/useRecoveryPhraseRegistration.ts
@@ -13,7 +13,10 @@ export function useRecoveryPhraseRegistration() {
       indexerURL: string
     ): Promise<{ success: boolean }> => {
       if (!phrase) {
-        logger.log('No recovery phrase available')
+        logger.warn(
+          'recoveryPhraseRegistration',
+          'No recovery phrase available'
+        )
         return { success: false }
       }
 
@@ -25,7 +28,11 @@ export function useRecoveryPhraseRegistration() {
         return { success: true }
       }
 
-      logger.log('Failed to register with mnemonic:', error)
+      logger.error(
+        'recoveryPhraseRegistration',
+        'Failed to register with mnemonic:',
+        error
+      )
       switch (error.type) {
         case 'cancelled':
           toast.show('Authorization cancelled')

--- a/src/hooks/useRecoveryPhraseValidation.ts
+++ b/src/hooks/useRecoveryPhraseValidation.ts
@@ -21,7 +21,12 @@ export function useRecoveryPhraseValidation(manualPhrase: string) {
         validateRecoveryPhrase(normalizedManualPhrase)
         return { isValid: true, error: null }
       } catch (e) {
-        if (__DEV__) logger.log('Recovery phrase validation failed:', e)
+        if (__DEV__)
+          logger.debug(
+            'recoveryPhraseValidation',
+            'Recovery phrase validation failed:',
+            e
+          )
 
         const message =
           e instanceof Error

--- a/src/hooks/useShareAction.tsx
+++ b/src/hooks/useShareAction.tsx
@@ -52,7 +52,7 @@ export function useShareAction({ fileId }: { fileId: string }) {
       })
     } catch (e) {
       if (typeof e === 'string' && !e.includes('User did not share')) {
-        logger.log('File sharing failed:', e)
+        logger.error('shareAction', 'File sharing failed:', e)
       }
     }
   }, [file, status.data?.fileUri])

--- a/src/lib/detectMimeType.ts
+++ b/src/lib/detectMimeType.ts
@@ -20,7 +20,7 @@ export async function detectMimeType(
     }
     return detectMimeTypeFromBytes(bytes)
   } catch (e) {
-    logger.log('[detectMimeType] error:', e)
+    logger.error('detectMimeType', 'error:', e)
     return null
   }
 }

--- a/src/lib/exportLogs.ts
+++ b/src/lib/exportLogs.ts
@@ -1,0 +1,97 @@
+import { File, Paths } from 'expo-file-system'
+import { logger } from './logger'
+import { readFileRecordByContentHash } from '../stores/files'
+import { uniqueId } from './uniqueId'
+import { calculateContentHash } from './contentHash'
+import { copyFileToFs } from '../stores/fs'
+import { createFileRecord } from '../stores/files'
+import { queueUploadForFileId } from '../managers/uploader'
+import { readLogs, useLogsStore } from '../stores/logs'
+
+/** Export logs to a library file. */
+export async function exportLogs(): Promise<string | null> {
+  try {
+    // Get current filter state.
+    const state = useLogsStore.getState()
+    // Read logs from database with current filters applied.
+    const logs = await readLogs(state.logLevel, state.logScopes)
+    if (logs.length === 0) {
+      return null
+    }
+
+    // Format logs as text file.
+    const content = logs
+      .map(
+        (entry) =>
+          `${entry.timestamp} ${entry.level.toUpperCase()} [${entry.scope}] ${
+            entry.message
+          }`
+      )
+      .join('\n')
+
+    // Write to temporary file.
+    const tempFileName = `logs-export-${Date.now()}.txt`
+    const tempFile = new File(Paths.document, tempFileName)
+    const contentBytes = new TextEncoder().encode(content)
+
+    // Create empty file first.
+    tempFile.create({ intermediates: true })
+
+    // Write content.
+    const writer = tempFile.writableStream().getWriter()
+    try {
+      await writer.write(contentBytes)
+    } finally {
+      await writer.close()
+    }
+
+    const fileId = uniqueId()
+    const size = contentBytes.length
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
+    const fileName = `logs-${timestamp}.txt`
+
+    // Copy temp file to FS storage.
+    const fsFileUri = await copyFileToFs(
+      { id: fileId, type: 'text/plain' },
+      tempFile
+    )
+
+    // Clean up temp file.
+    tempFile.delete()
+
+    // Calculate hash.
+    const hash = await calculateContentHash(fsFileUri)
+    if (!hash) {
+      throw new Error('Failed to calculate content hash')
+    }
+
+    // Check for duplicates.
+    const existingFile = await readFileRecordByContentHash(hash)
+    if (existingFile) {
+      return existingFile.id
+    }
+
+    // Create file record.
+    const now = Date.now()
+    await createFileRecord({
+      id: fileId,
+      name: fileName,
+      type: 'text/plain',
+      size,
+      hash,
+      createdAt: now,
+      updatedAt: now,
+      addedAt: now,
+      localId: null,
+      thumbForHash: undefined,
+      thumbSize: undefined,
+    })
+
+    queueUploadForFileId(fileId)
+
+    return fileId
+  } catch (error) {
+    logger.error('logExport', 'Failed to export logs', error)
+    throw error
+  }
+}

--- a/src/lib/logColors.ts
+++ b/src/lib/logColors.ts
@@ -1,0 +1,82 @@
+// ANSI color codes for terminal output.
+export const ANSI_RESET = '\x1b[0m'
+export const ANSI_BOLD = '\x1b[1m'
+const ANSI_CYAN = '\x1b[36m'
+const ANSI_GREEN = '\x1b[32m'
+const ANSI_YELLOW = '\x1b[33m'
+const ANSI_RED = '\x1b[31m'
+const ANSI_BLUE = '\x1b[34m'
+const ANSI_MAGENTA = '\x1b[35m'
+
+// Hex colors for UI display.
+const HEX_CYAN = '#06b6d4'
+const HEX_GREEN = '#22c55e'
+const HEX_YELLOW = '#eab308'
+const HEX_RED = '#ef4444'
+const HEX_BLUE = '#3b82f6'
+const HEX_MAGENTA = '#d946ef'
+const HEX_LIGHT_RED = '#f87171'
+const HEX_LIGHT_GREEN = '#4ade80'
+const HEX_LIGHT_YELLOW = '#fbbf24'
+const HEX_LIGHT_BLUE = '#60a5fa'
+const HEX_LIGHT_MAGENTA = '#f472b6'
+const HEX_LIGHT_CYAN = '#34d399'
+
+// Log level colors.
+export const LEVEL_COLORS = {
+  debug: { ansi: ANSI_CYAN, hex: HEX_CYAN },
+  info: { ansi: ANSI_GREEN, hex: HEX_GREEN },
+  warn: { ansi: ANSI_YELLOW, hex: HEX_YELLOW },
+  error: { ansi: ANSI_RED, hex: HEX_RED },
+} as const
+
+// Scope color palette.
+export const SCOPE_COLORS = [
+  { ansi: ANSI_MAGENTA, hex: HEX_MAGENTA },
+  { ansi: ANSI_BLUE, hex: HEX_BLUE },
+  { ansi: ANSI_CYAN, hex: HEX_CYAN },
+  { ansi: ANSI_YELLOW, hex: HEX_YELLOW },
+  { ansi: ANSI_GREEN, hex: HEX_GREEN },
+  { ansi: ANSI_RED, hex: HEX_RED },
+  { ansi: ANSI_RED, hex: HEX_LIGHT_RED },
+  { ansi: ANSI_GREEN, hex: HEX_LIGHT_GREEN },
+  { ansi: ANSI_YELLOW, hex: HEX_LIGHT_YELLOW },
+  { ansi: ANSI_BLUE, hex: HEX_LIGHT_BLUE },
+  { ansi: ANSI_MAGENTA, hex: HEX_LIGHT_MAGENTA },
+  { ansi: ANSI_CYAN, hex: HEX_LIGHT_CYAN },
+] as const
+
+// Map of scope to color index.
+const scopeColorMap = new Map<string, number>()
+
+/** Get ANSI color code for a scope. */
+export function getScopeColorAnsi(scope: string): string {
+  if (!scopeColorMap.has(scope)) {
+    scopeColorMap.set(scope, scopeColorMap.size % SCOPE_COLORS.length)
+  }
+  const index = scopeColorMap.get(scope) ?? 0
+  return SCOPE_COLORS[index]?.ansi ?? SCOPE_COLORS[0]?.ansi ?? ANSI_CYAN
+}
+
+/** Get hex color for a scope. */
+export function getScopeColorHex(scope: string): string {
+  if (!scopeColorMap.has(scope)) {
+    scopeColorMap.set(scope, scopeColorMap.size % SCOPE_COLORS.length)
+  }
+  const index = scopeColorMap.get(scope) ?? 0
+  return SCOPE_COLORS[index]?.hex ?? SCOPE_COLORS[0]?.hex ?? HEX_CYAN
+}
+
+/** Get ANSI color code for a log level. */
+export function getLevelColorAnsi(
+  level: 'debug' | 'info' | 'warn' | 'error'
+): string {
+  return LEVEL_COLORS[level]?.ansi ?? ANSI_CYAN
+}
+
+/** Get hex color for a log level. */
+export function getLevelColorHex(
+  level: 'debug' | 'info' | 'warn' | 'error'
+): string {
+  return LEVEL_COLORS[level]?.hex ?? HEX_CYAN
+}

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,40 +1,186 @@
-export const rustLogger = {
-  hasInitialized: false,
-  debug: (message: string) => {
-    logger.sdk('[rust][debug]', message)
-  },
-  info: (message: string) => {
-    logger.sdk('[rust][info]', message)
-  },
-  warn: (message: string) => {
-    logger.sdk('[rust][warn]', message)
-  },
-  error: (message: string) => {
-    logger.sdk('[rust][error]', message)
-  },
+import { appendLog } from '../stores/logs'
+import {
+  ANSI_RESET,
+  ANSI_BOLD,
+  getLevelColorAnsi,
+  getScopeColorAnsi,
+} from './logColors'
+
+// Log levels in order of severity.
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+
+// Parse log level from env var.
+function getLogLevelFromEnv(): LogLevel {
+  if (typeof process !== 'undefined' && process.env) {
+    const level = process.env.EXPO_PUBLIC_LOG_LEVEL?.toLowerCase()
+    if (
+      level === 'debug' ||
+      level === 'info' ||
+      level === 'warn' ||
+      level === 'error'
+    ) {
+      return level
+    }
+  }
+  return 'debug' // Default to debug in dev.
 }
 
-// Flip this to false locally to silence service logs in dev.
-// Saving this file likely crashes your dev app.
-const logServices = true
+/** Parse scope filter from env var (comma-separated). */
+function getScopeFilterFromEnv(): string[] | null {
+  if (typeof process !== 'undefined' && process.env) {
+    const filter = process.env.EXPO_PUBLIC_LOG_SCOPES
+    if (filter) {
+      return filter.split(',').map((s: string) => s.trim())
+    }
+  }
+  return null
+}
 
+/** Serialize a value to a string, converting objects/errors to JSON. */
+function serializeValue(value: unknown): string {
+  // Handle primitives.
+  if (value === null || value === undefined) {
+    return String(value)
+  }
+  if (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return String(value)
+  }
+
+  // Handle Error objects specially to capture message, stack, and other properties.
+  if (value instanceof Error) {
+    const errorObj: Record<string, unknown> = {
+      name: value.name,
+      message: value.message,
+    }
+    // Truncate stack trace to prevent extremely long log messages.
+    if (value.stack) {
+      const stack = value.stack
+      // Limit stack trace to first 500 characters to prevent UI issues.
+      errorObj.stack = stack.length > 500 ? `${stack.slice(0, 500)}...` : stack
+    }
+    // Include any additional properties on the error.
+    Object.keys(value).forEach((key) => {
+      if (!['name', 'message', 'stack'].includes(key)) {
+        errorObj[key] = (value as unknown as Record<string, unknown>)[key]
+      }
+    })
+    try {
+      const json = JSON.stringify(errorObj)
+      // Also limit total JSON size to prevent issues.
+      return json.length > 1000 ? `${json.slice(0, 1000)}...` : json
+    } catch {
+      return `Error: ${value.name} - ${value.message}`
+    }
+  }
+
+  // Handle objects and arrays - serialize to one-line JSON.
+  if (typeof value === 'object') {
+    try {
+      const json = JSON.stringify(value)
+      // Limit total JSON size to prevent extremely long log messages.
+      return json.length > 1000 ? `${json.slice(0, 1000)}...` : json
+    } catch {
+      // If JSON.stringify fails (circular reference, etc.), fall back to string representation.
+      return String(value)
+    }
+  }
+
+  // Fallback for anything else.
+  return String(value)
+}
+
+/** Check if a log should be output to terminal based on level and scope filters. */
+function shouldLogToTerminal(level: LogLevel, scope: string): boolean {
+  const envLevel = getLogLevelFromEnv()
+  const levelOrder: LogLevel[] = ['debug', 'info', 'warn', 'error']
+  const envLevelIndex = levelOrder.indexOf(envLevel)
+  const logLevelIndex = levelOrder.indexOf(level)
+
+  // Filter by level.
+  if (logLevelIndex < envLevelIndex) {
+    return false
+  }
+
+  // Filter by scope.
+  const scopeFilter = getScopeFilterFromEnv()
+  if (scopeFilter && scopeFilter.length > 0) {
+    return scopeFilter.includes(scope)
+  }
+
+  return true
+}
+
+/** Format log message for terminal. */
+function formatTerminalLog(
+  level: LogLevel,
+  scope: string,
+  ...args: unknown[]
+): string {
+  const levelColor = getLevelColorAnsi(level)
+  const scopeColor = getScopeColorAnsi(scope)
+  const levelUpper = level.toUpperCase().padEnd(5)
+  const timestamp = new Date().toLocaleTimeString()
+
+  const message = args.map(serializeValue).join(' ')
+  return `${timestamp} ${levelColor}${ANSI_BOLD}${levelUpper}${ANSI_RESET} ${scopeColor}${ANSI_BOLD}[${scope}]${ANSI_RESET} ${message}`
+}
+
+/** Create a logger function for a specific level. */
+function createLogger(level: LogLevel) {
+  return (scope: string, ...args: unknown[]) => {
+    const timestamp = new Date().toLocaleTimeString()
+    const message = args.map(serializeValue).join(' ')
+    const entry: LogEntry = {
+      timestamp,
+      level,
+      scope,
+      message,
+    }
+
+    appendLog(entry)
+
+    const terminalMessage = formatTerminalLog(level, scope, ...args)
+
+    if (shouldLogToTerminal(level, scope)) {
+      console.log(terminalMessage)
+    }
+  }
+}
+
+/** Structured log entry type. */
+export type LogEntry = {
+  timestamp: string
+  level: LogLevel
+  scope: string
+  message: string
+}
+
+/** Logger interface. */
 export const logger = {
-  log: (...args: any[]) => {
-    console.log(...args)
-  },
-  sdk: (...args: any[]) => {
-    console.log(...args)
-  },
+  debug: createLogger('debug'),
+  info: createLogger('info'),
+  warn: createLogger('warn'),
+  error: createLogger('error'),
   clear: () => {},
 }
 
-/**
- * Logs messages from background services and periodic tasks.
- * In development mode, logging can be toggled using the `logServices` flag.
- * In production, all service logs are always output.
- */
-export const serviceLog = (...args: any[]) => {
-  if (!__DEV__ || logServices) {
-    logger.log(...args)
-  }
+/** Rust logger using the rust scope. */
+export const rustLogger = {
+  hasInitialized: false,
+  debug: (message: string) => {
+    logger.debug('rust', message)
+  },
+  info: (message: string) => {
+    logger.info('rust', message)
+  },
+  warn: (message: string) => {
+    logger.warn('rust', message)
+  },
+  error: (message: string) => {
+    logger.error('rust', message)
+  },
 }

--- a/src/lib/processAssets.ts
+++ b/src/lib/processAssets.ts
@@ -195,8 +195,9 @@ export async function processAssets(
   const warnings: string[] = []
   const existingFilesByLocalIdCount = existingLocalIds.length
   const existingFilesByContentHashCount = existingContentHashes.length
-  logger.log(
-    `[processAssets] result: picked=${candidateFiles.length}, new=${newFiles.length}, incomplete=${incompleteFiles.length}, existing=${existingFiles.length}`
+  logger.debug(
+    'processAssets',
+    `result: picked=${candidateFiles.length}, new=${newFiles.length}, incomplete=${incompleteFiles.length}, existing=${existingFiles.length}`
   )
   if (existingFilesByLocalIdCount > 0 || existingFilesByContentHashCount > 0) {
     warnings.push('Some files were duplicates and were not included.')
@@ -206,8 +207,9 @@ export async function processAssets(
   await createManyFileRecords(newFiles)
 
   // Generate thumbnails for new image and video files.
-  logger.log(
-    `[processAssets] generating thumbnails for ${newFiles.length} new files`
+  logger.debug(
+    'processAssets',
+    `generating thumbnails for ${newFiles.length} new files`
   )
 
   // Generate thumbnails for new files, this will run in the background.

--- a/src/lib/readFileBytes.ts
+++ b/src/lib/readFileBytes.ts
@@ -47,7 +47,7 @@ export async function readFileBytes(
       reader.releaseLock()
     }
   } catch (e) {
-    logger.log('[readFileBytes] error:', e)
+    logger.error('readFileBytes', 'error:', e)
     return null
   }
 }

--- a/src/lib/retry.ts
+++ b/src/lib/retry.ts
@@ -33,8 +33,9 @@ export async function retry<T>(
         0,
         Math.round(exponentialDelay + jitterOffset)
       )
-      logger.log(
-        `[${name}] failed (attempt ${attempt}/${maxAttempts}), retrying in ${delayWithJitter}ms... error: ${
+      logger.warn(
+        'retry',
+        `${name} failed (attempt ${attempt}/${maxAttempts}), retrying in ${delayWithJitter}ms... error: ${
           error instanceof Error ? error.message : String(error)
         }`
       )

--- a/src/lib/serviceInterval.ts
+++ b/src/lib/serviceInterval.ts
@@ -1,4 +1,4 @@
-import { serviceLog } from './logger'
+import { logger } from './logger'
 
 // Scheduler state for a service: the latest token and its timeout handle.
 type SchedulerState = {
@@ -25,7 +25,7 @@ export function createServiceInterval({
       clearTimeout(existing.timeoutId)
     }
 
-    serviceLog(`[${name}] initializing`)
+    logger.debug(name, 'initializing')
 
     // Increment the token to invalidate any previously scheduled or in-flight ticks.
     const token = (existing?.token ?? 0) + 1

--- a/src/lib/shareLink.ts
+++ b/src/lib/shareLink.ts
@@ -8,7 +8,7 @@ export default async function shareLink({ url }: { url: string }) {
     })
     if (result.action === Share.sharedAction) {
       if (result.activityType) {
-        logger.log(result.activityType)
+        logger.debug('shareLink', result.activityType)
         // shared with activity type of result.activityType
       } else {
         // shared

--- a/src/lib/slotPool.ts
+++ b/src/lib/slotPool.ts
@@ -43,8 +43,9 @@ export class SlotPool {
   /** Acquire a slot. Resolves with a release function to free the slot. */
   async acquire(): Promise<() => void> {
     if (this.inUseCount < this.maxSlots) {
-      logger.log(
-        `[slotPool] acquired: inUse=${this.inUseCount + 1}/${
+      logger.debug(
+        'slotPool',
+        `acquired: inUse=${this.inUseCount + 1}/${
           this.maxSlots
         } queued=${Math.max(0, this.waitQueue.length - 1)}`
       )
@@ -60,13 +61,15 @@ export class SlotPool {
     }
 
     // Wait for a slot to free up.
-    logger.log(
-      `[slotPool] waiting: inUse=${this.inUseCount}/${this.maxSlots} queued=${this.waitQueue.length}`
+    logger.debug(
+      'slotPool',
+      `waiting: inUse=${this.inUseCount}/${this.maxSlots} queued=${this.waitQueue.length}`
     )
     return await new Promise<() => void>((resolve) => {
       const grant = () => {
-        logger.log(
-          `[slotPool] acquired: inUse=${this.inUseCount + 1}/${
+        logger.debug(
+          'slotPool',
+          `acquired: inUse=${this.inUseCount + 1}/${
             this.maxSlots
           } queued=${Math.max(0, this.waitQueue.length - 1)}`
         )
@@ -76,8 +79,9 @@ export class SlotPool {
           if (released) return
           released = true
           this.inUseCount -= 1
-          logger.log(
-            `[slotPool] released: inUse=${this.inUseCount}/${this.maxSlots} queued=${this.waitQueue.length}`
+          logger.debug(
+            'slotPool',
+            `released: inUse=${this.inUseCount}/${this.maxSlots} queued=${this.waitQueue.length}`
           )
           this.drain()
         }

--- a/src/managers/backgroundTasks.ts
+++ b/src/managers/backgroundTasks.ts
@@ -1,8 +1,8 @@
-import { serviceLog } from '../lib/logger'
+import { logger } from '../lib/logger'
 import BackgroundFetch, {
   BackgroundFetchConfig,
 } from 'react-native-background-fetch'
-import { secondsInMs } from '../lib/time'
+import { minutesInMs, secondsInMs } from '../lib/time'
 import { Platform } from 'react-native'
 import { getFileCountLocal } from '../stores/files'
 import BackgroundTimer from 'react-native-background-timer'
@@ -79,7 +79,7 @@ const taskStates: Record<TaskId, TaskState> = {
 }
 
 export async function initBackgroundTasks() {
-  serviceLog(`[backgroundTask] init`)
+  logger.info('backgroundTask', 'init')
 
   const status = await BackgroundFetch.configure(
     {
@@ -90,7 +90,7 @@ export async function initBackgroundTasks() {
       const config = taskConfigs[taskId as TaskId]
       const state = taskStates[taskId as TaskId]
       if (!config) {
-        serviceLog(`[backgroundTask] unknown task id: ${taskId}`)
+        logger.warn('backgroundTask', `unknown task id: ${taskId}`)
         BackgroundFetch.finish(taskId)
         return
       }
@@ -104,7 +104,7 @@ export async function initBackgroundTasks() {
       const state = taskStates[taskId as TaskId]
       transitionTaskState(state, 'finished')
       if (!config) {
-        serviceLog(`[backgroundTask] unknown task id: ${taskId}`)
+        logger.warn('backgroundTask', `unknown task id: ${taskId}`)
         BackgroundFetch.finish(taskId)
         return
       }
@@ -117,7 +117,7 @@ export async function initBackgroundTasks() {
     }
   )
 
-  serviceLog('[backgroundTask] configure status: ', status)
+  logger.info('backgroundTask', `configure status: ${status}`)
 
   // Schedule custom background processing task on iOS.
   if (Platform.OS === 'ios') {
@@ -126,15 +126,17 @@ export async function initBackgroundTasks() {
       const scheduled = await BackgroundFetch.scheduleTask({
         taskId: bgProcessingTaskConfig.id,
         periodic: true,
-        delay: secondsInMs(5),
+        delay: minutesInMs(31),
         ...sharedConfig,
       })
-      serviceLog(
-        `[backgroundTask] scheduleTask status for ${bgProcessingTaskConfig.id}: ${scheduled}`
+      logger.info(
+        'backgroundTask',
+        `scheduleTask status for ${bgProcessingTaskConfig.id}: ${scheduled}`
       )
     } catch (error) {
-      serviceLog(
-        `[backgroundTask] scheduleTask failed for ${bgProcessingTaskConfig.id}:`,
+      logger.error(
+        'backgroundTask',
+        `scheduleTask failed for ${bgProcessingTaskConfig.id}:`,
         error
       )
     }
@@ -194,9 +196,7 @@ function delay(ms: number) {
 
 function logTask(config: TaskConfig) {
   return (message: string) => {
-    serviceLog(
-      `[${new Date().toISOString()}][${config.type}][${config.id}] ${message}`
-    )
+    logger.debug('backgroundTask', `[${config.type}][${config.id}] ${message}`)
   }
 }
 

--- a/src/managers/downloader.ts
+++ b/src/managers/downloader.ts
@@ -78,7 +78,11 @@ export function useDownloadFromShareURL() {
         downloadState?.status === 'running' ||
         downloadState?.status === 'queued'
       ) {
-        logger.log('[useDownloadFromShareURL] download already in progress', id)
+        logger.debug(
+          'useDownloadFromShareURL',
+          'download already in progress',
+          id
+        )
         return id
       }
 
@@ -132,21 +136,22 @@ async function streamToCache(params: {
 }): Promise<void> {
   const { file, totalSize, getNextChunk, onAfterClose, signal } = params
   const targetFile = await getOrCreateTempDownloadFile(file)
-  logger.log('[streamToCache] writing to cache path:', targetFile.uri)
+  logger.debug('streamToCache', 'writing to cache path:', targetFile.uri)
   const writer = targetFile.writableStream().getWriter()
   let total = 0
   let chunks = 0
   try {
     while (true) {
       if (signal.aborted) {
-        logger.log('[streamToCache] abort received, stopping download...')
+        logger.debug('streamToCache', 'abort received, stopping download...')
         targetFile.delete()
         break
       }
       const chunk = await getNextChunk()
       if (!chunk || chunk.byteLength === 0) {
-        logger.log(
-          '[streamToCache] download stream ended. chunks=',
+        logger.debug(
+          'streamToCache',
+          'download stream ended. chunks=',
           chunks,
           'bytes=',
           total
@@ -163,11 +168,11 @@ async function streamToCache(params: {
         updateDownloadProgress(file.id, Math.min(0.99, (chunks % 20) / 20))
       }
       if (chunks % 10 === 0)
-        logger.log('[streamToCache] downloaded', total, 'bytes so far')
+        logger.debug('streamToCache', 'downloaded', total, 'bytes so far')
     }
   } finally {
     await writer.close()
-    logger.log('[streamToCache] writer closed. Total bytes:', total)
+    logger.debug('streamToCache', 'writer closed. Total bytes:', total)
   }
   if (onAfterClose) {
     await onAfterClose(targetFile)
@@ -187,8 +192,9 @@ export async function downloadFirstBytesFromShared(
     throw new Error('SDK not initialized')
   }
 
-  logger.log(
-    `[downloadFirstBytesFromShared] Downloading first ${byteCount} bytes`
+  logger.debug(
+    'downloadFirstBytesFromShared',
+    `Downloading first ${byteCount} bytes`
   )
 
   // Download only first N bytes for type detection.
@@ -230,6 +236,9 @@ export async function downloadFirstBytesFromShared(
     if (offset >= byteCount) break
   }
 
-  logger.log(`[downloadFirstBytesFromShared] Downloaded ${bytes.length} bytes`)
+  logger.debug(
+    'downloadFirstBytesFromShared',
+    `Downloaded ${bytes.length} bytes`
+  )
   return bytes
 }

--- a/src/managers/downloadsPool.ts
+++ b/src/managers/downloadsPool.ts
@@ -37,7 +37,7 @@ export async function acquireDownloadSlot(): Promise<() => void> {
 
 export async function setMaxDownloads(value: number) {
   if (!value) {
-    logger.log('[settings] setMaxDownloads: value must be 1 or greater')
+    logger.warn('settings', 'setMaxDownloads: value must be 1 or greater')
   }
   const clamped = Math.max(1, Math.floor(Number(value) || 1))
   await setAsyncStorageNumber('maxDownloads', clamped)

--- a/src/managers/fsEvictionScanner.ts
+++ b/src/managers/fsEvictionScanner.ts
@@ -4,7 +4,7 @@ import {
   FS_EVICTABLE_MIN_AGE,
 } from '../config'
 import { db } from '../db'
-import { serviceLog } from '../lib/logger'
+import { logger } from '../lib/logger'
 import { createServiceInterval } from '../lib/serviceInterval'
 import {
   calcFsFilesMetadataTotalSize,
@@ -43,7 +43,10 @@ export async function runFsEvictionScanner(): Promise<
     }
 
     let currentSize = totalSize
-    serviceLog('[fsEvictionScanner] total size over limit', { totalSize })
+    logger.warn(
+      'fsEvictionScanner',
+      `total size over limit totalSize=${totalSize}`
+    )
 
     let processedRows = 0
     let evicted = 0
@@ -69,10 +72,10 @@ export async function runFsEvictionScanner(): Promise<
           currentSize -= row.size
           evicted += 1
         } catch (error) {
-          serviceLog('[fsEvictionScanner] failed to remove file', {
-            fileId: row.fileId,
-            error,
-          })
+          logger.error(
+            'fsEvictionScanner',
+            `failed to remove file fileId=${row.fileId} error=${error}`
+          )
         }
       }
 
@@ -88,12 +91,13 @@ export async function runFsEvictionScanner(): Promise<
       evicted,
       currentSize,
     }
-    serviceLog(
-      `[fsEvictionScanner] summary processedRows=${processedRows} evicted=${evicted} currentSize=${currentSize}`
+    logger.info(
+      'fsEvictionScanner',
+      `summary processedRows=${processedRows} evicted=${evicted} currentSize=${currentSize}`
     )
     return results
   } catch (error) {
-    serviceLog('[fsEvictionScanner] error during scan', error)
+    logger.error('fsEvictionScanner', 'error during scan', error)
   } finally {
     await setFsEvictionLastRun()
   }

--- a/src/managers/fsOrphanScanner.ts
+++ b/src/managers/fsOrphanScanner.ts
@@ -1,6 +1,6 @@
 import { FS_ORPHAN_FREQUENCY } from '../config'
 import { db } from '../db'
-import { serviceLog } from '../lib/logger'
+import { logger } from '../lib/logger'
 import { createServiceInterval } from '../lib/serviceInterval'
 import {
   deleteFsFileMetadata,
@@ -49,22 +49,24 @@ export async function runFsOrphanScanner(): Promise<
         removed += 1
         await deleteFsFileMetadata(fileId)
         await fsTriggerRefresh(fileId)
-        serviceLog(
-          `[fsOrphanScanner] removed unindexed file fileId=${fileId} uri=${file.uri}`
+        logger.info(
+          'fsOrphanScanner',
+          `removed unindexed file fileId=${fileId} uri=${file.uri}`
         )
       } catch (error) {
-        serviceLog(
-          `[fsOrphanScanner] failed to delete file fileId=${fileId} uri=${file.uri} error=${error}`
+        logger.error(
+          'fsOrphanScanner',
+          `failed to delete file fileId=${fileId} uri=${file.uri} error=${error}`
         )
       }
     }
 
     if (removed > 0) {
-      serviceLog(`[fsOrphanScanner] summary removed=${removed}`)
+      logger.info('fsOrphanScanner', `summary removed=${removed}`)
     }
     return { removed }
   } catch (error) {
-    serviceLog('[fsOrphanScanner] error during scan', error)
+    logger.error('fsOrphanScanner', 'error during scan', error)
   } finally {
     await setFsOrphanLastRun()
   }

--- a/src/managers/logRotation.ts
+++ b/src/managers/logRotation.ts
@@ -1,0 +1,56 @@
+import { db } from '../db'
+import { logger } from '../lib/logger'
+import { createServiceInterval } from '../lib/serviceInterval'
+
+const MAX_LOGS = 100_000 // Maximum number of log entries to keep
+const ROTATION_INTERVAL_MS = 60_000 // Check and rotate every minute
+
+/**
+ * Rotate logs by removing old entries when they exceed the maximum count.
+ * Keeps only the most recent MAX_LOGS entries.
+ */
+export async function runLogRotation(): Promise<void> {
+  try {
+    if (!db()) {
+      return
+    }
+    // Count total logs.
+    const countResult = await db().getFirstAsync<{ count: number }>(
+      'SELECT COUNT(*) as count FROM logs'
+    )
+    const count = countResult?.count ?? 0
+
+    if (count <= MAX_LOGS) {
+      return
+    }
+
+    // Delete oldest logs, keeping only MAX_LOGS.
+    const toDelete = count - MAX_LOGS
+    await db().runAsync(
+      `DELETE FROM logs WHERE id IN (
+        SELECT id FROM logs ORDER BY createdAt ASC, id ASC LIMIT ?
+      )`,
+      toDelete
+    )
+    logger.debug('logRotation', `Rotated ${toDelete} log entries`)
+  } catch (error) {
+    logger.error('logRotation', 'Failed to rotate logs', error)
+  }
+}
+
+// Start log rotation interval and run initial rotation.
+export async function initLogRotation(): Promise<void> {
+  // Run initial rotation immediately.
+  await runLogRotation()
+  // Then start the interval.
+  initLogRotationInterval()
+}
+
+const initLogRotationInterval = createServiceInterval({
+  name: 'logRotation',
+  worker: async () => {
+    await runLogRotation()
+  },
+  getState: async () => true, // Always enabled.
+  interval: ROTATION_INTERVAL_MS,
+})

--- a/src/managers/syncDownEvents.ts
+++ b/src/managers/syncDownEvents.ts
@@ -1,4 +1,4 @@
-import { serviceLog } from '../lib/logger'
+import { logger } from '../lib/logger'
 import { SYNC_EVENTS_INTERVAL } from '../config'
 import { getIsConnected, getSdk } from '../stores/sdk'
 import { getAutoSyncDownEvents, getIndexerURL } from '../stores/settings'
@@ -49,12 +49,12 @@ type Counts = {
 export async function syncDownEvents(): Promise<void> {
   const isConnected = getIsConnected()
   if (!isConnected) {
-    serviceLog('[syncDownEvents] not connected to indexer, skipping sync')
+    logger.debug('syncDownEvents', 'not connected to indexer, skipping sync')
     return
   }
   const sdk = getSdk()
   if (!sdk) {
-    serviceLog('[syncDownEvents] no sdk, skipping sync')
+    logger.debug('syncDownEvents', 'no sdk, skipping sync')
     return
   }
 
@@ -67,19 +67,21 @@ export async function syncDownEvents(): Promise<void> {
   while (true) {
     try {
       const cursor = await getSyncDownCursor()
-      serviceLog(
-        `[syncDownEvents] syncing from id=${cursor?.key} after=${cursor?.after}`
+      logger.debug(
+        'syncDownEvents',
+        `syncing from id=${cursor?.key} after=${cursor?.after}`
       )
 
       const events = await sdk.objectEvents(cursor, batchSize)
 
       // If the batch size is 1, we are probably synced and repeatedly polling the last event.
       if (events.length === 1) {
-        serviceLog(
-          `[syncDownEvents] batch size=${events.length}, no new events found`
+        logger.debug(
+          'syncDownEvents',
+          `batch size=${events.length}, no new events found`
         )
       } else {
-        serviceLog(`[syncDownEvents] batch size=${events.length}`)
+        logger.info('syncDownEvents', `batch size=${events.length}`)
       }
 
       await processBatch(events, counts)
@@ -99,13 +101,14 @@ export async function syncDownEvents(): Promise<void> {
         break
       }
     } catch (e) {
-      serviceLog('[syncDownEvents] sync error', e)
+      logger.error('syncDownEvents', 'sync error', e)
       break
     }
   }
 
-  serviceLog(
-    `[syncDownEvents] synced, existingCount=${counts.existing}, addedCount=${counts.added}, deletedCount=${counts.deleted}`
+  logger.info(
+    'syncDownEvents',
+    `synced, existingCount=${counts.existing}, addedCount=${counts.added}, deletedCount=${counts.deleted}`
   )
 }
 
@@ -127,7 +130,7 @@ async function handleDeleteEvent(id: string, counts: Counts): Promise<void> {
   try {
     const existingFileRecord = await readFileRecordByObjectId(id)
     if (existingFileRecord) {
-      serviceLog(`[syncDownEvents] deleting file id=${existingFileRecord.id}`)
+      logger.info('syncDownEvents', `deleting file id=${existingFileRecord.id}`)
       await Promise.all([
         // Remove the file from the file system.
         removeFsFile(existingFileRecord),
@@ -138,12 +141,13 @@ async function handleDeleteEvent(id: string, counts: Counts): Promise<void> {
       ])
       counts.deleted++
     } else {
-      serviceLog(
-        `[syncDownEvents] no file record found for object id=${id}, skipping delete`
+      logger.debug(
+        'syncDownEvents',
+        `no file record found for object id=${id}, skipping delete`
       )
     }
   } catch (e) {
-    serviceLog(`[syncDownEvents] error handling delete for id=${id}`, e)
+    logger.error('syncDownEvents', `error handling delete for id=${id}`, e)
     throw e
   }
 }
@@ -183,9 +187,9 @@ async function handleUpdateEvent(
       )
       return
     }
-    serviceLog(`[syncDownEvents] incomplete metadata, skipping update`)
+    logger.debug('syncDownEvents', 'incomplete metadata, skipping update')
   } catch (e) {
-    serviceLog(`[syncDownEvents] error handling update for id=${id}`, e)
+    logger.error('syncDownEvents', `error handling update for id=${id}`, e)
     throw e
   }
 }
@@ -200,10 +204,11 @@ async function handleFileRecord(
 ) {
   if (existingFile) {
     if (type === 'file') {
-      serviceLog(`[syncDownEvents] updating file hash=${existingFile.hash}`)
+      logger.debug('syncDownEvents', `updating file hash=${existingFile.hash}`)
     } else {
-      serviceLog(
-        `[syncDownEvents] updating thumbnail thumbForHash=${existingFile.thumbForHash}`
+      logger.debug(
+        'syncDownEvents',
+        `updating thumbnail thumbForHash=${existingFile.thumbForHash}`
       )
     }
     const localObject = await pinnedObjectToLocalObject(
@@ -224,10 +229,11 @@ async function handleFileRecord(
     counts.existing++
   } else {
     if (type === 'file') {
-      serviceLog(`[syncDownEvents] creating file hash=${metadata.hash}`)
+      logger.info('syncDownEvents', `creating file hash=${metadata.hash}`)
     } else {
-      serviceLog(
-        `[syncDownEvents] creating thumbnail thumbForHash=${metadata.thumbForHash}`
+      logger.info(
+        'syncDownEvents',
+        `creating thumbnail thumbForHash=${metadata.thumbForHash}`
       )
     }
     const fileId = uniqueId()
@@ -292,6 +298,6 @@ export async function setSyncDownCursor(value: ObjectsCursor | undefined) {
 }
 
 export async function resetSyncDownCursor() {
-  serviceLog('[syncDownEvents] resetting sync down cursor')
+  logger.info('syncDownEvents', 'resetting sync down cursor')
   await setSyncDownCursor(undefined)
 }

--- a/src/managers/syncNewPhotos.ts
+++ b/src/managers/syncNewPhotos.ts
@@ -1,5 +1,5 @@
 import * as MediaLibrary from 'expo-media-library'
-import { serviceLog } from '../lib/logger'
+import { logger } from '../lib/logger'
 import { createServiceInterval } from '../lib/serviceInterval'
 import { settingsSwr } from '../stores/settings'
 import { processAssets } from '../lib/processAssets'
@@ -35,10 +35,10 @@ async function workForward(): Promise<void> {
       resolveWithFullInfo: true,
     })
     if (page.assets.length === 0) {
-      serviceLog('[syncNewPhotos] no new photos found')
+      logger.debug('syncNewPhotos', 'no new photos found')
       return
     }
-    serviceLog('[syncNewPhotos] batch size', page.assets.length)
+    logger.info('syncNewPhotos', `batch size=${page.assets.length}`)
     const lastAssetCreationTime =
       page.assets[page.assets.length - 1].creationTime
     const nextTimestamp = lastAssetCreationTime ? lastAssetCreationTime + 1 : 0
@@ -55,7 +55,7 @@ async function workForward(): Promise<void> {
     )
     if (files.length > 0) await librarySwr.triggerChange()
   } catch (e) {
-    serviceLog('[syncNewPhotos] batch error', e)
+    logger.error('syncNewPhotos', 'batch error', e)
   }
 }
 
@@ -101,6 +101,6 @@ export async function setPhotosNewCursor(value: number) {
 }
 
 export async function resetPhotosNewCursor() {
-  serviceLog('[syncNewPhotos] resetting photos new sync cursor')
+  logger.info('syncNewPhotos', 'resetting photos new sync cursor')
   await setPhotosNewCursor(defaultValue)
 }

--- a/src/managers/syncPhotosArchive.ts
+++ b/src/managers/syncPhotosArchive.ts
@@ -1,5 +1,5 @@
 import * as MediaLibrary from 'expo-media-library'
-import { serviceLog } from '../lib/logger'
+import { logger } from '../lib/logger'
 import { settingsSwr } from '../stores/settings'
 import { processAssets } from '../lib/processAssets'
 import { librarySwr } from '../stores/library'
@@ -35,11 +35,11 @@ export async function workBackward() {
       resolveWithFullInfo: true,
     })
     if (page.assets.length === 0) {
-      serviceLog('[syncPhotosArchive] archive is fully synced')
+      logger.info('syncPhotosArchive', 'archive is fully synced')
       await setPhotosArchiveCursor(0)
       return
     }
-    serviceLog('[syncPhotosArchive] batch size', page.assets.length)
+    logger.info('syncPhotosArchive', `batch size=${page.assets.length}`)
     const lastAssetCreationTime =
       page.assets[page.assets.length - 1].creationTime ?? 0
     const nextTimestamp = lastAssetCreationTime ? lastAssetCreationTime - 1 : 0
@@ -61,7 +61,7 @@ export async function workBackward() {
       return 0
     }
   } catch (e) {
-    serviceLog('[syncPhotosArchive] batch error', e)
+    logger.error('syncPhotosArchive', 'batch error', e)
   }
 }
 
@@ -105,11 +105,11 @@ export async function setPhotosArchiveCursor(value: number) {
 }
 
 export async function restartPhotosArchiveCursor() {
-  serviceLog('[syncPhotosArchive] restarting photos archive sync cursor')
+  logger.info('syncPhotosArchive', 'restarting photos archive sync cursor')
   await setPhotosArchiveCursor(Date.now())
 }
 
 export async function resetPhotosArchiveCursor() {
-  serviceLog('[syncPhotosArchive] disabling photos archive sync cursor')
+  logger.info('syncPhotosArchive', 'disabling photos archive sync cursor')
   await setPhotosArchiveCursor(defaultValue)
 }

--- a/src/managers/syncUpMetadata.ts
+++ b/src/managers/syncUpMetadata.ts
@@ -1,4 +1,4 @@
-import { serviceLog } from '../lib/logger'
+import { logger } from '../lib/logger'
 import {
   fileMetadataKeys,
   readAllFileRecords,
@@ -147,15 +147,14 @@ export async function setSyncUpCursor(
  */
 export async function runSyncUpMetadata(batchSize: number): Promise<void> {
   if (!getIsConnected()) {
-    serviceLog('[syncUpMetadata] not connected to indexer, skipping')
+    logger.debug('syncUpMetadata', 'not connected to indexer, skipping')
     return
   }
   const indexerURL = await getIndexerURL()
   const after = await getSyncUpCursor()
-  serviceLog(
-    `[syncUpMetadata] service tick: from ${after?.id ?? 'begin'} after=${
-      after?.updatedAt
-    }`
+  logger.debug(
+    'syncUpMetadata',
+    `service tick: from ${after?.id ?? 'begin'} after=${after?.updatedAt}`
   )
   const batch = await readAllFileRecords({
     order: 'ASC',
@@ -170,7 +169,7 @@ export async function runSyncUpMetadata(batchSize: number): Promise<void> {
       : undefined,
   })
   if (batch.length === 0) {
-    serviceLog('[syncUpMetadata] no new updates')
+    logger.debug('syncUpMetadata', 'no new updates')
     return
   }
   for (const f of batch) {
@@ -182,7 +181,8 @@ export async function runSyncUpMetadata(batchSize: number): Promise<void> {
       const diffs = diffFileMetadata(f, remoteMeta)
       if (Object.keys(diffs).length === 0) continue
       const isLocalNewer = (f.updatedAt || 0) >= (remoteMeta.updatedAt || 0)
-      serviceLog(
+      logger.info(
+        'syncUpMetadata',
         formatDiff({
           fileId: f.id,
           objectId: obj.id,
@@ -196,7 +196,7 @@ export async function runSyncUpMetadata(batchSize: number): Promise<void> {
         await updateMetadata(remote, encodeFileMetadata(f))
       }
     } catch (e) {
-      serviceLog('[syncUpMetadata] error', e)
+      logger.error('syncUpMetadata', 'error', e)
     }
   }
   const last = batch[batch.length - 1]
@@ -205,7 +205,7 @@ export async function runSyncUpMetadata(batchSize: number): Promise<void> {
       updatedAt: last.updatedAt + 1,
       id: last.id,
     })
-    serviceLog('[syncUpMetadata] end reached')
+    logger.debug('syncUpMetadata', 'end reached')
   } else {
     await setSyncUpCursor({
       updatedAt: last.updatedAt,

--- a/src/managers/thumbnailScanner.ts
+++ b/src/managers/thumbnailScanner.ts
@@ -1,4 +1,4 @@
-import { serviceLog } from '../lib/logger'
+import { logger } from '../lib/logger'
 import { createServiceInterval } from '../lib/serviceInterval'
 import { db } from '../db'
 import { type ThumbSize, ThumbSizes } from '../stores/files'
@@ -52,13 +52,14 @@ async function logOverallProgress() {
     const targetThumbs = originals * ThumbSizes.length
     const remaining = Math.max(targetThumbs - thumbs, 0)
     const percent = targetThumbs > 0 ? Math.min(1, thumbs / targetThumbs) : 1
-    serviceLog(
-      `[thumbnailScanner] overall originals=${originals} thumbs=${thumbs}/${targetThumbs} remaining=${remaining} percent=${Math.round(
+    logger.debug(
+      'thumbnailScanner',
+      `overall originals=${originals} thumbs=${thumbs}/${targetThumbs} remaining=${remaining} percent=${Math.round(
         percent * 100
       )}%`
     )
   } catch (e) {
-    serviceLog('[thumbnailScanner] progress error', e)
+    logger.error('thumbnailScanner', 'progress error', e)
   }
 }
 
@@ -145,7 +146,7 @@ export async function runThumbnailScanner(): Promise<ThumbnailScannerResult> {
   }
   let producedCount = 0
   try {
-    serviceLog('[thumbnailScanner] scanning...')
+    logger.debug('thumbnailScanner', 'scanning...')
     const skippedNoSourceUri = new Set<string>()
     const processedThisRun = new Set<string>()
 
@@ -182,16 +183,21 @@ export async function runThumbnailScanner(): Promise<ThumbnailScannerResult> {
           continue
         }
 
-        serviceLog('[thumbnailScanner] candidate', {
-          id: c.id,
-          hash: c.hash,
-          existingSizes,
-          missingSizes,
-        })
+        logger.debug(
+          'thumbnailScanner',
+          `candidate id=${c.id} hash=${
+            c.hash
+          } existingSizes=${existingSizes.join(
+            ','
+          )} missingSizes=${missingSizes.join(',')}`
+        )
 
         for (const size of missingSizes) {
           if (producedCount >= MAX_THUMBS_PER_TICK) break
-          serviceLog('[thumbnailScanner] attempt size', { id: c.id, size })
+          logger.debug(
+            'thumbnailScanner',
+            `attempt size id=${c.id} size=${size}`
+          )
           summary.attempts.push({
             originalId: c.id,
             originalHash: c.hash,
@@ -213,7 +219,7 @@ export async function runThumbnailScanner(): Promise<ThumbnailScannerResult> {
               size,
               thumbId: outcome.thumbId,
             })
-            serviceLog('[thumbnailScanner] produced', { id: c.id, size })
+            logger.info('thumbnailScanner', `produced id=${c.id} size=${size}`)
           } else if (outcome.status === 'duplicate') {
             summary.deduplicated.push({
               originalId: c.id,
@@ -232,16 +238,13 @@ export async function runThumbnailScanner(): Promise<ThumbnailScannerResult> {
         }
       }
     }
-    serviceLog(
-      `[thumbnailScanner] batch produced=${summary.produced.length}/${summary.processedCandidates}` +
-        ` skippedNoSource=${summary.skippedNoSource.length}/${summary.processedCandidates}` +
-        ` skippedFullyCovered=${summary.skippedFullyCovered.length}/${summary.processedCandidates}` +
-        ` errors=${summary.errors.length}/${summary.processedCandidates}` +
-        ` deduplicated=${summary.deduplicated.length}/${summary.processedCandidates}`
+    logger.info(
+      'thumbnailScanner',
+      `batch produced=${summary.produced.length}/${summary.processedCandidates} skippedNoSource=${summary.skippedNoSource.length}/${summary.processedCandidates} skippedFullyCovered=${summary.skippedFullyCovered.length}/${summary.processedCandidates} errors=${summary.errors.length}/${summary.processedCandidates} deduplicated=${summary.deduplicated.length}/${summary.processedCandidates}`
     )
     await logOverallProgress()
   } catch (e) {
-    serviceLog('[thumbnailScanner] scan error', e)
+    logger.error('thumbnailScanner', 'scan error', e)
   }
   return summary
 }

--- a/src/managers/thumbnailer.ts
+++ b/src/managers/thumbnailer.ts
@@ -43,7 +43,7 @@ export async function generateThumbnailsForFile(
     type: fileRecord.type,
   })
   if (!sourceUri) {
-    logger.log('[generateThumbnailsForFile] no source URI', {
+    logger.warn('generateThumbnailsForFile', 'no source URI', {
       fileId: fileRecord.id,
     })
     return
@@ -54,14 +54,14 @@ export async function generateThumbnailsForFile(
   const missingSizes = ThumbSizes.filter((s) => !existingSizes.includes(s))
 
   if (missingSizes.length === 0) {
-    logger.log('[generateThumbnailsForFile] all thumbnails already exist', {
+    logger.debug('generateThumbnailsForFile', 'all thumbnails already exist', {
       fileId: fileRecord.id,
     })
     return
   }
 
   // Generate missing thumbnails.
-  logger.log('[generateThumbnailsForFile] generating thumbnails', {
+  logger.debug('generateThumbnailsForFile', 'generating thumbnails', {
     fileId: fileRecord.id,
     missingSizes,
   })
@@ -83,7 +83,7 @@ export async function generateThumbnails(files: FileRecord[]) {
     try {
       await generateThumbnailsForFile(file)
     } catch (error) {
-      logger.log('[generateThumbnails] thumbnail generation error', {
+      logger.error('generateThumbnails', 'thumbnail generation error', {
         fileId: file.id,
         error,
       })
@@ -118,28 +118,28 @@ export async function ensureThumbnailForSize(params: {
     return { status: 'exists' }
   }
 
-  logger.log('[thumbnailer] source uri', { fileId, uri: sourceUri })
+  logger.debug('thumbnailer', 'source uri', { fileId, uri: sourceUri })
 
   // Compute input and target aspect-preserving dimensions for thumb size = size.
   let info: ThumbnailInfo | null = null
   try {
     if (fileType?.startsWith('video/')) {
       info = await prepareVideoThumbnail(sourceUri, size)
-      logger.log('[thumbnailer] video base frame prepared', {
+      logger.debug('thumbnailer', 'video base frame prepared', {
         fileId,
         size,
         info,
       })
     } else {
       info = await prepareImageThumbnail(sourceUri, size)
-      logger.log('[thumbnailer] image target size prepared', {
+      logger.debug('thumbnailer', 'image target size prepared', {
         fileId,
         size,
         info,
       })
     }
   } catch (e) {
-    logger.log('[thumbnailer] error preparing source', e)
+    logger.error('thumbnailer', 'error preparing source', e)
     return { status: 'error', error: e }
   }
 
@@ -151,7 +151,7 @@ export async function ensureThumbnailForSize(params: {
       compress: 0.8,
       format: SaveFormat.WEBP,
     })
-    logger.log('[thumbnailer] manipulated', {
+    logger.debug('thumbnailer', 'manipulated', {
       fileId,
       hash: fileHash,
       size,
@@ -170,14 +170,14 @@ export async function ensureThumbnailForSize(params: {
     const fileUri = await copyFileToFs(thumbFileInfo, new File(result.uri))
     const thumbHash = await calculateContentHash(fileUri)
     if (!thumbHash) {
-      logger.log('[thumbnailer] failed to calculate hash', { fileId, size })
+      logger.error('thumbnailer', 'failed to calculate hash', { fileId, size })
       return { status: 'error', error: new Error('Missing thumbnail hash') }
     }
 
     // Check if a thumbnail with this hash already exists (dedupe by content hash).
     const existingThumb = await readFileRecordByContentHash(thumbHash)
     if (existingThumb) {
-      logger.log('[thumbnailer] thumbnail already exists by hash', {
+      logger.debug('thumbnailer', 'thumbnail already exists by hash', {
         thumbId: existingThumb.id,
         hash: fileHash,
         size,
@@ -204,7 +204,7 @@ export async function ensureThumbnailForSize(params: {
       },
       true
     )
-    logger.log('[thumbnailer] created thumbnail record', {
+    logger.debug('thumbnailer', 'created thumbnail record', {
       thumbId,
       hash: fileHash,
       size,
@@ -221,7 +221,7 @@ export async function ensureThumbnailForSize(params: {
       height: result.height ?? null,
     }
   } catch (e) {
-    logger.log('[thumbnailer] error generating thumbnail', e)
+    logger.error('thumbnailer', 'error generating thumbnail', e)
     return { status: 'error', error: e }
   }
 }

--- a/src/managers/uploadScanner.ts
+++ b/src/managers/uploadScanner.ts
@@ -1,4 +1,4 @@
-import { serviceLog } from '../lib/logger'
+import { logger } from '../lib/logger'
 import { getActiveUploads, useActiveUploads } from '../stores/uploads'
 import {
   getFilesLocalOnly,
@@ -21,10 +21,10 @@ import { humanUploadPercent } from '../lib/uploadPercent'
 async function startUploadScanner(): Promise<void> {
   const isConnected = getIsConnected()
   if (!isConnected) {
-    serviceLog('[uploadScanner] not connected to indexer, skipping scan')
+    logger.debug('uploadScanner', 'not connected to indexer, skipping scan')
     return
   }
-  serviceLog('[uploadScanner] scanning...')
+  logger.debug('uploadScanner', 'scanning...')
   try {
     const maxUploads = await getMaxUploads()
     const maxTotalUploads = SCANNER_MAX_TOTAL_UPLOADS_FACTOR * maxUploads
@@ -34,14 +34,14 @@ async function startUploadScanner(): Promise<void> {
     }
     const files = await getNextUploads(maxToAdd)
     if (files.length > 0) {
-      serviceLog(
-        `[uploadScanner] queuing ${files.length} uploads`,
-        files.map((f) => f.id).join(', ')
+      logger.info(
+        'uploadScanner',
+        `queuing ${files.length} uploads: ${files.map((f) => f.id).join(', ')}`
       )
       files.forEach((f) => queueUploadForFileId(f.id))
     }
   } catch (e) {
-    serviceLog('[uploadScanner] scan error', e)
+    logger.error('uploadScanner', 'scan error', e)
   }
 }
 

--- a/src/managers/uploadToNetwork.ts
+++ b/src/managers/uploadToNetwork.ts
@@ -41,15 +41,17 @@ export async function uploadToNetwork(params: {
     metadata: encodeFileMetadata(file),
     progressCallback: {
       progress: (uploaded) => {
-        logger.log(
-          `[uploadToNetwork] ${file.id} progress`,
+        logger.debug(
+          'uploadToNetwork',
+          `${file.id} progress`,
           uploaded,
           'totalEncodedSize',
           totalEncodedSize
         )
         const percent = (uploaded * 1000n) / totalEncodedSize
-        logger.log(
-          `[uploadToNetwork] ${file.id} percent ${percent}, uploaded ${uploaded} bytes`
+        logger.debug(
+          'uploadToNetwork',
+          `${file.id} percent ${percent}, uploaded ${uploaded} bytes`
         )
         updateUploadProgress(file.id, Number(percent) / 1000)
       },
@@ -58,10 +60,10 @@ export async function uploadToNetwork(params: {
 
   const onAbort = () => {
     try {
-      logger.log('[uploadToNetwork] abort received, cancelling upload...')
+      logger.debug('uploadToNetwork', 'abort received, cancelling upload...')
       upload.cancel()
     } catch (e) {
-      logger.log('[uploadToNetwork] error cancelling upload', e)
+      logger.error('uploadToNetwork', 'error cancelling upload', e)
     }
   }
 
@@ -74,8 +76,9 @@ export async function uploadToNetwork(params: {
   const reader = stream.getReader()
   let uploadedBytes = 0
   // Read and upload from the file stream until exhausted or aborted.
-  logger.log(
-    `[uploadToNetwork] ${file.id} reading and uploading from stream...`
+  logger.debug(
+    'uploadToNetwork',
+    `${file.id} reading and uploading from stream...`
   )
   while (true) {
     if (signal.aborted) break
@@ -90,10 +93,11 @@ export async function uploadToNetwork(params: {
       uploadedBytes += value.byteLength
     }
   }
-  logger.log(
-    `[uploadToNetwork] ${file.id} uploaded ${uploadedBytes}/${fileSize} bytes`
+  logger.debug(
+    'uploadToNetwork',
+    `${file.id} uploaded ${uploadedBytes}/${fileSize} bytes`
   )
-  logger.log(`[uploadToNetwork] ${file.id} finalizing upload...`)
+  logger.debug('uploadToNetwork', `${file.id} finalizing upload...`)
   const pinnedObject = await upload.finalize({ signal })
 
   if (signal.aborted) {
@@ -101,15 +105,16 @@ export async function uploadToNetwork(params: {
     return
   }
 
-  logger.log(
-    `[uploadToNetwork] ${file.id} converting pinned object to local object...`
+  logger.debug(
+    'uploadToNetwork',
+    `${file.id} converting pinned object to local object...`
   )
   const localObject = await pinnedObjectToLocalObject(
     file.id,
     indexerURL,
     pinnedObject
   )
-  logger.log(`[uploadToNetwork] ${file.id} updating file object...`)
+  logger.debug('uploadToNetwork', `${file.id} updating file object...`)
   await upsertLocalObject(localObject)
 
   signal.removeEventListener('abort', onAbort)

--- a/src/managers/uploader.ts
+++ b/src/managers/uploader.ts
@@ -12,26 +12,27 @@ export function useUploader() {
   return useCallback(
     async (files: FileRecord[]) => {
       if (!sdk) {
-        logger.log('[uploader] sdk not initialized')
+        logger.warn('uploader', 'sdk not initialized')
         return
       }
       try {
         await Promise.all(
           files.map(async (file: FileRecord, index: number) => {
-            logger.log(
-              `[uploader] processing media ${index + 1}/${files.length}...`
+            logger.debug(
+              'uploader',
+              `processing media ${index + 1}/${files.length}...`
             )
             const fileUri = await getFsFileUri(file)
             if (!fileUri) {
-              logger.log(`[uploader] file not available locally ${file.id}`)
+              logger.warn('uploader', `file not available locally ${file.id}`)
               return
             }
-            logger.log(`[uploader] cached file ${file.id} -> ${fileUri}`)
+            logger.debug('uploader', `cached file ${file.id} -> ${fileUri}`)
             runUploadWithSlot({
               id: file.id,
               task: async (signal) => {
                 const indexerURL = await getIndexerURL()
-                logger.log(`[uploader] uploading ${file.id} to hosts...`)
+                logger.debug('uploader', `uploading ${file.id} to hosts...`)
                 await uploadToNetwork({
                   file,
                   indexerURL,
@@ -39,14 +40,14 @@ export function useUploader() {
                   fileUri,
                   signal,
                 })
-                logger.log(`[uploader] upload complete ${file.id}`)
+                logger.debug('uploader', `upload complete ${file.id}`)
               },
             })
           })
         )
-        logger.log('[uploader] all selected assets processed.')
+        logger.debug('uploader', 'all selected assets processed.')
       } catch (e) {
-        logger.log(`[uploader] error`, e)
+        logger.error('uploader', 'error', e)
       }
     },
     [sdk]
@@ -70,7 +71,7 @@ export function useReuploadFile() {
           if (!fileUri) {
             throw new Error('File not available locally')
           }
-          logger.log(`[uploader] uploading ${fileId}...`)
+          logger.debug('uploader', `uploading ${fileId}...`)
           await uploadToNetwork({
             file,
             indexerURL,
@@ -78,7 +79,7 @@ export function useReuploadFile() {
             fileUri,
             signal,
           })
-          logger.log(`[uploader] upload complete ${fileId}`)
+          logger.debug('uploader', `upload complete ${fileId}`)
         },
       }),
     []

--- a/src/managers/uploadsPool.ts
+++ b/src/managers/uploadsPool.ts
@@ -37,7 +37,7 @@ export async function acquireUploadSlot(): Promise<() => void> {
 
 export async function setMaxUploads(value: number) {
   if (!value) {
-    logger.log('[settings] setMaxUploads: value must be 1 or greater')
+    logger.warn('settings', 'setMaxUploads: value must be 1 or greater')
   }
   const clamped = Math.max(1, Math.floor(Number(value) || 1))
   await setAsyncStorageNumber('maxUploads', clamped)

--- a/src/screens/OnboardingRecoveryPhraseScreen.tsx
+++ b/src/screens/OnboardingRecoveryPhraseScreen.tsx
@@ -53,7 +53,7 @@ export default function OnboardingRecoveryPhraseScreen() {
         nav.navigate('FinishedOnboarding', { indexerURL })
       }
     } catch (err) {
-      logger.log('Error completing recovery phrase setup', err)
+      logger.error('onboarding', 'Error completing recovery phrase setup', err)
     }
   }
 

--- a/src/screens/SettingsLogsScreen.tsx
+++ b/src/screens/SettingsLogsScreen.tsx
@@ -1,21 +1,28 @@
 import { LogView } from '../components/LogView'
-import { useLogs } from '../stores/logs'
 import { type NativeStackScreenProps } from '@react-navigation/native-stack'
 import { type SettingsStackParamList } from '../stacks/types'
 import { useSettingsHeader } from '../hooks/useSettingsHeader'
 import { SettingsLogsControlBar } from '../components/SettingsLogsControlBar'
 import { SettingsFullLayout } from '../components/SettingsLayout'
+import { logsSwr } from '../hooks/useLogs'
 
 type Props = NativeStackScreenProps<SettingsStackParamList, 'Logs'>
 
 export function SettingsLogsScreen({ route, navigation }: Props) {
-  const logs = useLogs()
   useSettingsHeader()
+
+  const handleRefresh = async () => {
+    await logsSwr.triggerChange()
+  }
 
   return (
     <SettingsFullLayout>
-      <LogView logs={logs} />
-      <SettingsLogsControlBar navigation={navigation} route={route} />
+      <LogView />
+      <SettingsLogsControlBar
+        navigation={navigation}
+        route={route}
+        onRefresh={handleRefresh}
+      />
     </SettingsFullLayout>
   )
 }

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -27,6 +27,7 @@ import { initSyncUpMetadata } from '../managers/syncUpMetadata'
 import { initThumbnailScanner } from '../managers/thumbnailScanner'
 import { initFsOrphanScanner } from '../managers/fsOrphanScanner'
 import { initFsEvictionScanner } from '../managers/fsEvictionScanner'
+import { initLogRotation } from '../managers/logRotation'
 import { shutdownAllServiceIntervals } from '../lib/serviceInterval'
 import { clearAppKeys } from './appKey'
 import { clearMnemonicHash } from './mnemonic'
@@ -65,7 +66,6 @@ export async function initApp(): Promise<void> {
       label: 'Starting application',
       message: 'Initializing...',
       runner: async () => {
-        await initLogger()
         ensureFsStorageDirectory()
         ensureTempFsStorageDirectory()
       },
@@ -80,6 +80,7 @@ export async function initApp(): Promise<void> {
             updateDetail(event.message)
           },
         })
+        await initLogger()
       },
     },
   ]
@@ -112,6 +113,7 @@ export async function initApp(): Promise<void> {
       initThumbnailScanner()
       initFsOrphanScanner()
       initFsEvictionScanner()
+      await initLogRotation()
     },
   })
 
@@ -125,7 +127,7 @@ function cancelAllTransfers() {
   cancelAllDownloads()
 }
 
-export function shutdownApp() {
+export async function shutdownApp() {
   cancelAllTransfers()
 }
 

--- a/src/stores/downloads.ts
+++ b/src/stores/downloads.ts
@@ -67,10 +67,10 @@ export function cancelAllDownloads() {
   const current = getState().downloads
   Object.values(current).forEach((r) => {
     try {
-      logger.log('aborting download', r.id)
+      logger.debug('downloads', 'aborting download', r.id)
       r.controller?.abort()
     } catch (e) {
-      logger.log('error aborting download', r.id, e)
+      logger.error('downloads', 'error aborting download', r.id, e)
     }
   })
   useDownloadsStore.setState({ downloads: {} })
@@ -104,14 +104,14 @@ export async function runDownloadWithSlot<T>(params: {
   setDownloadState(id, 'queued', 0)
   const release = await acquireDownloadSlot()
   try {
-    logger.log('download running', id)
+    logger.debug('downloads', 'download running', id)
     setDownloadState(id, 'running', 0)
     const result = await task(controller.signal)
-    logger.log('download success', id)
+    logger.debug('downloads', 'download success', id)
     removeDownload(id)
     return result
   } catch (e) {
-    logger.log('download error', id, e)
+    logger.error('downloads', 'download error', id, e)
     const message = e instanceof Error ? e.message : String(e)
     setDownloadState(id, 'error', 0, message)
     throw e

--- a/src/stores/files.ts
+++ b/src/stores/files.ts
@@ -300,7 +300,7 @@ export async function readFileRecordByContentHash(hash: string) {
     hash
   )
   if (!row) {
-    logger.log('[db] file not found by hash', hash)
+    logger.debug('db', 'file not found by hash', hash)
     return null
   }
   const objects = await readLocalObjectsForFile(row.id)
@@ -313,7 +313,7 @@ export async function readFileRecord(id: string): Promise<FileRecord | null> {
     id
   )
   if (!row) {
-    logger.log('[db] file not found', id)
+    logger.debug('db', 'file not found', id)
     return null
   }
   const objects = await readLocalObjectsForFile(id)
@@ -415,7 +415,7 @@ export async function createFileRecordWithLocalObject(
     })
     await librarySwr.triggerChange()
   } catch (e) {
-    logger.log('[createFileRecordWithLocalObject] error', e)
+    logger.error('db', 'createFileRecordWithLocalObject error', e)
     throw e
   }
 }
@@ -433,7 +433,7 @@ export async function updateFileRecordWithLocalObject(
     })
     await librarySwr.triggerChange()
   } catch (e) {
-    logger.log('[updateFileRecordWithLocalObject] error', e)
+    logger.error('db', 'updateFileRecordWithLocalObject error', e)
     throw e
   }
 }

--- a/src/stores/fs.ts
+++ b/src/stores/fs.ts
@@ -105,7 +105,7 @@ export async function copyFileToFs(
   file: FsFileInfo,
   sourceFile: File
 ): Promise<string> {
-  logger.log(`[fs] copyFile ${file.id} from ${sourceFile.uri}`)
+  logger.debug('fs', `copyFile ${file.id} from ${sourceFile.uri}`)
   const target = getFsFileForId(file)
   const targetInfo = target.info()
   if (targetInfo.exists) {

--- a/src/stores/logs.ts
+++ b/src/stores/logs.ts
@@ -1,98 +1,216 @@
 import { create } from 'zustand'
 import { useShallow } from 'zustand/react/shallow'
-import { logger } from '../lib/logger'
-import { createGetterAndSelector } from '../lib/selectors'
-import { getAsyncStorageBoolean, setAsyncStorageBoolean } from './asyncStore'
+import { useState, useEffect } from 'react'
+import { logger, type LogLevel, type LogEntry } from '../lib/logger'
+import { getAsyncStorageString, setAsyncStorageString } from './asyncStore'
+import { db } from '../db'
+import { sqlInsert } from '../db/sql'
 
 export type LogsState = {
-  logs: string[]
-  enableSdkLogs: boolean
+  logLevel: LogLevel
+  logScopes: string[]
 }
 
 export const useLogsStore = create<LogsState>(() => ({
-  logs: [],
-  enableSdkLogs: false,
+  logLevel: 'debug',
+  logScopes: [],
 }))
 
-const { setState, getState } = useLogsStore
-
-export function appendLogLine(...args: unknown[]): void {
-  setState((state) => {
-    const line = `${new Date().toLocaleTimeString()} ${args
-      .map(String)
-      .join(' ')}`
-    const next = [...state.logs.slice(-100), line]
-    return { logs: next }
-  })
-}
-
-export function clearLogs(): void {
-  setState(() => {
-    return { logs: [] }
-  })
-}
+const { setState } = useLogsStore
 
 let hasInit = false
 
 export async function initLogger(): Promise<void> {
   if (hasInit) {
-    logger.log('[logs] initLogger already called, skipping')
     return
   }
-  logger.log('[logs] initLogger called')
 
-  // Init state with secure store value so that we can use an in memory value
-  // in the logger callbacks.
-  const enableSdkLogs = await getEnableSdkLogs()
+  // Now we can log.
+  logger.info('logs', 'initLogger called')
+
+  // Init state with stored values.
+  const storedLevel = await getLogLevel()
+  const storedScopes = await getLogScopes()
   setState((state) => {
-    return { ...state, enableSdkLogs }
+    return {
+      ...state,
+      logLevel: storedLevel,
+      logScopes: storedScopes,
+    }
   })
 
-  // Wire the global logger to the logs store.
-  logger.log = (...args: unknown[]) => {
-    console.log(...args)
-    appendLogLine(...args)
-  }
-  logger.sdk = (...args: unknown[]) => {
-    const state = getState()
-    if (state.enableSdkLogs) {
-      console.log(...args)
-      appendLogLine(...args)
-    }
-  }
-  logger.clear = () => {
-    clearLogs()
-  }
   hasInit = true
 }
 
-// selectors
-
-export function useLogs(): string[] {
-  return useLogsStore(useShallow((s) => s.logs))
+// Get available scopes from log files.
+export async function getAvailableScopes(): Promise<string[]> {
+  const logs = await readLogs()
+  return extractScopes(logs)
 }
 
-// Get the enable SDK logs flag from the store state.
-export const [getSDKLogsEnabled, useSDKLogsEnabled] = createGetterAndSelector(
-  useLogsStore,
-  (state) => state.enableSdkLogs
-)
+// Hook to get available scopes (reads from files).
+export function useAvailableScopes(): string[] {
+  const [scopes, setScopes] = useState<string[]>([])
 
-// Get the enable SDK logs flag from the secure store.
-export async function getEnableSdkLogs(): Promise<boolean> {
-  return getAsyncStorageBoolean('enableSdkLogs', false)
+  useEffect(() => {
+    getAvailableScopes().then(setScopes)
+  }, [])
+
+  return scopes
 }
 
-// Set the enable SDK logs flag in both the async store and the store state.
-export async function setEnableSdkLogs(value: boolean): Promise<void> {
-  await setAsyncStorageBoolean('enableSdkLogs', value)
+export function useLogLevel(): LogLevel {
+  return useLogsStore(useShallow((s) => s.logLevel))
+}
+
+export function useLogScopes(): string[] {
+  return useLogsStore(useShallow((s) => s.logScopes))
+}
+
+// Get the log level from async storage.
+export async function getLogLevel(): Promise<LogLevel> {
+  const stored = await getAsyncStorageString('logLevel', 'debug')
+  if (
+    stored === 'debug' ||
+    stored === 'info' ||
+    stored === 'warn' ||
+    stored === 'error'
+  ) {
+    return stored
+  }
+  return 'debug'
+}
+
+// Set the log level in both async storage and store state.
+export async function setLogLevel(value: LogLevel): Promise<void> {
+  await setAsyncStorageString('logLevel', value)
   setState((state) => {
-    return { ...state, enableSdkLogs: value }
+    return { ...state, logLevel: value }
   })
 }
 
-// Toggle the enable SDK logs flag in both the secure store and the store state.
-export async function toggleEnableSdkLogs(): Promise<void> {
-  const value = !getSDKLogsEnabled()
-  await setEnableSdkLogs(value)
+// Get the log scopes from async storage.
+export async function getLogScopes(): Promise<string[]> {
+  const stored = await getAsyncStorageString<string>('logScopes', '')
+  if (!stored) {
+    return []
+  }
+  return stored
+    .split(',')
+    .map((s: string) => s.trim())
+    .filter(Boolean)
+}
+
+// Set the log scopes in both async storage and store state.
+export async function setLogScopes(value: string[]): Promise<void> {
+  const valueStr = value.join(',')
+  await setAsyncStorageString<string>('logScopes', valueStr)
+  setState((state) => {
+    return { ...state, logScopes: value }
+  })
+}
+
+// Toggle a scope in the filter.
+export async function toggleLogScope(scope: string): Promise<void> {
+  const current = await getLogScopes()
+  const newScopes = current.includes(scope)
+    ? current.filter((s) => s !== scope)
+    : [...current, scope]
+  await setLogScopes(newScopes)
+}
+
+/** Append log entry directly to database. */
+export async function appendLog(entry: LogEntry): Promise<void> {
+  try {
+    if (!db()) {
+      // Database not initialized yet, skip appending log.
+      return
+    }
+    await sqlInsert('logs', {
+      timestamp: entry.timestamp,
+      level: entry.level,
+      scope: entry.scope,
+      message: entry.message,
+      createdAt: Date.now(),
+    })
+  } catch (error) {
+    console.error('[logs] Failed to append log:', error)
+  }
+}
+
+/** Get levels that should be included based on minimum level. */
+function getLevelsForFilter(minLevel: LogLevel): LogLevel[] {
+  const levelOrder: LogLevel[] = ['debug', 'info', 'warn', 'error']
+  const minIndex = levelOrder.indexOf(minLevel)
+  return levelOrder.slice(minIndex)
+}
+
+/** Read logs from database with optional filters. */
+export async function readLogs(
+  logLevel?: LogLevel,
+  logScopes?: string[]
+): Promise<LogEntry[]> {
+  try {
+    const conditions: string[] = []
+    const params: (string | number)[] = []
+
+    // Filter by level.
+    if (logLevel) {
+      const allowedLevels = getLevelsForFilter(logLevel)
+      const placeholders = allowedLevels.map(() => '?').join(',')
+      conditions.push(`level IN (${placeholders})`)
+      params.push(...allowedLevels)
+    }
+
+    // Filter by scope.
+    if (logScopes && logScopes.length > 0) {
+      const placeholders = logScopes.map(() => '?').join(',')
+      conditions.push(`scope IN (${placeholders})`)
+      params.push(...logScopes)
+    }
+
+    const whereClause =
+      conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
+
+    const query = `SELECT timestamp, level, scope, message FROM logs ${whereClause} ORDER BY createdAt DESC, id DESC`
+
+    const rows = await db().getAllAsync<{
+      timestamp: string
+      level: string
+      scope: string
+      message: string
+    }>(query, ...params)
+
+    return rows.map((row) => ({
+      timestamp: row.timestamp,
+      level: row.level as LogEntry['level'],
+      scope: row.scope,
+      message: row.message,
+    }))
+  } catch (error) {
+    console.error('[logs] Failed to read logs:', error)
+    return []
+  }
+}
+
+/** Extract unique scopes from entries. */
+export function extractScopes(entries: LogEntry[]): string[] {
+  const scopes = new Set<string>()
+  for (const entry of entries) {
+    scopes.add(entry.scope)
+  }
+  return Array.from(scopes).sort()
+}
+
+/** Clear all logs from the database. */
+export async function clearLogs(): Promise<void> {
+  try {
+    if (!db()) {
+      return
+    }
+    await db().runAsync('DELETE FROM logs')
+  } catch (error) {
+    console.error('[logs] Failed to clear logs:', error)
+    throw error
+  }
 }

--- a/src/stores/sdk.ts
+++ b/src/stores/sdk.ts
@@ -82,7 +82,7 @@ export async function connectSdk(): Promise<SdkInterface | null> {
 
     const [sdk, err] = await builderConnected(builder, appKey)
     if (err) {
-      logger.log('Error connecting', err)
+      logger.error('sdk', 'Error connecting', err)
       return null
     }
 
@@ -91,10 +91,10 @@ export async function connectSdk(): Promise<SdkInterface | null> {
       return sdk
     }
 
-    logger.log('SDK not connected, auth required')
+    logger.warn('sdk', 'SDK not connected, auth required')
     return null
   } catch (err) {
-    logger.log('Error initializing SDK', err)
+    logger.error('sdk', 'Error initializing SDK', err)
     return null
   }
 }
@@ -106,15 +106,15 @@ export async function connectSdk(): Promise<SdkInterface | null> {
  */
 export async function reconnectIndexer(): Promise<boolean> {
   if (getState().isReconnecting) {
-    logger.log('[sdk] already reconnecting, skipping')
+    logger.debug('sdk', 'already reconnecting, skipping')
     return false
   }
   setState({ isReconnecting: true })
 
-  logger.log('[sdk] reconnecting...')
+  logger.info('sdk', 'reconnecting...')
   const isAuthing = getState().isAuthing
   if (isAuthing) {
-    logger.log('[sdk] already authing, skipping')
+    logger.debug('sdk', 'already authing, skipping')
     setState({ isReconnecting: false })
     return false
   }
@@ -180,7 +180,7 @@ export type SwitchResult = Result<void, SwitchError>
 export async function authenticateIndexer(
   indexerURL: string
 ): Promise<AuthenticateResult> {
-  logger.log(`Authenticating with ${indexerURL}...`)
+  logger.info('sdk', `Authenticating with ${indexerURL}...`)
 
   // Check if we have an AppKey for this indexer (returning user).
   const appKey = await getAppKeyForIndexer(indexerURL)
@@ -190,11 +190,11 @@ export async function authenticateIndexer(
     const [sdk, connectedErr] = await builderConnected(builder, appKey)
     if (connectedErr) {
       setState({ isAuthing: false })
-      logger.log('Connection error', connectedErr)
+      logger.error('sdk', 'Connection error', connectedErr)
       return err({ type: 'error', message: connectedErr.message })
     }
     if (sdk) {
-      logger.log('Already registered, connected.')
+      logger.info('sdk', 'Already registered, connected.')
       setState({ sdk, isConnected: true, isAuthing: false })
       setIndexerURL(indexerURL)
       return ok({ alreadyConnected: true })
@@ -203,7 +203,7 @@ export async function authenticateIndexer(
   }
 
   // New user - run browser auth and save approved builder for registerWithIndexer.
-  logger.log('New user, running browser auth...')
+  logger.info('sdk', 'New user, running browser auth...')
   setState({ isAuthing: true, pendingApproval: null })
 
   const builder = new Builder(indexerURL)
@@ -225,7 +225,7 @@ export async function authenticateIndexer(
       : null,
   })
 
-  logger.log('Browser auth completed.')
+  logger.info('sdk', 'Browser auth completed.')
   return ok({ alreadyConnected: false })
 }
 
@@ -250,7 +250,7 @@ export function setSdk(sdk: SdkInterface | null) {
 export async function switchIndexer(
   newIndexerURL: string
 ): Promise<SwitchResult> {
-  logger.log(`Attempting to switch to ${newIndexerURL}...`)
+  logger.info('sdk', `Attempting to switch to ${newIndexerURL}...`)
 
   // First, check if we have an AppKey specifically for this indexer.
   const appKeyForIndexer = await getAppKeyForIndexer(newIndexerURL)
@@ -262,12 +262,12 @@ export async function switchIndexer(
     )
 
     if (connectedErr) {
-      logger.log('Connection error with stored AppKey', connectedErr)
+      logger.error('sdk', 'Connection error with stored AppKey', connectedErr)
       return err({ type: 'error', message: connectedErr.message })
     }
 
     if (sdk) {
-      logger.log('Connected using stored AppKey for this indexer.')
+      logger.info('sdk', 'Connected using stored AppKey for this indexer.')
       setState({ sdk, isConnected: true })
       setIndexerURL(newIndexerURL)
       return ok(undefined)
@@ -275,7 +275,7 @@ export async function switchIndexer(
   }
 
   // No stored AppKey for this indexer - user needs to enter mnemonic.
-  logger.log('No stored AppKey for this indexer, needs reauth')
+  logger.info('sdk', 'No stored AppKey for this indexer, needs reauth')
   return err({ type: 'needsReauth' })
 }
 
@@ -297,7 +297,7 @@ export async function registerWithIndexer(
   // Validate mnemonic against stored hash if one exists.
   const mnemonicValid = await validateMnemonic(mnemonic)
   if (mnemonicValid === 'invalid') {
-    logger.log('Mnemonic does not match stored hash')
+    logger.warn('sdk', 'Mnemonic does not match stored hash')
     // Keep pendingApproval so user can fix mnemonic and retry.
     setState({ isAuthing: false })
     return err({ type: 'mnemonicMismatch' })
@@ -308,11 +308,11 @@ export async function registerWithIndexer(
   let approvedBuilder: BuilderInterface | null = null
 
   if (pendingApproval && pendingApproval.indexerURL === indexerURL) {
-    logger.log('Using pending approval from authenticateIndexer')
+    logger.debug('sdk', 'Using pending approval from authenticateIndexer')
     approvedBuilder = pendingApproval.builder
   } else {
     // No pending approval - run browser auth (fallback for edge cases).
-    logger.log('No pending approval, running browser auth...')
+    logger.info('sdk', 'No pending approval, running browser auth...')
     const builder = new Builder(indexerURL)
     const [result, authErr] = await runBrowserAuthFlow(builder)
     if (authErr) {
@@ -331,7 +331,7 @@ export async function registerWithIndexer(
   const [sdk, registerErr] = await builderRegister(approvedBuilder, mnemonic)
   if (registerErr) {
     setState({ isAuthing: false, pendingApproval: null })
-    logger.log('Error registering with mnemonic', registerErr)
+    logger.error('sdk', 'Error registering with mnemonic', registerErr)
     return err({ type: 'error', message: registerErr.message })
   }
 
@@ -353,7 +353,7 @@ async function builderConnected(
   appKey: AppKey
 ): Promise<Result<SdkInterface | null>> {
   try {
-    logger.log('Attempting builder.connected...')
+    logger.debug('sdk', 'Attempting builder.connected...')
     const sdk = await withTimeout(
       builder.connected(appKey),
       CONNECTION_TIMEOUT_MS
@@ -371,7 +371,7 @@ async function builderRequestConnection(
   builder: Builder
 ): Promise<Result<BuilderInterface>> {
   try {
-    logger.log('Requesting app connection...')
+    logger.debug('sdk', 'Requesting app connection...')
     const result = await withTimeout(
       builder.requestConnection({
         id: hexToUint8(APP_KEY).buffer,
@@ -396,7 +396,7 @@ async function builderWaitForApproval(
   builder: BuilderInterface
 ): Promise<Result<BuilderInterface>> {
   try {
-    logger.log('Waiting for approval...')
+    logger.debug('sdk', 'Waiting for approval...')
     const result = await withTimeout(
       builder.waitForApproval(),
       CONNECTION_TIMEOUT_MS
@@ -415,7 +415,7 @@ async function builderRegister(
   mnemonic: string
 ): Promise<Result<SdkInterface>> {
   try {
-    logger.log('Registering with mnemonic...')
+    logger.info('sdk', 'Registering with mnemonic...')
     const result = await withTimeout(
       builder.register(mnemonic),
       CONNECTION_TIMEOUT_MS
@@ -458,7 +458,7 @@ async function runBrowserAuthFlow(
     builder
   )
   if (requestErr) {
-    logger.log('Error requesting connection', requestErr)
+    logger.error('sdk', 'Error requesting connection', requestErr)
     return err({ type: 'error', message: requestErr.message })
   }
 
@@ -467,9 +467,9 @@ async function runBrowserAuthFlow(
   )
   if (approvalErr) {
     if (approvalErr.type === 'cancelled') {
-      logger.log('App authorization cancelled by user')
+      logger.info('sdk', 'App authorization cancelled by user')
     } else {
-      logger.log('Error during approval', approvalErr)
+      logger.error('sdk', 'Error during approval', approvalErr)
     }
     return err(approvalErr)
   }

--- a/src/stores/uploads.ts
+++ b/src/stores/uploads.ts
@@ -65,10 +65,10 @@ export function cancelAllUploads() {
   const current = getState().uploads
   Object.values(current).forEach((r) => {
     try {
-      logger.log('aborting upload', r.id)
+      logger.debug('uploads', 'aborting upload', r.id)
       r.controller?.abort()
     } catch (e) {
-      logger.log('error aborting upload', r.id, e)
+      logger.error('uploads', 'error aborting upload', r.id, e)
     }
   })
   useUploadsStore.setState({ uploads: {} })
@@ -78,7 +78,7 @@ export function cancelUpload(id: string) {
   const current = getState().uploads
   const rec = current[id]
   if (!rec) return
-  logger.log('aborting upload', id)
+  logger.debug('uploads', 'aborting upload', id)
   rec.controller?.abort()
   removeUpload(id)
 }
@@ -111,14 +111,14 @@ export async function runUploadWithSlot<T>(params: {
   setUploadState(id, 'queued', 0)
   const release = await acquireUploadSlot()
   try {
-    logger.log('upload running', id)
+    logger.debug('uploads', 'upload running', id)
     setUploadState(id, 'running', 0)
     const result = await task(controller.signal)
-    logger.log('upload success', id)
+    logger.debug('uploads', 'upload success', id)
     removeUpload(id)
     return result
   } catch (e) {
-    logger.log('upload error', id, e)
+    logger.error('uploads', 'upload error', id, e)
     const message = e instanceof Error ? e.message : String(e)
     setUploadState(id, 'error', 0, message)
     throw e


### PR DESCRIPTION
- Logs are now structured, include a level and scope, and are stored in sqlite.
- Updated all log calls to use new API.
- Added env vars for filtering dev terminal logs by level and scope.
- Updated the log screen to support filtering by level and score.
- Updated the log screen to display logs, with a refresh button to render latest, this makes browsing easier.
- Added export/save button that saves the logs as a file in the user's library / uploads to Sia. The exported logs respect any applied filters.
- Added a button for clearing all rows in the logs table.
- Added color coding to both terminal and UI logs.
- Added log rotation service that keeps the logs capped at 100,000 records.

![Screenshot 2025-12-23 at 3.26.44 PM.png](https://app.graphite.com/user-attachments/assets/7d7ff606-4e11-49e6-ae76-73560d71f909.png)

![Screenshot 2025-12-23 at 3.19.18 PM.png](https://app.graphite.com/user-attachments/assets/19621a82-d28b-4c71-b1d0-71441045bac5.png)

![Screenshot 2025-12-23 at 3.19.39 PM.png](https://app.graphite.com/user-attachments/assets/2dd6993b-3aad-494f-ab32-0a41a3cfbecc.png)

