### PR TITLE
fix: use SafeAreaView from safe-area-context

### DIFF
--- a/polyfills.ts
+++ b/polyfills.ts
@@ -1,12 +1,10 @@
 /* eslint-disable import/order */
 
-// @ts-expect-error - @types/react-native doesn't cover this file
-import { polyfillGlobal } from 'react-native/Libraries/Utilities/PolyfillFunctions'
-
 // Use a WHATWG-compliant ReadableStream for File.stream().
 import { ReadableStream } from 'web-streams-polyfill'
 
-polyfillGlobal('ReadableStream', () => ReadableStream)
+// @ts-expect-error - globalThis.ReadableStream type mismatch with polyfill
+globalThis.ReadableStream = ReadableStream
 
 import '@azure/core-asynciterator-polyfill'
 

--- a/src/components/AuthWebViewModal.tsx
+++ b/src/components/AuthWebViewModal.tsx
@@ -2,12 +2,12 @@ import { useCallback, useRef, useState } from 'react'
 import {
   ActivityIndicator,
   Modal,
-  SafeAreaView,
   StyleSheet,
   Text,
   TouchableOpacity,
   View,
 } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import { WebView, type WebViewNavigation } from 'react-native-webview'
 import { useAuthWebViewStore } from '../stores/authWebView'
 import { palette } from '../styles/colors'


### PR DESCRIPTION
- Fixes a warning that states accessing nested variables from `react-native` is deprecated. 