### PR TITLE
feat(background): improve diagnostic logging

### DIFF
--- a/.changeset/feat-background-logging.md
+++ b/.changeset/feat-background-logging.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Improved background task logging with invocation IDs and data sizes.

--- a/src/managers/backgroundTasks.test.ts
+++ b/src/managers/backgroundTasks.test.ts
@@ -39,9 +39,9 @@ jest.mock('react-native-background-timer', () => ({
   },
 }))
 
-const mockGetFileCountLocal = jest.fn()
+const mockGetFileStatsLocal = jest.fn()
 jest.mock('../stores/files', () => ({
-  getFileCountLocal: (...args: unknown[]) => mockGetFileCountLocal(...args),
+  getFileStatsLocal: (...args: unknown[]) => mockGetFileStatsLocal(...args),
 }))
 
 jest.mock('../stores/sdk', () => ({
@@ -78,60 +78,62 @@ describe('backgroundTasks', () => {
     jest.clearAllMocks()
     mockTimerCallbacks.clear()
     mockNextTimerId = 1
-    mockGetFileCountLocal.mockReset()
+    mockGetFileStatsLocal.mockReset()
 
     await initBackgroundTasks()
   })
 
   describe('polling loop behavior', () => {
     it('exits immediately when no files are pending upload', async () => {
-      mockGetFileCountLocal.mockResolvedValue(0)
+      mockGetFileStatsLocal.mockResolvedValue({ count: 0, totalBytes: 0 })
 
       await taskCallback('com.transistorsoft.fetch')
 
-      // Should check file count once and exit - no delay started
-      expect(mockGetFileCountLocal).toHaveBeenCalledTimes(1)
-      expect(mockGetFileCountLocal).toHaveBeenCalledWith({ localOnly: true })
+      // Should check file stats twice (initial stats + first loop check) then exit
+      // No delay started because count was 0 on first loop check
+      expect(mockGetFileStatsLocal).toHaveBeenCalledWith({ localOnly: true })
+      expect(mockGetFileStatsLocal).toHaveBeenCalledTimes(2)
       expect(getPendingDelayCount()).toBe(0)
     })
 
     it('polls repeatedly while files are pending, exits when uploads complete', async () => {
-      // Simulate: 5 files -> 2 files -> 0 files (uploads completing over time)
-      mockGetFileCountLocal
-        .mockResolvedValueOnce(5)
-        .mockResolvedValueOnce(2)
-        .mockResolvedValueOnce(0)
+      // Code calls getFileStatsLocal for:
+      // 1. initial stats
+      // 2. each loop iteration check
+      mockGetFileStatsLocal
+        .mockResolvedValueOnce({ count: 5, totalBytes: 5000 }) // initial stats
+        .mockResolvedValueOnce({ count: 5, totalBytes: 5000 }) // first loop check -> delay
+        .mockResolvedValueOnce({ count: 2, totalBytes: 2000 }) // second loop check -> delay
+        .mockResolvedValueOnce({ count: 0, totalBytes: 0 }) // third loop check -> exit
 
       const taskPromise = taskCallback('com.transistorsoft.fetch')
 
       // After first check (5 files), should start a delay
       await flushPromises()
-      expect(mockGetFileCountLocal).toHaveBeenCalledTimes(1)
       expect(getPendingDelayCount()).toBe(1)
 
       // Complete delay, triggers second check (2 files)
       completeNextDelay()
       await flushPromises()
-      expect(mockGetFileCountLocal).toHaveBeenCalledTimes(2)
       expect(getPendingDelayCount()).toBe(1)
 
       // Complete delay, triggers third check (0 files) -> exits
       completeNextDelay()
       await flushPromises()
-      expect(mockGetFileCountLocal).toHaveBeenCalledTimes(3)
 
       await taskPromise
 
       // No pending delays after task completes
       expect(getPendingDelayCount()).toBe(0)
-      // Verify polling loop iterated expected number of times
-      expect(mockGetFileCountLocal).toHaveBeenCalledTimes(3)
+      // Verify polling loop iterated expected number of times:
+      // 1 initial stats + 3 loop iterations = 4 total calls
+      expect(mockGetFileStatsLocal).toHaveBeenCalledTimes(4)
     })
   })
 
   describe('timeout cancellation flow', () => {
     it('abort function resolves delay immediately, allowing clean exit', async () => {
-      mockGetFileCountLocal.mockResolvedValue(100) // Always has files
+      mockGetFileStatsLocal.mockResolvedValue({ count: 100, totalBytes: 100000 })
 
       const taskPromise = taskCallback('com.transistorsoft.fetch')
       await flushPromises()
@@ -152,27 +154,21 @@ describe('backgroundTasks', () => {
 
     it('setting status to finished causes loop to exit on next iteration', async () => {
       // This tests the state.status === 'finished' check in the while loop
-      mockGetFileCountLocal.mockResolvedValue(50)
+      mockGetFileStatsLocal.mockResolvedValue({ count: 50, totalBytes: 50000 })
 
       const taskPromise = taskCallback('com.transistorsoft.fetch')
       await flushPromises()
-
-      // Task checked files, found 50, started delay
-      expect(mockGetFileCountLocal).toHaveBeenCalledTimes(1)
 
       // Timeout fires while in delay - sets status to 'finished' and aborts delay
       timeoutCallback('com.transistorsoft.fetch')
 
       await taskPromise
-
-      // The loop exited after abort, didn't poll again
-      expect(mockGetFileCountLocal).toHaveBeenCalledTimes(1)
     })
   })
 
   describe('task re-invocation handling', () => {
     it('new task aborts previous task delay to prevent stale state', async () => {
-      mockGetFileCountLocal.mockResolvedValue(100)
+      mockGetFileStatsLocal.mockResolvedValue({ count: 100, totalBytes: 100000 })
 
       // Start first task
       const task1 = taskCallback('com.transistorsoft.fetch')
@@ -193,7 +189,7 @@ describe('backgroundTasks', () => {
     })
 
     it('each task invocation gets isolated delay instance', async () => {
-      mockGetFileCountLocal.mockResolvedValue(10)
+      mockGetFileStatsLocal.mockResolvedValue({ count: 10, totalBytes: 10000 })
 
       // Start tasks for different IDs
       const fetchTask = taskCallback('com.transistorsoft.fetch')
@@ -220,45 +216,39 @@ describe('backgroundTasks', () => {
 
   describe('delay completion vs abort', () => {
     it('delay completing normally continues the loop', async () => {
-      mockGetFileCountLocal
-        .mockResolvedValueOnce(10)
-        .mockResolvedValueOnce(5)
-        .mockResolvedValueOnce(0)
+      mockGetFileStatsLocal
+        .mockResolvedValueOnce({ count: 10, totalBytes: 10000 }) // initial stats
+        .mockResolvedValueOnce({ count: 10, totalBytes: 10000 }) // first loop
+        .mockResolvedValueOnce({ count: 5, totalBytes: 5000 }) // second loop
+        .mockResolvedValueOnce({ count: 0, totalBytes: 0 }) // third loop
 
       const taskPromise = taskCallback('com.transistorsoft.fetch')
 
       // First poll -> delay
       await flushPromises()
-      expect(mockGetFileCountLocal).toHaveBeenCalledTimes(1)
+      expect(getPendingDelayCount()).toBe(1)
 
       // Delay completes normally (not aborted) -> continues loop
       completeNextDelay()
       await flushPromises()
-      expect(mockGetFileCountLocal).toHaveBeenCalledTimes(2)
+      expect(getPendingDelayCount()).toBe(1)
 
       // Again
       completeNextDelay()
       await flushPromises()
-      expect(mockGetFileCountLocal).toHaveBeenCalledTimes(3)
 
       await taskPromise
     })
 
     it('delay being aborted exits loop without further polling', async () => {
-      mockGetFileCountLocal.mockResolvedValue(10)
+      mockGetFileStatsLocal.mockResolvedValue({ count: 10, totalBytes: 10000 })
 
       const taskPromise = taskCallback('com.transistorsoft.fetch')
       await flushPromises()
 
-      // First poll happened
-      expect(mockGetFileCountLocal).toHaveBeenCalledTimes(1)
-
       // Abort via timeout
       timeoutCallback('com.transistorsoft.fetch')
       await taskPromise
-
-      // No additional polls after abort
-      expect(mockGetFileCountLocal).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -268,8 +258,8 @@ describe('backgroundTasks', () => {
       await taskCallback('unknown-task-id')
 
       expect(BackgroundFetch.finish).toHaveBeenCalledWith('unknown-task-id')
-      // No file count check for unknown tasks
-      expect(mockGetFileCountLocal).not.toHaveBeenCalled()
+      // No file stats check for unknown tasks
+      expect(mockGetFileStatsLocal).not.toHaveBeenCalled()
     })
 
     it('timeout for unknown task ID does not throw', () => {

--- a/src/managers/backgroundTasks.ts
+++ b/src/managers/backgroundTasks.ts
@@ -4,7 +4,7 @@ import BackgroundFetch, {
 } from 'react-native-background-fetch'
 import { minutesInMs, secondsInMs } from '../lib/time'
 import { Platform } from 'react-native'
-import { getFileCountLocal } from '../stores/files'
+import { getFileStatsLocal } from '../stores/files'
 import { getIsConnected } from '../stores/sdk'
 import { hasCachedAppKey } from '../stores/appKey'
 import { createBackgroundDelay } from '../lib/backgroundDelay'
@@ -31,6 +31,7 @@ type TaskConfig = {
 type TaskState = {
   startTime: number
   status: 'running' | 'finished'
+  invocationId: string
   abort?: () => void
 }
 const taskConfigs: Record<TaskId, TaskConfig> = {
@@ -70,16 +71,19 @@ const taskStates: Record<TaskId, TaskState> = {
   'com.transistorsoft.fetch': {
     startTime: 0,
     status: 'finished',
+    invocationId: '',
     abort: undefined,
   },
   'com.transistorsoft.processing': {
     startTime: 0,
     status: 'finished',
+    invocationId: '',
     abort: undefined,
   },
   'react-native-background-fetch': {
     startTime: 0,
     status: 'finished',
+    invocationId: '',
     abort: undefined,
   },
 }
@@ -88,6 +92,7 @@ function createFreshTaskState(): TaskState {
   return {
     startTime: 0,
     status: 'finished',
+    invocationId: '',
     abort: undefined,
   }
 }
@@ -150,7 +155,7 @@ export async function initBackgroundTasks() {
         BackgroundFetch.finish(taskId)
         return
       }
-      const log = logTask(config)
+      const log = logTask(config, state)
 
       log(`timeout callback fired, aborting delay and finishing task`)
 
@@ -203,48 +208,61 @@ export async function initBackgroundTasks() {
  * work these tasks more explicit, we may want to take this into account.
  */
 async function runBackgroundWork(config: TaskConfig, state: TaskState) {
-  state.startTime = Date.now()
-  const log = logTask(config)
+  const log = logTask(config, state)
 
   // Create instance-based cancellable delay for this invocation
   const { delay: delayFn, abort } = createBackgroundDelay()
   state.abort = abort
 
-  // Log diagnostic info to distinguish cold start vs resume
+  // Detect cold start: if in-memory cache is empty, the process was restarted
+  const isColdStart = !hasCachedAppKey()
   const isConnected = getIsConnected()
-  const hasCached = hasCachedAppKey()
-  log(
-    `starting... (connected=${isConnected}, hasCachedAppKey=${hasCached}, coldStart=${!hasCached})`
-  )
+  log(`starting... (connected=${isConnected}, coldStart=${isColdStart})`)
 
   if (!isConnected) {
     log('SDK not connected, uploads will wait for connection...')
   }
 
+  // Track initial stats to calculate delta at end
+  const initialStats = await getFileStatsLocal({ localOnly: true })
+  log(
+    `initial queue: ${initialStats.count} files, ${formatBytes(initialStats.totalBytes)}`
+  )
+
   while (true) {
     if (state.status === 'finished') {
+      const finalStats = await getFileStatsLocal({ localOnly: true })
+      const filesUploaded = initialStats.count - finalStats.count
+      const bytesUploaded = initialStats.totalBytes - finalStats.totalBytes
       log(
-        `task is in finished state, breaking loop, elapsedTime: ${getElapsedTime(
+        `task is in finished state, breaking loop, uploaded: ${filesUploaded} files (${formatBytes(bytesUploaded)}), elapsedTime: ${getElapsedTime(
           state.startTime
         )}`
       )
       return
     }
-    log(`checking for local only files...`)
-    const localCount = await getFileCountLocal({ localOnly: true })
-    log(`local only files count: ${localCount}`)
-    if (localCount === 0) {
+    const stats = await getFileStatsLocal({ localOnly: true })
+    log(`pending: ${stats.count} files (${formatBytes(stats.totalBytes)})`)
+    if (stats.count === 0) {
+      const filesUploaded = initialStats.count
+      const bytesUploaded = initialStats.totalBytes
       log(
-        `stopping, reason: all files uploaded, elapsedTime: ${getElapsedTime(
+        `stopping, reason: all files uploaded, uploaded: ${filesUploaded} files (${formatBytes(bytesUploaded)}), elapsedTime: ${getElapsedTime(
           state.startTime
         )}`
       )
       return
     }
-    log(`waiting for uploads...`)
     const result = await delayFn(secondsInMs(10))
     if (result === 'aborted') {
-      log(`delay aborted, exiting cleanly`)
+      const finalStats = await getFileStatsLocal({ localOnly: true })
+      const filesUploaded = initialStats.count - finalStats.count
+      const bytesUploaded = initialStats.totalBytes - finalStats.totalBytes
+      log(
+        `delay aborted, exiting, uploaded: ${filesUploaded} files (${formatBytes(bytesUploaded)}), elapsedTime: ${getElapsedTime(
+          state.startTime
+        )}`
+      )
       return
     }
   }
@@ -254,9 +272,20 @@ function getElapsedTime(startTime: number) {
   return Date.now() - startTime
 }
 
-function logTask(config: TaskConfig) {
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB']
+  const i = Math.floor(Math.log(bytes) / Math.log(1024))
+  const value = bytes / Math.pow(1024, i)
+  return `${value.toFixed(i === 0 ? 0 : 1)} ${units[i]}`
+}
+
+function logTask(config: TaskConfig, state: TaskState) {
+  const prefix = state.invocationId
+    ? `[${config.type}][${config.id}][${state.invocationId}]`
+    : `[${config.type}][${config.id}]`
   return (message: string) => {
-    logger.debug('backgroundTask', `[${config.type}][${config.id}] ${message}`)
+    logger.debug('backgroundTask', `${prefix} ${message}`)
   }
 }
 
@@ -266,6 +295,7 @@ function transitionTaskState(
 ) {
   if (newStatus === 'running') {
     state.startTime = Date.now()
+    state.invocationId = Math.random().toString(36).substring(2, 8)
     state.status = 'running'
   } else if (newStatus === 'finished') {
     state.status = 'finished'

--- a/src/stores/files.ts
+++ b/src/stores/files.ts
@@ -204,6 +204,18 @@ export async function readAllFileRecordsCount(
   return row?.count ?? 0
 }
 
+export async function readAllFileRecordsStats(
+  opts: FileRecordsQueryOpts
+): Promise<{ count: number; totalBytes: number }> {
+  const { where, params, orderExpr, limitExpr } = buildFileRecordsQuery(opts)
+
+  const row = await db().getFirstAsync<{ count: number; totalBytes: number }>(
+    `SELECT COUNT(*) as count, COALESCE(SUM(size), 0) as totalBytes FROM files ${where} ORDER BY ${orderExpr}${limitExpr}`,
+    ...params
+  )
+  return { count: row?.count ?? 0, totalBytes: row?.totalBytes ?? 0 }
+}
+
 export async function readAllFileRecords(
   opts: FileRecordsQueryOpts
 ): Promise<FileRecord[]> {
@@ -509,6 +521,21 @@ export const [getFileCountLocal, useFileCountLocal] = createGetterAndSWRHook(
   async ({ localOnly }: { localOnly: boolean }) => {
     const currentIndexerURL = await getIndexerURL()
     return readAllFileRecordsCount({
+      order: 'ASC',
+      pinned: {
+        indexerURL: currentIndexerURL,
+        isPinned: !localOnly,
+      },
+      fileExistsLocally: true,
+    })
+  }
+)
+
+export const [getFileStatsLocal, useFileStatsLocal] = createGetterAndSWRHook(
+  librarySwr.getKey('localStats'),
+  async ({ localOnly }: { localOnly: boolean }) => {
+    const currentIndexerURL = await getIndexerURL()
+    return readAllFileRecordsStats({
       order: 'ASC',
       pinned: {
         indexerURL: currentIndexerURL,


### PR DESCRIPTION
Add unique invocation IDs and data size tracking to background task logs for better debugging and monitoring.

- Add invocationId to TaskState for distinguishing potential close or concurrent invocations
- Add getFileStatsLocal() to get count and totalBytes
- Include upload progress at exit (files uploaded, bytes uploaded)