### PR TITLE
refactor: modular build scripts with devicectl support


### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -5,11 +5,9 @@ default_platform(:ios)
 # Path to the iOS workspace
 IOS_WORKSPACE_PATH = File.expand_path("../ios/SiaStorage.xcworkspace", __dir__)
 
-# iOS IPA names
+# iOS IPA path for releases
 IOS_RELEASE_IPA_NAME = "SiaStorage.ipa"
-IOS_DEV_IPA_NAME = "SiaStorageDev.ipa"
 IOS_RELEASE_IPA_PATH = File.expand_path("../ios/build/#{IOS_RELEASE_IPA_NAME}", __dir__)
-IOS_DEV_IPA_PATH = File.expand_path("../ios/build/#{IOS_DEV_IPA_NAME}", __dir__)
 
 # Path to the Android AAB file
 ANDROID_AAB_PATH = File.expand_path("../android/app/build/outputs/bundle/release/app-release.aab", __dir__)
@@ -77,48 +75,6 @@ def get_app_store_connect_api_key
 end
 
 platform :ios do
-  desc "Build and install dev build on connected iOS device"
-  lane :dev_device do
-    # Builds a development build and installs it on the connected physical device
-    # This automates: expo run:ios -> Xcode -> configure signing -> run
-    
-    team_id = ENV["APPLE_TEAM_ID"]
-    if team_id.nil? || team_id.empty?
-      UI.user_error!("APPLE_TEAM_ID environment variable is required")
-    end
-    
-    # Dev builds use SiaStorageDev workspace (when RELEASE != true)
-    dev_workspace = File.expand_path("../ios/SiaStorageDev.xcworkspace", __dir__)
-    if !File.exist?(dev_workspace)
-      UI.user_error!("Dev workspace not found at #{dev_workspace}. Run 'expo prebuild' first.")
-    end
-    
-    # Build the app for development
-    build_app(
-      workspace: dev_workspace,
-      scheme: "SiaStorageDev",
-      configuration: "Debug", # Use Debug for dev builds
-      export_method: "development", # Development signing for physical devices
-      output_directory: File.expand_path("../ios/build", __dir__),
-      output_name: "SiaStorageDev.ipa",
-      # Set DEVELOPMENT_TEAM during build phase (expo prebuild regenerates the project)
-      xcargs: "DEVELOPMENT_TEAM=#{team_id}",
-      export_options: {
-        method: "development",
-        signingStyle: "automatic"
-      }
-    )
-    
-    # Install the generated IPA on the connected device
-    if !File.exist?(IOS_DEV_IPA_PATH)
-      UI.user_error!("Could not find generated IPA file at #{IOS_DEV_IPA_PATH}")
-    end
-    
-    install_on_device(
-      ipa: IOS_DEV_IPA_PATH
-    )
-  end
-
   desc "Build and export iOS IPA for App Store"
   lane :build_ipa do
     # This does the same as:

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -8,5 +8,6 @@ module.exports = {
   transformIgnorePatterns: [
     'node_modules/(?!(react-native|@react-native|react-native-fs|react-native-quick-crypto|expo|@expo|expo-.*|expo-sqlite|expo-modules-core)/)',
   ],
+  testPathIgnorePatterns: ['/node_modules/', '/scripts/'],
   moduleNameMapper: {},
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "main": "index.ts",
   "scripts": {
     "fresh": "bunx rimraf .expo android ios node_modules && bun install",
-    "start": "expo start --dev-client",
+    "start": "bun scripts/start.ts",
     "dev:ios": "bun scripts/dev.ts ios",
     "dev:ios:device": "bun scripts/dev.ts ios:device",
     "dev:android": "bun scripts/dev.ts android",
@@ -18,7 +18,7 @@
     "release:android:production": "bun scripts/releaseAndroid.ts production",
     "release:ios:internal": "bun scripts/releaseIos.ts testflight",
     "release:ios:production": "bun scripts/releaseIos.ts appstore",
-    "test": "jest",
+    "test": "jest && bun test scripts/",
     "e2e:ios": "bun scripts/e2e.ts ios",
     "e2e:android": "bun scripts/e2e.ts android",
     "android": "expo run:android",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -16,7 +16,7 @@ import {
   writeBuildLog,
   getBuildLogTail,
 } from './buildCache'
-import { ProgressIndicator } from './progress'
+import { runProcess } from './lib/process'
 
 export interface BuildOptions {
   target: BuildTarget
@@ -25,16 +25,29 @@ export interface BuildOptions {
 }
 
 /**
+ * Kill any existing build processes to prevent zombies.
+ */
+async function killExistingBuilds(platform: 'ios' | 'android'): Promise<void> {
+  if (platform === 'ios') {
+    // Kill xcodebuild processes for this project
+    await $`pkill -f "xcodebuild.*SiaStorageDev" 2>/dev/null`.quiet().nothrow()
+  } else {
+    // Kill gradle processes for this project
+    await $`pkill -f "gradlew.*assembleDebug" 2>/dev/null`.quiet().nothrow()
+  }
+}
+
+/**
  * Build iOS app for simulator
  */
 export async function buildIosSim(options: BuildOptions): Promise<void> {
   const { target, alwaysClean = false } = options
   const paths = getTargetPaths(target)
-  const label = 'Building iOS'
 
   console.log(`   Build log: ${paths.buildLog}`)
   $.cwd(PROJECT_ROOT)
   ensureCacheDir(target)
+  await killExistingBuilds('ios')
 
   const iosDir = join(PROJECT_ROOT, 'ios')
 
@@ -46,89 +59,126 @@ export async function buildIosSim(options: BuildOptions): Promise<void> {
     }
 
     console.log('   Prebuilding...')
-    const prebuildResult = await $`bunx expo prebuild --platform ios 2>&1`.quiet().nothrow()
+    const prebuildResult =
+      await $`bunx expo prebuild --platform ios 2>&1`.quiet().nothrow()
     writeBuildLog(target, `=== PREBUILD ===\n${prebuildResult.stdout}\n`)
 
     if (prebuildResult.exitCode !== 0) {
-      console.error('❌ Prebuild failed. Last 30 lines:')
+      console.error('   Prebuild failed. Last 30 lines:')
       console.error(getBuildLogTail(target, 30))
       throw new Error('iOS prebuild failed')
     }
   }
 
-  // Build for simulator
-  const progress = new ProgressIndicator()
-  progress.start(label)
+  // Build for simulator using unified process runner
+  writeBuildLog(target, '=== XCODEBUILD ===\n', true)
 
-  const proc = Bun.spawn(['xcodebuild',
-    '-workspace', 'ios/SiaStorageDev.xcworkspace',
-    '-scheme', 'SiaStorageDev',
-    '-configuration', 'Debug',
-    '-sdk', 'iphonesimulator',
-    '-arch', 'arm64',
-    '-derivedDataPath', paths.derivedData,
-    'build',
-    'CODE_SIGN_IDENTITY=-',
-    'CODE_SIGNING_ALLOWED=YES'
-  ], {
+  const result = await runProcess({
+    command: [
+      'xcodebuild',
+      '-workspace',
+      'ios/SiaStorageDev.xcworkspace',
+      '-scheme',
+      'SiaStorageDev',
+      '-configuration',
+      'Debug',
+      '-sdk',
+      'iphonesimulator',
+      '-arch',
+      'arm64',
+      '-derivedDataPath',
+      paths.derivedData,
+      'build',
+      'CODE_SIGN_IDENTITY=-',
+      'CODE_SIGNING_ALLOWED=YES',
+    ],
     cwd: PROJECT_ROOT,
-    stdout: 'pipe',
-    stderr: 'pipe',
+    target,
+    label: 'Building iOS',
   })
 
-  let output = ''
-  const reader = proc.stdout.getReader()
-  const decoder = new TextDecoder()
-
-  while (true) {
-    const { done, value } = await reader.read()
-    if (done) break
-    const chunk = decoder.decode(value)
-    output += chunk
-    progress.updatePhase(chunk)
-  }
-
-  const exitCode = await proc.exited
-  writeBuildLog(target, `=== XCODEBUILD ===\n${output}`, true)
-
-  if (exitCode !== 0 || output.includes('BUILD FAILED')) {
-    progress.stop(false)
-    console.error('❌ Build failed. Last 50 lines:')
+  if (!result.success) {
+    console.error('   Build failed. Last 50 lines:')
     console.error(getBuildLogTail(target, 50))
     throw new Error('iOS build failed - see ' + paths.buildLog)
   }
 
-  progress.stop(true)
   saveBuildHash(target)
 }
 
 /**
- * Build iOS app for device via fastlane
+ * Build iOS app for device using xcodebuild directly.
+ * Note: Installation is handled separately in dev.ts using devicectl.
  */
 export async function buildIosDevice(options: BuildOptions): Promise<void> {
-  const { target } = options
+  const { target, alwaysClean = false } = options
   const paths = getTargetPaths(target)
-  const label = 'Building iOS (device)'
 
   console.log(`   Build log: ${paths.buildLog}`)
+  $.cwd(PROJECT_ROOT)
   ensureCacheDir(target)
+  await killExistingBuilds('ios')
 
-  const progress = new ProgressIndicator()
-  progress.start(label)
+  const iosDir = join(PROJECT_ROOT, 'ios')
 
-  const buildResult = await $`fastlane ios dev_device 2>&1`.quiet().nothrow()
-  const output = buildResult.stdout.toString()
-  writeBuildLog(target, `=== FASTLANE ===\n${output}`, true)
-  progress.updatePhase(output)
+  // Clean and prebuild if explicitly requested or dir doesn't exist
+  if (alwaysClean || !existsSync(iosDir)) {
+    if (existsSync(iosDir)) {
+      console.log('   Cleaning ios/...')
+      await $`rm -rf ${iosDir}`.quiet().nothrow()
+    }
 
-  if (buildResult.exitCode !== 0) {
-    progress.stop(false)
-    console.error('❌ Build failed. Last 50 lines:')
-    console.error(getBuildLogTail(target, 50))
-    throw new Error('iOS device build failed')
+    console.log('   Prebuilding...')
+    const prebuildResult =
+      await $`bunx expo prebuild --platform ios 2>&1`.quiet().nothrow()
+    writeBuildLog(target, `=== PREBUILD ===\n${prebuildResult.stdout}\n`)
+
+    if (prebuildResult.exitCode !== 0) {
+      console.error('   Prebuild failed. Last 30 lines:')
+      console.error(getBuildLogTail(target, 30))
+      throw new Error('iOS prebuild failed')
+    }
   }
 
-  progress.stop(true)
+  // Get the team ID from environment
+  const teamId = process.env.APPLE_TEAM_ID
+  if (!teamId) {
+    throw new Error('APPLE_TEAM_ID environment variable is required for device builds')
+  }
+
+  // Build for device using xcodebuild directly (no fastlane)
+  writeBuildLog(target, '=== XCODEBUILD (device) ===\n', true)
+
+  const result = await runProcess({
+    command: [
+      'xcodebuild',
+      '-workspace',
+      'ios/SiaStorageDev.xcworkspace',
+      '-scheme',
+      'SiaStorageDev',
+      '-configuration',
+      'Debug',
+      '-sdk',
+      'iphoneos',
+      '-arch',
+      'arm64',
+      '-derivedDataPath',
+      paths.derivedData,
+      'build',
+      `DEVELOPMENT_TEAM=${teamId}`,
+      'CODE_SIGN_STYLE=Automatic',
+    ],
+    cwd: PROJECT_ROOT,
+    target,
+    label: 'Building iOS (device)',
+  })
+
+  if (!result.success) {
+    console.error('   Build failed. Last 50 lines:')
+    console.error(getBuildLogTail(target, 50))
+    throw new Error('iOS device build failed - see ' + paths.buildLog)
+  }
+
   saveBuildHash(target)
 }
 
@@ -138,11 +188,11 @@ export async function buildIosDevice(options: BuildOptions): Promise<void> {
 export async function buildAndroid(options: BuildOptions): Promise<void> {
   const { target, alwaysClean = false } = options
   const paths = getTargetPaths(target)
-  const label = 'Building Android'
 
   console.log(`   Build log: ${paths.buildLog}`)
   $.cwd(PROJECT_ROOT)
   ensureCacheDir(target)
+  await killExistingBuilds('android')
 
   const androidDir = join(PROJECT_ROOT, 'android')
 
@@ -154,48 +204,45 @@ export async function buildAndroid(options: BuildOptions): Promise<void> {
     }
 
     console.log('   Prebuilding...')
-    const prebuildResult = await $`bunx expo prebuild --platform android 2>&1`.quiet().nothrow()
+    const prebuildResult =
+      await $`bunx expo prebuild --platform android 2>&1`.quiet().nothrow()
     writeBuildLog(target, `=== PREBUILD ===\n${prebuildResult.stdout}\n`)
 
     if (prebuildResult.exitCode !== 0) {
-      console.error('❌ Prebuild failed. Last 30 lines:')
+      console.error('   Prebuild failed. Last 30 lines:')
       console.error(getBuildLogTail(target, 30))
       throw new Error('Android prebuild failed')
     }
   }
 
-  // Build APK
-  const progress = new ProgressIndicator()
-  progress.start(label)
+  // Build APK using unified process runner
+  writeBuildLog(target, '=== GRADLE ===\n', true)
 
-  const proc = Bun.spawn(['./gradlew', 'assembleDebug', '--no-daemon'], {
+  const result = await runProcess({
+    command: ['./gradlew', 'assembleDebug', '--no-daemon'],
     cwd: join(PROJECT_ROOT, 'android'),
-    stdout: 'pipe',
-    stderr: 'pipe',
+    target,
+    label: 'Building Android',
   })
 
-  let output = ''
-  const reader = proc.stdout.getReader()
-  const decoder = new TextDecoder()
-
-  while (true) {
-    const { done, value } = await reader.read()
-    if (done) break
-    const chunk = decoder.decode(value)
-    output += chunk
-    progress.updatePhase(chunk)
-  }
-
-  const exitCode = await proc.exited
-  writeBuildLog(target, `=== GRADLE ===\n${output}`, true)
-
-  if (exitCode !== 0 || output.includes('BUILD FAILED')) {
-    progress.stop(false)
-    console.error('❌ Build failed. Last 50 lines:')
+  if (!result.success) {
+    console.error('   Build failed. Last 50 lines:')
     console.error(getBuildLogTail(target, 50))
     throw new Error('Android build failed - see ' + paths.buildLog)
   }
 
-  progress.stop(true)
   saveBuildHash(target)
+}
+
+/**
+ * Find the built iOS app for device in DerivedData.
+ */
+export async function findIosDeviceApp(target: BuildTarget): Promise<string | null> {
+  const paths = getTargetPaths(target)
+  const result =
+    await $`find ${paths.derivedData} -name "*.app" -path "*Debug-iphoneos*" -type d 2>/dev/null`
+      .quiet()
+      .nothrow()
+  const found = result.stdout.toString().trim().split('\n').filter(Boolean)[0]
+  return found || null
 }

--- a/scripts/buildCache.ts
+++ b/scripts/buildCache.ts
@@ -10,7 +10,7 @@
  * - Cache stored in .build-cache/ directory (survives rimraf ios/android)
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
+import { existsSync, readFileSync, writeFileSync, appendFileSync, mkdirSync } from 'fs'
 import { createHash } from 'crypto'
 import { join } from 'path'
 import { Glob } from 'bun'
@@ -143,10 +143,18 @@ export function writeBuildLog(target: BuildTarget, content: string, append = fal
   const paths = getTargetPaths(target)
   mkdirSync(paths.dir, { recursive: true })
   if (append && existsSync(paths.buildLog)) {
-    writeFileSync(paths.buildLog, readFileSync(paths.buildLog, 'utf-8') + content)
+    appendFileSync(paths.buildLog, content)
   } else {
     writeFileSync(paths.buildLog, content)
   }
+}
+
+/**
+ * Append to build log file (efficient streaming).
+ */
+export function appendBuildLog(target: BuildTarget, content: string): void {
+  const paths = getTargetPaths(target)
+  appendFileSync(paths.buildLog, content)
 }
 
 /**

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -31,11 +31,21 @@ import {
   getTargetPaths,
   needsRebuild,
 } from './buildCache'
-import { buildIosSim, buildIosDevice, buildAndroid } from './build'
+import { buildIosSim, buildIosDevice, buildAndroid, findIosDeviceApp } from './build'
+import {
+  listDevices,
+  selectDevice,
+  installIosApp,
+  launchIosApp,
+  installAndroidApp,
+  launchAndroidApp,
+  type Device,
+} from './lib/devices'
+import { waitForDeviceUnlock } from './lib/ui'
 
 // Parse arguments
 const args = process.argv.slice(2)
-const targetArg = args.find(a => !a.startsWith('-'))
+const targetArg = args.find((a) => !a.startsWith('-'))
 const forceRebuild = args.includes('--rebuild')
 const noRun = args.includes('--no-run')
 
@@ -59,7 +69,7 @@ function getTarget(): BuildTarget {
       console.error('')
       console.error('Flags:')
       console.error('  --rebuild    Full clean build (delete platform dir, prebuild, build)')
-      console.error('  --no-run     Build only, don\'t launch the app')
+      console.error("  --no-run     Build only, don't launch the app")
       process.exit(1)
   }
 }
@@ -72,7 +82,9 @@ const paths = getTargetPaths(target)
 // Print header
 console.log(`\n🚀 Smart Dev Build`)
 console.log(`   Target: ${targetArg}`)
-console.log(`   Flags: ${[forceRebuild && '--rebuild', noRun && '--no-run'].filter(Boolean).join(' ') || 'none'}`)
+console.log(
+  `   Flags: ${[forceRebuild && '--rebuild', noRun && '--no-run'].filter(Boolean).join(' ') || 'none'}`
+)
 console.log(`   Cache: .build-cache/${target}/`)
 console.log('')
 
@@ -85,6 +97,25 @@ if (forceRebuild) {
   rmSync(join(PROJECT_ROOT, platform), { recursive: true, force: true })
   console.log(`   Removing .build-cache/${target}/...`)
   rmSync(paths.dir, { recursive: true, force: true })
+  console.log('')
+}
+
+// For device builds, check for connected device first
+let selectedDevice: Device | null = null
+if (isDevice) {
+  console.log('📱 Checking for iOS device...')
+  selectedDevice = await selectDevice('ios', 'device')
+
+  if (!selectedDevice) {
+    console.error('')
+    console.error('   No iOS device connected')
+    console.error('')
+    console.error('   Please connect your iPhone with a USB cable and unlock it.')
+    console.error('   Run `xcrun devicectl list devices` to verify.')
+    process.exit(1)
+  }
+
+  console.log(`   Found: ${selectedDevice.name}`)
   console.log('')
 }
 
@@ -123,38 +154,99 @@ if (!noRun) {
 // === Run iOS App ===
 async function runIos(): Promise<void> {
   if (isDevice) {
-    console.log('📱 Running on iOS device...')
-    // For device, we typically use ios-deploy or the app was installed by fastlane
-    console.log('   App should be installed on device. Open it manually or use ios-deploy.')
+    await runIosDevice()
   } else {
-    console.log('📱 Running on iOS Simulator...')
-
-    // Find the built app
-    const appPath = await findIosSimApp()
-    if (!appPath) {
-      console.error('❌ Could not find built app')
-      process.exit(1)
-    }
-
-    // Boot simulator if needed
-    const bootedResult = await $`xcrun simctl list devices booted`.quiet().nothrow()
-    if (!bootedResult.stdout.toString().includes('iPhone')) {
-      console.log('   Booting simulator...')
-      const devices = await $`xcrun simctl list devices available`.text()
-      const match = devices.match(/iPhone[^(]*\(([^)]+)\)/)
-      if (match) {
-        await $`xcrun simctl boot ${match[1]}`.quiet().nothrow()
-        await $`open -a Simulator`.nothrow()
-      }
-    }
-
-    // Install and launch
-    console.log('   Installing app...')
-    await $`xcrun simctl install booted ${appPath}`.quiet()
-    console.log('   Launching app...')
-    await $`xcrun simctl launch booted sia.storage.dev`.quiet()
-    console.log('✅ App launched')
+    await runIosSimulator()
   }
+}
+
+// === Run iOS on Physical Device ===
+async function runIosDevice(): Promise<void> {
+  console.log('📱 Installing on iOS device...')
+
+  // Find the built app
+  const appPath = await findIosDeviceApp(target)
+  if (!appPath) {
+    console.error('   Could not find built app')
+    process.exit(1)
+  }
+
+  // Get fresh device list (in case state changed)
+  const device = await selectDevice('ios', 'device')
+  if (!device) {
+    console.error('   Device disconnected')
+    process.exit(1)
+  }
+
+  // Install with retry loop for device unlock
+  while (true) {
+    const installResult = await installIosApp(device, appPath)
+
+    if (installResult.success) {
+      console.log('   Installed successfully')
+      break
+    }
+
+    if (installResult.error === 'locked') {
+      await waitForDeviceUnlock(device.name)
+      continue
+    }
+
+    console.error(`   Install failed: ${installResult.message}`)
+    process.exit(1)
+  }
+
+  // Launch the app
+  console.log('🚀 Launching app...')
+  const bundleId = 'sia.storage.dev'
+
+  while (true) {
+    const launchResult = await launchIosApp(device, bundleId)
+
+    if (launchResult.success) {
+      console.log('✅ App launched')
+      break
+    }
+
+    if (launchResult.error === 'locked') {
+      await waitForDeviceUnlock(device.name)
+      continue
+    }
+
+    console.error(`   Launch failed: ${launchResult.message}`)
+    process.exit(1)
+  }
+}
+
+// === Run iOS on Simulator ===
+async function runIosSimulator(): Promise<void> {
+  console.log('📱 Running on iOS Simulator...')
+
+  // Find the built app
+  const appPath = await findIosSimApp()
+  if (!appPath) {
+    console.error('   Could not find built app')
+    process.exit(1)
+  }
+
+  // Boot simulator if needed
+  const bootedResult = await $`xcrun simctl list devices booted`.quiet().nothrow()
+  if (!bootedResult.stdout.toString().includes('iPhone')) {
+    console.log('   Booting simulator...')
+    const devices = await $`xcrun simctl list devices available`.text()
+    const match = devices.match(/iPhone[^(]*\(([^)]+)\)/)
+    if (match) {
+      await $`xcrun simctl boot ${match[1]}`.quiet().nothrow()
+      await $`open -a Simulator`.nothrow()
+    }
+  }
+
+  // Install and launch
+  console.log('   Installing app...')
+  await $`xcrun simctl install booted ${appPath}`.quiet()
+  console.log('   Launching app...')
+  await $`xcrun simctl launch booted sia.storage.dev`.quiet()
+  console.log('✅ App launched')
 }
 
 // === Run Android App ===
@@ -164,45 +256,81 @@ async function runAndroid(): Promise<void> {
   // Find APK
   const apkDir = join(PROJECT_ROOT, 'android/app/build/outputs/apk/debug')
   const apkResult = await $`find ${apkDir} -name "*.apk" 2>/dev/null`.quiet().nothrow()
-  const apkPath = apkResult.stdout.toString().trim().split('\n').filter(Boolean)[0]
+  const apkPath = apkResult.stdout
+    .toString()
+    .trim()
+    .split('\n')
+    .filter(Boolean)[0]
 
   if (!apkPath) {
-    console.error('❌ Could not find APK')
+    console.error('   Could not find APK')
     process.exit(1)
   }
 
   // Check for connected device/emulator
-  const devices = await $`adb devices`.quiet()
-  if (!devices.stdout.toString().includes('\tdevice')) {
+  const devices = await listDevices('android')
+  let device = devices.find((d) => d.state === 'available')
+
+  if (!device) {
     console.log('   No device connected. Starting emulator...')
     const avdsResult = await $`emulator -list-avds`.quiet().nothrow()
-    const avds = avdsResult.stdout.toString().trim().split('\n').filter(Boolean)
+    const avds = avdsResult.stdout
+      .toString()
+      .trim()
+      .split('\n')
+      .filter(Boolean)
     if (avds.length === 0) {
-      console.error('❌ No Android emulator found. Create one in Android Studio.')
+      console.error('   No Android emulator found. Create one in Android Studio.')
       process.exit(1)
     }
-    Bun.spawn(['sh', '-c', `emulator -avd ${avds[0]} &`], { stdout: 'ignore', stderr: 'ignore' })
+    Bun.spawn(['sh', '-c', `emulator -avd ${avds[0]} &`], {
+      stdout: 'ignore',
+      stderr: 'ignore',
+    })
     console.log('   Waiting for emulator...')
     await $`adb wait-for-device`
     // Wait for boot
     for (let i = 0; i < 60; i++) {
-      const bootResult = await $`adb shell getprop sys.boot_completed 2>/dev/null`.quiet().nothrow()
+      const bootResult =
+        await $`adb shell getprop sys.boot_completed 2>/dev/null`.quiet().nothrow()
       if (bootResult.stdout.toString().trim() === '1') break
-      await new Promise(r => setTimeout(r, 2000))
+      await new Promise((r) => setTimeout(r, 2000))
     }
+
+    // Get the device again
+    const updatedDevices = await listDevices('android')
+    device = updatedDevices.find((d) => d.state === 'available')
+  }
+
+  if (!device) {
+    console.error('   Could not connect to Android device')
+    process.exit(1)
   }
 
   // Install and launch
   console.log('   Installing APK...')
-  await $`adb install -r ${apkPath}`.quiet()
+  const installResult = await installAndroidApp(device, apkPath)
+  if (!installResult.success) {
+    console.error(`   Install failed: ${installResult.message}`)
+    process.exit(1)
+  }
+
   console.log('   Launching app...')
-  await $`adb shell am start -n sia.storage.dev/.MainActivity`.quiet()
+  const launchResult = await launchAndroidApp(device, 'sia.storage.dev')
+  if (!launchResult.success) {
+    console.error(`   Launch failed: ${launchResult.message}`)
+    process.exit(1)
+  }
+
   console.log('✅ App launched')
 }
 
 // Find iOS Simulator app in DerivedData
 async function findIosSimApp(): Promise<string | null> {
-  const result = await $`find ${paths.derivedData} -name "*.app" -path "*Debug-iphonesimulator*" -type d 2>/dev/null`.quiet().nothrow()
+  const result =
+    await $`find ${paths.derivedData} -name "*.app" -path "*Debug-iphonesimulator*" -type d 2>/dev/null`
+      .quiet()
+      .nothrow()
   const found = result.stdout.toString().trim().split('\n').filter(Boolean)[0]
   return found || null
 }

--- a/scripts/lib/devices.test.ts
+++ b/scripts/lib/devices.test.ts
@@ -1,0 +1,424 @@
+import {
+  parseDevicectlOutput,
+  parseSimctlOutput,
+  parseAdbOutput,
+} from './devices'
+
+/**
+ * Output from: xcrun devicectl list devices --json-output /dev/stdout
+ *
+ * Note: devicectl outputs BOTH human-readable text AND JSON to stdout.
+ * The JSON starts after the table. Identifiers/serials are sanitized.
+ */
+const DEVICECTL_LIST_DEVICES_OUTPUT = `Devices:
+Name   Hostname                                     Identifier                             State                Model
+----   ------------------------------------------   ------------------------------------   ------------------   ----------------------
+MyPhone   00001234-000000001234CDEF.coredevice.local   AAAAAAAA-1111-2222-3333-BBBBBBBBBBBB   available (paired)   iPhone 16 (iPhone17,3)
+{
+  "info" : {
+    "arguments" : [
+      "devicectl",
+      "list",
+      "devices",
+      "--json-output",
+      "/dev/stdout"
+    ],
+    "commandType" : "devicectl.list.devices",
+    "environment" : {
+      "TERM" : "xterm-256color"
+    },
+    "jsonVersion" : 2,
+    "outcome" : "success",
+    "version" : "397.28"
+  },
+  "result" : {
+    "devices" : [
+      {
+        "capabilities" : [
+          {
+            "featureIdentifier" : "com.apple.coredevice.feature.acquireusageassertion",
+            "name" : "Acquire Usage Assertion"
+          },
+          {
+            "featureIdentifier" : "com.apple.coredevice.feature.unpairdevice",
+            "name" : "Unpair Device"
+          },
+          {
+            "featureIdentifier" : "com.apple.coredevice.feature.connectdevice",
+            "name" : "Connect to Device"
+          }
+        ],
+        "connectionProperties" : {
+          "authenticationType" : "manualPairing",
+          "isMobileDeviceOnly" : false,
+          "lastConnectionDate" : "2026-01-27T23:24:05.892Z",
+          "pairingState" : "paired",
+          "potentialHostnames" : [
+            "00001234-000000001234CDEF.coredevice.local",
+            "AAAAAAAA-1111-2222-3333-BBBBBBBBBBBB.coredevice.local"
+          ],
+          "transportType" : "localNetwork",
+          "tunnelState" : "disconnected",
+          "tunnelTransportProtocol" : "tcp"
+        },
+        "deviceProperties" : {
+          "bootedFromSnapshot" : true,
+          "bootedSnapshotName" : "com.apple.os.update-AAAAAAAAAA",
+          "ddiServicesAvailable" : false,
+          "developerModeStatus" : "enabled",
+          "hasInternalOSBuild" : false,
+          "name" : "MyPhone",
+          "osBuildUpdate" : "22C55",
+          "osVersionNumber" : "18.2",
+          "rootFileSystemIsWritable" : false
+        },
+        "hardwareProperties" : {
+          "cpuType" : {
+            "name" : "arm64e",
+            "subType" : 2,
+            "type" : 16777228
+          },
+          "deviceType" : "iPhone",
+          "ecid" : 1234567890123456,
+          "hardwareModel" : "D47AP",
+          "internalStorageCapacity" : 256000000000,
+          "isProductionFused" : true,
+          "marketingName" : "iPhone 16",
+          "platform" : "iOS",
+          "productType" : "iPhone17,3",
+          "reality" : "physical",
+          "serialNumber" : "XXXX1234XX",
+          "supportedCPUTypes" : [
+            {
+              "name" : "arm64e",
+              "subType" : 2,
+              "type" : 16777228
+            }
+          ],
+          "supportedDeviceFamilies" : [
+            1
+          ],
+          "thinningProductType" : "iPhone17,3",
+          "udid" : "00001234-000000001234CDEF"
+        },
+        "identifier" : "AAAAAAAA-1111-2222-3333-BBBBBBBBBBBB",
+        "tags" : [
+
+        ],
+        "visibilityClass" : "default"
+      }
+    ]
+  }
+}`
+
+/**
+ * Output from: xcrun devicectl list devices --json-output /dev/stdout
+ * When device is connected but tunnel is active (USB connected)
+ */
+const DEVICECTL_LIST_DEVICES_CONNECTED_OUTPUT = `Devices:
+Name   Hostname                                     Identifier                             State                Model
+----   ------------------------------------------   ------------------------------------   ------------------   ----------------------
+MyPhone   00001234-000000001234CDEF.coredevice.local   AAAAAAAA-1111-2222-3333-BBBBBBBBBBBB   available (paired)   iPhone 16 (iPhone17,3)
+{
+  "info" : {
+    "arguments" : ["devicectl", "list", "devices", "--json-output", "/dev/stdout"],
+    "commandType" : "devicectl.list.devices",
+    "jsonVersion" : 2,
+    "outcome" : "success",
+    "version" : "397.28"
+  },
+  "result" : {
+    "devices" : [
+      {
+        "capabilities" : [],
+        "connectionProperties" : {
+          "authenticationType" : "manualPairing",
+          "pairingState" : "paired",
+          "transportType" : "wired",
+          "tunnelState" : "connected",
+          "tunnelTransportProtocol" : "tcp"
+        },
+        "deviceProperties" : {
+          "developerModeStatus" : "enabled",
+          "name" : "MyPhone",
+          "osVersionNumber" : "18.2"
+        },
+        "hardwareProperties" : {
+          "deviceType" : "iPhone",
+          "marketingName" : "iPhone 16",
+          "platform" : "iOS",
+          "udid" : "00001234-000000001234CDEF"
+        },
+        "identifier" : "AAAAAAAA-1111-2222-3333-BBBBBBBBBBBB",
+        "visibilityClass" : "default"
+      }
+    ]
+  }
+}`
+
+/**
+ * Output from: xcrun devicectl list devices --json-output /dev/stdout
+ * When no devices are connected
+ */
+const DEVICECTL_LIST_DEVICES_EMPTY_OUTPUT = `Devices:
+Name   Hostname   Identifier   State   Model
+----   --------   ----------   -----   -----
+{
+  "info" : {
+    "arguments" : ["devicectl", "list", "devices", "--json-output", "/dev/stdout"],
+    "commandType" : "devicectl.list.devices",
+    "jsonVersion" : 2,
+    "outcome" : "success",
+    "version" : "397.28"
+  },
+  "result" : {
+    "devices" : []
+  }
+}`
+
+/**
+ * Output from: xcrun simctl list devices booted --json
+ * When a simulator is booted
+ */
+const SIMCTL_LIST_DEVICES_BOOTED_OUTPUT = `{
+  "devices" : {
+    "com.apple.CoreSimulator.SimRuntime.iOS-18-3" : [
+      {
+        "lastBootedAt" : "2026-01-27T20:28:25Z",
+        "dataPath" : "/Users/user/Library/Developer/CoreSimulator/Devices/CCCCCCCC-4444-5555-6666-DDDDDDDDDDDD/data",
+        "dataPathSize" : 2734256128,
+        "logPath" : "/Users/user/Library/Logs/CoreSimulator/CCCCCCCC-4444-5555-6666-DDDDDDDDDDDD",
+        "udid" : "CCCCCCCC-4444-5555-6666-DDDDDDDDDDDD",
+        "isAvailable" : true,
+        "logPathSize" : 581632,
+        "deviceTypeIdentifier" : "com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro",
+        "state" : "Booted",
+        "name" : "iPhone 16 Pro"
+      }
+    ]
+  }
+}`
+
+/**
+ * Output from: xcrun simctl list devices booted --json
+ * When multiple simulators are booted across different runtimes
+ */
+const SIMCTL_LIST_DEVICES_MULTIPLE_BOOTED_OUTPUT = `{
+  "devices" : {
+    "com.apple.CoreSimulator.SimRuntime.iOS-18-3" : [
+      {
+        "udid" : "CCCCCCCC-4444-5555-6666-DDDDDDDDDDDD",
+        "isAvailable" : true,
+        "deviceTypeIdentifier" : "com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro",
+        "state" : "Booted",
+        "name" : "iPhone 16 Pro"
+      },
+      {
+        "udid" : "EEEEEEEE-7777-8888-9999-FFFFFFFFFFFF",
+        "isAvailable" : true,
+        "deviceTypeIdentifier" : "com.apple.CoreSimulator.SimDeviceType.iPhone-SE-3rd-generation",
+        "state" : "Booted",
+        "name" : "iPhone SE (3rd generation)"
+      }
+    ],
+    "com.apple.CoreSimulator.SimRuntime.iOS-17-5" : [
+      {
+        "udid" : "11111111-AAAA-BBBB-CCCC-222222222222",
+        "isAvailable" : true,
+        "deviceTypeIdentifier" : "com.apple.CoreSimulator.SimDeviceType.iPad-Pro-11-inch-M4-8GB",
+        "state" : "Booted",
+        "name" : "iPad Pro 11-inch (M4)"
+      }
+    ]
+  }
+}`
+
+/**
+ * Output from: xcrun simctl list devices booted --json
+ * When no simulators are booted
+ */
+const SIMCTL_LIST_DEVICES_NONE_BOOTED_OUTPUT = `{
+  "devices" : {
+    "com.apple.CoreSimulator.SimRuntime.iOS-18-3" : [
+
+    ]
+  }
+}`
+
+/**
+ * Output from: adb devices -l
+ * When an emulator is connected
+ */
+const ADB_DEVICES_EMULATOR_OUTPUT = `List of devices attached
+emulator-5554          device product:sdk_gphone64_arm64 model:sdk_gphone64_arm64 device:emu64a transport_id:1`
+
+/**
+ * Output from: adb devices -l
+ * When a physical Android device is connected
+ */
+const ADB_DEVICES_PHYSICAL_OUTPUT = `List of devices attached
+RFXXXXXXXX             device usb:1234567X product:starqltesq model:SM_G965U device:starqltesq transport_id:2`
+
+/**
+ * Output from: adb devices -l
+ * When multiple devices are connected
+ */
+const ADB_DEVICES_MULTIPLE_OUTPUT = `List of devices attached
+emulator-5554          device product:sdk_gphone64_arm64 model:sdk_gphone64_arm64 device:emu64a transport_id:1
+RFXXXXXXXX             device usb:1234567X product:starqltesq model:SM_G965U device:starqltesq transport_id:2
+emulator-5556          device product:sdk_gphone64_arm64 model:Pixel_7_Pro device:emu64a transport_id:3`
+
+/**
+ * Output from: adb devices -l
+ * When no devices are connected
+ */
+const ADB_DEVICES_NONE_OUTPUT = `List of devices attached`
+
+/**
+ * Output from: adb devices -l
+ * When a device is unauthorized (needs to accept USB debugging prompt)
+ */
+const ADB_DEVICES_UNAUTHORIZED_OUTPUT = `List of devices attached
+RFXXXXXXXX             unauthorized usb:1234567X transport_id:1`
+
+describe('parseDevicectlOutput', () => {
+  test('parses device with paired state (network connection)', () => {
+    const devices = parseDevicectlOutput(DEVICECTL_LIST_DEVICES_OUTPUT)
+
+    expect(devices).toHaveLength(1)
+    expect(devices[0]).toEqual({
+      id: 'AAAAAAAA-1111-2222-3333-BBBBBBBBBBBB',
+      name: 'MyPhone',
+      platform: 'ios',
+      type: 'device',
+      state: 'available',
+    })
+  })
+
+  test('parses device with connected tunnel state (USB connection)', () => {
+    const devices = parseDevicectlOutput(DEVICECTL_LIST_DEVICES_CONNECTED_OUTPUT)
+
+    expect(devices).toHaveLength(1)
+    expect(devices[0]).toEqual({
+      id: 'AAAAAAAA-1111-2222-3333-BBBBBBBBBBBB',
+      name: 'MyPhone',
+      platform: 'ios',
+      type: 'device',
+      state: 'available',
+    })
+  })
+
+  test('returns empty array when no devices', () => {
+    const devices = parseDevicectlOutput(DEVICECTL_LIST_DEVICES_EMPTY_OUTPUT)
+    expect(devices).toHaveLength(0)
+  })
+
+  test('returns empty array when no JSON found', () => {
+    const devices = parseDevicectlOutput('Some random output without JSON')
+    expect(devices).toHaveLength(0)
+  })
+
+  test('handles output with human-readable table before JSON', () => {
+    // The key feature: devicectl outputs a table THEN JSON
+    // We need to skip the table and find the JSON
+    const devices = parseDevicectlOutput(DEVICECTL_LIST_DEVICES_OUTPUT)
+    expect(devices).toHaveLength(1)
+    expect(devices[0].name).toBe('MyPhone')
+  })
+})
+
+describe('parseSimctlOutput', () => {
+  test('parses single booted simulator', () => {
+    const devices = parseSimctlOutput(SIMCTL_LIST_DEVICES_BOOTED_OUTPUT)
+
+    expect(devices).toHaveLength(1)
+    expect(devices[0]).toEqual({
+      id: 'CCCCCCCC-4444-5555-6666-DDDDDDDDDDDD',
+      name: 'iPhone 16 Pro',
+      platform: 'ios',
+      type: 'simulator',
+      state: 'available',
+    })
+  })
+
+  test('parses multiple booted simulators across runtimes', () => {
+    const devices = parseSimctlOutput(SIMCTL_LIST_DEVICES_MULTIPLE_BOOTED_OUTPUT)
+
+    expect(devices).toHaveLength(3)
+    expect(devices.map((d) => d.name)).toEqual([
+      'iPhone 16 Pro',
+      'iPhone SE (3rd generation)',
+      'iPad Pro 11-inch (M4)',
+    ])
+    expect(devices.every((d) => d.type === 'simulator')).toBe(true)
+    expect(devices.every((d) => d.state === 'available')).toBe(true)
+  })
+
+  test('returns empty array when no simulators booted', () => {
+    const devices = parseSimctlOutput(SIMCTL_LIST_DEVICES_NONE_BOOTED_OUTPUT)
+    expect(devices).toHaveLength(0)
+  })
+})
+
+describe('parseAdbOutput', () => {
+  test('parses emulator device', () => {
+    const devices = parseAdbOutput(ADB_DEVICES_EMULATOR_OUTPUT)
+
+    expect(devices).toHaveLength(1)
+    expect(devices[0]).toEqual({
+      id: 'emulator-5554',
+      name: 'sdk_gphone64_arm64', // model takes precedence
+      platform: 'android',
+      type: 'simulator', // emulator-* prefix = simulator
+      state: 'available',
+    })
+  })
+
+  test('parses physical Android device', () => {
+    const devices = parseAdbOutput(ADB_DEVICES_PHYSICAL_OUTPUT)
+
+    expect(devices).toHaveLength(1)
+    expect(devices[0]).toEqual({
+      id: 'RFXXXXXXXX',
+      name: 'SM_G965U',
+      platform: 'android',
+      type: 'device', // Not emulator-* prefix = physical device
+      state: 'available',
+    })
+  })
+
+  test('parses multiple devices', () => {
+    const devices = parseAdbOutput(ADB_DEVICES_MULTIPLE_OUTPUT)
+
+    expect(devices).toHaveLength(3)
+
+    // First emulator
+    expect(devices[0].id).toBe('emulator-5554')
+    expect(devices[0].type).toBe('simulator')
+
+    // Physical device
+    expect(devices[1].id).toBe('RFXXXXXXXX')
+    expect(devices[1].type).toBe('device')
+
+    // Second emulator with different model name
+    expect(devices[2].id).toBe('emulator-5556')
+    expect(devices[2].name).toBe('Pixel_7_Pro')
+    expect(devices[2].type).toBe('simulator')
+  })
+
+  test('returns empty array when no devices', () => {
+    const devices = parseAdbOutput(ADB_DEVICES_NONE_OUTPUT)
+    expect(devices).toHaveLength(0)
+  })
+
+  test('ignores unauthorized devices', () => {
+    const devices = parseAdbOutput(ADB_DEVICES_UNAUTHORIZED_OUTPUT)
+    expect(devices).toHaveLength(0)
+  })
+
+  test('prefers model over device name', () => {
+    const devices = parseAdbOutput(ADB_DEVICES_PHYSICAL_OUTPUT)
+    // model:SM_G965U should be used, not device:starqltesq
+    expect(devices[0].name).toBe('SM_G965U')
+  })
+})

--- a/scripts/lib/devices.ts
+++ b/scripts/lib/devices.ts
@@ -1,0 +1,408 @@
+/**
+ * Device Detection and Operations
+ *
+ * Reliable device detection using:
+ * - iOS: xcrun devicectl with JSON output (replaces deprecated ios-deploy)
+ * - Android: adb devices
+ *
+ * Supports both simulators/emulators and physical devices.
+ */
+
+import { $ } from 'bun'
+import { runSimpleCommand } from './process'
+
+export type Platform = 'ios' | 'android'
+export type DeviceType = 'simulator' | 'device'
+
+export interface Device {
+  id: string
+  name: string
+  platform: Platform
+  type: DeviceType
+  state: 'available' | 'unavailable' | 'locked' | 'unknown'
+}
+
+interface DevicectlDevice {
+  capabilities: Array<{ name: string; featureIdentifier?: string }>
+  connectionProperties: {
+    authenticationType?: string
+    isMobileDeviceOnly?: boolean
+    localHostnames?: string[]
+    pairingState?: string
+    potentialHostnames?: string[]
+    transportType?: string
+    tunnelIPAddress?: string
+    tunnelState?: string
+    usbProductId?: number
+  }
+  deviceProperties: {
+    bootedFromSnapshot?: boolean
+    bootedSnapshotName?: string
+    ddiServicesAvailable?: boolean
+    developerModeStatus?: string
+    hasInternalOSBuild?: boolean
+    name: string
+    osBuildUpdate?: string
+    osVersionNumber?: string
+    rootFileSystemIsWritable?: boolean
+  }
+  hardwareProperties: {
+    cpuType: { name: string; subType: number; type: number }
+    deviceType: string
+    ecid?: string
+    hardwareModel?: string
+    internalStorageCapacity?: number
+    isProductionFused?: boolean
+    marketingName?: string
+    platform: string
+    productType?: string
+    reality?: string
+    serialNumber?: string
+    supportedCPUTypes?: Array<{ name: string; subType: number; type: number }>
+    supportedDeviceFamilies?: number[]
+    thinningProductType?: string
+    udid: string
+  }
+  identifier: string
+  visibilityClass: string
+}
+
+interface DevicectlOutput {
+  info: {
+    arguments: string[]
+    commandType: string
+    environment: Record<string, string>
+    jsonVersion: number
+    outcome: string
+    version: string
+  }
+  result: {
+    devices: DevicectlDevice[]
+  }
+}
+
+/**
+ * Parse devicectl JSON output to extract device list.
+ * Exported for testing.
+ */
+export function parseDevicectlOutput(stdout: string): Device[] {
+  // devicectl outputs both human-readable text AND JSON to stdout
+  // Extract just the JSON portion starting from the first '{'
+  const jsonStart = stdout.indexOf('{')
+  if (jsonStart === -1) {
+    return []
+  }
+  const jsonStr = stdout.slice(jsonStart)
+  const data: DevicectlOutput = JSON.parse(jsonStr)
+
+  return data.result.devices.map((d) => {
+    // Determine device state
+    let state: Device['state'] = 'unknown'
+    if (d.connectionProperties.tunnelState === 'connected') {
+      state = 'available'
+    } else if (d.connectionProperties.pairingState === 'paired') {
+      state = 'available'
+    }
+
+    return {
+      id: d.identifier,
+      name: d.deviceProperties.name,
+      platform: 'ios' as Platform,
+      type: 'device' as DeviceType,
+      state,
+    }
+  })
+}
+
+/**
+ * List all available iOS devices using devicectl JSON API.
+ */
+async function listIosDevices(): Promise<Device[]> {
+  const result = await runSimpleCommand([
+    'xcrun',
+    'devicectl',
+    'list',
+    'devices',
+    '--json-output',
+    '/dev/stdout',
+  ])
+
+  if (!result.success) {
+    console.error('Failed to list iOS devices:', result.stderr)
+    return []
+  }
+
+  try {
+    return parseDevicectlOutput(result.stdout)
+  } catch (e) {
+    console.error('Failed to parse devicectl output:', e)
+    return []
+  }
+}
+
+/**
+ * Parse simctl JSON output to extract booted simulators.
+ * Exported for testing.
+ */
+export function parseSimctlOutput(stdout: string): Device[] {
+  const data = JSON.parse(stdout)
+  const devices: Device[] = []
+
+  for (const runtime in data.devices) {
+    for (const device of data.devices[runtime]) {
+      if (device.state === 'Booted') {
+        devices.push({
+          id: device.udid,
+          name: device.name,
+          platform: 'ios',
+          type: 'simulator',
+          state: 'available',
+        })
+      }
+    }
+  }
+
+  return devices
+}
+
+/**
+ * List all booted iOS simulators.
+ */
+async function listIosSimulators(): Promise<Device[]> {
+  const result = await $`xcrun simctl list devices booted --json`.quiet().nothrow()
+  if (result.exitCode !== 0) {
+    return []
+  }
+
+  try {
+    return parseSimctlOutput(result.stdout.toString())
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Parse adb devices output to extract connected devices.
+ * Exported for testing.
+ */
+export function parseAdbOutput(stdout: string): Device[] {
+  const devices: Device[] = []
+  const lines = stdout.trim().split('\n').slice(1) // Skip header
+
+  for (const line of lines) {
+    if (!line.trim()) continue
+
+    const parts = line.split(/\s+/)
+    const id = parts[0]
+    const status = parts[1]
+
+    if (status !== 'device') continue
+
+    // Extract device name from properties
+    const modelMatch = line.match(/model:(\S+)/)
+    const deviceMatch = line.match(/device:(\S+)/)
+    const name = modelMatch?.[1] || deviceMatch?.[1] || id
+
+    // Determine if emulator or device
+    const type: DeviceType = id.startsWith('emulator-') ? 'simulator' : 'device'
+
+    devices.push({
+      id,
+      name,
+      platform: 'android',
+      type,
+      state: 'available',
+    })
+  }
+
+  return devices
+}
+
+/**
+ * List all connected Android devices/emulators.
+ */
+async function listAndroidDevices(): Promise<Device[]> {
+  const result = await $`adb devices -l`.quiet().nothrow()
+  if (result.exitCode !== 0) {
+    return []
+  }
+
+  return parseAdbOutput(result.stdout.toString())
+}
+
+/**
+ * List all devices for a platform.
+ */
+export async function listDevices(
+  platform: Platform,
+  type?: DeviceType
+): Promise<Device[]> {
+  let devices: Device[]
+
+  if (platform === 'ios') {
+    if (type === 'simulator') {
+      devices = await listIosSimulators()
+    } else if (type === 'device') {
+      devices = await listIosDevices()
+    } else {
+      const [simulators, physicalDevices] = await Promise.all([
+        listIosSimulators(),
+        listIosDevices(),
+      ])
+      devices = [...simulators, ...physicalDevices]
+    }
+  } else {
+    devices = await listAndroidDevices()
+    if (type) {
+      devices = devices.filter((d) => d.type === type)
+    }
+  }
+
+  return devices
+}
+
+/**
+ * Select a device - auto-selects if only one, otherwise returns first available.
+ * In the future, this could prompt the user to choose.
+ */
+export async function selectDevice(
+  platform: Platform,
+  type: DeviceType
+): Promise<Device | null> {
+  const devices = await listDevices(platform, type)
+
+  if (devices.length === 0) {
+    return null
+  }
+
+  // Return first available device
+  const available = devices.find((d) => d.state === 'available')
+  return available || devices[0]
+}
+
+export interface InstallResult {
+  success: boolean
+  error?: 'locked' | 'not_found' | 'unknown'
+  message?: string
+}
+
+/**
+ * Install an app on an iOS device using devicectl.
+ */
+export async function installIosApp(
+  device: Device,
+  appPath: string
+): Promise<InstallResult> {
+  const result = await runSimpleCommand([
+    'xcrun',
+    'devicectl',
+    'device',
+    'install',
+    'app',
+    '--device',
+    device.id,
+    appPath,
+  ])
+
+  if (result.success) {
+    return { success: true }
+  }
+
+  const output = result.stdout + result.stderr
+
+  // Check for common error patterns
+  if (
+    output.includes('device is locked') ||
+    output.includes('passcode') ||
+    output.includes('unlock')
+  ) {
+    return { success: false, error: 'locked', message: 'Device is locked' }
+  }
+
+  if (output.includes('not found') || output.includes('No device')) {
+    return { success: false, error: 'not_found', message: 'Device not found' }
+  }
+
+  return { success: false, error: 'unknown', message: output }
+}
+
+/**
+ * Launch an app on an iOS device using devicectl.
+ */
+export async function launchIosApp(
+  device: Device,
+  bundleId: string
+): Promise<InstallResult> {
+  const result = await runSimpleCommand([
+    'xcrun',
+    'devicectl',
+    'device',
+    'process',
+    'launch',
+    '--device',
+    device.id,
+    bundleId,
+  ])
+
+  if (result.success) {
+    return { success: true }
+  }
+
+  const output = result.stdout + result.stderr
+
+  if (
+    output.includes('device is locked') ||
+    output.includes('passcode') ||
+    output.includes('unlock')
+  ) {
+    return { success: false, error: 'locked', message: 'Device is locked' }
+  }
+
+  return { success: false, error: 'unknown', message: output }
+}
+
+/**
+ * Install an APK on an Android device using adb.
+ */
+export async function installAndroidApp(
+  device: Device,
+  apkPath: string
+): Promise<InstallResult> {
+  const result = await $`adb -s ${device.id} install -r ${apkPath}`
+    .quiet()
+    .nothrow()
+
+  if (result.exitCode === 0) {
+    return { success: true }
+  }
+
+  return {
+    success: false,
+    error: 'unknown',
+    message: result.stderr.toString(),
+  }
+}
+
+/**
+ * Launch an app on an Android device using adb.
+ */
+export async function launchAndroidApp(
+  device: Device,
+  packageName: string,
+  activityName = '.MainActivity'
+): Promise<InstallResult> {
+  const result =
+    await $`adb -s ${device.id} shell am start -n ${packageName}/${packageName}${activityName}`
+      .quiet()
+      .nothrow()
+
+  if (result.exitCode === 0) {
+    return { success: true }
+  }
+
+  return {
+    success: false,
+    error: 'unknown',
+    message: result.stderr.toString(),
+  }
+}

--- a/scripts/lib/process.ts
+++ b/scripts/lib/process.ts
@@ -1,0 +1,111 @@
+/**
+ * Unified Process Runner
+ *
+ * Single abstraction for spawning processes with streaming output,
+ * progress updates, and log file writing.
+ */
+
+import type { BuildTarget } from '../buildCache'
+import { appendBuildLog } from '../buildCache'
+import { ProgressIndicator } from '../progress'
+
+export interface RunProcessOptions {
+  /** Command and arguments to execute */
+  command: string[]
+  /** Working directory */
+  cwd: string
+  /** Build target for logging */
+  target: BuildTarget
+  /** Label for progress indicator */
+  label: string
+  /** Optional callback for each output chunk */
+  onChunk?: (chunk: string) => void
+}
+
+export interface ProcessResult {
+  success: boolean
+  exitCode: number
+  output: string
+}
+
+/**
+ * Run a process with streaming output to log file and progress updates.
+ *
+ * This replaces the duplicated streaming loops in buildIosSim, buildIosDevice,
+ * and buildAndroid. The process output is:
+ * 1. Streamed to the build log file
+ * 2. Used to update the progress indicator phase
+ * 3. Accumulated for error detection
+ */
+export async function runProcess(options: RunProcessOptions): Promise<ProcessResult> {
+  const { command, cwd, target, label, onChunk } = options
+
+  const progress = new ProgressIndicator()
+  progress.start(label)
+
+  const proc = Bun.spawn(command, {
+    cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+
+  let output = ''
+  const decoder = new TextDecoder()
+
+  // Stream stdout
+  const stdoutReader = proc.stdout.getReader()
+  const stderrReader = proc.stderr.getReader()
+
+  // Read both streams concurrently
+  const readStream = async (
+    reader: ReadableStreamDefaultReader<Uint8Array>,
+    isStderr = false
+  ) => {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      const chunk = decoder.decode(value)
+      output += chunk
+      appendBuildLog(target, chunk)
+      progress.updatePhase(chunk)
+      onChunk?.(chunk)
+    }
+  }
+
+  await Promise.all([readStream(stdoutReader), readStream(stderrReader, true)])
+
+  const exitCode = await proc.exited
+
+  // Check for failure - non-zero exit code OR "BUILD FAILED" in output
+  const hasBuildFailed = output.includes('BUILD FAILED')
+  const success = exitCode === 0 && !hasBuildFailed
+
+  progress.stop(success)
+
+  return { success, exitCode, output }
+}
+
+/**
+ * Run a simple command and return its output.
+ * For commands that don't need streaming/progress.
+ */
+export async function runSimpleCommand(
+  command: string[],
+  options: { cwd?: string } = {}
+): Promise<{ success: boolean; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(command, {
+    cwd: options.cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+
+  const stdout = await new Response(proc.stdout).text()
+  const stderr = await new Response(proc.stderr).text()
+  const exitCode = await proc.exited
+
+  return {
+    success: exitCode === 0,
+    stdout,
+    stderr,
+  }
+}

--- a/scripts/lib/ui.ts
+++ b/scripts/lib/ui.ts
@@ -1,0 +1,61 @@
+/**
+ * UI Utilities
+ *
+ * Interactive prompts and user feedback for build scripts.
+ */
+
+import * as readline from 'readline'
+
+/**
+ * Wait for user to press Enter.
+ */
+export async function waitForKeypress(message: string): Promise<void> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  })
+
+  return new Promise((resolve) => {
+    rl.question(message, () => {
+      rl.close()
+      resolve()
+    })
+  })
+}
+
+/**
+ * Prompt user to unlock their device and wait for keypress.
+ */
+export async function waitForDeviceUnlock(deviceName: string): Promise<void> {
+  console.log('')
+  console.log(`   Device is locked - please unlock ${deviceName}`)
+  await waitForKeypress('   Press Enter when unlocked...')
+}
+
+/**
+ * Print a section header with icon.
+ */
+export function printHeader(icon: string, title: string): void {
+  console.log(`\n${icon} ${title}`)
+}
+
+/**
+ * Print an indented info line.
+ */
+export function printInfo(message: string): void {
+  console.log(`   ${message}`)
+}
+
+/**
+ * Print an error message with icon.
+ */
+export function printError(message: string): void {
+  console.error(`   ${message}`)
+}
+
+/**
+ * Print a success message.
+ */
+export function printSuccess(message: string): void {
+  console.log(`   ${message}`)
+}

--- a/scripts/start.ts
+++ b/scripts/start.ts
@@ -1,0 +1,27 @@
+#!/usr/bin/env bun
+/**
+ * Start the Expo dev server, killing any existing Metro process first.
+ *
+ * Uses stdio: 'inherit' so the interactive Expo menu works properly.
+ */
+
+import { $ } from 'bun'
+
+// Kill any existing process on port 8081 (Metro bundler)
+const killResult = await $`lsof -ti:8081`.quiet().nothrow()
+const pids = killResult.stdout.toString().trim()
+
+if (pids) {
+  await $`kill -9 ${pids}`.quiet().nothrow()
+  console.log('Killed existing Metro process')
+}
+
+// Start Expo dev server with inherited stdio for interactive menu
+const proc = Bun.spawn(['bunx', 'expo', 'start', '--dev-client'], {
+  cwd: import.meta.dir + '/..',
+  stdio: ['inherit', 'inherit', 'inherit'],
+  env: process.env,
+})
+
+// Wait for the process to exit
+await proc.exited


### PR DESCRIPTION
This PR further refined and refactors the build scripts:
- Replace deprecated ios-deploy with devicectl for iOS 17+.
- No longer need a fastlane script for dev, it was just calling ios-deploy.
- Modularize scripts and add user prompts for device connection steps.
- Kill any running metro server.
- Stream logs to the file.
- Add tests for interacting with device APIs.

![Screenshot 2026-01-27 at 4.55.27 PM.png](https://app.graphite.com/user-attachments/assets/70f14a91-e275-48c0-bb51-713fd3eadb8f.png)

