### PR TITLE
feat: allow caching more than one build target at a time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,9 +37,16 @@ yarn-error.*
 *.tsbuildinfo
 android/
 ios/
+.build-cache/
 # env files
 .env
 .env.*
 !.env.example
 !.env.test
 android-release.keystore
+
+# Claude Code
+CLAUDE.md
+.claude/
+
+test/e2e/.maestro/

--- a/scripts/buildCache.ts
+++ b/scripts/buildCache.ts
@@ -1,0 +1,161 @@
+/**
+ * Build Cache Utilities
+ *
+ * Shared module for smart build caching across dev and E2E scripts.
+ *
+ * How it works:
+ * - Computes a hash from files that affect native builds (package.json, plugins, etc.)
+ * - Each build target (ios-sim, ios-device, android, e2e-ios, e2e-android) has its own cache
+ * - Skips rebuild if hash matches and artifacts exist
+ * - Cache stored in .build-cache/ directory (survives rimraf ios/android)
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
+import { createHash } from 'crypto'
+import { join } from 'path'
+import { Glob } from 'bun'
+
+// Project paths
+export const PROJECT_ROOT = join(import.meta.dir, '..')
+export const BUILD_CACHE_DIR = join(PROJECT_ROOT, '.build-cache')
+
+// Build targets - each has isolated cache
+export type BuildTarget =
+  | 'ios-sim'      // iOS Simulator dev builds
+  | 'ios-device'   // iOS real device dev builds
+  | 'android'      // Android emulator/device dev builds
+  | 'e2e-ios'      // E2E iOS simulator builds
+  | 'e2e-android'  // E2E Android builds
+
+// Get paths for a specific build target
+export function getTargetPaths(target: BuildTarget) {
+  const targetDir = join(BUILD_CACHE_DIR, target)
+  return {
+    dir: targetDir,
+    hashFile: join(targetDir, 'build-hash'),
+    derivedData: join(targetDir, 'DerivedData'),
+    buildLog: join(targetDir, 'build.log'),
+  }
+}
+
+/**
+ * Compute hash from all files that affect native builds.
+ * Same files used for both dev and E2E to ensure consistency.
+ */
+export function computeBuildHash(): string {
+  // Core config files that affect native builds
+  const coreFiles = [
+    'package.json',
+    'bun.lock',
+    'app.config.js',
+    'eas.json',
+  ]
+
+  // Find all plugin files (custom native code)
+  const pluginGlob = new Glob('plugins/*.js')
+  const pluginFiles = Array.from(pluginGlob.scanSync({ cwd: PROJECT_ROOT })).sort()
+
+  const allFiles = [...coreFiles, ...pluginFiles]
+  const content = allFiles.map(f => {
+    const path = join(PROJECT_ROOT, f)
+    return existsSync(path) ? readFileSync(path, 'utf-8') : ''
+  }).join('')
+
+  return createHash('md5').update(content).digest('hex').slice(0, 12)
+}
+
+/**
+ * Check if a rebuild is needed for the given target.
+ * Returns [needed, reason] tuple.
+ */
+export function needsRebuild(
+  target: BuildTarget,
+  options: { forceRebuild?: boolean } = {}
+): [boolean, string] {
+  if (options.forceRebuild) {
+    return [true, '--rebuild flag specified']
+  }
+
+  const paths = getTargetPaths(target)
+  const currentHash = computeBuildHash()
+
+  // Check if cache directory exists
+  if (!existsSync(paths.dir)) {
+    return [true, 'no build cache found']
+  }
+
+  // Check if hash file exists
+  if (!existsSync(paths.hashFile)) {
+    return [true, 'build hash not found']
+  }
+
+  // Check if hash matches
+  const savedHash = readFileSync(paths.hashFile, 'utf-8').trim()
+  if (savedHash !== currentHash) {
+    return [true, `hash changed (${savedHash} -> ${currentHash})`]
+  }
+
+  // Check if build artifacts exist
+  const platform = target.includes('ios') ? 'ios' : 'android'
+
+  if (platform === 'ios') {
+    // Check for DerivedData with built app
+    if (!existsSync(paths.derivedData)) {
+      return [true, 'DerivedData not found']
+    }
+  } else {
+    // Android: check for APK in standard location
+    const apkDir = join(PROJECT_ROOT, 'android/app/build/outputs/apk/debug')
+    if (!existsSync(apkDir)) {
+      return [true, 'no Android APK found']
+    }
+  }
+
+  // Check platform source directory exists (needed for build)
+  const platformDir = join(PROJECT_ROOT, platform)
+  if (!existsSync(platformDir)) {
+    return [true, `${platform}/ directory not found (run prebuild)`]
+  }
+
+  return [false, `hash matches (${currentHash})`]
+}
+
+/**
+ * Save build hash after successful build.
+ */
+export function saveBuildHash(target: BuildTarget): void {
+  const paths = getTargetPaths(target)
+  mkdirSync(paths.dir, { recursive: true })
+  writeFileSync(paths.hashFile, computeBuildHash())
+}
+
+/**
+ * Ensure the build cache directory exists.
+ */
+export function ensureCacheDir(target: BuildTarget): void {
+  const paths = getTargetPaths(target)
+  mkdirSync(paths.dir, { recursive: true })
+}
+
+/**
+ * Write to build log file (instead of flooding stdout).
+ */
+export function writeBuildLog(target: BuildTarget, content: string, append = false): void {
+  const paths = getTargetPaths(target)
+  mkdirSync(paths.dir, { recursive: true })
+  if (append && existsSync(paths.buildLog)) {
+    writeFileSync(paths.buildLog, readFileSync(paths.buildLog, 'utf-8') + content)
+  } else {
+    writeFileSync(paths.buildLog, content)
+  }
+}
+
+/**
+ * Get the last N lines from build log (for error display).
+ */
+export function getBuildLogTail(target: BuildTarget, lines = 50): string {
+  const paths = getTargetPaths(target)
+  if (!existsSync(paths.buildLog)) return ''
+  const content = readFileSync(paths.buildLog, 'utf-8')
+  return content.split('\n').slice(-lines).join('\n')
+}

--- a/scripts/ci-test-build-android.ts
+++ b/scripts/ci-test-build-android.ts
@@ -1,0 +1,22 @@
+import { $ } from 'bun'
+import path from 'node:path'
+
+const projectRoot = path.resolve(import.meta.dir, '..')
+
+$.cwd(projectRoot)
+
+console.log('=== Android Build (Debug) ===')
+
+// Step 1: Clean and prebuild
+console.log('Step 1/2: Cleaning and prebuilding...')
+await $`bunx rimraf .expo android`
+await $`bunx expo prebuild --platform android`
+
+// Step 2: Build debug APK (no signing required)
+console.log('Step 2/2: Building debug APK...')
+const jvmArgs =
+  '-Xmx4096m -XX:MaxMetaspaceSize=1024m -XX:+HeapDumpOnOutOfMemoryError'
+
+await $`cd android && ./gradlew assembleDebug --no-daemon -Dorg.gradle.jvmargs=${jvmArgs}`
+
+console.log('=== Android build complete! ===')

--- a/scripts/ci-test-build-ios.ts
+++ b/scripts/ci-test-build-ios.ts
@@ -1,0 +1,19 @@
+import { $ } from 'bun'
+import path from 'node:path'
+
+const projectRoot = path.resolve(import.meta.dir, '..')
+
+$.cwd(projectRoot)
+
+console.log('=== iOS Build (Simulator) ===')
+
+// Step 1: Clean and prebuild
+console.log('Step 1/2: Cleaning and prebuilding...')
+await $`bunx rimraf .expo ios`
+await $`bunx expo prebuild --platform ios`
+
+// Step 2: Build for simulator (no code signing required)
+console.log('Step 2/2: Building for iOS Simulator...')
+await $`xcodebuild -workspace ios/SiaStorageDev.xcworkspace -scheme SiaStorageDev -configuration Release -sdk iphonesimulator -destination generic/platform=iOS\ Simulator build CODE_SIGNING_ALLOWED=NO EXCLUDED_ARCHS=x86_64`
+
+console.log('=== iOS build complete! ===')

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -1,0 +1,282 @@
+#!/usr/bin/env bun
+/**
+ * Smart Development Build Runner
+ *
+ * Usage:
+ *   bun scripts/dev.ts ios          # Build & run on iOS Simulator
+ *   bun scripts/dev.ts ios:device   # Build & run on real iOS device
+ *   bun scripts/dev.ts android      # Build & run on Android emulator/device
+ *
+ * Flags:
+ *   --rebuild    Force a fresh build (ignore cache)
+ *   --no-run     Build only, don't launch the app
+ *   --clean      Full clean build (rimraf + prebuild + build)
+ *
+ * How caching works:
+ *   - Computes hash from package.json, bun.lock, app.config.js, eas.json, plugins/*.js
+ *   - Each target (ios, ios:device, android) has isolated cache in .build-cache/
+ *   - Skips rebuild if hash matches and artifacts exist
+ *   - Use --rebuild to force rebuild, --clean for full clean build
+ *
+ * Cache locations:
+ *   .build-cache/ios-sim/       - iOS Simulator builds
+ *   .build-cache/ios-device/    - iOS device builds
+ *   .build-cache/android/       - Android builds
+ */
+
+import { $ } from 'bun'
+import { existsSync, rmSync } from 'fs'
+import { join } from 'path'
+import {
+  PROJECT_ROOT,
+  type BuildTarget,
+  getTargetPaths,
+  needsRebuild,
+  saveBuildHash,
+  ensureCacheDir,
+  writeBuildLog,
+  getBuildLogTail,
+} from './buildCache'
+
+// Parse arguments
+const args = process.argv.slice(2)
+const targetArg = args.find(a => !a.startsWith('-'))
+const forceRebuild = args.includes('--rebuild')
+const noRun = args.includes('--no-run')
+const cleanBuild = args.includes('--clean')
+
+// Map CLI arg to build target
+function getTarget(): BuildTarget {
+  switch (targetArg) {
+    case 'ios':
+    case 'ios:sim':
+      return 'ios-sim'
+    case 'ios:device':
+      return 'ios-device'
+    case 'android':
+      return 'android'
+    default:
+      console.error('Usage: bun scripts/dev.ts <target> [flags]')
+      console.error('')
+      console.error('Targets:')
+      console.error('  ios          Build & run on iOS Simulator')
+      console.error('  ios:device   Build & run on real iOS device')
+      console.error('  android      Build & run on Android emulator/device')
+      console.error('')
+      console.error('Flags:')
+      console.error('  --rebuild    Force a fresh build (ignore cache)')
+      console.error('  --no-run     Build only, don\'t launch the app')
+      console.error('  --clean      Full clean build (rimraf + prebuild + build)')
+      process.exit(1)
+  }
+}
+
+const target = getTarget()
+const platform = target.includes('ios') ? 'ios' : 'android'
+const isDevice = target === 'ios-device'
+const paths = getTargetPaths(target)
+
+// Print header
+console.log(`\n🚀 Smart Dev Build`)
+console.log(`   Target: ${targetArg}`)
+console.log(`   Flags: ${[forceRebuild && '--rebuild', noRun && '--no-run', cleanBuild && '--clean'].filter(Boolean).join(' ') || 'none'}`)
+console.log(`   Cache: .build-cache/${target}/`)
+console.log('')
+
+$.cwd(PROJECT_ROOT)
+
+// Clean build: wipe everything and start fresh
+if (cleanBuild) {
+  console.log('🧹 Clean build requested')
+  console.log(`   Removing ${platform}/...`)
+  rmSync(join(PROJECT_ROOT, platform), { recursive: true, force: true })
+  console.log(`   Removing .build-cache/${target}/...`)
+  rmSync(paths.dir, { recursive: true, force: true })
+  console.log('')
+}
+
+// Check if rebuild needed
+const [rebuildNeeded, reason] = needsRebuild(target, { forceRebuild: forceRebuild || cleanBuild })
+
+if (rebuildNeeded) {
+  console.log(`🔨 Build needed: ${reason}`)
+  ensureCacheDir(target)
+
+  // Prebuild if platform directory doesn't exist
+  const platformDir = join(PROJECT_ROOT, platform)
+  if (!existsSync(platformDir)) {
+    console.log(`   Prebuilding ${platform}...`)
+    const prebuildResult = await $`bunx expo prebuild --platform ${platform} 2>&1`.quiet().nothrow()
+    writeBuildLog(target, `=== PREBUILD ===\n${prebuildResult.stdout}\n`)
+
+    if (prebuildResult.exitCode !== 0) {
+      console.error('❌ Prebuild failed. Last 30 lines:')
+      console.error(getBuildLogTail(target, 30))
+      process.exit(1)
+    }
+  }
+
+  // Platform-specific build
+  if (platform === 'ios') {
+    await buildIos()
+  } else {
+    await buildAndroid()
+  }
+
+  saveBuildHash(target)
+  console.log('✅ Build complete')
+} else {
+  console.log(`✅ Using cached build (${reason})`)
+}
+
+// Run the app unless --no-run
+if (!noRun) {
+  console.log('')
+  if (platform === 'ios') {
+    await runIos()
+  } else {
+    await runAndroid()
+  }
+}
+
+// === iOS Build ===
+async function buildIos(): Promise<void> {
+  console.log(`   Building iOS (${isDevice ? 'device' : 'simulator'})...`)
+  console.log(`   Build log: ${paths.buildLog}`)
+
+  if (isDevice) {
+    // Device build via fastlane
+    const buildResult = await $`fastlane ios dev_device 2>&1`.quiet().nothrow()
+    writeBuildLog(target, `=== FASTLANE ===\n${buildResult.stdout}`, true)
+
+    if (buildResult.exitCode !== 0) {
+      console.error('❌ Build failed. Last 50 lines:')
+      console.error(getBuildLogTail(target, 50))
+      throw new Error('iOS device build failed')
+    }
+  } else {
+    // Simulator build via xcodebuild with dedicated DerivedData
+    const buildResult = await $`xcodebuild \
+      -workspace ios/SiaStorageDev.xcworkspace \
+      -scheme SiaStorageDev \
+      -configuration Debug \
+      -sdk iphonesimulator \
+      -arch arm64 \
+      -derivedDataPath ${paths.derivedData} \
+      build \
+      CODE_SIGNING_ALLOWED=NO 2>&1`.quiet().nothrow()
+
+    writeBuildLog(target, `=== XCODEBUILD ===\n${buildResult.stdout}`, true)
+
+    if (buildResult.exitCode !== 0 || buildResult.stdout.toString().includes('BUILD FAILED')) {
+      console.error('❌ Build failed. Last 50 lines:')
+      console.error(getBuildLogTail(target, 50))
+      throw new Error('iOS simulator build failed')
+    }
+  }
+}
+
+// === Android Build ===
+async function buildAndroid(): Promise<void> {
+  console.log('   Building Android...')
+  console.log(`   Build log: ${paths.buildLog}`)
+
+  $.cwd(join(PROJECT_ROOT, 'android'))
+  const buildResult = await $`./gradlew assembleDebug --no-daemon 2>&1`.quiet().nothrow()
+  $.cwd(PROJECT_ROOT)
+
+  writeBuildLog(target, `=== GRADLE ===\n${buildResult.stdout}`, true)
+
+  if (buildResult.exitCode !== 0 || buildResult.stdout.toString().includes('BUILD FAILED')) {
+    console.error('❌ Build failed. Last 50 lines:')
+    console.error(getBuildLogTail(target, 50))
+    throw new Error('Android build failed')
+  }
+}
+
+// === Run iOS App ===
+async function runIos(): Promise<void> {
+  if (isDevice) {
+    console.log('📱 Running on iOS device...')
+    // For device, we typically use ios-deploy or the app was installed by fastlane
+    console.log('   App should be installed on device. Open it manually or use ios-deploy.')
+  } else {
+    console.log('📱 Running on iOS Simulator...')
+
+    // Find the built app
+    const appPath = await findIosSimApp()
+    if (!appPath) {
+      console.error('❌ Could not find built app')
+      process.exit(1)
+    }
+
+    // Boot simulator if needed
+    const bootedResult = await $`xcrun simctl list devices booted`.quiet().nothrow()
+    if (!bootedResult.stdout.toString().includes('iPhone')) {
+      console.log('   Booting simulator...')
+      const devices = await $`xcrun simctl list devices available`.text()
+      const match = devices.match(/iPhone[^(]*\(([^)]+)\)/)
+      if (match) {
+        await $`xcrun simctl boot ${match[1]}`.quiet().nothrow()
+        await $`open -a Simulator`.nothrow()
+      }
+    }
+
+    // Install and launch
+    console.log('   Installing app...')
+    await $`xcrun simctl install booted ${appPath}`.quiet()
+    console.log('   Launching app...')
+    await $`xcrun simctl launch booted sia.storage.dev`.quiet()
+    console.log('✅ App launched')
+  }
+}
+
+// === Run Android App ===
+async function runAndroid(): Promise<void> {
+  console.log('🤖 Running on Android...')
+
+  // Find APK
+  const apkDir = join(PROJECT_ROOT, 'android/app/build/outputs/apk/debug')
+  const apkResult = await $`find ${apkDir} -name "*.apk" 2>/dev/null`.quiet().nothrow()
+  const apkPath = apkResult.stdout.toString().trim().split('\n').filter(Boolean)[0]
+
+  if (!apkPath) {
+    console.error('❌ Could not find APK')
+    process.exit(1)
+  }
+
+  // Check for connected device/emulator
+  const devices = await $`adb devices`.quiet()
+  if (!devices.stdout.toString().includes('\tdevice')) {
+    console.log('   No device connected. Starting emulator...')
+    const avdsResult = await $`emulator -list-avds`.quiet().nothrow()
+    const avds = avdsResult.stdout.toString().trim().split('\n').filter(Boolean)
+    if (avds.length === 0) {
+      console.error('❌ No Android emulator found. Create one in Android Studio.')
+      process.exit(1)
+    }
+    Bun.spawn(['sh', '-c', `emulator -avd ${avds[0]} &`], { stdout: 'ignore', stderr: 'ignore' })
+    console.log('   Waiting for emulator...')
+    await $`adb wait-for-device`
+    // Wait for boot
+    for (let i = 0; i < 60; i++) {
+      const bootResult = await $`adb shell getprop sys.boot_completed 2>/dev/null`.quiet().nothrow()
+      if (bootResult.stdout.toString().trim() === '1') break
+      await new Promise(r => setTimeout(r, 2000))
+    }
+  }
+
+  // Install and launch
+  console.log('   Installing APK...')
+  await $`adb install -r ${apkPath}`.quiet()
+  console.log('   Launching app...')
+  await $`adb shell am start -n sia.storage.dev/.MainActivity`.quiet()
+  console.log('✅ App launched')
+}
+
+// Find iOS Simulator app in DerivedData
+async function findIosSimApp(): Promise<string | null> {
+  const result = await $`find ${paths.derivedData} -name "*.app" -path "*Debug-iphonesimulator*" -type d 2>/dev/null`.quiet().nothrow()
+  const found = result.stdout.toString().trim().split('\n').filter(Boolean)[0]
+  return found || null
+}


### PR DESCRIPTION
- Different build types are now cached in unique directories.
- Builds now check a cache key to see if they are required before running app.
- This should save time during development when switching between running a simulator, real device, and e2e tests.