### PR TITLE
fix: prevent thumbnail generation race condition

### DIFF
--- a/src/managers/thumbnailScanner.ts
+++ b/src/managers/thumbnailScanner.ts
@@ -5,7 +5,7 @@ import { createServiceInterval } from '../lib/serviceInterval'
 import { type ThumbSize, ThumbSizes } from '../stores/files'
 import { getFsFileUri } from '../stores/fs'
 import { readThumbnailSizesForHash } from '../stores/thumbnails'
-import { ensureThumbnailForSize } from './thumbnailer'
+import { ensureThumbnailForSize, isFileBeingProcessed } from './thumbnailer'
 
 const MAX_THUMBS_PER_TICK = 10
 
@@ -159,6 +159,12 @@ export async function runThumbnailScanner(): Promise<ThumbnailScannerResult> {
       for (const c of batch) {
         if (producedCount >= MAX_THUMBS_PER_TICK) break
         processedThisRun.add(c.id)
+
+        // Skip files currently being processed by generateThumbnailsForFile.
+        if (isFileBeingProcessed(c.id)) {
+          continue
+        }
+
         summary.processedCandidates += 1
         // Determine missing sizes for this original so we don't attempt existing ones.
         const existingSizes = await readThumbnailSizesForHash(c.hash)

--- a/src/managers/thumbnailer.ts
+++ b/src/managers/thumbnailer.ts
@@ -20,6 +20,14 @@ import {
   thumbnailSwr,
 } from '../stores/thumbnails'
 
+// Track files currently being processed to prevent race conditions
+// between generateThumbnailsForFile and thumbnailScanner.
+const processingFiles = new Set<string>()
+
+export function isFileBeingProcessed(fileId: string): boolean {
+  return processingFiles.has(fileId)
+}
+
 /**
  * Generate thumbnails for a file record.
  * This will generate all missing thumbnail sizes for the given file.
@@ -37,44 +45,54 @@ export async function generateThumbnailsForFile(
     return
   }
 
-  // Get the source URI for the file.
-  const sourceUri = await getFsFileUri({
-    id: fileRecord.id,
-    type: fileRecord.type,
-  })
-  if (!sourceUri) {
-    logger.warn('generateThumbnailsForFile', 'no source URI', {
-      fileId: fileRecord.id,
+  // Mark file as being processed to prevent scanner from picking it up.
+  processingFiles.add(fileRecord.id)
+  try {
+    // Get the source URI for the file.
+    const sourceUri = await getFsFileUri({
+      id: fileRecord.id,
+      type: fileRecord.type,
     })
-    return
-  }
+    if (!sourceUri) {
+      logger.warn('generateThumbnailsForFile', 'no source URI', {
+        fileId: fileRecord.id,
+      })
+      return
+    }
 
-  // Check which sizes already exist.
-  const existingSizes = await readThumbnailSizesForHash(fileRecord.hash)
-  const missingSizes = ThumbSizes.filter((s) => !existingSizes.includes(s))
+    // Check which sizes already exist.
+    const existingSizes = await readThumbnailSizesForHash(fileRecord.hash)
+    const missingSizes = ThumbSizes.filter((s) => !existingSizes.includes(s))
 
-  if (missingSizes.length === 0) {
-    logger.debug('generateThumbnailsForFile', 'all thumbnails already exist', {
+    if (missingSizes.length === 0) {
+      logger.debug(
+        'generateThumbnailsForFile',
+        'all thumbnails already exist',
+        {
+          fileId: fileRecord.id,
+        },
+      )
+      return
+    }
+
+    // Generate missing thumbnails.
+    logger.debug('generateThumbnailsForFile', 'generating thumbnails', {
       fileId: fileRecord.id,
+      missingSizes,
     })
-    return
-  }
 
-  // Generate missing thumbnails.
-  logger.debug('generateThumbnailsForFile', 'generating thumbnails', {
-    fileId: fileRecord.id,
-    missingSizes,
-  })
-
-  for (const size of missingSizes) {
-    await ensureThumbnailForSize({
-      fileId: fileRecord.id,
-      fileHash: fileRecord.hash,
-      fileType: fileRecord.type,
-      fileLocalId: fileRecord.localId,
-      size,
-      sourceUri,
-    })
+    for (const size of missingSizes) {
+      await ensureThumbnailForSize({
+        fileId: fileRecord.id,
+        fileHash: fileRecord.hash,
+        fileType: fileRecord.type,
+        fileLocalId: fileRecord.localId,
+        size,
+        sourceUri,
+      })
+    }
+  } finally {
+    processingFiles.delete(fileRecord.id)
   }
 }
 

--- a/test/thumbnail-scanner-no-race.test.ts
+++ b/test/thumbnail-scanner-no-race.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Verifies concurrent thumbnail generation doesn't create duplicates.
+ */
+
+import './utils/setup'
+
+import { generateThumbnailsForFile } from '../src/managers/thumbnailer'
+import { readFileRecord } from '../src/stores/files'
+import { readThumbnailsByHash } from '../src/stores/thumbnails'
+import {
+  type AppCoreHarness,
+  addTestFilesToHarness,
+  createHarness,
+  generateTestFilesFromAssets,
+} from './utils/harness'
+import { TEST_ASSETS_DIR } from './utils/setup'
+import { sleep } from './utils/waitFor'
+
+describe('Regression: Thumbnail Scanner Race Condition', () => {
+  let harness: AppCoreHarness
+
+  beforeEach(async () => {
+    harness = createHarness()
+    await harness.start()
+  })
+
+  afterEach(async () => {
+    await harness.shutdown()
+  })
+
+  it('thumbnail scanner skips files being processed', async () => {
+    // Add an image file
+    const fileFactories = generateTestFilesFromAssets(TEST_ASSETS_DIR, [
+      'test-image-3.png',
+    ])
+    const files = await addTestFilesToHarness(harness, fileFactories)
+    const fileId = files[0].id
+    const fileHash = files[0].hash
+
+    // Get the file record
+    const fileRecord = await readFileRecord(fileId)
+    expect(fileRecord).not.toBeNull()
+
+    // Start manual thumbnail generation
+    const manualPromise = generateThumbnailsForFile(fileRecord!)
+
+    // Immediately wait a bit to let scanner potentially also start
+    // BUG: Without fix, scanner might also start generating
+    // resulting in race condition
+    await sleep(500)
+
+    await manualPromise
+
+    // Wait for any scanner activity to settle
+    await sleep(2000)
+
+    // Check only one set of thumbnails exists
+    const thumbnails = await readThumbnailsByHash(fileHash)
+    // Should have expected count, not duplicates
+    // Each thumbnail size should appear at most once
+    const sizeCount = new Map<number, number>()
+    for (const thumb of thumbnails) {
+      const size = thumb.thumbSize ?? 0
+      sizeCount.set(size, (sizeCount.get(size) ?? 0) + 1)
+    }
+
+    // No size should appear more than once (no duplicates)
+    for (const [, count] of sizeCount.entries()) {
+      expect(count).toBeLessThanOrEqual(1)
+    }
+
+    // Should have at most 2 thumbnails (64px and 512px) or 3 if there's another size
+    expect(thumbnails.length).toBeLessThanOrEqual(3)
+  }, 30_000)
+})


### PR DESCRIPTION
- Prevent thumbnail generation race condition.
- The scanner would sometimes run at the same time and schedule the same file.