### PR TITLE
fix: add error cooldown and magic byte detection for thumbnails

### DIFF
--- a/.changeset/thumbnail-error-cooldown.md
+++ b/.changeset/thumbnail-error-cooldown.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Added error cooldown and magic byte detection for thumbnail generation.

--- a/src/managers/thumbnailScanner.ts
+++ b/src/managers/thumbnailScanner.ts
@@ -5,7 +5,11 @@ import { createServiceInterval } from '../lib/serviceInterval'
 import { type ThumbSize, ThumbSizes } from '../stores/files'
 import { getFsFileUri } from '../stores/fs'
 import { readThumbnailSizesForHash } from '../stores/thumbnails'
-import { ensureThumbnailForSize, isFileBeingProcessed } from './thumbnailer'
+import {
+  ensureThumbnailForSize,
+  isFileBeingProcessed,
+  isFileInErrorCooldown,
+} from './thumbnailer'
 
 const MAX_THUMBS_PER_TICK = 10
 
@@ -34,6 +38,7 @@ export type ThumbnailScannerResult = {
   deduplicated: DeduplicatedThumbnail[]
   skippedNoSource: Array<{ fileId: string; hash: string }>
   skippedFullyCovered: Array<{ fileId: string; hash: string }>
+  skippedErrorCooldown: Array<{ fileId: string; hash: string }>
   errors: ThumbnailGenerationError[]
 }
 
@@ -142,6 +147,7 @@ export async function runThumbnailScanner(): Promise<ThumbnailScannerResult> {
     deduplicated: [],
     skippedNoSource: [],
     skippedFullyCovered: [],
+    skippedErrorCooldown: [],
     errors: [],
   }
   let producedCount = 0
@@ -162,6 +168,12 @@ export async function runThumbnailScanner(): Promise<ThumbnailScannerResult> {
 
         // Skip files currently being processed by generateThumbnailsForFile.
         if (isFileBeingProcessed(c.id)) {
+          continue
+        }
+
+        // Skip files that recently errored (cooldown period).
+        if (isFileInErrorCooldown(c.id)) {
+          summary.skippedErrorCooldown.push({ fileId: c.id, hash: c.hash })
           continue
         }
 
@@ -244,10 +256,15 @@ export async function runThumbnailScanner(): Promise<ThumbnailScannerResult> {
         }
       }
     }
-    logger.info(
-      'thumbnailScanner',
-      `batch produced=${summary.produced.length}/${summary.processedCandidates} skippedNoSource=${summary.skippedNoSource.length}/${summary.processedCandidates} skippedFullyCovered=${summary.skippedFullyCovered.length}/${summary.processedCandidates} errors=${summary.errors.length}/${summary.processedCandidates} deduplicated=${summary.deduplicated.length}/${summary.processedCandidates}`,
-    )
+    logger.info('thumbnailScanner', 'batch complete', {
+      produced: summary.produced.length,
+      skippedNoSource: summary.skippedNoSource.length,
+      skippedFullyCovered: summary.skippedFullyCovered.length,
+      skippedErrorCooldown: summary.skippedErrorCooldown.length,
+      errors: summary.errors.length,
+      deduplicated: summary.deduplicated.length,
+      total: summary.processedCandidates + summary.skippedErrorCooldown.length,
+    })
     await logOverallProgress()
   } catch (e) {
     logger.error('thumbnailScanner', 'scan error', e)

--- a/src/managers/thumbnailer.ts
+++ b/src/managers/thumbnailer.ts
@@ -3,6 +3,7 @@ import { ImageManipulator, SaveFormat } from 'expo-image-manipulator'
 import * as VideoThumbnails from 'expo-video-thumbnails'
 import { Image } from 'react-native'
 import { calculateContentHash } from '../lib/contentHash'
+import { detectMimeType } from '../lib/detectMimeType'
 import { getMimeType } from '../lib/fileTypes'
 import { logger } from '../lib/logger'
 import { uniqueId } from '../lib/uniqueId'
@@ -24,8 +25,27 @@ import {
 // between generateThumbnailsForFile and thumbnailScanner.
 const processingFiles = new Set<string>()
 
+// Maps fileId to last error timestamp. Files are skipped for ERROR_COOLDOWN_MS.
+const erroredFiles = new Map<string, number>()
+const ERROR_COOLDOWN_MS = 60 * 60 * 1000 // 1 hour
+
 export function isFileBeingProcessed(fileId: string): boolean {
   return processingFiles.has(fileId)
+}
+
+export function isFileInErrorCooldown(fileId: string): boolean {
+  const lastError = erroredFiles.get(fileId)
+  if (!lastError) return false
+  const elapsed = Date.now() - lastError
+  if (elapsed >= ERROR_COOLDOWN_MS) {
+    erroredFiles.delete(fileId)
+    return false
+  }
+  return true
+}
+
+function markFileErrored(fileId: string): void {
+  erroredFiles.set(fileId, Date.now())
 }
 
 /**
@@ -136,12 +156,45 @@ export async function ensureThumbnailForSize(params: {
     return { status: 'exists' }
   }
 
-  logger.debug('thumbnailer', 'source uri', { fileId, uri: sourceUri })
+  // Detect actual MIME type from file content using magic bytes.
+  const detectedType = await detectMimeType(sourceUri)
+  const actualType = detectedType ?? fileType
+
+  // Log if there's a mismatch between stored and detected types.
+  if (detectedType && detectedType !== fileType) {
+    logger.warn('thumbnailer', 'type mismatch detected', {
+      fileId,
+      storedType: fileType,
+      detectedType,
+      sourceUri,
+    })
+  }
+
+  // Skip unsupported formats early.
+  if (!actualType?.startsWith('image/') && !actualType?.startsWith('video/')) {
+    logger.error('thumbnailer', 'unsupported format', {
+      fileId,
+      fileHash,
+      size,
+      storedType: fileType,
+      detectedType,
+      sourceUri,
+    })
+    markFileErrored(fileId)
+    return { status: 'error', error: new Error('Unsupported format') }
+  }
+
+  logger.debug('thumbnailer', 'source uri', {
+    fileId,
+    uri: sourceUri,
+    storedType: fileType,
+    detectedType,
+  })
 
   // Compute input and target aspect-preserving dimensions for thumb size = size.
   let info: ThumbnailInfo | null = null
   try {
-    if (fileType?.startsWith('video/')) {
+    if (actualType?.startsWith('video/')) {
       info = await prepareVideoThumbnail(sourceUri, size)
       logger.debug('thumbnailer', 'video base frame prepared', {
         fileId,
@@ -157,7 +210,16 @@ export async function ensureThumbnailForSize(params: {
       })
     }
   } catch (e) {
-    logger.error('thumbnailer', 'error preparing source', e)
+    logger.error('thumbnailer', 'error preparing source', {
+      fileId,
+      fileHash,
+      size,
+      storedType: fileType,
+      detectedType,
+      sourceUri,
+      error: e,
+    })
+    markFileErrored(fileId)
     return { status: 'error', error: e }
   }
 
@@ -189,6 +251,7 @@ export async function ensureThumbnailForSize(params: {
     const thumbHash = await calculateContentHash(fileUri)
     if (!thumbHash) {
       logger.error('thumbnailer', 'failed to calculate hash', { fileId, size })
+      markFileErrored(fileId)
       return { status: 'error', error: new Error('Missing thumbnail hash') }
     }
 
@@ -239,7 +302,17 @@ export async function ensureThumbnailForSize(params: {
       height: result.height ?? null,
     }
   } catch (e) {
-    logger.error('thumbnailer', 'error generating thumbnail', e)
+    logger.error('thumbnailer', 'error generating thumbnail', {
+      fileId,
+      fileHash,
+      size,
+      storedType: fileType,
+      detectedType,
+      sourceUri,
+      inputUri: info.inputUri,
+      error: e,
+    })
+    markFileErrored(fileId)
     return { status: 'error', error: e }
   }
 }


### PR DESCRIPTION
- Thumbnails errors were being retried endlessly, this gives them a cooldown so the thumbnailer can process other files. Errors should never really occur, if we see any more errors in logs we should investigate.
- This also adds magic byte type detection, with fallback to the stored type, and logs when they differ, which should never really occur.