### PR TITLE
fix: prevent download UI flicker and remove download toasts

### DIFF
--- a/src/components/FileActionsSheet.tsx
+++ b/src/components/FileActionsSheet.tsx
@@ -297,17 +297,13 @@ function BulkFileActionsSheet({
   const handleDownloadToDevice = useCallback(async () => {
     if (!counts) return
     try {
-      let queued = 0
       for (const file of counts.files) {
         const hasSealed = fileHasASealedObject(file)
         const uri = await getFsFileUri(file)
         if (hasSealed && !uri) {
-          // Fire and forget - don't await, just queue the download
           void downloadFile(file)
-          queued++
         }
       }
-      toast.show(`Queued ${queued} downloads`)
       onComplete?.()
     } catch (e) {
       logger.error('FileActionsSheet', 'failed to queue downloads', e)

--- a/src/components/FileViewer/index.tsx
+++ b/src/components/FileViewer/index.tsx
@@ -79,7 +79,7 @@ export function FileViewer({
         ) : null}
 
         {isQueued ? (
-          <Text style={{ color: colors.textPrimary }}>Queued</Text>
+          <Text style={{ color: colors.textPrimary }}>Download queued</Text>
         ) : null}
 
         {isDownloading && !isQueued ? (

--- a/src/lib/file.ts
+++ b/src/lib/file.ts
@@ -56,6 +56,8 @@ function computeFileStatus({
   const isDownloading =
     downloadState?.status === 'running' || downloadState?.status === 'queued'
   const hasSealedObject = fileHasASealedObject(file)
+  // Treat as downloaded if we have the URI OR download just finished ('done')
+  const isDownloaded = !!fileUri || downloadState?.status === 'done'
   return {
     isUploading,
     isDownloading,
@@ -64,7 +66,7 @@ function computeFileStatus({
     isPacking,
     batchFileCount: uploadState?.batchFileCount ?? 0,
     isUploaded: hasSealedObject || !!isShared,
-    isDownloaded: !!fileUri,
+    isDownloaded,
     isErrored: uploadStatus === 'error' || downloadState?.status === 'error',
     uploadProgress: uploadState?.progress ?? 0,
     downloadProgress: downloadState?.progress ?? 0,

--- a/src/managers/downloader.ts
+++ b/src/managers/downloader.ts
@@ -34,9 +34,10 @@ export async function downloadFile(file: FileRecord): Promise<void> {
   const downloadState = getDownloadState(file.id)
   if (
     downloadState?.status === 'running' ||
-    downloadState?.status === 'queued'
+    downloadState?.status === 'queued' ||
+    downloadState?.status === 'done'
   ) {
-    return // Already downloading
+    return // Already downloading or just completed
   }
 
   await runDownloadWithSlot({
@@ -87,9 +88,7 @@ export function useDownload(file?: FileRecord | null) {
       toast.show('No slabs available for this file')
       return
     }
-    // Fire and forget - queue the download
     downloadFile(file)
-    toast.show('Download queued')
   }, [sdk, file, toast])
 }
 

--- a/src/stores/downloads.ts
+++ b/src/stores/downloads.ts
@@ -127,7 +127,10 @@ export async function runDownloadWithSlot<T>(params: {
     setDownloadState(id, 'running', 0)
     const result = await task(controller.signal)
     logger.debug('downloads', 'download success', id)
-    removeDownload(id)
+    // Set 'done' status and delay removal to prevent re-triggering downloads
+    // while components may not have fetched the new file uri yet.
+    setDownloadState(id, 'done', 1)
+    setTimeout(() => removeDownload(id), 5000)
     return result
   } catch (e) {
     logger.error('downloads', 'download error', id, e)
@@ -136,7 +139,6 @@ export async function runDownloadWithSlot<T>(params: {
     throw e
   } finally {
     release()
-    removeDownload(id)
   }
 }
 

--- a/src/stores/fs.ts
+++ b/src/stores/fs.ts
@@ -127,7 +127,7 @@ export async function copyFileToFs(
     addedAt: previous?.addedAt ?? Date.now(),
     usedAt: Date.now(),
   })
-  fsTriggerRefresh(file.id)
+  await fsTriggerRefresh(file.id)
   return target.uri
 }
 


### PR DESCRIPTION
- Added a 'done' status to downloads that persists for 5s after completion, this is to give components enough time to discover the files new local URI which is what we use to consider a file downloaded / locally available.
- Remove "download queued" toasts from single and bulk download actions. This was toasting constantly when syncing between devices, and is unrelated to the current user action.