### PR TITLE
feat: add separate simulator/emulator and device commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "scripts": {
     "fresh": "bunx rimraf .expo android ios node_modules && bun install",
     "start": "bun scripts/start.ts",
-    "dev:ios": "bun scripts/dev.ts ios",
+    "dev:ios:simulator": "bun scripts/dev.ts ios:simulator",
     "dev:ios:device": "bun scripts/dev.ts ios:device",
-    "dev:android": "bun scripts/dev.ts android",
+    "dev:android:emulator": "bun scripts/dev.ts android:emulator",
+    "dev:android:device": "bun scripts/dev.ts android:device",
     "fastlane:ios:build-ipa": "fastlane ios build_ipa",
     "fastlane:android:distribute-play-store": "fastlane android distribute_play_store",
     "fastlane:android:distribute-internal": "fastlane android distribute_internal",

--- a/scripts/buildCache.ts
+++ b/scripts/buildCache.ts
@@ -27,10 +27,11 @@ export const BUILD_CACHE_DIR = join(PROJECT_ROOT, '.build-cache')
 
 // Build targets - each has isolated cache
 // Note: E2E uses the same targets as dev since builds are identical
+// Note: Android emulator and device share the same build (same APK works for both)
 export type BuildTarget =
   | 'ios-sim' // iOS Simulator builds (dev and e2e)
   | 'ios-device' // iOS real device builds
-  | 'android' // Android builds (dev and e2e)
+  | 'android' // Android builds (emulator and device share same APK)
 
 // Get paths for a specific build target
 export function getTargetPaths(target: BuildTarget) {

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -4,9 +4,10 @@
  * Smart Development Build Runner
  *
  * Usage:
- *   bun scripts/dev.ts ios          # Build & run on iOS Simulator
- *   bun scripts/dev.ts ios:device   # Build & run on real iOS device
- *   bun scripts/dev.ts android      # Build & run on Android emulator/device
+ *   bun scripts/dev.ts ios:simulator    # Build & run on iOS Simulator
+ *   bun scripts/dev.ts ios:device       # Build & run on real iOS device
+ *   bun scripts/dev.ts android:emulator # Build & run on Android emulator
+ *   bun scripts/dev.ts android:device   # Build & run on real Android device
  *
  * Flags:
  *   --rebuild    Full clean build (delete platform dir, prebuild, build)
@@ -14,13 +15,13 @@
  *
  * How caching works:
  *   - Computes hash from package.json, bun.lock, app.config.js, eas.json, plugins/*.js
- *   - Each target (ios, ios:device, android) has isolated cache in .build-cache/
+ *   - Each target has isolated cache in .build-cache/
  *   - Skips rebuild if hash matches and artifacts exist
  *
  * Cache locations:
- *   .build-cache/ios-sim/       - iOS Simulator builds
- *   .build-cache/ios-device/    - iOS device builds
- *   .build-cache/android/       - Android builds
+ *   .build-cache/ios-sim/    - iOS Simulator builds
+ *   .build-cache/ios-device/ - iOS device builds
+ *   .build-cache/android/    - Android builds (shared by emulator and device)
  */
 
 import { rmSync } from 'node:fs'
@@ -45,6 +46,8 @@ import {
   launchAndroidApp,
   launchIosApp,
   listDevices,
+  selectAndroidDevice,
+  selectAndroidEmulator,
   selectDevice,
 } from './lib/devices'
 import { waitForDeviceUnlock } from './lib/ui'
@@ -58,20 +61,24 @@ const noRun = args.includes('--no-run')
 // Map CLI arg to build target
 function getTarget(): BuildTarget {
   switch (targetArg) {
-    case 'ios':
+    case 'ios:simulator':
     case 'ios:sim':
       return 'ios-sim'
     case 'ios:device':
       return 'ios-device'
-    case 'android':
+    case 'android:emulator':
+    case 'android:emu':
       return 'android'
+    case 'android:device':
+      return 'android' // Same build as emulator, just different device selection
     default:
       console.error('Usage: bun scripts/dev.ts <target> [flags]')
       console.error('')
       console.error('Targets:')
-      console.error('  ios          Build & run on iOS Simulator')
-      console.error('  ios:device   Build & run on real iOS device')
-      console.error('  android      Build & run on Android emulator/device')
+      console.error('  ios:simulator    Build & run on iOS Simulator')
+      console.error('  ios:device       Build & run on real iOS device')
+      console.error('  android:emulator Build & run on Android emulator')
+      console.error('  android:device   Build & run on real Android device')
       console.error('')
       console.error('Flags:')
       console.error(
@@ -84,7 +91,7 @@ function getTarget(): BuildTarget {
 
 const target = getTarget()
 const platform = target.includes('ios') ? 'ios' : 'android'
-const isDevice = target === 'ios-device'
+const isDevice = target === 'ios-device' || targetArg === 'android:device'
 const paths = getTargetPaths(target)
 
 // Print header
@@ -108,9 +115,9 @@ if (forceRebuild) {
   console.log('')
 }
 
-// For device builds, check for connected device first
+// For iOS device builds, check for connected device first (before building)
 let selectedDevice: Device | null = null
-if (isDevice) {
+if (target === 'ios-device') {
   console.log('📱 Checking for iOS device...')
   selectedDevice = await selectDevice('ios', 'device')
 
@@ -263,9 +270,15 @@ async function runIosSimulator(): Promise<void> {
 
 // === Run Android App ===
 async function runAndroid(): Promise<void> {
-  console.log('🤖 Running on Android...')
+  if (isDevice) {
+    await runAndroidDevice()
+  } else {
+    await runAndroidEmulator()
+  }
+}
 
-  // Find APK
+// Find Android APK
+async function findAndroidApk(): Promise<string> {
   const apkDir = join(PROJECT_ROOT, 'android/app/build/outputs/apk/debug')
   const apkResult = await $`find ${apkDir} -name "*.apk" 2>/dev/null`
     .quiet()
@@ -280,48 +293,11 @@ async function runAndroid(): Promise<void> {
     console.error('   Could not find APK')
     process.exit(1)
   }
+  return apkPath
+}
 
-  // Check for connected device/emulator
-  const devices = await listDevices('android')
-  let device = devices.find((d) => d.state === 'available')
-
-  if (!device) {
-    console.log('   No device connected. Starting emulator...')
-    const avdsResult = await $`emulator -list-avds`.quiet().nothrow()
-    const avds = avdsResult.stdout.toString().trim().split('\n').filter(Boolean)
-    if (avds.length === 0) {
-      console.error(
-        '   No Android emulator found. Create one in Android Studio.',
-      )
-      process.exit(1)
-    }
-    Bun.spawn(['sh', '-c', `emulator -avd ${avds[0]} &`], {
-      stdout: 'ignore',
-      stderr: 'ignore',
-    })
-    console.log('   Waiting for emulator...')
-    await $`adb wait-for-device`
-    // Wait for boot
-    for (let i = 0; i < 60; i++) {
-      const bootResult =
-        await $`adb shell getprop sys.boot_completed 2>/dev/null`
-          .quiet()
-          .nothrow()
-      if (bootResult.stdout.toString().trim() === '1') break
-      await new Promise((r) => setTimeout(r, 2000))
-    }
-
-    // Get the device again
-    const updatedDevices = await listDevices('android')
-    device = updatedDevices.find((d) => d.state === 'available')
-  }
-
-  if (!device) {
-    console.error('   Could not connect to Android device')
-    process.exit(1)
-  }
-
-  // Install and launch
+// Install and launch Android app (used by emulator path)
+async function installAndLaunchAndroid(device: Device, apkPath: string) {
   console.log('   Installing APK...')
   const installResult = await installAndroidApp(device, apkPath)
   if (!installResult.success) {
@@ -336,7 +312,131 @@ async function runAndroid(): Promise<void> {
     process.exit(1)
   }
 
-  console.log('✅ App launched')
+  console.log('✅ App launched on emulator')
+}
+
+// === Run Android on Physical Device ===
+async function runAndroidDevice(): Promise<void> {
+  console.log('🤖 Running on Android device...')
+
+  const apkPath = await findAndroidApk()
+
+  // Look only for physical devices (not emulators)
+  console.log('   Looking for connected device...')
+  let devices = await listDevices('android')
+  let device = selectAndroidDevice(devices)
+
+  // If no device found, restart adb and try again (helps with flaky USB connections)
+  if (!device) {
+    console.log('   No device detected, restarting adb server...')
+    await $`adb kill-server`.quiet().nothrow()
+    await $`adb start-server`.quiet().nothrow()
+    await new Promise((r) => setTimeout(r, 2000))
+    devices = await listDevices('android')
+    device = selectAndroidDevice(devices)
+  }
+
+  if (!device) {
+    console.error('')
+    console.error('   No Android device connected.')
+    console.error('')
+    console.error('   Connect a device via USB and enable USB debugging.')
+    console.error('   Run `adb devices` to verify.')
+    process.exit(1)
+  }
+
+  console.log(`   Found: ${device.name} (${device.id})`)
+
+  // Install with retry for flaky USB connections
+  console.log('   Installing APK... (keep device connected)')
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    const installResult = await installAndroidApp(device, apkPath)
+
+    if (installResult.success) {
+      break
+    }
+
+    if (installResult.error === 'not_found' && attempt < 3) {
+      console.log(
+        `   Device disconnected, reconnecting... (attempt ${attempt + 1}/3)`,
+      )
+      await $`adb kill-server`.quiet().nothrow()
+      await $`adb start-server`.quiet().nothrow()
+      await new Promise((r) => setTimeout(r, 2000))
+
+      // Refresh device (only physical devices)
+      const refreshedDevices = await listDevices('android')
+      const refreshedDevice = selectAndroidDevice(refreshedDevices)
+      if (refreshedDevice) {
+        device = refreshedDevice
+        console.log(`   Reconnected: ${device.name} (${device.id})`)
+        console.log('   Retrying install...')
+        continue
+      }
+    }
+
+    console.error('')
+    console.error(`   Install failed: ${installResult.message}`)
+    process.exit(1)
+  }
+
+  console.log('   Launching app...')
+  const launchResult = await launchAndroidApp(device, 'sia.storage.dev')
+  if (!launchResult.success) {
+    console.error(`   Launch failed: ${launchResult.message}`)
+    process.exit(1)
+  }
+
+  console.log('✅ App launched on device')
+}
+
+// === Run Android on Emulator ===
+async function runAndroidEmulator(): Promise<void> {
+  console.log('🤖 Running on Android Emulator...')
+
+  const apkPath = await findAndroidApk()
+
+  // Look only for emulators (not physical devices)
+  console.log('   Looking for running emulator...')
+  const devices = await listDevices('android')
+  let device = selectAndroidEmulator(devices)
+
+  if (!device) {
+    console.log('   No emulator running, starting one...')
+    const avdsResult = await $`emulator -list-avds`.quiet().nothrow()
+    const avds = avdsResult.stdout.toString().trim().split('\n').filter(Boolean)
+    if (avds.length === 0) {
+      console.error('')
+      console.error('   No Android emulator found.')
+      console.error('   Create one in Android Studio > Device Manager.')
+      process.exit(1)
+    }
+    console.log(`   Starting: ${avds[0]}`)
+    Bun.spawn(['sh', '-c', `emulator -avd ${avds[0]} &`], {
+      stdout: 'ignore',
+      stderr: 'ignore',
+    })
+    console.log('   Waiting for emulator to boot...')
+    for (let i = 0; i < 60; i++) {
+      const updatedDevices = await listDevices('android')
+      const emulator = selectAndroidEmulator(updatedDevices)
+      if (emulator) {
+        device = emulator
+        break
+      }
+      await new Promise((r) => setTimeout(r, 2000))
+    }
+  }
+
+  if (!device) {
+    console.error('')
+    console.error('   Emulator failed to start within 2 minutes.')
+    console.error('   Try starting it manually from Android Studio.')
+    process.exit(1)
+  }
+
+  console.log(`   Found: ${device.name} (${device.id})`)
+  await installAndLaunchAndroid(device, apkPath)
 }
 
 // Find iOS Simulator app in DerivedData

--- a/scripts/lib/devices.test.ts
+++ b/scripts/lib/devices.test.ts
@@ -1,7 +1,11 @@
 import {
+  type Device,
+  parseAdbInstallError,
   parseAdbOutput,
   parseDevicectlOutput,
   parseSimctlOutput,
+  selectAndroidDevice,
+  selectAndroidEmulator,
 } from './devices'
 
 /**
@@ -424,5 +428,153 @@ describe('parseAdbOutput', () => {
     const devices = parseAdbOutput(ADB_DEVICES_PHYSICAL_OUTPUT)
     // model:SM_G965U should be used, not device:starqltesq
     expect(devices[0].name).toBe('SM_G965U')
+  })
+})
+
+describe('selectAndroidEmulator', () => {
+  test('selects emulator when only emulators available', () => {
+    const devices = parseAdbOutput(ADB_DEVICES_EMULATOR_OUTPUT)
+    const selected = selectAndroidEmulator(devices)
+
+    expect(selected).toBeDefined()
+    expect(selected?.type).toBe('simulator')
+    expect(selected?.id).toBe('emulator-5554')
+  })
+
+  test('ignores physical devices, returns undefined when only physical devices', () => {
+    const devices = parseAdbOutput(ADB_DEVICES_PHYSICAL_OUTPUT)
+    const selected = selectAndroidEmulator(devices)
+
+    expect(selected).toBeUndefined()
+  })
+
+  test('selects only emulator when both emulators and physical devices present', () => {
+    const devices = parseAdbOutput(ADB_DEVICES_MULTIPLE_OUTPUT)
+    const selected = selectAndroidEmulator(devices)
+
+    expect(selected).toBeDefined()
+    expect(selected?.type).toBe('simulator')
+    expect(selected?.id).toBe('emulator-5554')
+  })
+
+  test('returns undefined when no devices', () => {
+    const devices = parseAdbOutput(ADB_DEVICES_NONE_OUTPUT)
+    const selected = selectAndroidEmulator(devices)
+
+    expect(selected).toBeUndefined()
+  })
+
+  test('ignores unavailable emulators', () => {
+    const devices: Device[] = [
+      {
+        id: 'emulator-5554',
+        name: 'Pixel_7',
+        platform: 'android',
+        type: 'simulator',
+        state: 'unavailable',
+      },
+    ]
+    const selected = selectAndroidEmulator(devices)
+
+    expect(selected).toBeUndefined()
+  })
+})
+
+describe('selectAndroidDevice', () => {
+  test('selects physical device when only physical devices available', () => {
+    const devices = parseAdbOutput(ADB_DEVICES_PHYSICAL_OUTPUT)
+    const selected = selectAndroidDevice(devices)
+
+    expect(selected).toBeDefined()
+    expect(selected?.type).toBe('device')
+    expect(selected?.id).toBe('RFXXXXXXXX')
+  })
+
+  test('ignores emulators, returns undefined when only emulators', () => {
+    const devices = parseAdbOutput(ADB_DEVICES_EMULATOR_OUTPUT)
+    const selected = selectAndroidDevice(devices)
+
+    expect(selected).toBeUndefined()
+  })
+
+  test('selects only physical device when both emulators and physical devices present', () => {
+    const devices = parseAdbOutput(ADB_DEVICES_MULTIPLE_OUTPUT)
+    const selected = selectAndroidDevice(devices)
+
+    expect(selected).toBeDefined()
+    expect(selected?.type).toBe('device')
+    expect(selected?.id).toBe('RFXXXXXXXX')
+  })
+
+  test('returns undefined when no devices', () => {
+    const devices = parseAdbOutput(ADB_DEVICES_NONE_OUTPUT)
+    const selected = selectAndroidDevice(devices)
+
+    expect(selected).toBeUndefined()
+  })
+
+  test('ignores unavailable physical devices', () => {
+    const devices: Device[] = [
+      {
+        id: 'RFXXXXXXXX',
+        name: 'SM_G965U',
+        platform: 'android',
+        type: 'device',
+        state: 'unavailable',
+      },
+    ]
+    const selected = selectAndroidDevice(devices)
+
+    expect(selected).toBeUndefined()
+  })
+})
+
+describe('parseAdbInstallError', () => {
+  test('detects device offline error', () => {
+    const result = parseAdbInstallError(
+      'error: device offline\nadb: failed to install app.apk',
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('not_found')
+    expect(result.message).toBe('Device disconnected')
+  })
+
+  test('detects no devices error', () => {
+    const result = parseAdbInstallError(
+      'error: no devices/emulators found\nadb: failed to install app.apk',
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('not_found')
+    expect(result.message).toBe('Device disconnected')
+  })
+
+  test('detects device not found error', () => {
+    const result = parseAdbInstallError(
+      "error: device 'RFXXXXXXXX' not found\nadb: failed to install app.apk",
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('not_found')
+    expect(result.message).toBe('Device disconnected')
+  })
+
+  test('returns unknown error for other failures', () => {
+    const result = parseAdbInstallError(
+      'Failure [INSTALL_FAILED_INSUFFICIENT_STORAGE]',
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('unknown')
+    expect(result.message).toBe('Failure [INSTALL_FAILED_INSUFFICIENT_STORAGE]')
+  })
+
+  test('returns default message for empty output', () => {
+    const result = parseAdbInstallError('')
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('unknown')
+    expect(result.message).toBe('Install failed')
   })
 })

--- a/scripts/lib/devices.ts
+++ b/scripts/lib/devices.ts
@@ -282,6 +282,22 @@ export async function selectDevice(
   return available || devices[0]
 }
 
+/**
+ * Select an Android emulator from a list of devices.
+ * Only considers devices with type 'simulator', ignores physical devices.
+ */
+export function selectAndroidEmulator(devices: Device[]): Device | undefined {
+  return devices.find((d) => d.state === 'available' && d.type === 'simulator')
+}
+
+/**
+ * Select an Android physical device from a list of devices.
+ * Only considers devices with type 'device', ignores emulators.
+ */
+export function selectAndroidDevice(devices: Device[]): Device | undefined {
+  return devices.find((d) => d.state === 'available' && d.type === 'device')
+}
+
 export interface InstallResult {
   success: boolean
   error?: 'locked' | 'not_found' | 'unknown'
@@ -378,10 +394,32 @@ export async function installAndroidApp(
     return { success: true }
   }
 
+  const output = result.stdout.toString() + result.stderr.toString()
+  return parseAdbInstallError(output)
+}
+
+/**
+ * Parse adb install error output to determine the error type.
+ * Exported for testing.
+ */
+export function parseAdbInstallError(output: string): InstallResult {
+  // Device disconnected during install
+  if (
+    output.includes('device offline') ||
+    output.includes('no devices') ||
+    output.includes('not found')
+  ) {
+    return {
+      success: false,
+      error: 'not_found',
+      message: 'Device disconnected',
+    }
+  }
+
   return {
     success: false,
     error: 'unknown',
-    message: result.stderr.toString(),
+    message: output || 'Install failed',
   }
 }
 


### PR DESCRIPTION
- Add `bun run dev:ios:simulator` and `bun run dev:ios:device`
- Add `bun run dev:android:emulator` and `bun run dev:android:device`
- Ensure physical device and simulator commands only consider running on applicable devices.