### PR TITLE
fix: use current file record slab data for map host markers

### DIFF
--- a/src/components/FileDetails/FileMap.tsx
+++ b/src/components/FileDetails/FileMap.tsx
@@ -1,37 +1,24 @@
 import React, { useMemo } from 'react'
 import { StyleSheet, View } from 'react-native'
-import useSWR from 'swr'
 import { AddressProtocol, Host } from 'react-native-sia'
-import { DEFAULT_INDEXER_URL } from '../../config'
 import { type FileRecord } from '../../stores/files'
 import { useHosts } from '../../stores/hosts'
-import { useSdk } from '../../stores/sdk'
+import { getOneSealedObject } from '../../lib/file'
 import Map from '../Map/Map'
 import { MapMarker } from '../Map/MapMarker'
 import { determineBestRegion } from '../Map/mapHelpers'
 import { SWROverlay } from '../SWROverlay'
 
 export function FileMap({ file }: { file: FileRecord }) {
-  const sdk = useSdk()
   const hosts = useHosts()
 
-  const firstSlabID = useMemo(() => {
-    const slabs = file.objects[DEFAULT_INDEXER_URL]?.slabs ?? []
-    return slabs[0]?.id
-  }, [file])
-
-  const slab = useSWR(
-    sdk && firstSlabID ? ['sdk/slab', firstSlabID] : null,
-    () => sdk?.slab(firstSlabID!)
-  )
+  const firstSlab = getOneSealedObject(file)?.sealedObject.slabs[0]
 
   const matchingHosts: Host[] = useMemo(() => {
-    if (!hosts.data || !slab.data) return []
-    const keys = new Set(
-      (slab.data.sectors ?? []).map((sec: any) => sec.hostKey)
-    )
+    if (!hosts.data || !firstSlab) return []
+    const keys = new Set(firstSlab.sectors.map((sec) => sec.hostKey))
     return hosts.data.filter((h) => keys.has(h.publicKey))
-  }, [hosts.data, slab.data])
+  }, [hosts.data, firstSlab])
 
   const region = useMemo(() => {
     if (matchingHosts.length === 0) return undefined


### PR DESCRIPTION
This fixes slab/host pins not displaying on the FileDetail map. The solution I went with is to simply not make the slab call. We have the slabs in the FileRecord type and so...we can just use those. I'm not sure if the sdk no longer allows you to look up slabs or how that all works now since slabs don't have IDs, but this avoids that exercise.