### PR TITLE
fix: optimize library list item props

### DIFF
--- a/src/components/FileGallery.tsx
+++ b/src/components/FileGallery.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import { ActivityIndicator, FlatList, Platform, StyleSheet } from 'react-native'
 import { useFlatListControls } from '../hooks/useFlatListControls'
 import type { FileRecord } from '../stores/files'
@@ -8,16 +9,12 @@ type Props = {
   onPressItem: (item: FileRecord) => void
   onLongPressItem?: (item: FileRecord) => void
   numColumns?: number
-  isSelectionMode?: boolean
-  selectedFileIds?: Set<string>
 }
 
 export function FileGallery({
   onPressItem,
   onLongPressItem,
   numColumns = 3,
-  isSelectionMode = false,
-  selectedFileIds,
 }: Props) {
   const { data: files, size, setSize, isValidating, hasMore } = useFileList()
   const { isLoadingMore, handleEndReached } = useFlatListControls({
@@ -27,6 +24,19 @@ export function FileGallery({
     isValidating,
     hasMore,
   })
+
+  const renderItem = useCallback(
+    ({ item }: { item: FileRecord }) => {
+      return (
+        <FileGalleryItem
+          file={item}
+          onPressItem={onPressItem}
+          onLongPressItem={onLongPressItem}
+        />
+      )
+    },
+    [onPressItem, onLongPressItem],
+  )
 
   return (
     <FlatList
@@ -39,15 +49,7 @@ export function FileGallery({
       automaticallyAdjustKeyboardInsets={false}
       automaticallyAdjustsScrollIndicatorInsets={false}
       contentContainerStyle={styles.galleryContent}
-      renderItem={({ item }) => (
-        <FileGalleryItem
-          file={item}
-          onPressItem={onPressItem}
-          onLongPressItem={onLongPressItem}
-          isSelectionMode={isSelectionMode}
-          isSelected={selectedFileIds?.has(item.id) ?? false}
-        />
-      )}
+      renderItem={renderItem}
       onEndReachedThreshold={0.95}
       onEndReached={handleEndReached}
       initialNumToRender={36}

--- a/src/components/FileGalleryItem.tsx
+++ b/src/components/FileGalleryItem.tsx
@@ -2,6 +2,7 @@ import { CircleCheckIcon, CircleIcon } from 'lucide-react-native'
 import { memo } from 'react'
 import { Pressable, StyleSheet, View } from 'react-native'
 import { useFileStatus } from '../lib/file'
+import { useIsFileSelected, useIsSelectionMode } from '../stores/fileSelection'
 import type { FileRecord } from '../stores/files'
 import { colors, palette, whiteA } from '../styles/colors'
 import { FileThumbnail } from './FileThumbnail'
@@ -11,17 +12,16 @@ type Props = {
   file: FileRecord
   onPressItem: (item: FileRecord) => void
   onLongPressItem?: (item: FileRecord) => void
-  isSelectionMode?: boolean
-  isSelected?: boolean
 }
 
 function FileGalleryItemComponent({
   file,
   onPressItem,
   onLongPressItem,
-  isSelectionMode = false,
-  isSelected = false,
 }: Props) {
+  const isSelectionMode = useIsSelectionMode()
+  const isSelected = useIsFileSelected(file.id)
+
   const status = useFileStatus(file)
   return (
     <View collapsable={false} style={styles.thumbCell}>
@@ -67,9 +67,7 @@ export const FileGalleryItem = memo(FileGalleryItemComponent, (prev, next) => {
     prev.file.updatedAt === next.file.updatedAt &&
     prev.file.objects === next.file.objects &&
     prev.onPressItem === next.onPressItem &&
-    prev.onLongPressItem === next.onLongPressItem &&
-    prev.isSelectionMode === next.isSelectionMode &&
-    prev.isSelected === next.isSelected
+    prev.onLongPressItem === next.onLongPressItem
   )
 })
 

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import { ActivityIndicator, FlatList, Platform } from 'react-native'
 import { useFlatListControls } from '../hooks/useFlatListControls'
 import type { FileRecord } from '../stores/files'
@@ -7,16 +8,9 @@ import { FileListItem } from './FileListItem'
 type Props = {
   onPressItem: (item: FileRecord) => void
   onLongPressItem?: (item: FileRecord) => void
-  isSelectionMode?: boolean
-  selectedFileIds?: Set<string>
 }
 
-export function FileList({
-  onPressItem,
-  onLongPressItem,
-  isSelectionMode = false,
-  selectedFileIds,
-}: Props) {
+export function FileList({ onPressItem, onLongPressItem }: Props) {
   const { data: files, size, setSize, isValidating, hasMore } = useFileList()
   const { isLoadingMore, handleEndReached } = useFlatListControls({
     data: files,
@@ -25,6 +19,19 @@ export function FileList({
     isValidating,
     hasMore,
   })
+
+  const renderItem = useCallback(
+    ({ item }: { item: FileRecord }) => {
+      return (
+        <FileListItem
+          file={item}
+          onPressItem={onPressItem}
+          onLongPressItem={onLongPressItem}
+        />
+      )
+    },
+    [onPressItem, onLongPressItem],
+  )
 
   return (
     <FlatList
@@ -40,16 +47,7 @@ export function FileList({
         gap: 8,
         paddingBottom: 130,
       }}
-      extraData={isSelectionMode ? selectedFileIds : undefined}
-      renderItem={({ item }) => (
-        <FileListItem
-          file={item}
-          onPressItem={onPressItem}
-          onLongPressItem={onLongPressItem}
-          isSelectionMode={isSelectionMode}
-          isSelected={selectedFileIds?.has(item.id) ?? false}
-        />
-      )}
+      renderItem={renderItem}
       onEndReachedThreshold={0.9}
       onEndReached={handleEndReached}
       initialNumToRender={36}

--- a/src/components/FileListItem.tsx
+++ b/src/components/FileListItem.tsx
@@ -3,6 +3,7 @@ import { memo } from 'react'
 import { Pressable, StyleSheet, Text, View } from 'react-native'
 import { useFileStatus } from '../lib/file'
 import { humanSize } from '../lib/humanSize'
+import { useIsFileSelected, useIsSelectionMode } from '../stores/fileSelection'
 import type { FileRecord } from '../stores/files'
 import { palette, whiteA } from '../styles/colors'
 import { FileThumbnail } from './FileThumbnail'
@@ -12,17 +13,11 @@ type Props = {
   file: FileRecord
   onPressItem: (item: FileRecord) => void
   onLongPressItem?: (item: FileRecord) => void
-  isSelectionMode?: boolean
-  isSelected?: boolean
 }
 
-function FileListItemComponent({
-  file,
-  onPressItem,
-  onLongPressItem,
-  isSelectionMode = false,
-  isSelected = false,
-}: Props) {
+function FileListItemComponent({ file, onPressItem, onLongPressItem }: Props) {
+  const isSelectionMode = useIsSelectionMode()
+  const isSelected = useIsFileSelected(file.id)
   const status = useFileStatus(file)
   return (
     <Pressable
@@ -84,9 +79,7 @@ export const FileListItem = memo(FileListItemComponent, (prev, next) => {
     prev.file.updatedAt === next.file.updatedAt &&
     prev.file.objects === next.file.objects &&
     prev.onPressItem === next.onPressItem &&
-    prev.onLongPressItem === next.onLongPressItem &&
-    prev.isSelectionMode === next.isSelectionMode &&
-    prev.isSelected === next.isSelected
+    prev.onLongPressItem === next.onLongPressItem
   )
 })
 

--- a/src/screens/LibraryScreen.tsx
+++ b/src/screens/LibraryScreen.tsx
@@ -63,28 +63,30 @@ export function LibraryScreen({ route, navigation }: Props) {
   const isSelectionMode = useIsSelectionMode()
   const selectedFileIds = useSelectedFileIds()
 
+  // Ref to track selection mode for stable callbacks
+  const isSelectionModeRef = useRef(isSelectionMode)
+  useEffect(() => {
+    isSelectionModeRef.current = isSelectionMode
+  }, [isSelectionMode])
+
   // Handle item press - opens carousel or toggles selection
-  const handlePressItem = useCallback(
-    (file: FileRecord) => {
-      if (isSelectionMode) {
-        toggleFileSelection(file.id)
-      } else {
-        setSelectedFile(file)
-      }
-    },
-    [isSelectionMode],
-  )
+  // Using ref for isSelectionMode to keep callback reference stable
+  const handlePressItem = useCallback((file: FileRecord) => {
+    if (isSelectionModeRef.current) {
+      toggleFileSelection(file.id)
+    } else {
+      setSelectedFile(file)
+    }
+  }, [])
 
   // Handle long press - enters selection mode with file selected
-  const handleLongPressItem = useCallback(
-    (file: FileRecord) => {
-      if (!isSelectionMode) {
-        enterSelectionMode()
-      }
-      selectFile(file.id)
-    },
-    [isSelectionMode],
-  )
+  // Using ref for isSelectionMode to keep callback reference stable
+  const handleLongPressItem = useCallback((file: FileRecord) => {
+    if (!isSelectionModeRef.current) {
+      enterSelectionMode()
+    }
+    selectFile(file.id)
+  }, [])
 
   // Handle opening the action sheet from carousel
   const handleShowCarouselActions = useCallback(() => {
@@ -206,15 +208,11 @@ export function LibraryScreen({ route, navigation }: Props) {
             <FileGallery
               onPressItem={handlePressItem}
               onLongPressItem={handleLongPressItem}
-              isSelectionMode={isSelectionMode}
-              selectedFileIds={selectedFileIds}
             />
           ) : (
             <FileList
               onPressItem={handlePressItem}
               onLongPressItem={handleLongPressItem}
-              isSelectionMode={isSelectionMode}
-              selectedFileIds={selectedFileIds}
             />
           )
         ) : (


### PR DESCRIPTION
- Use refs for stable callback references in list handlers. Ensures as little as possible changes.
- Push selection hooks into item components to reduce library memoization props.