### PR TITLE
feat: add floating new logs button with auto-follow mode

### DIFF
--- a/.changeset/floating-new-logs-button.md
+++ b/.changeset/floating-new-logs-button.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Added a floating "New logs" button with auto-follow mode to the logs screen.

--- a/src/components/LogView.tsx
+++ b/src/components/LogView.tsx
@@ -1,7 +1,9 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import {
   ActivityIndicator,
   FlatList,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
   Platform,
   StyleSheet,
   Text,
@@ -12,8 +14,40 @@ import { getLevelColorHex, getScopeColorHex } from '../lib/logColors'
 import type { LogEntry } from '../lib/logger'
 import { palette } from '../styles/colors'
 
-export function LogView() {
+type LogViewProps = {
+  isFollowing?: boolean
+  onLogCountChange?: (count: number) => void
+  onScrollAwayFromBottom?: () => void
+}
+
+export function LogView({
+  isFollowing,
+  onLogCountChange,
+  onScrollAwayFromBottom,
+}: LogViewProps) {
   const { data: logs = [], isLoading, error } = useLogs()
+  const flatListRef = useRef<FlatList<LogEntry>>(null)
+
+  const logCount = logs.length
+  useEffect(() => {
+    onLogCountChange?.(logCount)
+  }, [logCount, onLogCountChange])
+
+  useEffect(() => {
+    if (isFollowing && logCount > 0) {
+      flatListRef.current?.scrollToOffset({ offset: 0, animated: false })
+    }
+  }, [isFollowing, logCount])
+
+  const handleScrollBeginDrag = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const offsetY = event.nativeEvent.contentOffset.y
+      if (offsetY > 10) {
+        onScrollAwayFromBottom?.()
+      }
+    },
+    [onScrollAwayFromBottom],
+  )
 
   const renderLogItem = useCallback(
     ({ item, index }: { item: LogEntry; index: number }) => {
@@ -69,6 +103,7 @@ export function LogView() {
   return (
     <View style={styles.container}>
       <FlatList
+        ref={flatListRef}
         data={logs}
         renderItem={renderLogItem}
         keyExtractor={(item, index) =>
@@ -77,9 +112,7 @@ export function LogView() {
         inverted
         contentContainerStyle={styles.content}
         showsVerticalScrollIndicator
-        maintainVisibleContentPosition={{
-          minIndexForVisible: 0,
-        }}
+        onScrollBeginDrag={handleScrollBeginDrag}
       />
     </View>
   )

--- a/src/components/SettingsLogsControlBar.tsx
+++ b/src/components/SettingsLogsControlBar.tsx
@@ -5,7 +5,6 @@ import {
   CopyIcon,
   DownloadIcon,
   FilterIcon,
-  RefreshCwIcon,
   Trash2Icon,
 } from 'lucide-react-native'
 import { useCallback, useMemo, useState } from 'react'
@@ -33,13 +32,11 @@ import { BottomControlBar, iconColors } from './BottomControlBar'
 import { type OverflowAction, OverflowActions } from './OverflowActions'
 import { SpinnerIcon } from './SpinnerIcon'
 
-type Props = NativeStackScreenProps<MenuStackParamList, 'Logs'> & {
-  onRefresh?: () => void
-}
+type Props = NativeStackScreenProps<MenuStackParamList, 'Logs'>
 
 const LOG_LEVELS: LogLevel[] = ['debug', 'info', 'warn', 'error']
 
-export function SettingsLogsControlBar({ navigation, onRefresh }: Props) {
+export function SettingsLogsControlBar({ navigation }: Props) {
   const logLevel = useLogLevel()
   const logScopes = useLogScopes()
   const availableScopes = useAvailableScopes()
@@ -154,16 +151,6 @@ export function SettingsLogsControlBar({ navigation, onRefresh }: Props) {
         label: 'Copy to Clipboard',
         onPress: handleCopyLogs,
       },
-      ...(onRefresh
-        ? [
-            {
-              key: 'refresh',
-              icon: <RefreshCwIcon color={iconColors.white} />,
-              label: 'Refresh',
-              onPress: onRefresh,
-            },
-          ]
-        : []),
       {
         key: 'export',
         icon: isExporting ? (
@@ -183,7 +170,7 @@ export function SettingsLogsControlBar({ navigation, onRefresh }: Props) {
         variant: 'danger' as const,
       },
     ],
-    [handleClearLogs, handleCopyLogs, handleExportLogs, isExporting, onRefresh],
+    [handleClearLogs, handleCopyLogs, handleExportLogs, isExporting],
   )
 
   return (

--- a/src/hooks/useLogs.ts
+++ b/src/hooks/useLogs.ts
@@ -1,6 +1,6 @@
 import useSWR from 'swr'
 import { buildSWRHelpers } from '../lib/swr'
-import { readLogs, useLogLevel, useLogScopes } from '../stores/logs'
+import { countLogs, readLogs, useLogLevel, useLogScopes } from '../stores/logs'
 
 export const logsSwr = buildSWRHelpers('logs')
 
@@ -16,4 +16,22 @@ export function useLogs() {
       revalidateOnReconnect: false,
     },
   )
+}
+
+/** Returns true if there are new logs available for the current filter. */
+export function useHasNewLogs(displayedCount: number): boolean {
+  const logLevel = useLogLevel()
+  const logScopes = useLogScopes()
+
+  const { data: dbCount = 0 } = useSWR(
+    ['logCount', logLevel, logScopes.join(',')],
+    () => countLogs(logLevel, logScopes),
+    {
+      refreshInterval: 2000,
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+    },
+  )
+
+  return dbCount > displayedCount
 }

--- a/src/screens/SettingsLogsScreen.tsx
+++ b/src/screens/SettingsLogsScreen.tsx
@@ -1,28 +1,78 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack'
+import { ArrowDownIcon } from 'lucide-react-native'
+import { useCallback, useEffect, useState } from 'react'
+import { Pressable, StyleSheet, Text, View } from 'react-native'
 import { LogView } from '../components/LogView'
 import { SettingsFullLayout } from '../components/SettingsLayout'
 import { SettingsLogsControlBar } from '../components/SettingsLogsControlBar'
-import { logsSwr } from '../hooks/useLogs'
+import { logsSwr, useHasNewLogs } from '../hooks/useLogs'
 import { useMenuHeader } from '../hooks/useMenuHeader'
 import type { MenuStackParamList } from '../stacks/types'
+import { palette } from '../styles/colors'
 
 type Props = NativeStackScreenProps<MenuStackParamList, 'Logs'>
 
 export function SettingsLogsScreen({ route, navigation }: Props) {
   useMenuHeader()
+  const [displayedCount, setDisplayedCount] = useState(0)
+  const [isFollowing, setIsFollowing] = useState(true)
+  const hasNewLogs = useHasNewLogs(displayedCount)
 
-  const handleRefresh = async () => {
-    await logsSwr.triggerChange()
+  useEffect(() => {
+    if (isFollowing && hasNewLogs) {
+      logsSwr.triggerChange()
+    }
+  }, [isFollowing, hasNewLogs])
+
+  const handleScrollAwayFromBottom = useCallback(() => {
+    setIsFollowing(false)
+  }, [])
+
+  const handleShowNewLogs = () => {
+    setIsFollowing(true)
+    logsSwr.triggerChange()
   }
 
   return (
     <SettingsFullLayout>
-      <LogView />
-      <SettingsLogsControlBar
-        navigation={navigation}
-        route={route}
-        onRefresh={handleRefresh}
+      <LogView
+        isFollowing={isFollowing}
+        onLogCountChange={setDisplayedCount}
+        onScrollAwayFromBottom={handleScrollAwayFromBottom}
       />
+      {!isFollowing && hasNewLogs && (
+        <View style={styles.floatingButtonContainer}>
+          <Pressable style={styles.floatingButton} onPress={handleShowNewLogs}>
+            <ArrowDownIcon size={16} color={palette.gray[50]} />
+            <Text style={styles.floatingButtonText}>New logs</Text>
+          </Pressable>
+        </View>
+      )}
+      <SettingsLogsControlBar navigation={navigation} route={route} />
     </SettingsFullLayout>
   )
 }
+
+const styles = StyleSheet.create({
+  floatingButtonContainer: {
+    position: 'absolute',
+    bottom: 95,
+    left: 0,
+    right: 0,
+    alignItems: 'center',
+  },
+  floatingButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    backgroundColor: palette.blue[500],
+    borderRadius: 20,
+  },
+  floatingButtonText: {
+    color: palette.gray[50],
+    fontSize: 14,
+    fontWeight: '600',
+  },
+})

--- a/src/stores/logs.ts
+++ b/src/stores/logs.ts
@@ -150,6 +150,33 @@ function getLevelsForFilter(minLevel: LogLevel): LogLevel[] {
   return levelOrder.slice(minIndex)
 }
 
+/** Build WHERE clause and params for log queries. */
+function buildLogFilterQuery(
+  logLevel?: LogLevel,
+  logScopes?: string[],
+): { whereClause: string; params: (string | number)[] } {
+  const conditions: string[] = []
+  const params: (string | number)[] = []
+
+  if (logLevel) {
+    const allowedLevels = getLevelsForFilter(logLevel)
+    const placeholders = allowedLevels.map(() => '?').join(',')
+    conditions.push(`level IN (${placeholders})`)
+    params.push(...allowedLevels)
+  }
+
+  if (logScopes && logScopes.length > 0) {
+    const placeholders = logScopes.map(() => '?').join(',')
+    conditions.push(`scope IN (${placeholders})`)
+    params.push(...logScopes)
+  }
+
+  const whereClause =
+    conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
+
+  return { whereClause, params }
+}
+
 /** Read logs from database with optional filters. */
 export async function readLogs(
   logLevel?: LogLevel,
@@ -159,27 +186,8 @@ export async function readLogs(
     if (!dbInitialized) {
       return []
     }
-    const conditions: string[] = []
-    const params: (string | number)[] = []
 
-    // Filter by level.
-    if (logLevel) {
-      const allowedLevels = getLevelsForFilter(logLevel)
-      const placeholders = allowedLevels.map(() => '?').join(',')
-      conditions.push(`level IN (${placeholders})`)
-      params.push(...allowedLevels)
-    }
-
-    // Filter by scope.
-    if (logScopes && logScopes.length > 0) {
-      const placeholders = logScopes.map(() => '?').join(',')
-      conditions.push(`scope IN (${placeholders})`)
-      params.push(...logScopes)
-    }
-
-    const whereClause =
-      conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
-
+    const { whereClause, params } = buildLogFilterQuery(logLevel, logScopes)
     const query = `SELECT timestamp, level, scope, message FROM logs ${whereClause} ORDER BY createdAt DESC, id DESC`
 
     const rows = await db().getAllAsync<{
@@ -198,6 +206,26 @@ export async function readLogs(
   } catch (error) {
     console.error('[logs] Failed to read logs:', error)
     return []
+  }
+}
+
+/** Count logs matching the current filters. */
+export async function countLogs(
+  logLevel?: LogLevel,
+  logScopes?: string[],
+): Promise<number> {
+  try {
+    if (!dbInitialized) {
+      return 0
+    }
+
+    const { whereClause, params } = buildLogFilterQuery(logLevel, logScopes)
+    const query = `SELECT COUNT(*) as count FROM logs ${whereClause}`
+    const result = await db().getFirstAsync<{ count: number }>(query, ...params)
+    return result?.count ?? 0
+  } catch (error) {
+    console.error('[logs] Failed to count logs:', error)
+    return 0
   }
 }
 


### PR DESCRIPTION
- Currently you must press refresh which is nice since logs don't jump out of view, but it might be confusing.
- Also the overflow menu is now dynamic, so depending on screen size the refresh button might get hidden.
- This change makes the logs auto pause when you scroll up, after which the user must hit the button to see new logs and re-actives automatic scrolling.

![Screenshot 2026-02-05 at 10.13.58 AM.png](https://app.graphite.com/user-attachments/assets/d2ac46b2-aa99-451a-ba20-5358e6d15193.png)

