### PR TITLE
fix(background): use instance-based cancellable delay

### DIFF
--- a/.changeset/fix-cancellable-delay.md
+++ b/.changeset/fix-cancellable-delay.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fixed background tasks freezing when iOS fires timeout callback.

--- a/src/lib/backgroundDelay.test.ts
+++ b/src/lib/backgroundDelay.test.ts
@@ -1,0 +1,82 @@
+import BackgroundTimer from 'react-native-background-timer'
+import { createBackgroundDelay } from './backgroundDelay'
+
+jest.mock('react-native-background-timer', () => ({
+  __esModule: true,
+  default: {
+    setTimeout: jest.fn(),
+    clearTimeout: jest.fn(),
+  },
+}))
+
+const mockTimer = jest.mocked(BackgroundTimer)
+
+describe('createBackgroundDelay', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('resolves "completed" when timer fires', async () => {
+    mockTimer.setTimeout.mockImplementation((cb: () => void) => {
+      cb()
+      return 1
+    })
+
+    const { delay } = createBackgroundDelay()
+
+    expect(await delay(1000)).toBe('completed')
+    expect(mockTimer.setTimeout).toHaveBeenCalledWith(
+      expect.any(Function),
+      1000
+    )
+  })
+
+  it('resolves "aborted" when abort() called', async () => {
+    mockTimer.setTimeout.mockImplementation(() => 42)
+
+    const { delay, abort } = createBackgroundDelay()
+    const promise = delay(10000)
+
+    abort()
+
+    expect(await promise).toBe('aborted')
+    expect(mockTimer.clearTimeout).toHaveBeenCalledWith(42)
+  })
+
+  it('abort() is safe to call when no delay pending', () => {
+    const { abort } = createBackgroundDelay()
+
+    abort()
+
+    expect(mockTimer.clearTimeout).not.toHaveBeenCalled()
+  })
+
+  it('multiple abort() calls only clear timer once', () => {
+    mockTimer.setTimeout.mockImplementation(() => 1)
+
+    const { delay, abort } = createBackgroundDelay()
+    delay(1000)
+
+    abort()
+    abort()
+    abort()
+
+    expect(mockTimer.clearTimeout).toHaveBeenCalledTimes(1)
+  })
+
+  it('each instance has independent state', () => {
+    let id = 0
+    mockTimer.setTimeout.mockImplementation(() => ++id)
+
+    const a = createBackgroundDelay()
+    const b = createBackgroundDelay()
+
+    a.delay(1000)
+    b.delay(2000)
+
+    a.abort()
+
+    expect(mockTimer.clearTimeout).toHaveBeenCalledTimes(1)
+    expect(mockTimer.clearTimeout).toHaveBeenCalledWith(1)
+  })
+})

--- a/src/lib/backgroundDelay.ts
+++ b/src/lib/backgroundDelay.ts
@@ -1,0 +1,40 @@
+import BackgroundTimer from 'react-native-background-timer'
+
+// It appears that setTimeout does not work in background tasks on Android,
+// so we use react-native-background-timer instead.
+//
+// This delay is abortable - when iOS fires the timeout callback, we need to
+// immediately resolve any pending delay so the while loop can exit cleanly.
+// Without this, the await delay() Promise stays pending while iOS suspends
+// the app, causing the next background task to inherit stale state.
+
+type AbortFn = () => void
+
+export function createBackgroundDelay(): {
+  delay: (ms: number) => Promise<'completed' | 'aborted'>
+  abort: AbortFn
+} {
+  let pendingAbort: AbortFn | null = null
+
+  const delay = (ms: number): Promise<'completed' | 'aborted'> => {
+    return new Promise((resolve) => {
+      const timerId = BackgroundTimer.setTimeout(() => {
+        pendingAbort = null
+        resolve('completed')
+      }, ms)
+
+      // Store abort function that cancels timer and resolves immediately
+      pendingAbort = () => {
+        BackgroundTimer.clearTimeout(timerId)
+        pendingAbort = null
+        resolve('aborted')
+      }
+    })
+  }
+
+  const abort: AbortFn = () => {
+    pendingAbort?.()
+  }
+
+  return { delay, abort }
+}

--- a/src/managers/backgroundTasks.test.ts
+++ b/src/managers/backgroundTasks.test.ts
@@ -1,0 +1,282 @@
+import BackgroundFetch from 'react-native-background-fetch'
+import BackgroundTimer from 'react-native-background-timer'
+import { initBackgroundTasks } from './backgroundTasks'
+
+// Capture the callbacks passed to BackgroundFetch.configure so we can simulate OS behavior
+let taskCallback: (taskId: string) => Promise<void>
+let timeoutCallback: (taskId: string) => void
+
+jest.mock('react-native-background-fetch', () => ({
+  __esModule: true,
+  default: {
+    configure: jest.fn((config, onTask, onTimeout) => {
+      taskCallback = onTask
+      timeoutCallback = onTimeout
+      return Promise.resolve(0)
+    }),
+    scheduleTask: jest.fn(() => Promise.resolve(true)),
+    finish: jest.fn(),
+    NETWORK_TYPE_UNMETERED: 2,
+  },
+}))
+
+// Track timer state to simulate BackgroundTimer behavior
+// Variables must be prefixed with 'mock' to be accessible inside jest.mock()
+let mockTimerCallbacks: Map<number, () => void> = new Map()
+let mockNextTimerId = 1
+
+jest.mock('react-native-background-timer', () => ({
+  __esModule: true,
+  default: {
+    setTimeout: jest.fn((cb: () => void, _ms: number) => {
+      const id = mockNextTimerId++
+      mockTimerCallbacks.set(id, cb)
+      return id
+    }),
+    clearTimeout: jest.fn((id: number) => {
+      mockTimerCallbacks.delete(id)
+    }),
+  },
+}))
+
+const mockGetFileCountLocal = jest.fn()
+jest.mock('../stores/files', () => ({
+  getFileCountLocal: (...args: unknown[]) => mockGetFileCountLocal(...args),
+}))
+
+jest.mock('../stores/sdk', () => ({
+  getIsConnected: jest.fn(() => true),
+}))
+
+jest.mock('../stores/appKey', () => ({
+  hasCachedAppKey: jest.fn(() => true),
+}))
+
+jest.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+}))
+
+const mockTimer = jest.mocked(BackgroundTimer)
+
+// Helpers
+const flushPromises = () => new Promise(setImmediate)
+
+function completeNextDelay() {
+  const [id, cb] = mockTimerCallbacks.entries().next().value || []
+  if (cb) {
+    mockTimerCallbacks.delete(id)
+    cb()
+  }
+}
+
+function getPendingDelayCount() {
+  return mockTimerCallbacks.size
+}
+
+describe('backgroundTasks', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    mockTimerCallbacks.clear()
+    mockNextTimerId = 1
+    mockGetFileCountLocal.mockReset()
+
+    await initBackgroundTasks()
+  })
+
+  describe('polling loop behavior', () => {
+    it('exits immediately when no files are pending upload', async () => {
+      mockGetFileCountLocal.mockResolvedValue(0)
+
+      await taskCallback('com.transistorsoft.fetch')
+
+      // Should check file count once and exit - no delay started
+      expect(mockGetFileCountLocal).toHaveBeenCalledTimes(1)
+      expect(mockGetFileCountLocal).toHaveBeenCalledWith({ localOnly: true })
+      expect(getPendingDelayCount()).toBe(0)
+    })
+
+    it('polls repeatedly while files are pending, exits when uploads complete', async () => {
+      // Simulate: 5 files -> 2 files -> 0 files (uploads completing over time)
+      mockGetFileCountLocal
+        .mockResolvedValueOnce(5)
+        .mockResolvedValueOnce(2)
+        .mockResolvedValueOnce(0)
+
+      const taskPromise = taskCallback('com.transistorsoft.fetch')
+
+      // After first check (5 files), should start a delay
+      await flushPromises()
+      expect(mockGetFileCountLocal).toHaveBeenCalledTimes(1)
+      expect(getPendingDelayCount()).toBe(1)
+
+      // Complete delay, triggers second check (2 files)
+      completeNextDelay()
+      await flushPromises()
+      expect(mockGetFileCountLocal).toHaveBeenCalledTimes(2)
+      expect(getPendingDelayCount()).toBe(1)
+
+      // Complete delay, triggers third check (0 files) -> exits
+      completeNextDelay()
+      await flushPromises()
+      expect(mockGetFileCountLocal).toHaveBeenCalledTimes(3)
+
+      await taskPromise
+
+      // No pending delays after task completes
+      expect(getPendingDelayCount()).toBe(0)
+      // Verify polling loop iterated expected number of times
+      expect(mockGetFileCountLocal).toHaveBeenCalledTimes(3)
+    })
+  })
+
+  describe('timeout cancellation flow', () => {
+    it('abort function resolves delay immediately, allowing clean exit', async () => {
+      mockGetFileCountLocal.mockResolvedValue(100) // Always has files
+
+      const taskPromise = taskCallback('com.transistorsoft.fetch')
+      await flushPromises()
+
+      // Task is now in delay, waiting
+      expect(getPendingDelayCount()).toBe(1)
+
+      // Simulate iOS timeout - this should abort the delay and exit cleanly
+      timeoutCallback('com.transistorsoft.fetch')
+
+      await taskPromise
+
+      // Timer was cleared (not left dangling)
+      expect(mockTimer.clearTimeout).toHaveBeenCalled()
+      // No pending delays
+      expect(getPendingDelayCount()).toBe(0)
+    })
+
+    it('setting status to finished causes loop to exit on next iteration', async () => {
+      // This tests the state.status === 'finished' check in the while loop
+      mockGetFileCountLocal.mockResolvedValue(50)
+
+      const taskPromise = taskCallback('com.transistorsoft.fetch')
+      await flushPromises()
+
+      // Task checked files, found 50, started delay
+      expect(mockGetFileCountLocal).toHaveBeenCalledTimes(1)
+
+      // Timeout fires while in delay - sets status to 'finished' and aborts delay
+      timeoutCallback('com.transistorsoft.fetch')
+
+      await taskPromise
+
+      // The loop exited after abort, didn't poll again
+      expect(mockGetFileCountLocal).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('task re-invocation handling', () => {
+    it('new task aborts previous task delay to prevent stale state', async () => {
+      mockGetFileCountLocal.mockResolvedValue(100)
+
+      // Start first task
+      const task1 = taskCallback('com.transistorsoft.fetch')
+      await flushPromises()
+      expect(getPendingDelayCount()).toBe(1)
+
+      // Start second task for same ID before first completes
+      // This simulates OS re-triggering the task
+      const task2 = taskCallback('com.transistorsoft.fetch')
+      await flushPromises()
+
+      // First task's delay should have been aborted (clearTimeout called)
+      expect(mockTimer.clearTimeout).toHaveBeenCalled()
+
+      // Clean up - timeout the active task
+      timeoutCallback('com.transistorsoft.fetch')
+      await Promise.all([task1, task2])
+    })
+
+    it('each task invocation gets isolated delay instance', async () => {
+      mockGetFileCountLocal.mockResolvedValue(10)
+
+      // Start tasks for different IDs
+      const fetchTask = taskCallback('com.transistorsoft.fetch')
+      await flushPromises()
+
+      const processingTask = taskCallback('com.transistorsoft.processing')
+      await flushPromises()
+
+      // Both tasks have pending delays
+      expect(getPendingDelayCount()).toBe(2)
+
+      // Timeout only affects its own task
+      timeoutCallback('com.transistorsoft.fetch')
+      await fetchTask
+
+      // Processing task still has its delay
+      expect(getPendingDelayCount()).toBe(1)
+
+      // Clean up
+      timeoutCallback('com.transistorsoft.processing')
+      await processingTask
+    })
+  })
+
+  describe('delay completion vs abort', () => {
+    it('delay completing normally continues the loop', async () => {
+      mockGetFileCountLocal
+        .mockResolvedValueOnce(10)
+        .mockResolvedValueOnce(5)
+        .mockResolvedValueOnce(0)
+
+      const taskPromise = taskCallback('com.transistorsoft.fetch')
+
+      // First poll -> delay
+      await flushPromises()
+      expect(mockGetFileCountLocal).toHaveBeenCalledTimes(1)
+
+      // Delay completes normally (not aborted) -> continues loop
+      completeNextDelay()
+      await flushPromises()
+      expect(mockGetFileCountLocal).toHaveBeenCalledTimes(2)
+
+      // Again
+      completeNextDelay()
+      await flushPromises()
+      expect(mockGetFileCountLocal).toHaveBeenCalledTimes(3)
+
+      await taskPromise
+    })
+
+    it('delay being aborted exits loop without further polling', async () => {
+      mockGetFileCountLocal.mockResolvedValue(10)
+
+      const taskPromise = taskCallback('com.transistorsoft.fetch')
+      await flushPromises()
+
+      // First poll happened
+      expect(mockGetFileCountLocal).toHaveBeenCalledTimes(1)
+
+      // Abort via timeout
+      timeoutCallback('com.transistorsoft.fetch')
+      await taskPromise
+
+      // No additional polls after abort
+      expect(mockGetFileCountLocal).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles unknown task ID gracefully', async () => {
+      // Should not throw, just finish immediately
+      await taskCallback('unknown-task-id')
+
+      expect(BackgroundFetch.finish).toHaveBeenCalledWith('unknown-task-id')
+      // No file count check for unknown tasks
+      expect(mockGetFileCountLocal).not.toHaveBeenCalled()
+    })
+
+    it('timeout for unknown task ID does not throw', () => {
+      // Should not throw
+      timeoutCallback('unknown-task-id')
+
+      expect(BackgroundFetch.finish).toHaveBeenCalledWith('unknown-task-id')
+    })
+  })
+})

--- a/src/managers/backgroundTasks.ts
+++ b/src/managers/backgroundTasks.ts
@@ -5,9 +5,9 @@ import BackgroundFetch, {
 import { minutesInMs, secondsInMs } from '../lib/time'
 import { Platform } from 'react-native'
 import { getFileCountLocal } from '../stores/files'
-import BackgroundTimer from 'react-native-background-timer'
 import { getIsConnected } from '../stores/sdk'
 import { hasCachedAppKey } from '../stores/appKey'
+import { createBackgroundDelay } from '../lib/backgroundDelay'
 
 /**
  * Background tasks are scheduled by the operating system and run for about the following durations:
@@ -31,6 +31,7 @@ type TaskConfig = {
 type TaskState = {
   startTime: number
   status: 'running' | 'finished'
+  abort?: () => void
 }
 const taskConfigs: Record<TaskId, TaskConfig> = {
   // This is the library's default task ID on Android.
@@ -68,20 +69,55 @@ const sharedConfig: BackgroundFetchConfig = {
 const taskStates: Record<TaskId, TaskState> = {
   'com.transistorsoft.fetch': {
     startTime: 0,
-    status: 'running',
+    status: 'finished',
+    abort: undefined,
   },
   'com.transistorsoft.processing': {
     startTime: 0,
-    status: 'running',
+    status: 'finished',
+    abort: undefined,
   },
   'react-native-background-fetch': {
     startTime: 0,
-    status: 'running',
+    status: 'finished',
+    abort: undefined,
   },
+}
+
+function createFreshTaskState(): TaskState {
+  return {
+    startTime: 0,
+    status: 'finished',
+    abort: undefined,
+  }
+}
+
+/**
+ * Reset a specific task's state, aborting any pending operations.
+ */
+function resetTaskState(taskId: TaskId) {
+  const state = taskStates[taskId]
+  // Abort any pending delay from previous invocation
+  state.abort?.()
+  // Reset to fresh state
+  Object.assign(state, createFreshTaskState())
+}
+
+/**
+ * Reset all task states, aborting any pending operations.
+ * Called on init to ensure clean startup.
+ */
+function resetAllTaskStates() {
+  for (const taskId of Object.keys(taskStates) as TaskId[]) {
+    resetTaskState(taskId)
+  }
 }
 
 export async function initBackgroundTasks() {
   logger.info('backgroundTask', 'init')
+
+  // Clean up any stale state from previous initialization
+  resetAllTaskStates()
 
   const status = await BackgroundFetch.configure(
     {
@@ -91,11 +127,16 @@ export async function initBackgroundTasks() {
     async (taskId: string) => {
       const config = taskConfigs[taskId as TaskId]
       const state = taskStates[taskId as TaskId]
-      if (!config) {
+      if (!config || !state) {
         logger.warn('backgroundTask', `unknown task id: ${taskId}`)
         BackgroundFetch.finish(taskId)
         return
       }
+
+      // Reset state for this task to ensure fresh start,
+      // aborting any lingering operations from previous invocation
+      resetTaskState(taskId as TaskId)
+
       transitionTaskState(state, 'running')
       await runBackgroundWork(config, state)
       transitionTaskState(state, 'finished')
@@ -104,14 +145,21 @@ export async function initBackgroundTasks() {
     (taskId: string) => {
       const config = taskConfigs[taskId as TaskId]
       const state = taskStates[taskId as TaskId]
-      transitionTaskState(state, 'finished')
-      if (!config) {
+      if (!config || !state) {
         logger.warn('backgroundTask', `unknown task id: ${taskId}`)
         BackgroundFetch.finish(taskId)
         return
       }
-      BackgroundFetch.finish(taskId)
-      logTask(config)(
+      const log = logTask(config)
+
+      log(`timeout callback fired, aborting delay and finishing task`)
+
+      // Abort any pending delay BEFORE setting status, so the while loop
+      // can exit cleanly when the Promise resolves.
+      state.abort?.()
+      transitionTaskState(state, 'finished')
+      BackgroundFetch.finish(config.id)
+      log(
         `finished, reason: timeout, elapsedTime: ${getElapsedTime(
           state.startTime
         )}`
@@ -158,6 +206,10 @@ async function runBackgroundWork(config: TaskConfig, state: TaskState) {
   state.startTime = Date.now()
   const log = logTask(config)
 
+  // Create instance-based cancellable delay for this invocation
+  const { delay: delayFn, abort } = createBackgroundDelay()
+  state.abort = abort
+
   // Log diagnostic info to distinguish cold start vs resume
   const isConnected = getIsConnected()
   const hasCached = hasCachedAppKey()
@@ -190,20 +242,16 @@ async function runBackgroundWork(config: TaskConfig, state: TaskState) {
       return
     }
     log(`waiting for uploads...`)
-    await delay(secondsInMs(10))
+    const result = await delayFn(secondsInMs(10))
+    if (result === 'aborted') {
+      log(`delay aborted, exiting cleanly`)
+      return
+    }
   }
 }
 
 function getElapsedTime(startTime: number) {
   return Date.now() - startTime
-}
-
-// It appears that setTimeout does not work in background tasks on Android,
-// so we use react-native-background-timer instead.
-function delay(ms: number) {
-  return new Promise((resolve) => {
-    BackgroundTimer.setTimeout(() => resolve(true), ms)
-  })
 }
 
 function logTask(config: TaskConfig) {


### PR DESCRIPTION
- Debugging revealed that subsequent background tasks sometimes resumed the previous task's JS context from where it was blocked on delay.
- Make the delay used in background tasks cancelable.
- Move backgroundDelay to its own file, add cancelation tests.
- Also covers background task with tests reflecting all cases seen in debug logs.