### PR TITLE
fix: auto-refresh local storage stats while status sheet is open

### DIFF
--- a/.changeset/fix-local-storage-stats.md
+++ b/.changeset/fix-local-storage-stats.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Local storage stats now auto-refresh while the status sheet is open.

--- a/src/components/LibraryStatusSheet.tsx
+++ b/src/components/LibraryStatusSheet.tsx
@@ -12,6 +12,8 @@ import { RowGroup } from './Group'
 import { InfoCard } from './InfoCard'
 import { LabeledValueRow } from './LabeledValueRow'
 
+const refreshInterval = 5_000
+
 export function LibraryStatusSheet() {
   const isConnected = useIsConnected()
   const isOnline = useIsOnline()
@@ -20,12 +22,18 @@ export function LibraryStatusSheet() {
     ['upload-stats', isOpen ?? null],
     () => getUploadStats(),
     {
-      refreshInterval: 5_000,
+      refreshInterval,
     },
   )
-  const lostCount = useFileCountLost()
-  const localCount = useFileCountLocal({ localOnly: false })
-  const localOnlyCount = useFileCountLocal({ localOnly: true })
+  const lostCount = useFileCountLost({ refreshInterval })
+  const localCount = useFileCountLocal(
+    { localOnly: false },
+    { refreshInterval },
+  )
+  const localOnlyCount = useFileCountLocal(
+    { localOnly: true },
+    { refreshInterval },
+  )
 
   return (
     <ActionSheet

--- a/src/lib/selectors.ts
+++ b/src/lib/selectors.ts
@@ -1,4 +1,4 @@
-import useSWR, { type SWRResponse } from 'swr'
+import useSWR, { type SWRConfiguration, type SWRResponse } from 'swr'
 import type { StoreApi, UseBoundStore } from 'zustand'
 import { useShallow } from 'zustand/react/shallow'
 
@@ -48,10 +48,15 @@ export function createGetterAndSWRHook<T, Args extends any[] = []>(
   fetcher: (...args: Args) => Promise<T>,
 ): [
   (...args: Args) => Promise<T>,
-  (...args: Args) => SWRResponse<T, any, any>,
+  (...args: [...Args, SWRConfiguration?]) => SWRResponse<T, any, any>,
 ] {
+  const argCount = fetcher.length
   return [
     (...args: Args) => fetcher(...args),
-    (...args: Args) => useSWR([...key, ...args], () => fetcher(...args)),
+    (...argsAndConfig: [...Args, SWRConfiguration?]) => {
+      const args = argsAndConfig.slice(0, argCount) as unknown as Args
+      const config = argsAndConfig[argCount] as SWRConfiguration | undefined
+      return useSWR([...key, ...args], () => fetcher(...args), config)
+    },
   ]
 }


### PR DESCRIPTION
- During debugging noticed the upload status sheet was showing stale values for the local file counts.
- This change makes those values refresh while the sheet is open.
- Adds support for passing an SWR config to our createGetterAndSelector utils.