### PR TITLE
fix: add pinObject call after finalize and serialize uploads

### DIFF
--- a/.changeset/feat-upload-packing.md
+++ b/.changeset/feat-upload-packing.md
@@ -2,4 +2,4 @@
 default: minor
 ---
 
-Files are now packed into 120 MiB slabs for more efficient uploads.
+Files are now packed into 40 MiB slabs for more efficient uploads.

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -19,11 +19,14 @@ export const UPLOAD_DATA_SHARDS = 10
 export const UPLOAD_PARITY_SHARDS = 20
 // Sia protocol constant: sector size in bytes (4 MiB).
 export const SECTOR_SIZE = 4 * 1024 * 1024
-// Slab data capacity = SECTOR_SIZE × total shards.
-export const SLAB_SIZE =
-  SECTOR_SIZE * (UPLOAD_DATA_SHARDS + UPLOAD_PARITY_SHARDS)
+// Slab data capacity = SECTOR_SIZE × data shards.
+export const SLAB_SIZE = SECTOR_SIZE * UPLOAD_DATA_SHARDS
 // Packer idle timeout - flush partial slab after this delay.
 export const PACKER_IDLE_TIMEOUT = secondsInMs(10)
+// Max batch duration before forcing flush (limits time data is unpinned).
+export const PACKER_MAX_BATCH_DURATION = secondsInMs(60)
+// Max slabs before forcing flush (limits unpinned data, ~400 MiB at 10 slabs).
+export const PACKER_MAX_SLABS = 10
 // Minimum slab fill percentage before allowing flush (0.0 - 1.0).
 // Prevents flushing when we could pack more efficiently.
 export const SLAB_FILL_THRESHOLD = 0.9

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -36,6 +36,8 @@ export async function closeDb(): Promise<void> {
 
 // Drop all tables and run migrations again
 export async function resetDb() {
+  // Disable log appender before dropping tables to prevent "no such table: logs" errors
+  dbInitialized = false
   await database.withTransactionAsync(async () => {
     const rows = await database.getAllAsync<{ name: string }>(
       `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'`,

--- a/src/managers/uploader.test.ts
+++ b/src/managers/uploader.test.ts
@@ -1,15 +1,17 @@
 // Mock config MUST be at the very top before any imports
 // Constants must be inlined in jest.mock due to hoisting
-const MOCK_SLAB_SIZE = 4 * 1024 * 1024 * 30 // 120 MiB (SECTOR_SIZE * TOTAL_SHARDS)
+const MOCK_SLAB_SIZE = 4 * 1024 * 1024 * 10 // 40 MiB (SECTOR_SIZE * DATA_SHARDS)
 
 jest.mock('../config', () => ({
   __esModule: true,
   UPLOAD_MAX_INFLIGHT: 15,
   UPLOAD_DATA_SHARDS: 10,
-  UPLOAD_PARITY_SHARDS: 20,
+  UPLOAD_PARITY_SHARDS: 0,
   SECTOR_SIZE: 4 * 1024 * 1024,
-  SLAB_SIZE: 4 * 1024 * 1024 * 30, // 120 MiB
+  SLAB_SIZE: 4 * 1024 * 1024 * 10, // 40 MiB (SECTOR_SIZE * DATA_SHARDS)
   PACKER_IDLE_TIMEOUT: 5000,
+  PACKER_MAX_BATCH_DURATION: 60000, // 60 seconds
+  PACKER_MAX_SLABS: 10,
   SLAB_FILL_THRESHOLD: 0.9,
 }))
 
@@ -155,6 +157,7 @@ function createMockSdk(
 ): jest.Mocked<SdkInterface> {
   return {
     uploadPacked: jest.fn().mockResolvedValue(packer),
+    pinObject: jest.fn().mockResolvedValue(undefined),
   } as unknown as jest.Mocked<SdkInterface>
 }
 
@@ -348,6 +351,59 @@ describe('UploadManager', () => {
       expect(upload2?.status).toBe('error')
     })
 
+    it('sets error when pinObject fails and does not save to local DB', async () => {
+      const entry = await createTestFile('pin-fail-file')
+      manager.initialize(mockSdk, TEST_INDEXER_URL)
+      mockPacker.finalize.mockResolvedValueOnce([mockPinnedObject])
+      mockSdk.pinObject.mockRejectedValueOnce(new Error('Indexer unavailable'))
+
+      await manager.queueFiles([entry])
+      await manager.flush()
+
+      // File should have error status
+      const upload = getUploadState('pin-fail-file')
+      expect(upload).toBeDefined()
+      expect(upload?.status).toBe('error')
+      expect(upload?.error).toBe('Indexer unavailable')
+
+      // No local object should be created
+      const localObjects = await readLocalObjectsForFile('pin-fail-file')
+      expect(localObjects).toHaveLength(0)
+    })
+
+    it('only saves successfully pinned files when some pinObject calls fail', async () => {
+      const entry1 = await createTestFile('pin-success')
+      const entry2 = await createTestFile('pin-fail')
+
+      manager.initialize(mockSdk, TEST_INDEXER_URL)
+      mockPacker.finalize.mockResolvedValueOnce([
+        mockPinnedObject,
+        mockPinnedObject,
+      ])
+      // First call succeeds, second fails
+      mockSdk.pinObject
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error('Pin failed'))
+
+      await manager.queueFiles([entry1, entry2])
+      await manager.flush()
+
+      // pin-success should be removed from uploads (completed successfully)
+      expect(getUploadState('pin-success')).toBeUndefined()
+
+      // pin-fail should have error status
+      const upload2 = getUploadState('pin-fail')
+      expect(upload2).toBeDefined()
+      expect(upload2?.status).toBe('error')
+      expect(upload2?.error).toBe('Pin failed')
+
+      // Only pin-success should have local object
+      const objects1 = await readLocalObjectsForFile('pin-success')
+      const objects2 = await readLocalObjectsForFile('pin-fail')
+      expect(objects1).toHaveLength(1)
+      expect(objects2).toHaveLength(0)
+    })
+
     it('creates new packer for files added after flush', async () => {
       manager.initialize(mockSdk, TEST_INDEXER_URL)
 
@@ -388,7 +444,7 @@ describe('UploadManager', () => {
   })
 
   describe('threshold-based flush', () => {
-    // At 90% threshold with 120 MiB slab, threshold is 108 MiB
+    // At 90% threshold with 40 MiB slab, threshold is 36 MiB
 
     it('does NOT flush when below threshold', async () => {
       manager.initialize(mockSdk, TEST_INDEXER_URL)
@@ -593,6 +649,136 @@ describe('UploadManager', () => {
       expect(objects2).toHaveLength(1)
       expect(objects1[0].fileId).toBe('batch-file-1')
       expect(objects2[0].fileId).toBe('batch-file-2')
+    })
+  })
+
+  describe('upload serialization', () => {
+    it('queues files added during finalize and processes them after', async () => {
+      manager.initialize(mockSdk, TEST_INDEXER_URL)
+
+      // Make finalize take some time
+      let resolveFinalize: () => void
+      mockPacker.finalize.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveFinalize = () => resolve([mockPinnedObject])
+          }),
+      )
+
+      await manager.queueFiles([createFileEntry('file1')])
+
+      // Start flush (will block on finalize)
+      const flushPromise = manager.flush()
+
+      // Queue more files while finalize is in progress
+      await manager.queueFiles([createFileEntry('file2')])
+
+      // Should not have created a second packer yet
+      expect(mockSdk.uploadPacked).toHaveBeenCalledTimes(1)
+
+      // Complete the finalize
+      resolveFinalize!()
+      await flushPromise
+
+      // Now the pending file should be processed with a new packer
+      expect(mockSdk.uploadPacked).toHaveBeenCalledTimes(2)
+      expect(mockPacker.add).toHaveBeenCalledTimes(2)
+    })
+
+    it('does not create concurrent packers', async () => {
+      manager.initialize(mockSdk, TEST_INDEXER_URL)
+
+      let resolveFinalize: () => void
+      mockPacker.finalize.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveFinalize = () => resolve([mockPinnedObject])
+          }),
+      )
+
+      await manager.queueFiles([createFileEntry('file1')])
+      const flushPromise = manager.flush()
+
+      // Queue multiple files during finalize
+      await manager.queueFiles([createFileEntry('file2')])
+      await manager.queueFiles([createFileEntry('file3')])
+
+      // Still only one packer
+      expect(mockSdk.uploadPacked).toHaveBeenCalledTimes(1)
+
+      resolveFinalize!()
+      await flushPromise
+
+      // After finalize, pending files processed with new packer
+      expect(mockSdk.uploadPacked).toHaveBeenCalledTimes(2)
+      // file1 on first packer, file2 and file3 on second packer
+      expect(mockPacker.add).toHaveBeenCalledTimes(3)
+    })
+
+    it('cancels pending files when cancelBatch is called', async () => {
+      manager.initialize(mockSdk, TEST_INDEXER_URL)
+
+      // Make finalize hang so we can test cancellation mid-flight
+      mockPacker.finalize.mockImplementation(() => new Promise(() => {}))
+
+      await manager.queueFiles([createFileEntry('file1')])
+      manager.flush() // Don't await
+
+      // Queue file during finalize
+      await manager.queueFiles([createFileEntry('pending-file')])
+
+      // Cancel everything
+      manager.cancelBatch()
+
+      // Pending file should be removed from uploads
+      expect(getUploadState('pending-file')).toBeUndefined()
+    })
+  })
+
+  describe('batch limits', () => {
+    const MB = 1024 * 1024
+    // 40 MiB slab, 10 slabs max = 400 MiB absolute limit
+
+    it('max slabs limit triggers flush at 400MB', async () => {
+      manager.initialize(mockSdk, TEST_INDEXER_URL)
+
+      // Add files to fill exactly 10 slabs (400 MiB)
+      // Using 40 MiB files = exactly 1 slab each
+      for (let i = 0; i < 10; i++) {
+        const file = createFileEntry(`slab-file-${i}`, MOCK_SLAB_SIZE)
+        await manager.queueFiles([file])
+      }
+
+      // After 10 slabs (400 MiB), max slabs limit should trigger flush
+      expect(mockPacker.finalize).toHaveBeenCalled()
+    })
+
+    it('duration timer triggers flush after 60 seconds', async () => {
+      manager.initialize(mockSdk, TEST_INDEXER_URL)
+
+      // Add data under max slabs limit
+      for (let i = 0; i < 5; i++) {
+        const file = createFileEntry(`duration-file-${i}`, MOCK_SLAB_SIZE)
+        await manager.queueFiles([file])
+      }
+
+      expect(mockPacker.finalize).not.toHaveBeenCalled()
+
+      // Duration timer (60 seconds) fires - forces flush
+      jest.advanceTimersByTime(60000 + 100)
+      expect(mockPacker.finalize).toHaveBeenCalled()
+    })
+
+    it('many small photos hit max slabs limit before 400MB', async () => {
+      manager.initialize(mockSdk, TEST_INDEXER_URL)
+
+      // 2MB photos: 20 per slab, 200 photos = 10 slabs = 400 MiB
+      for (let i = 0; i < 200; i++) {
+        const file = createFileEntry(`photo-${i}`, 2 * MB)
+        await manager.queueFiles([file])
+      }
+
+      expect(mockPacker.finalize).toHaveBeenCalled()
     })
   })
 })

--- a/src/managers/uploader.ts
+++ b/src/managers/uploader.ts
@@ -6,6 +6,8 @@ import type {
 } from 'react-native-sia'
 import {
   PACKER_IDLE_TIMEOUT,
+  PACKER_MAX_BATCH_DURATION,
+  PACKER_MAX_SLABS,
   SLAB_FILL_THRESHOLD,
   SLAB_SIZE,
   UPLOAD_DATA_SHARDS,
@@ -45,6 +47,7 @@ type BatchState = {
   files: FileEntry[]
   totalSize: number
   slabsFilled: number // Number of slabs filled so far in this batch
+  startedAt: number // Timestamp when batch was created
   abortController: AbortController // For cancelling batch operations
 }
 
@@ -54,8 +57,10 @@ class UploadManager {
   private currentBatch: BatchState | null = null
   private uploadingBatch: BatchState | null = null // Batch currently being uploaded
   private idleTimer: NodeJS.Timeout | null = null
+  private durationTimer: NodeJS.Timeout | null = null // Max duration timer
   private isProcessing = false
   private indexerURL: string = ''
+  private pendingFiles: FileEntry[] = [] // Files queued while a batch is finalizing
 
   /**
    * Set SDK instance and indexer URL
@@ -66,7 +71,8 @@ class UploadManager {
   }
 
   /**
-   * Queue multiple files at once (smart batching)
+   * Queue multiple files at once (smart batching).
+   * If a batch is currently finalizing, files are queued and processed after.
    */
   async queueFiles(files: FileEntry[]): Promise<void> {
     if (!this.sdk) {
@@ -77,6 +83,16 @@ class UploadManager {
     // Register all files as queued
     for (const file of files) {
       registerUpload(file.fileId)
+    }
+
+    // If currently finalizing a batch, queue files for later to avoid concurrent uploads
+    if (this.isProcessing) {
+      logger.info(
+        'uploadManager',
+        `Batch finalizing, queuing ${files.length} files for later`,
+      )
+      this.pendingFiles.push(...files)
+      return
     }
 
     // Process each file sequentially
@@ -99,14 +115,7 @@ class UploadManager {
       // Check if we should flush before adding this file.
       // Flush if: current slab is >= threshold full AND adding this file would overflow.
       if (this.currentBatch && this.shouldFlushBeforeAdding(entry.size)) {
-        const fillPercent = this.getCurrentSlabFillPercent()
-        logger.info(
-          'uploadManager',
-          `Slab ${Math.round(
-            fillPercent * 100,
-          )}% full, flushing before adding ${entry.size} byte file`,
-        )
-        await this.flush()
+        await this.flush('slab_threshold')
       }
 
       // Initialize packer if needed
@@ -117,9 +126,11 @@ class UploadManager {
           files: [],
           totalSize: 0,
           slabsFilled: 0,
+          startedAt: Date.now(),
           abortController: new AbortController(),
         }
         this.currentBatch = batch
+        this.startDurationTimer()
         this.packer = await this.sdk.uploadPacked(
           {
             maxInflight: UPLOAD_MAX_INFLIGHT,
@@ -175,6 +186,12 @@ class UploadManager {
         )}% of current slab`,
       )
 
+      // Check if we've hit max slabs limit
+      if (this.shouldFlushDueToLimits()) {
+        await this.flush('max_slabs')
+        return
+      }
+
       // Reset idle timer
       this.resetIdleTimer()
     } catch (e) {
@@ -182,6 +199,14 @@ class UploadManager {
       logger.error('uploadManager', `Error processing file ${entry.fileId}`, e)
       setUploadError(entry.fileId, message)
     }
+  }
+
+  /**
+   * Check if batch limits have been exceeded (max slabs).
+   */
+  private shouldFlushDueToLimits(): boolean {
+    if (!this.currentBatch) return false
+    return this.currentBatch.slabsFilled >= PACKER_MAX_SLABS
   }
 
   /**
@@ -250,9 +275,8 @@ class UploadManager {
       clearTimeout(this.idleTimer)
     }
     this.idleTimer = setTimeout(async () => {
-      logger.info('uploadManager', 'Idle timeout reached, flushing batch')
       try {
-        await this.flush()
+        await this.flush('idle_timeout')
       } catch (error) {
         logger.error(
           'uploadManager',
@@ -264,12 +288,44 @@ class UploadManager {
   }
 
   /**
-   * Flush current packer (finalize and save objects)
+   * Start the max duration timer for the current batch
    */
-  async flush(): Promise<void> {
+  private startDurationTimer(): void {
+    if (this.durationTimer) {
+      clearTimeout(this.durationTimer)
+    }
+    this.durationTimer = setTimeout(async () => {
+      try {
+        await this.flush('max_duration')
+      } catch (error) {
+        logger.error(
+          'uploadManager',
+          'Error flushing batch after duration timeout',
+          error,
+        )
+      }
+    }, PACKER_MAX_BATCH_DURATION)
+  }
+
+  /**
+   * Flush current packer (finalize and save objects)
+   * @param reason - What triggered the flush (for logging)
+   */
+  async flush(
+    reason:
+      | 'idle_timeout'
+      | 'max_duration'
+      | 'max_slabs'
+      | 'slab_threshold'
+      | 'manual' = 'manual',
+  ): Promise<void> {
     if (this.idleTimer) {
       clearTimeout(this.idleTimer)
       this.idleTimer = null
+    }
+    if (this.durationTimer) {
+      clearTimeout(this.durationTimer)
+      this.durationTimer = null
     }
 
     if (!this.packer || !this.currentBatch) {
@@ -293,10 +349,21 @@ class UploadManager {
     this.packer = null
     this.currentBatch = null
 
-    logger.info(
-      'uploadManager',
-      `Flushing batch ${batch.batchId} with ${batch.files.length} files`,
-    )
+    // Calculate efficiency metrics
+    const durationMs = Date.now() - batch.startedAt
+    const durationSec = (durationMs / 1000).toFixed(1)
+    const slabCapacity = (batch.slabsFilled + 1) * SLAB_SIZE
+    const fillPercent = Math.round((batch.totalSize / slabCapacity) * 100)
+
+    logger.info('uploadManager', 'Flushing batch', {
+      reason,
+      batchId: batch.batchId,
+      files: batch.files.length,
+      totalSize: batch.totalSize,
+      slabsFilled: batch.slabsFilled,
+      fillPercent: `${fillPercent}%`,
+      durationSec,
+    })
 
     try {
       // Set all files to uploading status
@@ -304,7 +371,7 @@ class UploadManager {
         setUploadStatus(entry.fileId, 'uploading')
       }
 
-      // Finalize the packer - this uploads all slabs to the network
+      // Finalize the packer - completes any partial slab upload and waits for all uploads
       const pinnedObjects = await packer.finalize({
         signal: batch.abortController.signal,
       })
@@ -343,24 +410,30 @@ class UploadManager {
     } finally {
       this.isProcessing = false
       this.uploadingBatch = null
-      // Check if a new batch was queued while we were processing.
-      // Its idle timer may have fired and been ignored, so flush it now.
-      this.flushPendingBatch()
+      // Process any files that were queued while we were finalizing
+      await this.processPendingFiles()
     }
   }
 
   /**
-   * Flush any pending batch that may have been queued during processing.
-   * This handles the case where files were added while a batch was uploading,
-   * and their idle timer fired but flush() was skipped due to isProcessing=true.
+   * Process any files that were queued while a batch was finalizing.
+   * This ensures uploads are serialized - only one packer uploads at a time.
    */
-  private flushPendingBatch(): void {
-    if (this.currentBatch && this.currentBatch.files.length > 0) {
-      logger.info(
-        'uploadManager',
-        `Found pending batch after processing, flushing`,
-      )
-      this.flush()
+  private async processPendingFiles(): Promise<void> {
+    if (this.pendingFiles.length === 0) {
+      return
+    }
+
+    const files = this.pendingFiles
+    this.pendingFiles = []
+
+    logger.info(
+      'uploadManager',
+      `Processing ${files.length} files queued during finalize`,
+    )
+
+    for (const entry of files) {
+      await this.processFile(entry)
     }
   }
 
@@ -398,6 +471,9 @@ class UploadManager {
         // Update metadata on the pinned object
         pinnedObject.updateMetadata(encodeFileMetadata(entry.file))
 
+        // Pin the object to the indexer (this saves slabs + object metadata)
+        await this.sdk!.pinObject(pinnedObject)
+
         // Convert to local object and save
         const localObject = await pinnedObjectToLocalObject(
           entry.fileId,
@@ -432,6 +508,10 @@ class UploadManager {
       clearTimeout(this.idleTimer)
       this.idleTimer = null
     }
+    if (this.durationTimer) {
+      clearTimeout(this.durationTimer)
+      this.durationTimer = null
+    }
 
     // Cancel batch being packed
     if (this.currentBatch) {
@@ -457,6 +537,12 @@ class UploadManager {
       }
     }
 
+    // Clear pending files
+    for (const entry of this.pendingFiles) {
+      removeUpload(entry.fileId)
+    }
+    this.pendingFiles = []
+
     this.packer = null
     this.currentBatch = null
   }
@@ -479,10 +565,15 @@ class UploadManager {
       clearTimeout(this.idleTimer)
       this.idleTimer = null
     }
+    if (this.durationTimer) {
+      clearTimeout(this.durationTimer)
+      this.durationTimer = null
+    }
     this.packer = null
     this.currentBatch = null
     this.uploadingBatch = null
     this.isProcessing = false
+    this.pendingFiles = []
     this.sdk = null
     this.indexerURL = ''
   }


### PR DESCRIPTION
- Fixed the slab calculation to only use data shards.
- Added packer max duration and max slabs flush triggers.
- Adjusted packer to wait for finalize call to finish before starting a new batch.