### PR TITLE
fix: prevent current file flicker when library updates

### DIFF
--- a/.changeset/fix_file_viewer_flickering_when_library_updates.md
+++ b/.changeset/fix_file_viewer_flickering_when_library_updates.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix file viewer flickering when library updates.

--- a/src/stores/fileCarousel.test.ts
+++ b/src/stores/fileCarousel.test.ts
@@ -592,6 +592,7 @@ describe('useVirtualFileList hook', () => {
       // file-2 is at position 1 (DESC: file-3, file-2, file-1)
       expect(result.current.totalCount).toBe(3)
       expect(result.current.currentIndex).toBe(1)
+      expect(result.current.currentFile?.id).toBe('file-2')
 
       // Delete file-3 (the one before file-2), so file-2 moves to position 0
       await deleteRecord('file-3')
@@ -604,6 +605,9 @@ describe('useVirtualFileList hook', () => {
         expect(result.current.totalCount).toBe(2)
       })
       expect(result.current.currentIndex).toBe(0)
+      // Current file should remain available (not null) after position change
+      expect(result.current.currentFile).not.toBeNull()
+      expect(result.current.currentFile?.id).toBe('file-2')
     })
   })
 

--- a/src/stores/fileCarousel.ts
+++ b/src/stores/fileCarousel.ts
@@ -481,15 +481,30 @@ export function useVirtualFileList({
         fetchFilePosition(currentFileID, queryParams),
       ])
 
-      if (newCount !== totalCount || newPosition !== currentIndex) {
+      // Clear cache when position or count changes
+      const positionChanged =
+        newCount !== totalCount || newPosition !== currentIndex
+      if (positionChanged) {
+        // Preserve the current file to avoid a flash or loading state.
+        const currentFile = cacheRef.current.get(currentIndex)
+
         setTotalCount(newCount)
         setCurrentIndexState(newPosition)
         cacheRef.current.clear()
         fetchingRef.current.clear()
+
+        if (currentFile) {
+          cacheRef.current.set(newPosition, currentFile)
+        }
+
         setCacheVersion((v) => v + 1)
       }
 
-      const cachedFile = cacheRef.current.get(currentIndex)
+      // Use newPosition for cache lookups when position changed, since
+      // state updates are async and currentIndex is stale in this callback.
+      const effectiveIndex = positionChanged ? newPosition : currentIndex
+
+      const cachedFile = cacheRef.current.get(effectiveIndex)
       if (cachedFile && cachedFile.id === currentFileID) {
         const freshFile = await fetchFileByID(currentFileID)
         if (freshFile) {
@@ -501,7 +516,7 @@ export function useVirtualFileList({
             cachedFile.type !== freshFile.type
 
           if (metadataChanged) {
-            cacheRef.current.set(currentIndex, freshFile)
+            cacheRef.current.set(effectiveIndex, freshFile)
             setCacheVersion((v) => v + 1)
 
             const message = nameChanged ? 'File renamed' : 'File info updated'
@@ -512,7 +527,7 @@ export function useVirtualFileList({
                 currentFileID,
                 queryParams,
               )
-              if (updatedPosition !== currentIndex) {
+              if (updatedPosition !== effectiveIndex) {
                 setCurrentIndexState(updatedPosition)
                 cacheRef.current.clear()
                 fetchingRef.current.clear()


### PR DESCRIPTION
This addresses https://github.com/SiaFoundation/sia-mobile/issues/358. 

When the total count of the sort/filter list changes, we invalidate the FileCarousel cache. This is necessary because even one file changing could change the current position of tall files, including the one we're currently viewing. Things out of view within our window can re-fetch without the user's knowledge. However, the currently viewed file doesn't need to be evicted—its data is still valid, just at a different index. By preserving and restoring the current file across cache clears, we avoid a flash of loading state while the file is re-fetched. Updates to the currently viewed file are handled separately further down in handleLibraryChange, where fresh data is fetched and the cache is updated in place.