### PR TITLE
fix: enable keychain access in iOS background mode

### DIFF
--- a/src/stores/secureStore.ts
+++ b/src/stores/secureStore.ts
@@ -1,14 +1,23 @@
 import * as SecureStore from 'expo-secure-store'
+import { Platform } from 'react-native'
 import { retry } from '../lib/retry'
+
+// Use AFTER_FIRST_UNLOCK on iOS to allow keychain access in background mode
+// when the device is locked (after it has been unlocked once since boot).
+// This is required for background upload tasks to access credentials.
+const SECURE_STORE_OPTIONS: SecureStore.SecureStoreOptions = Platform.select({
+  ios: { keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK },
+  default: {},
+})
 
 export async function setSecureStoreBoolean(key: string, value: boolean) {
   validateKey(key)
-  return SecureStore.setItemAsync(key, value ? 'true' : 'false')
+  return SecureStore.setItemAsync(key, value ? 'true' : 'false', SECURE_STORE_OPTIONS)
 }
 
 export async function getSecureStoreBoolean(key: string, initialValue = false) {
   return retry('getSecureStoreBoolean', async () => {
-    const found = await SecureStore.getItemAsync(key)
+    const found = await SecureStore.getItemAsync(key, SECURE_STORE_OPTIONS)
     if (typeof found === 'string') {
       if (found === 'true') {
         return true
@@ -24,12 +33,12 @@ export async function getSecureStoreBoolean(key: string, initialValue = false) {
 export async function setSecureStoreNumber(key: string, value: number) {
   validateKey(key)
   const str = Number.isFinite(value) ? String(Math.floor(value)) : '0'
-  return SecureStore.setItemAsync(key, str)
+  return SecureStore.setItemAsync(key, str, SECURE_STORE_OPTIONS)
 }
 
 export async function getSecureStoreNumber(key: string, initialValue = 0) {
   return retry('getSecureStoreNumber', async () => {
-    const found = await SecureStore.getItemAsync(key)
+    const found = await SecureStore.getItemAsync(key, SECURE_STORE_OPTIONS)
     if (typeof found === 'string' && found.trim().length > 0) {
       const n = Number(found)
       if (Number.isFinite(n)) {
@@ -46,7 +55,7 @@ export async function setSecureStoreString<T extends string>(
   value: T
 ) {
   validateKey(key)
-  return SecureStore.setItemAsync(key, value)
+  return SecureStore.setItemAsync(key, value, SECURE_STORE_OPTIONS)
 }
 
 export async function getSecureStoreString<T extends string>(
@@ -54,7 +63,7 @@ export async function getSecureStoreString<T extends string>(
   initialValue: T
 ): Promise<T> {
   return retry('getSecureStoreString', async () => {
-    const found = await SecureStore.getItemAsync(key)
+    const found = await SecureStore.getItemAsync(key, SECURE_STORE_OPTIONS)
     if (typeof found === 'string' && found.trim().length > 0) {
       return found as T
     }
@@ -75,14 +84,14 @@ export async function setSecureStoreJSON<TStorage, TDomain>(
 ) {
   validateKey(key)
   if (value == null) {
-    return SecureStore.setItemAsync(key, '')
+    return SecureStore.setItemAsync(key, '', SECURE_STORE_OPTIONS)
   }
   try {
     const encoded = codec.encode(value)
     const json = JSON.stringify(encoded)
-    return SecureStore.setItemAsync(key, json)
+    return SecureStore.setItemAsync(key, json, SECURE_STORE_OPTIONS)
   } catch {
-    return SecureStore.setItemAsync(key, '')
+    return SecureStore.setItemAsync(key, '', SECURE_STORE_OPTIONS)
   }
 }
 
@@ -92,7 +101,7 @@ export async function getSecureStoreJSON<TStorage, TDomain>(
   initialValue?: TDomain
 ): Promise<TDomain | undefined> {
   const storedValue = await retry('getSecureStoreJSON', async () => {
-    const found = await SecureStore.getItemAsync(key)
+    const found = await SecureStore.getItemAsync(key, SECURE_STORE_OPTIONS)
     if (typeof found !== 'string' || found.trim().length === 0) {
       return undefined
     }


### PR DESCRIPTION
- Use AFTER_FIRST_UNLOCK accessibility for expo-secure-store on iOS.
- This allows background tasks to access the keychain when the device is locked (after first unlock since boot), fixing the upload failures caused by "User interaction is not allowed" errors.