### PR TITLE
perf: optimize service batching for slab packing

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -23,7 +23,7 @@ export const SECTOR_SIZE = 4 * 1024 * 1024
 export const SLAB_SIZE =
   SECTOR_SIZE * (UPLOAD_DATA_SHARDS + UPLOAD_PARITY_SHARDS)
 // Packer idle timeout - flush partial slab after this delay.
-export const PACKER_IDLE_TIMEOUT = secondsInMs(5)
+export const PACKER_IDLE_TIMEOUT = secondsInMs(10)
 // Minimum slab fill percentage before allowing flush (0.0 - 1.0).
 // Prevents flushing when we could pack more efficiently.
 export const SLAB_FILL_THRESHOLD = 0.9
@@ -32,7 +32,7 @@ export const SCANNER_INTERVAL = secondsInMs(5) // 5 seconds
 // Sync events interval.
 export const SYNC_EVENTS_INTERVAL = secondsInMs(10) // 10 seconds
 // Sync new photos interval.
-export const SYNC_NEW_PHOTOS_INTERVAL = secondsInMs(30) // 30 seconds
+export const SYNC_NEW_PHOTOS_INTERVAL = secondsInMs(5) // 5 seconds
 // Sync archive photos interval.
 export const SYNC_PHOTOS_ARCHIVE_INTERVAL = secondsInMs(5) // 5 seconds
 // Thumbnail scanner interval.

--- a/src/lib/processAssets.ts
+++ b/src/lib/processAssets.ts
@@ -14,6 +14,19 @@ import { logger } from './logger'
 import { getMediaLibraryUri } from './mediaLibrary'
 import { uniqueId } from './uniqueId'
 
+const BATCH_SIZE = 10
+
+async function processInBatches<T>(
+  items: T[],
+  batchSize: number,
+  processor: (item: T) => Promise<void>,
+): Promise<void> {
+  for (let i = 0; i < items.length; i += batchSize) {
+    const batch = items.slice(i, i + batchSize)
+    await Promise.all(batch.map(processor))
+  }
+}
+
 type Asset = {
   id: string | undefined
   sourceUri: string | undefined
@@ -98,48 +111,49 @@ export async function processAssets(
 
   // Copy files to the app's file cache.
   // Add content hash and file size to files that are still new.
-  await Promise.all(
-    candidateFiles
-      .filter((f) => f.status === 'new')
-      .map(async (f) => {
-        // Verify that the localId is a valid Media Library or MediaStore ID.
-        const localUri = await getMediaLibraryUri(f.localId)
-        if (!localUri) {
-          f.localId = null
-        }
+  // Process in batches to limit memory pressure from large files.
+  await processInBatches(
+    candidateFiles.filter((f) => f.status === 'new'),
+    BATCH_SIZE,
+    async (f) => {
+      // Verify that the localId is a valid Media Library or MediaStore ID.
+      const localUri = await getMediaLibraryUri(f.localId)
+      if (!localUri) {
+        f.localId = null
+      }
 
-        // Verify we have a URI.
-        const bestUri = localUri ?? f.sourceUri
-        if (!bestUri) {
-          f.status = 'incomplete'
-          f.statusDetails = 'noUri'
-          return
-        }
+      // Verify we have a URI.
+      const bestUri = localUri ?? f.sourceUri
+      if (!bestUri) {
+        f.status = 'incomplete'
+        f.statusDetails = 'noUri'
+        return
+      }
 
-        // Copy the file to the app's file cache.
-        const fileUri = await copyFileToFs(f, new File(bestUri))
-        if (!fileUri) {
-          f.status = 'incomplete'
-          f.statusDetails = 'invalidUri'
-          return
-        }
+      // Copy the file to the app's file cache.
+      const fileUri = await copyFileToFs(f, new File(bestUri))
+      if (!fileUri) {
+        f.status = 'incomplete'
+        f.statusDetails = 'invalidUri'
+        return
+      }
 
-        const hash = await calculateContentHash(fileUri)
-        if (!hash) {
-          f.status = 'incomplete'
-          f.statusDetails = 'noContentHash'
-          return
-        }
-        f.hash = hash
+      const hash = await calculateContentHash(fileUri)
+      if (!hash) {
+        f.status = 'incomplete'
+        f.statusDetails = 'noContentHash'
+        return
+      }
+      f.hash = hash
 
-        const size = getFileSize(fileUri)
-        if (!size) {
-          f.status = 'incomplete'
-          f.statusDetails = 'noFileSize'
-          return
-        }
-        f.size = size
-      }),
+      const size = getFileSize(fileUri)
+      if (!size) {
+        f.status = 'incomplete'
+        f.statusDetails = 'noFileSize'
+        return
+      }
+      f.size = size
+    },
   )
 
   // Check for duplicates by content hash.

--- a/src/managers/syncPhotosArchive.ts
+++ b/src/managers/syncPhotosArchive.ts
@@ -18,7 +18,7 @@ import {
 import { librarySwr } from '../stores/library'
 import { settingsSwr } from '../stores/settings'
 
-const PAGE_SIZE = 1
+const PAGE_SIZE = 50
 
 export async function workBackward() {
   if (!(await getMediaLibraryPermissions())) return

--- a/src/managers/uploadScanner.ts
+++ b/src/managers/uploadScanner.ts
@@ -48,7 +48,7 @@ async function startUploadScanner(): Promise<void> {
 
     // Get candidate files, sorted by size ascending (small files first)
     const candidateFiles = await getFilesLocalOnly({
-      limit: 50,
+      limit: 200,
       order: 'ASC',
     })
 


### PR DESCRIPTION
- Upload scanner queries 200 candidates for better potential packing efficiency.
- Sync photos archive in batches of 50 every 5 seconds. (Up from 1 every 5 seconds).
- At batch limit to processAssets. Does not consider the size (often unknown at this stage) but provides a little bit of simple limiting.
- Sync new photos more frequently, every 5 seconds.