### PR TITLE
refactor: tie uploader lifecycle to SDK

### DIFF
--- a/.changeset/improve-upload-cleanup.md
+++ b/.changeset/improve-upload-cleanup.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Improved packed uploader cleanup when SDK is reset.

--- a/src/managers/uploadScanner.ts
+++ b/src/managers/uploadScanner.ts
@@ -10,11 +10,7 @@ import {
 } from '../stores/files'
 import { getFsFileUri } from '../stores/fs'
 import { getIsConnected, getSdk } from '../stores/sdk'
-import {
-  getAutoScanUploads,
-  getIndexerURL,
-  useAutoScanUploads,
-} from '../stores/settings'
+import { getAutoScanUploads, useAutoScanUploads } from '../stores/settings'
 import { getActiveUploads, useActiveUploads } from '../stores/uploads'
 import { type FileEntry, getUploadManager } from './uploader'
 
@@ -40,8 +36,6 @@ async function startUploadScanner(): Promise<void> {
   try {
     logger.debug('uploadScanner', 'scanning...')
     const uploadManager = getUploadManager()
-    const indexerURL = await getIndexerURL()
-    uploadManager.initialize(sdk, indexerURL)
 
     // Check how much space is left in current slab
     const slabRemaining = await uploadManager.getSlabRemaining()

--- a/src/managers/uploader.test.ts
+++ b/src/managers/uploader.test.ts
@@ -521,7 +521,7 @@ describe('UploadManager', () => {
     })
   })
 
-  describe('cancelBatch', () => {
+  describe('shutdown', () => {
     it('removes all files from upload store', async () => {
       manager.initialize(mockSdk, TEST_INDEXER_URL)
 
@@ -533,7 +533,7 @@ describe('UploadManager', () => {
       // Before cancel, files should be in store
       expect(getActiveUploads()).toHaveLength(2)
 
-      manager.cancelBatch()
+      manager.shutdown()
 
       // After cancel, all uploads should be removed
       expect(getActiveUploads()).toHaveLength(0)
@@ -545,7 +545,7 @@ describe('UploadManager', () => {
       manager.initialize(mockSdk, TEST_INDEXER_URL)
 
       await manager.queueFiles([createFileEntry('file1')])
-      manager.cancelBatch()
+      manager.shutdown()
 
       jest.advanceTimersByTime(PACKER_IDLE_TIMEOUT + 1000)
       expect(mockPacker.finalize).not.toHaveBeenCalled()
@@ -570,7 +570,7 @@ describe('UploadManager', () => {
       expect(capturedSignal?.aborted).toBe(false)
 
       // Cancel the batch
-      manager.cancelBatch()
+      manager.shutdown()
 
       // Signal should now be aborted
       expect(capturedSignal?.aborted).toBe(true)
@@ -715,7 +715,7 @@ describe('UploadManager', () => {
       expect(mockPacker.add).toHaveBeenCalledTimes(3)
     })
 
-    it('cancels pending files when cancelBatch is called', async () => {
+    it('cancels pending files when shutdown is called', async () => {
       manager.initialize(mockSdk, TEST_INDEXER_URL)
 
       // Make finalize hang so we can test cancellation mid-flight
@@ -728,7 +728,7 @@ describe('UploadManager', () => {
       await manager.queueFiles([createFileEntry('pending-file')])
 
       // Cancel everything
-      manager.cancelBatch()
+      manager.shutdown()
 
       // Pending file should be removed from uploads
       expect(getUploadState('pending-file')).toBeUndefined()

--- a/src/managers/uploader.ts
+++ b/src/managers/uploader.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback } from 'react'
 import type {
   PackedUploadInterface,
   PinnedObjectInterface,
@@ -24,7 +24,6 @@ import { type FileRecordRow, readFileRecord } from '../stores/files'
 import { getFsFileUri } from '../stores/fs'
 import { upsertLocalObject } from '../stores/localObjects'
 import { getSdk, useSdk } from '../stores/sdk'
-import { getIndexerURL, useIndexerURL } from '../stores/settings'
 import {
   registerUpload,
   removeUpload,
@@ -499,11 +498,10 @@ class UploadManager {
   }
 
   /**
-   * Cancel current and uploading batches by aborting network operations and
-   * removing files from the upload store. This will abort any in-progress packer
-   * operations including file reads and network uploads.
+   * Shutdown the upload manager, cancelling all uploads.
+   * Called when SDK is replaced or reset.
    */
-  cancelBatch(): void {
+  shutdown(): void {
     if (this.idleTimer) {
       clearTimeout(this.idleTimer)
       this.idleTimer = null
@@ -590,17 +588,11 @@ export function getUploadManager(): UploadManager {
 }
 
 /**
- * Hook to initialize the upload manager and provide an upload function
+ * Hook to provide an upload function.
+ * Uploader is initialized when SDK is created (in sdk.ts).
  */
 export function useUploader() {
   const sdk = useSdk()
-  const indexerURL = useIndexerURL()
-
-  useEffect(() => {
-    if (sdk && indexerURL.data) {
-      getUploadManager().initialize(sdk, indexerURL.data)
-    }
-  }, [sdk, indexerURL.data])
 
   return useCallback(
     async (files: FileRecordRow[]) => {
@@ -640,9 +632,6 @@ export async function reuploadFile(fileId: string): Promise<void> {
   const fileUri = await getFsFileUri(file)
   if (!fileUri) throw new Error('File not available locally')
 
-  const indexerURL = await getIndexerURL()
-  getUploadManager().initialize(sdk, indexerURL)
-
   await getUploadManager().queueFiles([
     { fileId: file.id, fileUri, file, size: file.size },
   ])
@@ -669,9 +658,6 @@ export async function queueUploadForFileId(fileId: string): Promise<void> {
 
   const fileUri = await getFsFileUri(file)
   if (!fileUri) return
-
-  const indexerURL = await getIndexerURL()
-  getUploadManager().initialize(sdk, indexerURL)
 
   await getUploadManager().queueFiles([
     { fileId: file.id, fileUri, file, size: file.size },

--- a/src/stores/sdk.ts
+++ b/src/stores/sdk.ts
@@ -32,6 +32,7 @@ import { openAuthURL } from '../lib/openAuthUrl'
 import { err, ok, type Result } from '../lib/result'
 import { createGetterAndSelector } from '../lib/selectors'
 import { withTimeout } from '../lib/timeout'
+import { getUploadManager } from '../managers/uploader'
 import { getAppKey, getAppKeyForIndexer, setAppKeyForIndexer } from './appKey'
 import { setMnemonicHash, validateMnemonic } from './mnemonic'
 import { getIndexerURL, setIndexerURL } from './settings'
@@ -70,6 +71,25 @@ const { getState, setState } = useSdkStore
 const CONNECTION_TIMEOUT_MS = 10_000
 
 /**
+ * Sets SDK and manages uploader lifecycle.
+ * Shuts down existing uploader when SDK changes, initializes with new SDK.
+ * Exported for use by test harness.
+ */
+export async function setSdkWithUploader(
+  sdk: SdkInterface | null,
+): Promise<void> {
+  const currentSdk = getState().sdk
+  if (currentSdk && currentSdk !== sdk) {
+    getUploadManager().shutdown()
+  }
+  setState({ sdk })
+  if (sdk) {
+    const indexerURL = await getIndexerURL()
+    getUploadManager().initialize(sdk, indexerURL)
+  }
+}
+
+/**
  * Initializes the SDK only if it has already been authenticated with the indexer.
  *
  * @returns SDK if connected, null if not
@@ -87,7 +107,7 @@ export async function connectSdk(): Promise<SdkInterface | null> {
     }
 
     if (sdk) {
-      setState({ sdk })
+      await setSdkWithUploader(sdk)
       return sdk
     }
 
@@ -195,8 +215,9 @@ export async function authenticateIndexer(
     }
     if (sdk) {
       logger.info('sdk', 'Already registered, connected.')
-      setState({ sdk, isConnected: true, isAuthing: false })
       setIndexerURL(indexerURL)
+      await setSdkWithUploader(sdk)
+      setState({ isAuthing: false, isConnected: true })
       return ok({ alreadyConnected: true })
     }
     setState({ isAuthing: false })
@@ -268,8 +289,9 @@ export async function switchIndexer(
 
     if (sdk) {
       logger.info('sdk', 'Connected using stored AppKey for this indexer.')
-      setState({ sdk, isConnected: true })
       setIndexerURL(newIndexerURL)
+      await setSdkWithUploader(sdk)
+      setState({ isConnected: true })
       return ok(undefined)
     }
   }
@@ -340,7 +362,8 @@ export async function registerWithIndexer(
   await setMnemonicHash(mnemonic)
   await setIndexerURL(indexerURL)
 
-  setState({ sdk, isConnected: true, isAuthing: false, pendingApproval: null })
+  await setSdkWithUploader(sdk)
+  setState({ isAuthing: false, isConnected: true, pendingApproval: null })
   return ok(undefined)
 }
 
@@ -519,9 +542,10 @@ export async function getPinnedObject(
 }
 
 /**
- * Resets the SDK state.
+ * Resets the SDK state and shuts down uploader.
  */
 export async function resetSdk() {
+  getUploadManager().shutdown()
   setState({
     sdk: null,
     isConnected: false,

--- a/test/utils/harness.ts
+++ b/test/utils/harness.ts
@@ -39,7 +39,11 @@ import {
   ensureFsStorageDirectory,
   fsStorageDirectory,
 } from '../../src/stores/fs'
-import { setIsConnected, setSdk } from '../../src/stores/sdk'
+import {
+  setIsConnected,
+  setSdk,
+  setSdkWithUploader,
+} from '../../src/stores/sdk'
 import { getIndexerURL } from '../../src/stores/settings'
 import { readThumbnailsByHash } from '../../src/stores/thumbnails'
 import {
@@ -122,6 +126,7 @@ interface HarnessOptions {
 }
 
 let testCounter = 0
+let fileIdCounter = 0
 
 class AppCoreHarnessImpl implements AppCoreHarness {
   sdk: MockSdk
@@ -159,15 +164,15 @@ class AppCoreHarnessImpl implements AppCoreHarness {
     // Ensure the fs storage directory exists
     ensureFsStorageDirectory()
 
-    // Set up SDK
+    // Set up SDK and initialize uploader
     if (!this.options.skipSdkConnection) {
-      // Type assertion because setSdk expects the full SdkInterface
-      setSdk(this.sdk as unknown as Parameters<typeof setSdk>[0])
-      setIsConnected(true)
-
-      // Set up app key for the test indexer
+      // Set up app key for the test indexer first
       const indexerURL = await getIndexerURL()
       await setAppKeyForIndexer(indexerURL, this.sdk.appKey())
+      await setSdkWithUploader(
+        this.sdk as unknown as Parameters<typeof setSdkWithUploader>[0],
+      )
+      setIsConnected(true)
     }
 
     // Initialize services
@@ -406,10 +411,12 @@ export function generateTestFilesFromAssets(
   assetDir: string,
   fileNames: string[],
 ): ((harness: AppCoreHarness) => TestFileInput)[] {
-  return fileNames.map((fileName, i) => {
+  return fileNames.map((fileName) => {
     return (harness: AppCoreHarness): TestFileInput => {
+      // Increment counter when factory is called to ensure unique IDs across tests
+      fileIdCounter++
+      const fileId = `test-file-${fileIdCounter}`
       const srcPath = path.join(assetDir, fileName)
-      const fileId = `test-file-${i + 1}`
 
       // Determine type from extension
       const ext = path.extname(fileName).toLowerCase()


### PR DESCRIPTION
- This PR tightens the relationship between the SDK instance and the uploader instance. Before the uploader technically could use a stale SDK reference, although it does not seem like the current code actually allows this. These changes tie their creation and cleanup lifecycle together.
- When the SDK needs to fully reconnect, we cancel any in progress packed uploads and recreate the uploader with the new SDK.