### PR TITLE
perf: RAF-throttle progress updates, fs usedAt throttle, library debounce

### DIFF
--- a/.changeset/debounce-library-updates.md
+++ b/.changeset/debounce-library-updates.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Improved performance for quick interactions, bulk uploads, and progress updates.

--- a/src/hooks/useDebouncedCallback.ts
+++ b/src/hooks/useDebouncedCallback.ts
@@ -1,0 +1,16 @@
+import { useCallback, useRef } from 'react'
+
+export function useDebouncedCallback<T extends (...args: never[]) => void>(
+  callback: T,
+  delayMs: number,
+): T {
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  return useCallback(
+    ((...args) => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
+      timeoutRef.current = setTimeout(() => callback(...args), delayMs)
+    }) as T,
+    [callback, delayMs],
+  )
+}

--- a/src/managers/uploader.test.ts
+++ b/src/managers/uploader.test.ts
@@ -31,6 +31,7 @@ import type { LocalObject } from '../encoding/localObject'
 import { createFileRecord, readFileRecord } from '../stores/files'
 import { readLocalObjectsForFile } from '../stores/localObjects'
 import {
+  flushPendingUploadProgress,
   getActiveUploads,
   getUploadState,
   useUploadsStore,
@@ -561,6 +562,9 @@ describe('UploadManager', () => {
 
       // Simulate progress update (50%)
       progressCallback!(BigInt(50), BigInt(100))
+
+      // Flush the RAF-batched progress update
+      flushPendingUploadProgress()
 
       // Progress should be updated in store
       const uploadAfter = getUploadState('file1')

--- a/src/stores/downloads.ts
+++ b/src/stores/downloads.ts
@@ -23,6 +23,25 @@ export const useDownloadsStore = create<DownloadsStore>(() => ({
 
 const { getState, setState } = useDownloadsStore
 
+const pendingDownloadProgress = new Map<string, number>()
+let downloadRafScheduled = false
+
+function flushDownloadProgress() {
+  if (pendingDownloadProgress.size === 0) return
+  setState((state) => {
+    const downloads = { ...state.downloads }
+    for (const [id, progress] of pendingDownloadProgress) {
+      const prev = downloads[id]
+      if (prev) {
+        downloads[id] = { ...prev, progress }
+      }
+    }
+    pendingDownloadProgress.clear()
+    downloadRafScheduled = false
+    return { downloads }
+  })
+}
+
 function registerDownload(id: string): AbortController {
   const controller = new AbortController()
   setState((state) => {
@@ -122,18 +141,11 @@ export async function runDownloadWithSlot<T>(params: {
 }
 
 export function updateDownloadProgress(id: string, progress: number) {
-  setState((state) => {
-    const prev = state.downloads[id]
-    if (!prev) return state
-    const next: DownloadState = {
-      id,
-      controller: prev.controller,
-      status: prev.status,
-      progress,
-      error: prev.error,
-    }
-    return { downloads: { ...state.downloads, [id]: next } }
-  })
+  pendingDownloadProgress.set(id, progress)
+  if (!downloadRafScheduled) {
+    downloadRafScheduled = true
+    requestAnimationFrame(flushDownloadProgress)
+  }
 }
 
 export const [getDownloadState, useDownloadState] = createGetterAndSelector(

--- a/src/stores/fs.ts
+++ b/src/stores/fs.ts
@@ -50,15 +50,18 @@ function getFsFileForId(file: FsFileInfo): File {
   return new File(fsStorageDirectory, `${file.id}${extFromMime(file.type)}`)
 }
 
+// Throttle usedAt updates to reduce DB writes during browsing.
+const USED_AT_UPDATE_INTERVAL_MS = 60 * 60 * 1000 // 1 hour
+
 export async function getFsFileUri(file: FsFileInfo): Promise<string | null> {
   const existingMeta = await readFsFileMetadata(file.id)
   const fsFile = getFsFileForId(file)
   const info = fsFile.info()
+
   if (!info.exists) {
     // If the file no longer exists, remove the metadata.
     if (existingMeta) {
       await deleteFsFileMetadata(file.id)
-      await fsTriggerRefresh(file.id)
     }
     return null
   }
@@ -74,10 +77,12 @@ export async function getFsFileUri(file: FsFileInfo): Promise<string | null> {
       addedAt: now,
       usedAt: now,
     })
-    await fsTriggerRefresh(file.id)
   } else {
-    // If the file exists, update the last used timestamp.
-    await updateFsFileMetadataUsedAt(file.id, now)
+    // File exists and is tracked - only update usedAt if it's stale
+    const timeSinceLastUse = now - existingMeta.usedAt
+    if (timeSinceLastUse > USED_AT_UPDATE_INTERVAL_MS) {
+      await updateFsFileMetadataUsedAt(file.id, now)
+    }
   }
 
   return fsFile.uri

--- a/src/stores/library.ts
+++ b/src/stores/library.ts
@@ -1,7 +1,9 @@
+import { useEffect, useMemo } from 'react'
 import useSWR from 'swr'
 import useSWRInfinite from 'swr/infinite'
 import { create } from 'zustand'
 import { db } from '../db'
+import { useDebouncedCallback } from '../hooks/useDebouncedCallback'
 import { type FileRecord, type FileRecordRow, transformRow } from './files'
 import { librarySwr } from './librarySwr'
 import { readLocalObjectsForFiles } from './localObjects'
@@ -101,10 +103,20 @@ export function useFileList() {
     { revalidateOnFocus: false, revalidateAll: true },
   )
 
-  librarySwr.addChangeCallback('infiniteList', swr.mutate)
+  const debouncedMutate = useDebouncedCallback(() => swr.mutate(), 100)
+
+  useEffect(() => {
+    librarySwr.addChangeCallback('infiniteList', debouncedMutate)
+    return () => {
+      librarySwr.removeChangeCallback('infiniteList')
+    }
+  }, [debouncedMutate])
 
   const pages = swr.data
-  const flat = pages ? pages.flat() : undefined
+
+  const flat = useMemo(() => {
+    return pages ? pages.flat() : undefined
+  }, [pages])
 
   const lastPage = pages?.[pages.length - 1]
   const hasMore = !!lastPage && lastPage.length === PAGE_SIZE

--- a/src/stores/uploads.ts
+++ b/src/stores/uploads.ts
@@ -27,6 +27,33 @@ export const useUploadsStore = create<UploadsStore>(() => ({ uploads: {} }))
 
 const { setState } = useUploadsStore
 
+const pendingUploadProgress = new Map<string, number>()
+let uploadRafScheduled = false
+
+function flushUploadProgress() {
+  if (pendingUploadProgress.size === 0) return
+  setState((state) => {
+    const uploads = { ...state.uploads }
+    for (const [id, progress] of pendingUploadProgress) {
+      const prev = uploads[id]
+      if (prev) {
+        uploads[id] = { ...prev, progress }
+      }
+    }
+    pendingUploadProgress.clear()
+    uploadRafScheduled = false
+    return { uploads }
+  })
+}
+
+/**
+ * Immediately flush any pending progress updates.
+ * Primarily used for testing where RAF may not work correctly.
+ */
+export function flushPendingUploadProgress(): void {
+  flushUploadProgress()
+}
+
 export function registerUpload(id: string): void {
   setState((state) => {
     const next: UploadState = {
@@ -136,15 +163,11 @@ export const [getUploadCounts, useUploadCounts] = createGetterAndSelector(
 )
 
 export function updateUploadProgress(id: string, progress: number) {
-  setState((state) => {
-    const prev = state.uploads[id]
-    if (!prev) return state
-    const next: UploadState = {
-      ...prev,
-      progress,
-    }
-    return { uploads: { ...state.uploads, [id]: next } }
-  })
+  pendingUploadProgress.set(id, progress)
+  if (!uploadRafScheduled) {
+    uploadRafScheduled = true
+    requestAnimationFrame(flushUploadProgress)
+  }
 }
 
 export const [getUploadState, useUploadState] = createGetterAndSelector(

--- a/test/utils/setup.ts
+++ b/test/utils/setup.ts
@@ -206,8 +206,9 @@ jest.mock('../../src/lib/fileReader', () => ({
   }),
 }))
 
-// Library SWR - keep as mock for simplicity
+// Library SWR - keep as mock for simplicity, but include real query building functions
 jest.mock('../../src/stores/library', () => ({
+  ...jest.requireActual('../../src/stores/library'),
   librarySwr: {
     triggerChange: jest.fn(),
     addChangeCallback: jest.fn(),


### PR DESCRIPTION
- Added batch updates with request animation frame for upload/download progress updates, just in-case many come through at once.
- Added throttling to fs usedAt updates to reduce DB writes during browsing.
- Debounced library change callbacks during bulk operations.