### PR TITLE
feat: add WKWebView auth modal for E2E compatibility

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -20,6 +20,7 @@ import { ShareIntentConsumer } from './components/ShareIntentConsumer'
 import { AppSplash } from './components/AppSplash'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet'
+import { AuthWebViewModal } from './components/AuthWebViewModal'
 
 const darkNavigationTheme = {
   ...DarkTheme,
@@ -98,6 +99,7 @@ export function Root() {
                   </>
                 )}
               </BottomSheetModalProvider>
+              <AuthWebViewModal />
             </ShareIntentProvider>
           </SafeAreaView>
         </ToastProvider>

--- a/src/components/AuthWebViewModal.tsx
+++ b/src/components/AuthWebViewModal.tsx
@@ -1,0 +1,129 @@
+import React, { useRef, useCallback, useState } from 'react'
+import {
+  Modal,
+  View,
+  StyleSheet,
+  SafeAreaView,
+  TouchableOpacity,
+  Text,
+  ActivityIndicator,
+} from 'react-native'
+import { WebView, type WebViewNavigation } from 'react-native-webview'
+import { palette } from '../styles/colors'
+import { useAuthWebViewStore } from '../stores/authWebView'
+
+export function AuthWebViewModal() {
+  const webViewRef = useRef<WebView>(null)
+  const [loading, setLoading] = useState(true)
+  const { visible, url, close, callback } = useAuthWebViewStore()
+
+  const handleNavigationStateChange = useCallback(
+    (navState: WebViewNavigation) => {
+      if (navState.url.startsWith('sia://')) {
+        callback(navState.url)
+      }
+    },
+    [callback]
+  )
+
+  const handleShouldStartLoadWithRequest = useCallback(
+    (request: { url: string }) => {
+      if (request.url.startsWith('sia://')) {
+        callback(request.url)
+        return false
+      }
+      return true
+    },
+    [callback]
+  )
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={close}
+    >
+      <SafeAreaView style={styles.container}>
+        <View style={styles.header}>
+          <TouchableOpacity
+            onPress={close}
+            style={styles.cancelButton}
+            testID="auth-webview-cancel"
+          >
+            <Text style={styles.cancelText}>Cancel</Text>
+          </TouchableOpacity>
+          <Text style={styles.title} numberOfLines={1}>
+            Authorize
+          </Text>
+          <View style={styles.placeholder} />
+        </View>
+
+        {loading && (
+          <View style={styles.loadingContainer}>
+            <ActivityIndicator size="small" color={palette.gray[400]} />
+          </View>
+        )}
+
+        <WebView
+          ref={webViewRef}
+          source={{ uri: url }}
+          style={styles.webview}
+          onNavigationStateChange={handleNavigationStateChange}
+          onShouldStartLoadWithRequest={handleShouldStartLoadWithRequest}
+          onLoadStart={() => setLoading(true)}
+          onLoadEnd={() => setLoading(false)}
+          javaScriptEnabled
+          domStorageEnabled
+          startInLoadingState
+          originWhitelist={['https://*', 'http://*', 'sia://*']}
+          testID="auth-webview"
+        />
+      </SafeAreaView>
+    </Modal>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: palette.gray[950],
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: palette.gray[800],
+  },
+  cancelButton: {
+    paddingVertical: 4,
+  },
+  cancelText: {
+    color: palette.gray[300],
+    fontSize: 15,
+  },
+  title: {
+    color: palette.gray[100],
+    fontSize: 15,
+    fontWeight: '500',
+    flex: 1,
+    textAlign: 'center',
+  },
+  placeholder: {
+    width: 50,
+  },
+  webview: {
+    flex: 1,
+    backgroundColor: palette.gray[950],
+  },
+  loadingContainer: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: palette.gray[950],
+    zIndex: 1,
+  },
+})

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -8,6 +8,7 @@ export function Button({
   children,
   variant = 'primary',
   accessibilityLabel,
+  testID,
 }: {
   style?: StyleProp<ViewStyle>
   disabled?: boolean
@@ -15,9 +16,11 @@ export function Button({
   children: React.ReactNode
   variant?: 'primary' | 'secondary' | 'danger'
   accessibilityLabel?: string
+  testID?: string
 }) {
   return (
     <Pressable
+      testID={testID}
       accessibilityRole="button"
       accessibilityLabel={accessibilityLabel}
       style={[

--- a/src/components/IndexerSelector.tsx
+++ b/src/components/IndexerSelector.tsx
@@ -44,6 +44,7 @@ export function IndexerSelector({
         ]}
       >
         <Pressable
+          testID="indexer-option-default"
           accessibilityRole="radio"
           accessibilityState={{ selected: !isUsingCustomProvider }}
           onPress={handleSelectDefault}
@@ -65,6 +66,7 @@ export function IndexerSelector({
         ]}
       >
         <Pressable
+          testID="indexer-option-custom"
           accessibilityRole="radio"
           accessibilityState={{ selected: isUsingCustomProvider }}
           onPress={handleUseCustom}

--- a/src/components/LibraryControlBar.tsx
+++ b/src/components/LibraryControlBar.tsx
@@ -41,7 +41,7 @@ export function LibraryControlBar({ route, navigation }: Props) {
               <ListIcon color={iconColors.white} />
             )}
           </IconButton>
-          <IconButton onPress={() => openSheet('addFile')}>
+          <IconButton testID="library-add-button" onPress={() => openSheet('addFile')}>
             <PlusIcon color={iconColors.white} />
           </IconButton>
           <FileSearchButton onOpen={() => setSearchActive((s) => !s)} />

--- a/src/lib/openAuthUrl.ts
+++ b/src/lib/openAuthUrl.ts
@@ -1,14 +1,10 @@
-import { openInAppBrowser } from './inAppBrowser'
+import { openAuthWebView } from '../stores/authWebView'
 
 /**
- * Opens the auth URL in the in-app browser.
- * Waits for the user to complete authentication via the sia:// callback URL.
- * @param authURL - The auth URL to open.
- * @returns True if the auth URL was opened and the sia:// callback was received, false otherwise.
+ * Opens the auth URL in the in-app WebView modal.
+ * Returns true if auth succeeded (sia:// callback received), false otherwise.
  */
 export async function openAuthURL(authURL: string): Promise<boolean> {
-  const result = await openInAppBrowser(authURL, {
-    onResponseURL: (url) => url.startsWith('sia://'),
-  })
-  return result ?? false
+  const callbackUrl = await openAuthWebView(authURL)
+  return callbackUrl !== null && callbackUrl.startsWith('sia://')
 }

--- a/src/screens/OnboardingFinishedScreen.tsx
+++ b/src/screens/OnboardingFinishedScreen.tsx
@@ -117,7 +117,7 @@ export default function OnboardingFinishedScreen() {
                 rotation={90}
               />
             </View>
-            <Animated.Text style={[styles.title, { opacity: fadeInValue }]}>
+            <Animated.Text testID="finished-title" style={[styles.title, { opacity: fadeInValue }]}>
               All set!
             </Animated.Text>
           </View>
@@ -134,6 +134,7 @@ export default function OnboardingFinishedScreen() {
 
       <View style={[styles.footer, { paddingBottom: bottom }]}>
         <Button
+          testID="finished-upload-button"
           variant="primary"
           onPress={async () => {
             await setHasOnboarded(true)

--- a/src/screens/OnboardingIndexerScreen.tsx
+++ b/src/screens/OnboardingIndexerScreen.tsx
@@ -63,7 +63,7 @@ export default function OnboardingIndexerScreen() {
         {showWaiting ? (
           <View style={styles.waitingWrap}>
             <BlocksLoader colorStart={1} size={20} />
-            <Text style={styles.waitingText}>
+            <Text testID="indexer-connecting-text" style={styles.waitingText}>
               {isNavigating ? 'Connected' : 'Connecting...'}
             </Text>
           </View>
@@ -79,7 +79,7 @@ export default function OnboardingIndexerScreen() {
                   style={styles.titleIconGlyph}
                 />
               </View>
-              <Text style={styles.title}>Connect to a provider</Text>
+              <Text testID="indexer-title" style={styles.title}>Connect to a provider</Text>
             </View>
             <Text style={styles.subtitle}>
               Use our provider or link whichever one you prefer. This can be
@@ -97,6 +97,7 @@ export default function OnboardingIndexerScreen() {
       {!showWaiting ? (
         <View style={[styles.footer, { paddingBottom: bottom + 12 }]}>
           <Button
+            testID="indexer-back-button"
             variant="secondary"
             onPress={handleBack}
             style={styles.footerButton}
@@ -104,6 +105,7 @@ export default function OnboardingIndexerScreen() {
             Back
           </Button>
           <Button
+            testID="indexer-authorize-button"
             onPress={handleContinue}
             style={styles.footerButton}
             disabled={isInputEmpty}

--- a/src/screens/OnboardingRecoveryPhraseScreen.tsx
+++ b/src/screens/OnboardingRecoveryPhraseScreen.tsx
@@ -92,7 +92,7 @@ export default function OnboardingRecoveryPhraseScreen() {
                 ringStart={0}
               />
             </View>
-            <Text style={styles.title}>Recovery Phrase</Text>
+            <Text testID="recovery-title" style={styles.title}>Recovery Phrase</Text>
           </View>
 
           <Text style={styles.subtitle}>
@@ -108,7 +108,7 @@ export default function OnboardingRecoveryPhraseScreen() {
                   showsVerticalScrollIndicator={false}
                   keyboardShouldPersistTaps="handled"
                 >
-                  <Text style={styles.phraseText} selectable>
+                  <Text testID="recovery-phrase-text" style={styles.phraseText} selectable>
                     {recoveryPhrase ?? ''}
                   </Text>
                 </ScrollView>
@@ -116,6 +116,7 @@ export default function OnboardingRecoveryPhraseScreen() {
 
               <View style={styles.actionsRow}>
                 <Button
+                  testID="recovery-generate-button"
                   variant="secondary"
                   onPress={makeNewRecoveryPhrase}
                   style={styles.button}
@@ -123,6 +124,7 @@ export default function OnboardingRecoveryPhraseScreen() {
                   Generate new key
                 </Button>
                 <Button
+                  testID="recovery-copy-button"
                   variant="secondary"
                   onPress={() => {
                     Clipboard.setString(recoveryPhrase)
@@ -134,7 +136,7 @@ export default function OnboardingRecoveryPhraseScreen() {
                 </Button>
               </View>
 
-              <Pressable onPress={() => setMode('manual')}>
+              <Pressable testID="recovery-toggle-manual" onPress={() => setMode('manual')}>
                 <Text style={styles.toggleText}>
                   Already have a recovery phrase?
                 </Text>
@@ -151,7 +153,7 @@ export default function OnboardingRecoveryPhraseScreen() {
                 editable={!isSubmitting}
               />
 
-              <Pressable onPress={() => setMode('generated')}>
+              <Pressable testID="recovery-toggle-generated" onPress={() => setMode('generated')}>
                 <Text style={styles.toggleText}>
                   Generate a new recovery phrase instead.
                 </Text>
@@ -163,6 +165,7 @@ export default function OnboardingRecoveryPhraseScreen() {
 
       <View style={[styles.footer, { paddingBottom: bottom }]}>
         <Pressable
+          testID="recovery-checkbox"
           onPress={() => setAckSaved((v) => !v)}
           style={styles.checkboxRow}
           accessibilityRole="checkbox"
@@ -179,6 +182,7 @@ export default function OnboardingRecoveryPhraseScreen() {
         </Pressable>
 
         <Button
+          testID="recovery-continue-button"
           onPress={handleContinue}
           disabled={!canContinue || isSubmitting}
         >

--- a/src/screens/OnboardingWelcomeScreen.tsx
+++ b/src/screens/OnboardingWelcomeScreen.tsx
@@ -74,7 +74,7 @@ export default function OnboardingWelcomeScreen() {
       >
         <View style={styles.card}>
           <View style={styles.center}>
-            <Text style={styles.title}>Sia Storage</Text>
+            <Text testID="welcome-title" style={styles.title}>Sia Storage</Text>
           </View>
         </View>
       </Animated.View>
@@ -86,6 +86,7 @@ export default function OnboardingWelcomeScreen() {
         ]}
       >
         <Button
+          testID="welcome-get-started-button"
           style={styles.footerButton}
           onPress={() => nav.navigate('ChooseIndexer')}
         >

--- a/src/stores/authWebView.ts
+++ b/src/stores/authWebView.ts
@@ -1,0 +1,54 @@
+import { create } from 'zustand'
+
+/**
+ * State for the authentication WebView modal.
+ *
+ * This store manages a WKWebView-based authentication flow that can be automated
+ * by E2E testing tools like Maestro (unlike SFSafariViewController which runs
+ * in a separate process).
+ */
+type AuthWebViewState = {
+  visible: boolean
+  url: string
+  resolver: ((value: string | null) => void) | null
+  /** Opens the WebView and returns a promise that resolves with the callback URL or null if cancelled */
+  open: (url: string) => Promise<string | null>
+  /** Closes the WebView without completing auth (user cancelled) */
+  close: () => void
+  /** Called when auth completes successfully with the callback URL */
+  callback: (callbackUrl: string) => void
+}
+
+export const useAuthWebViewStore = create<AuthWebViewState>((set, get) => ({
+  visible: false,
+  url: '',
+  resolver: null,
+
+  open: (url: string) => {
+    // Return a promise that will be resolved when callback() or close() is called
+    return new Promise((resolve) => {
+      set({ visible: true, url, resolver: resolve })
+    })
+  },
+
+  close: () => {
+    // User cancelled - resolve with null
+    const { resolver } = get()
+    if (resolver) resolver(null)
+    set({ visible: false, url: '', resolver: null })
+  },
+
+  callback: (callbackUrl: string) => {
+    // Auth succeeded - resolve with the callback URL containing the token
+    const { resolver } = get()
+    if (resolver) resolver(callbackUrl)
+    set({ visible: false, url: '', resolver: null })
+  },
+}))
+
+/**
+ * Opens the auth WebView modal and waits for completion.
+ * Returns the callback URL on success, or null if the user cancelled.
+ */
+export const openAuthWebView = (url: string) =>
+  useAuthWebViewStore.getState().open(url)


### PR DESCRIPTION
- Use WKWebView instead of SFSafariViewController for auth flows.
- Maestro cannot automate Safari views, so this enables E2E testing.
- I tried the other major frameworks, they all have this issue.
- Also adds testID props to components for E2E selectors.