### PR TITLE
fix: carousel windowSize, starting index, and DB query optimization

### DIFF
--- a/src/components/FileCarousel/index.tsx
+++ b/src/components/FileCarousel/index.tsx
@@ -109,6 +109,31 @@ export function FileCarousel({
     return Array.from({ length: totalCount }, (_, i) => i)
   }, [totalCount])
 
+  // Scroll to the file's position once we know it. The carousel's defaultIndex
+  // only works on mount, but currentIndex is determined asynchronously after
+  // querying the DB for the file's position in the sorted list. Once totalCount
+  // transitions from placeholder (0 or 1) to the real count, scroll to position.
+  const hasScrolledToInitialPosition = useRef(false)
+  const previousTotalCount = useRef(totalCount)
+
+  useEffect(() => {
+    const wasInitial = previousTotalCount.current <= 1
+    const isNowReal = totalCount > 1
+    const carousel = carouselRef.current
+    const carouselReady = viewerSize.width > 0 && carousel
+
+    if (
+      wasInitial &&
+      isNowReal &&
+      carouselReady &&
+      !hasScrolledToInitialPosition.current
+    ) {
+      hasScrolledToInitialPosition.current = true
+      carousel.scrollTo({ index: currentIndex, animated: false })
+    }
+    previousTotalCount.current = totalCount
+  }, [totalCount, currentIndex, viewerSize.width])
+
   // Unlock screen orientation.
   useEffect(() => {
     ScreenOrientation.lockAsync(
@@ -282,6 +307,7 @@ export function FileCarousel({
               onSnapToItem={handleSnapToItem}
               loop={false}
               enabled={!isZoomed}
+              windowSize={5}
               onConfigurePanGesture={(gesture) => {
                 gesture.activeOffsetX([-10, 10])
               }}

--- a/src/stores/fileCarousel.test.ts
+++ b/src/stores/fileCarousel.test.ts
@@ -9,9 +9,22 @@ import {
 import { createFileRecord } from './files'
 import type { Category } from './library'
 
-// Track registered change callbacks so tests can trigger them.
-// Prefixed with "mock" to satisfy Jest's module factory variable restriction.
 const mockChangeCallbacks = new Map<string, () => void>()
+
+jest.mock('./librarySwr', () => ({
+  librarySwr: {
+    triggerChange: jest.fn(() => {
+      mockChangeCallbacks.forEach((callback) => callback())
+    }),
+    addChangeCallback: jest.fn((key: string, callback: () => void) => {
+      mockChangeCallbacks.set(key, callback)
+    }),
+    removeChangeCallback: jest.fn((key: string) => {
+      mockChangeCallbacks.delete(key)
+    }),
+    getKey: jest.fn((key: string) => key),
+  },
+}))
 
 jest.mock('./library', () => {
   const actual = jest.requireActual('./library')
@@ -23,16 +36,6 @@ jest.mock('./library', () => {
       selectedCategories: new Set(),
       searchQuery: '',
     }),
-    librarySwr: {
-      triggerChange: jest.fn(),
-      addChangeCallback: jest.fn((key: string, cb: () => void) => {
-        mockChangeCallbacks.set(key, cb)
-      }),
-      removeChangeCallback: jest.fn((key: string) => {
-        mockChangeCallbacks.delete(key)
-      }),
-      getKey: jest.fn((key: string) => key),
-    },
   }
 })
 
@@ -503,7 +506,7 @@ describe('useVirtualFileList hook', () => {
   }
 
   function triggerSyncChange() {
-    mockChangeCallbacks.forEach((cb) => cb())
+    mockChangeCallbacks.forEach((callback) => callback())
   }
 
   describe('sync event handling', () => {
@@ -601,6 +604,119 @@ describe('useVirtualFileList hook', () => {
         expect(result.current.totalCount).toBe(2)
       })
       expect(result.current.currentIndex).toBe(0)
+    })
+  })
+
+  describe('cache duplicate bug - opening file at position N', () => {
+    test('opening 3rd file and navigating back shows unique files', async () => {
+      // DESC order: file-6(0), file-5(1), file-4(2), file-3(3), file-2(4), file-1(5)
+      await createRecord({ id: 'file-1', name: 'a.jpg', createdAt: base })
+      await createRecord({ id: 'file-2', name: 'b.jpg', createdAt: base + 10 })
+      await createRecord({ id: 'file-3', name: 'c.jpg', createdAt: base + 20 })
+      await createRecord({ id: 'file-4', name: 'd.jpg', createdAt: base + 30 })
+      await createRecord({ id: 'file-5', name: 'e.jpg', createdAt: base + 40 })
+      await createRecord({ id: 'file-6', name: 'f.jpg', createdAt: base + 50 })
+
+      const initialFile = {
+        id: 'file-3',
+        name: 'c.jpg',
+        type: 'image/jpeg',
+        size: 100,
+        hash: 'hash-file-3',
+        createdAt: base + 20,
+        updatedAt: base + 20,
+        localId: null,
+        addedAt: base + 20,
+        thumbForHash: undefined,
+        thumbSize: undefined,
+        objects: {},
+        objectsHash: '',
+      }
+
+      // file-3 is at position 3, prefetchRadius: 1 means positions 2-4 are fetched
+      const { result } = renderHook(() =>
+        useVirtualFileList({
+          initialId: 'file-3',
+          initialFile,
+          prefetchRadius: 1,
+        }),
+      )
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+        expect(result.current.currentIndex).toBe(3)
+      })
+
+      expect(result.current.currentFile?.id).toBe('file-3')
+      expect(result.current.totalCount).toBe(6)
+
+      // Position 0 should not have a cached file (not in prefetch range)
+      const file0 = result.current.getFileAtIndex(0)
+      expect(file0).toBeNull()
+    })
+
+    test('opening 5th file shows unique files across all positions', async () => {
+      await createRecord({ id: 'file-1', name: 'a.jpg', createdAt: base })
+      await createRecord({ id: 'file-2', name: 'b.jpg', createdAt: base + 10 })
+      await createRecord({ id: 'file-3', name: 'c.jpg', createdAt: base + 20 })
+      await createRecord({ id: 'file-4', name: 'd.jpg', createdAt: base + 30 })
+      await createRecord({ id: 'file-5', name: 'e.jpg', createdAt: base + 40 })
+      await createRecord({ id: 'file-6', name: 'f.jpg', createdAt: base + 50 })
+
+      // User taps on file-2 (which is at position 4 in DESC order)
+      const { result } = renderHook(() =>
+        useVirtualFileList({
+          initialId: 'file-2',
+          prefetchRadius: 5,
+        }),
+      )
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      expect(result.current.currentIndex).toBe(4)
+
+      // Get all files
+      const files = []
+      for (let i = 0; i < 6; i++) {
+        files.push(result.current.getFileAtIndex(i))
+      }
+
+      // All 6 positions should have unique files
+      const ids = files.map((f) => f?.id).filter(Boolean)
+      expect(new Set(ids).size).toBe(6)
+
+      // Verify correct order (DESC by createdAt)
+      expect(files[0]?.id).toBe('file-6')
+      expect(files[1]?.id).toBe('file-5')
+      expect(files[2]?.id).toBe('file-4')
+      expect(files[3]?.id).toBe('file-3')
+      expect(files[4]?.id).toBe('file-2')
+      expect(files[5]?.id).toBe('file-1')
+    })
+
+    test('opening first file (position 0) keeps file at index 0', async () => {
+      await createRecord({ id: 'file-1', name: 'a.jpg', createdAt: base })
+      await createRecord({ id: 'file-2', name: 'b.jpg', createdAt: base + 10 })
+      await createRecord({ id: 'file-3', name: 'c.jpg', createdAt: base + 20 })
+
+      // User taps on file-3 (which is at position 0 in DESC order)
+      const { result } = renderHook(() =>
+        useVirtualFileList({
+          initialId: 'file-3',
+          prefetchRadius: 2,
+        }),
+      )
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      expect(result.current.currentIndex).toBe(0)
+      expect(result.current.getFileAtIndex(0)?.id).toBe('file-3')
+      expect(result.current.getFileAtIndex(1)?.id).toBe('file-2')
+      expect(result.current.getFileAtIndex(2)?.id).toBe('file-1')
     })
   })
 })

--- a/src/stores/fileCarousel.ts
+++ b/src/stores/fileCarousel.ts
@@ -5,11 +5,11 @@ import { type FileRecord, type FileRecordRow, transformRow } from './files'
 import {
   buildLibraryQueryParts,
   type Category,
-  librarySwr,
   type SortBy,
   type SortDir,
   useLibrary,
 } from './library'
+import { librarySwr } from './librarySwr'
 import { readLocalObjectsForFiles } from './localObjects'
 
 const FILE_COLUMNS =
@@ -143,7 +143,9 @@ export async function fetchFilePosition(
     fileId,
   )
 
-  if (!anchorRow) return 0
+  if (!anchorRow) {
+    return 0
+  }
 
   const beforeCursor =
     params.sortBy === 'NAME'
@@ -175,17 +177,15 @@ export async function fetchFilePosition(
   return result?.count ?? 0
 }
 
-type FileRecordRowWithIndex = FileRecordRow & { __virtual_index: number }
-
-// Fetches multiple files by their sorted position in a single query.
-// We build one SELECT per index, tag each with its position, then UNION ALL
-// them together so we only make one database round-trip.
+// Fetches files at the given indices by querying the contiguous range they span.
 export async function fetchFilesAtIndices(
   indices: number[],
   params: VirtualListQueryParams,
 ): Promise<Map<number, FileRecord>> {
   const result = new Map<number, FileRecord>()
-  if (indices.length === 0) return result
+  if (indices.length === 0) {
+    return result
+  }
 
   const { where, params: queryParams } = buildLibraryQueryParts({
     sortBy: params.sortBy,
@@ -197,34 +197,30 @@ export async function fetchFilesAtIndices(
 
   const orderExpr = buildOrderExpr(params.sortBy, params.sortDir)
 
-  // Build a UNION ALL query: one SELECT per index, each tagged with its index.
-  // Each sub-SELECT is wrapped in a subquery so ORDER BY/LIMIT/OFFSET apply
-  // to each individually (SQLite requires ORDER BY after UNION otherwise).
-  const selectStatements: string[] = []
-  const allParams: (string | number | null)[] = []
+  // Find the range of indices we need
+  const minIndex = Math.min(...indices)
+  const maxIndex = Math.max(...indices)
+  const rangeSize = maxIndex - minIndex + 1
 
-  for (const index of indices) {
-    selectStatements.push(
-      `SELECT *, ? as __virtual_index FROM (SELECT ${FILE_COLUMNS} FROM files f ${
-        where ?? ''
-      } ORDER BY ${orderExpr} LIMIT 1 OFFSET ?)`,
-    )
-    // Parameter order: virtual index tag, then WHERE params, then OFFSET value
-    allParams.push(index, ...queryParams, index)
-  }
-
-  const sql = selectStatements.join(' UNION ALL ')
-  const rows = await db().getAllAsync<FileRecordRowWithIndex>(sql, ...allParams)
+  // Single query: fetch the entire range with one LIMIT/OFFSET
+  // This is O(n) instead of O(n*m) for m indices
+  const sql = `SELECT ${FILE_COLUMNS} FROM files f ${where ?? ''} ORDER BY ${orderExpr} LIMIT ? OFFSET ?`
+  const rows = await db().getAllAsync<FileRecordRow>(
+    sql,
+    ...queryParams,
+    rangeSize,
+    minIndex,
+  )
 
   // Hydrate all rows in one batch
   const hydratedFiles = await hydrateRows(rows)
 
-  // Map each file back to its index using the tagged __virtual_index
-  for (let i = 0; i < rows.length; i++) {
-    const row = rows[i]
-    const file = hydratedFiles[i]
-    if (file) {
-      result.set(row.__virtual_index, file)
+  // Map each file to its absolute index
+  const indicesSet = new Set(indices)
+  for (let i = 0; i < hydratedFiles.length; i++) {
+    const absoluteIndex = minIndex + i
+    if (indicesSet.has(absoluteIndex)) {
+      result.set(absoluteIndex, hydratedFiles[i])
     }
   }
 
@@ -296,18 +292,17 @@ export function useVirtualFileList({
   const sortingDir: SortDir = sortDir ?? (sortBy === 'NAME' ? 'ASC' : 'DESC')
 
   const [currentIndex, setCurrentIndexState] = useState<number>(0)
-  // Seed with 1 if we have initialFile so carousel can render before count loads.
   const [totalCount, setTotalCount] = useState<number>(initialFile ? 1 : 0)
-  const [isLoading, setIsLoading] = useState(true)
+  const [isLoading, setIsLoading] = useState(!initialFile)
 
-  const cacheRef = useRef<Map<number, FileRecord>>(new Map())
+  const cacheRef = useRef<Map<number, FileRecord>>(
+    initialFile ? new Map([[0, initialFile]]) : new Map(),
+  )
   const fetchingRef = useRef<Set<number>>(new Set())
   const [cacheVersion, setCacheVersion] = useState(0)
 
-  // Store initialFile in a ref so it doesn't cause re-init when reference changes
   const initialFileRef = useRef(initialFile)
 
-  // Serialize categories to a stable string to avoid re-init when Set reference changes
   const categoriesKey = useMemo(
     () =>
       Array.from(selectedCategories ?? new Set())
@@ -331,8 +326,12 @@ export function useVirtualFileList({
     let cancelled = false
 
     async function init() {
-      setIsLoading(true)
-      cacheRef.current.clear()
+      // If we have initialFile, don't show loading state - render immediately
+      // while we fetch position/count in the background
+      if (!initialFileRef.current) {
+        setIsLoading(true)
+        cacheRef.current.clear()
+      }
       fetchingRef.current.clear()
 
       try {
@@ -342,6 +341,14 @@ export function useVirtualFileList({
         ])
 
         if (cancelled) return
+
+        // Move initialFile from index 0 to its actual position.
+        if (initialFileRef.current) {
+          if (position !== 0) {
+            cacheRef.current.delete(0)
+          }
+          cacheRef.current.set(position, initialFileRef.current)
+        }
 
         setTotalCount(count)
         setCurrentIndexState(position)
@@ -353,10 +360,6 @@ export function useVirtualFileList({
           i++
         ) {
           indicesToFetch.push(i)
-        }
-
-        if (initialFileRef.current) {
-          cacheRef.current.set(position, initialFileRef.current)
         }
 
         const fetched = await fetchFilesAtIndices(
@@ -460,87 +463,84 @@ export function useVirtualFileList({
     currentFileIDRef.current = file?.id ?? null
   }, [currentIndex, cacheVersion])
 
-  useEffect(() => {
+  const handleLibraryChange = useCallback(async () => {
     if (isLoading) return
 
-    const handleChange = async () => {
-      const currentFileID = currentFileIDRef.current
-      if (!currentFileID) return
+    const currentFileID = currentFileIDRef.current
+    if (!currentFileID) return
 
-      try {
-        const exists = await fileExists(currentFileID)
-        if (!exists) {
-          onDeleted?.()
-          return
-        }
+    try {
+      const exists = await fileExists(currentFileID)
+      if (!exists) {
+        onDeleted?.()
+        return
+      }
 
-        const [newCount, newPosition] = await Promise.all([
-          fetchTotalCount(queryParams),
-          fetchFilePosition(currentFileID, queryParams),
-        ])
+      const [newCount, newPosition] = await Promise.all([
+        fetchTotalCount(queryParams),
+        fetchFilePosition(currentFileID, queryParams),
+      ])
 
-        if (newCount !== totalCount || newPosition !== currentIndex) {
-          setTotalCount(newCount)
-          setCurrentIndexState(newPosition)
-          cacheRef.current.clear()
-          fetchingRef.current.clear()
-          setCacheVersion((v) => v + 1)
-        }
+      if (newCount !== totalCount || newPosition !== currentIndex) {
+        setTotalCount(newCount)
+        setCurrentIndexState(newPosition)
+        cacheRef.current.clear()
+        fetchingRef.current.clear()
+        setCacheVersion((v) => v + 1)
+      }
 
-        const cachedFile = cacheRef.current.get(currentIndex)
-        if (cachedFile && cachedFile.id === currentFileID) {
-          const freshFile = await fetchFileByID(currentFileID)
-          if (freshFile) {
-            const nameChanged = cachedFile.name !== freshFile.name
-            const metadataChanged =
-              nameChanged ||
-              cachedFile.updatedAt !== freshFile.updatedAt ||
-              cachedFile.size !== freshFile.size ||
-              cachedFile.type !== freshFile.type
+      const cachedFile = cacheRef.current.get(currentIndex)
+      if (cachedFile && cachedFile.id === currentFileID) {
+        const freshFile = await fetchFileByID(currentFileID)
+        if (freshFile) {
+          const nameChanged = cachedFile.name !== freshFile.name
+          const metadataChanged =
+            nameChanged ||
+            cachedFile.updatedAt !== freshFile.updatedAt ||
+            cachedFile.size !== freshFile.size ||
+            cachedFile.type !== freshFile.type
 
-            if (metadataChanged) {
-              cacheRef.current.set(currentIndex, freshFile)
-              setCacheVersion((v) => v + 1)
+          if (metadataChanged) {
+            cacheRef.current.set(currentIndex, freshFile)
+            setCacheVersion((v) => v + 1)
 
-              const message = nameChanged ? 'File renamed' : 'File info updated'
-              onUpdated?.(message)
+            const message = nameChanged ? 'File renamed' : 'File info updated'
+            onUpdated?.(message)
 
-              if (nameChanged && sortBy === 'NAME') {
-                const updatedPosition = await fetchFilePosition(
-                  currentFileID,
-                  queryParams,
-                )
-                if (updatedPosition !== currentIndex) {
-                  setCurrentIndexState(updatedPosition)
-                  cacheRef.current.clear()
-                  fetchingRef.current.clear()
-                  setCacheVersion((v) => v + 1)
-                }
+            if (nameChanged && sortBy === 'NAME') {
+              const updatedPosition = await fetchFilePosition(
+                currentFileID,
+                queryParams,
+              )
+              if (updatedPosition !== currentIndex) {
+                setCurrentIndexState(updatedPosition)
+                cacheRef.current.clear()
+                fetchingRef.current.clear()
+                setCacheVersion((v) => v + 1)
               }
             }
           }
         }
-      } catch (_e) {
-        // Silently ignore errors during sync handling.
       }
-    }
-
-    const callbackKey = `virtualFileList-${initialId}`
-    librarySwr.addChangeCallback(callbackKey, handleChange)
-
-    return () => {
-      librarySwr.removeChangeCallback(callbackKey)
+    } catch (_e) {
+      // Silently ignore errors during sync handling.
     }
   }, [
     isLoading,
-    initialId,
+    onDeleted,
     queryParams,
     totalCount,
     currentIndex,
     sortBy,
-    onDeleted,
     onUpdated,
   ])
+
+  useEffect(() => {
+    librarySwr.addChangeCallback('carousel', handleLibraryChange)
+    return () => {
+      librarySwr.removeChangeCallback('carousel')
+    }
+  }, [handleLibraryChange])
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: cacheVersion forces new function reference when cache updates
   const getFileAtIndex = useCallback(


### PR DESCRIPTION
- The carousel was locking up the app when tested with large libraries, this was due to lack of windowSize prop.
- Items were being loaded out of order, this was an issue with defaultIndex and adjusting for async initial index.
- The database query was slow, updated to a simpler faster query.
- Fixed an issue where files would not appear immediately even if they were available.