### PR TITLE
test: add sync up metadata integration tests

### DIFF
--- a/src/managers/syncUpMetadata.ts
+++ b/src/managers/syncUpMetadata.ts
@@ -108,6 +108,21 @@ export type MetadataSyncResult = {
   failed: number
 }
 
+type LogContext = { fileId: string; objectId: string; fileName: string }
+
+async function tryWithLog<T>(
+  fn: () => T | Promise<T>,
+  operation: string,
+  ctx: LogContext,
+): Promise<T | null> {
+  try {
+    return await fn()
+  } catch (e) {
+    logger.error('syncUpMetadata', `${operation} failed`, { ...ctx, error: e })
+    return null
+  }
+}
+
 // Persistent cursor saved for next batch.
 const syncUpCursorCodec = z.codec(
   z.object({
@@ -175,28 +190,45 @@ export async function runSyncUpMetadata(batchSize: number): Promise<void> {
   for (const f of batch) {
     const obj = f.objects[indexerURL]
     if (!obj || !obj.id) continue
-    try {
-      const remote = await getPinnedObject(obj.id)
-      const remoteMeta = decodeFileMetadata(remote.metadata())
-      const diffs = diffFileMetadata(f, remoteMeta)
-      if (Object.keys(diffs).length === 0) continue
-      const isLocalNewer = (f.updatedAt || 0) >= (remoteMeta.updatedAt || 0)
-      logger.info(
-        'syncUpMetadata',
-        formatDiff({
-          fileId: f.id,
-          objectId: obj.id,
-          localMeta: f,
-          remoteMeta,
-          diffs,
-          isLocalNewer,
-        }),
+
+    const ctx = { fileId: f.id, objectId: obj.id, fileName: f.name }
+
+    const remote = await tryWithLog(
+      () => getPinnedObject(obj.id),
+      'getPinnedObject',
+      ctx,
+    )
+    if (!remote) continue
+
+    const remoteMeta = await tryWithLog(
+      () => decodeFileMetadata(remote.metadata()),
+      'decodeFileMetadata',
+      ctx,
+    )
+    if (!remoteMeta) continue
+
+    const diffs = diffFileMetadata(f, remoteMeta)
+    if (Object.keys(diffs).length === 0) continue
+
+    const isLocalNewer = (f.updatedAt || 0) >= (remoteMeta.updatedAt || 0)
+    logger.info(
+      'syncUpMetadata',
+      formatDiff({
+        fileId: f.id,
+        objectId: obj.id,
+        localMeta: f,
+        remoteMeta,
+        diffs,
+        isLocalNewer,
+      }),
+    )
+
+    if (isLocalNewer) {
+      await tryWithLog(
+        () => updateMetadata(remote, encodeFileMetadata(f)),
+        'updateMetadata',
+        ctx,
       )
-      if (isLocalNewer) {
-        await updateMetadata(remote, encodeFileMetadata(f))
-      }
-    } catch (e) {
-      logger.error('syncUpMetadata', 'error', e)
     }
   }
   const last = batch[batch.length - 1]

--- a/test/sync-up-metadata.test.ts
+++ b/test/sync-up-metadata.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for syncUpMetadata service - pushing local metadata changes to remote.
+ */
+
+import './utils/setup'
+
+import { decodeFileMetadata } from '../src/encoding/fileMetadata'
+import { readFileRecord, updateFileRecord } from '../src/stores/files'
+import { readLocalObjectsForFile } from '../src/stores/localObjects'
+import { getUploadState } from '../src/stores/uploads'
+import {
+  type AppCoreHarness,
+  addTestFilesToHarness,
+  createHarness,
+  generateTestFilesFromAssets,
+} from './utils/harness'
+import { TEST_ASSETS_DIR } from './utils/setup'
+import { waitForCondition } from './utils/waitFor'
+
+describe('Sync Up Metadata', () => {
+  let harness: AppCoreHarness
+
+  beforeEach(async () => {
+    harness = createHarness()
+    await harness.start()
+  })
+
+  afterEach(async () => {
+    await harness.shutdown()
+  })
+
+  /**
+   * Scenario: User renames a file locally while online.
+   * The syncUpMetadata service should push the rename to the remote server.
+   */
+  it('pushes local file rename to remote', async () => {
+    // Upload a real image file
+    const [file] = await addTestFilesToHarness(
+      harness,
+      generateTestFilesFromAssets(TEST_ASSETS_DIR, ['test-image-1.png']),
+    )
+
+    // Wait for scanner to detect the file
+    await waitForCondition(() => getUploadState(file.id) !== undefined, {
+      timeout: 10_000,
+      message: 'File to be detected by scanner',
+    })
+
+    // Wait for upload to complete
+    await harness.waitForNoActiveUploads()
+    const localObjects = await readLocalObjectsForFile(file.id)
+    expect(localObjects.length).toBeGreaterThan(0)
+    const objectId = localObjects[0].id
+
+    // Verify the file exists on the remote server
+    const remoteBeforeRename = await harness.sdk.object(objectId)
+    expect(remoteBeforeRename).toBeDefined()
+
+    // Simulate local rename by updating the file record
+    const newName = 'renamed-file.png'
+    const renameTimestamp = Date.now()
+    await updateFileRecord(
+      { id: file.id, name: newName, updatedAt: renameTimestamp },
+      true,
+      { includeUpdatedAt: true },
+    )
+
+    // Wait for syncUpMetadata service (runs every 2s) to propagate the change
+    await waitForCondition(
+      async () => {
+        const remote = await harness.sdk.object(objectId)
+        const remoteMeta = decodeFileMetadata(remote.metadata())
+        return remoteMeta.name === newName
+      },
+      { timeout: 10_000, message: 'Remote metadata to have new name' },
+    )
+
+    // Verify remote metadata has the new name
+    const remoteAfterSync = await harness.sdk.object(objectId)
+    const remoteMeta = decodeFileMetadata(remoteAfterSync.metadata())
+    expect(remoteMeta.name).toBe(newName)
+  }, 30_000)
+
+  /**
+   * Scenario: Remote has newer changes than local.
+   * The syncUpMetadata service should NOT overwrite newer remote changes.
+   */
+  it('does not overwrite newer remote changes', async () => {
+    // Upload two image files
+    const [file1, file2] = await addTestFilesToHarness(
+      harness,
+      generateTestFilesFromAssets(TEST_ASSETS_DIR, [
+        'test-image-1.png',
+        'test-image-2.png',
+      ]),
+    )
+
+    // Wait for uploads to complete
+    await waitForCondition(() => getUploadState(file1.id) !== undefined, {
+      timeout: 10_000,
+      message: 'File 1 to be detected by scanner',
+    })
+    await waitForCondition(() => getUploadState(file2.id) !== undefined, {
+      timeout: 10_000,
+      message: 'File 2 to be detected by scanner',
+    })
+    await harness.waitForNoActiveUploads()
+
+    const localObjects1 = await readLocalObjectsForFile(file1.id)
+    const localObjects2 = await readLocalObjectsForFile(file2.id)
+    expect(localObjects1.length).toBeGreaterThan(0)
+    expect(localObjects2.length).toBeGreaterThan(0)
+    const objectId1 = localObjects1[0].id
+    const objectId2 = localObjects2[0].id
+
+    // Read current file to get baseline updatedAt
+    const currentFile1 = await readFileRecord(file1.id)
+    const T1 = currentFile1!.updatedAt
+
+    // For file 1: Inject a remote metadata change with a FUTURE timestamp
+    const remoteNewerName = 'remote-edited-name.png'
+    const T_remote = T1 + 10000 // 10 seconds in the future
+    harness.sdk.injectMetadataChange(objectId1, {
+      name: remoteNewerName,
+      updatedAt: T_remote,
+    })
+
+    // Make a local edit to file 1 with an OLDER timestamp (will be ignored)
+    const localOlderName = 'local-older-edit.png'
+    const T_local_old = T1 + 1000 // 1 second after original, but before remote
+    await updateFileRecord(
+      { id: file1.id, name: localOlderName, updatedAt: T_local_old },
+      true,
+      { includeUpdatedAt: true },
+    )
+
+    // Make a normal local edit to file 2 (newer timestamp, should sync)
+    const file2NewName = 'file2-local-rename.png'
+    const T_file2 = Date.now()
+    await updateFileRecord(
+      { id: file2.id, name: file2NewName, updatedAt: T_file2 },
+      true,
+      { includeUpdatedAt: true },
+    )
+
+    // Wait for file 2's change to sync (proves the service ran)
+    await waitForCondition(
+      async () => {
+        const remote = await harness.sdk.object(objectId2)
+        const remoteMeta = decodeFileMetadata(remote.metadata())
+        return remoteMeta.name === file2NewName
+      },
+      { timeout: 10_000, message: 'File 2 remote metadata to have new name' },
+    )
+
+    // Verify file 1's remote metadata still has the newer remote edit (wasn't overwritten)
+    const remote1AfterSync = await harness.sdk.object(objectId1)
+    const remoteMeta1 = decodeFileMetadata(remote1AfterSync.metadata())
+    expect(remoteMeta1.name).toBe(remoteNewerName)
+    expect(remoteMeta1.updatedAt).toBe(T_remote)
+  }, 30_000)
+})


### PR DESCRIPTION
- Add integration tests for syncUpMetadata service.
- Improve error logging around sync failures, it was unclear which call was erroring.