### PR TITLE
fix: remove misleading single upload cancellation

### DIFF
--- a/.changeset/remove-single-upload-cancel.md
+++ b/.changeset/remove-single-upload-cancel.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Cancel uploads now actually aborts in-flight batches instead of only clearing UI state.

--- a/src/components/SettingsAdvancedTransfers.tsx
+++ b/src/components/SettingsAdvancedTransfers.tsx
@@ -1,7 +1,8 @@
 import { useInputValue } from '../hooks/useInputValue'
 import { setMaxDownloads, useMaxDownloads } from '../managers/downloadsPool'
+import { getUploadManager } from '../managers/uploader'
 import { cancelAllDownloads, useDownloadCounts } from '../stores/downloads'
-import { cancelAllUploads, useUploadCounts } from '../stores/uploads'
+import { clearAllUploads, useUploadCounts } from '../stores/uploads'
 import { Button } from './Button'
 import { RowGroup } from './Group'
 import { InfoCard } from './InfoCard'
@@ -40,7 +41,8 @@ export function SettingsAdvancedTransfers() {
           style={{ marginTop: 10 }}
           disabled={uploadCounts.total === 0}
           onPress={() => {
-            cancelAllUploads()
+            getUploadManager().shutdown()
+            clearAllUploads()
           }}
         >
           Cancel uploads

--- a/src/lib/deleteFile.tsx
+++ b/src/lib/deleteFile.tsx
@@ -11,7 +11,7 @@ import {
 } from '../stores/localObjects'
 import { getSdk } from '../stores/sdk'
 import { removeTempDownloadFile } from '../stores/tempFs'
-import { cancelUpload } from '../stores/uploads'
+import { removeUploads } from '../stores/uploads'
 import { logger } from './logger'
 import { tryCatch } from './result'
 
@@ -27,7 +27,7 @@ async function tryStep<T>(
 }
 
 export async function permanentlyDeleteFile(file: FileRecord) {
-  cancelUpload(file.id)
+  removeUploads([file.id])
   await tryStep('deleteFileRecord', file.id, () =>
     deleteFileRecordAndThumbnails(file.id),
   )
@@ -51,8 +51,7 @@ export async function permanentlyDeleteFiles(
   const ids = files.map((f) => f.id)
   const hashes = files.map((f) => f.hash).filter(Boolean)
 
-  // Cancel uploads synchronously (fast, in-memory)
-  ids.forEach((id) => void cancelUpload(id))
+  removeUploads(ids)
 
   // Batch DB deletes (single transaction, single SWR trigger)
   // Also delete thumbnails for these files

--- a/src/managers/app.ts
+++ b/src/managers/app.ts
@@ -10,7 +10,7 @@ import { clearMnemonicHash } from '../stores/mnemonic'
 import { reconnectIndexer, resetSdk } from '../stores/sdk'
 import { getHasOnboarded, setHasOnboarded } from '../stores/settings'
 import { ensureTempFsStorageDirectory } from '../stores/tempFs'
-import { cancelAllUploads } from '../stores/uploads'
+import { clearAllUploads } from '../stores/uploads'
 import { initBackgroundTasks } from './backgroundTasks'
 import { initFsEvictionScanner } from './fsEvictionScanner'
 import { initFsOrphanScanner } from './fsOrphanScanner'
@@ -23,6 +23,7 @@ import {
 } from './syncPhotosArchive'
 import { initSyncUpMetadata } from './syncUpMetadata'
 import { initThumbnailScanner } from './thumbnailScanner'
+import { getUploadManager } from './uploader'
 import { initUploadScanner } from './uploadScanner'
 
 export async function initApp(): Promise<void> {
@@ -93,7 +94,8 @@ export async function initApp(): Promise<void> {
 }
 
 function cancelAllTransfers() {
-  cancelAllUploads()
+  getUploadManager().shutdown()
+  clearAllUploads()
   cancelAllDownloads()
 }
 

--- a/src/managers/syncDownEvents.test.ts
+++ b/src/managers/syncDownEvents.test.ts
@@ -14,7 +14,7 @@ import { readLocalObjectsForFile } from '../stores/localObjects'
 import { getIsConnected, getSdk } from '../stores/sdk'
 import { getIndexerURL } from '../stores/settings'
 import { removeTempDownloadFile } from '../stores/tempFs'
-import { cancelUpload } from '../stores/uploads'
+import { removeUpload } from '../stores/uploads'
 import {
   getSyncDownCursor,
   resetSyncDownCursor,
@@ -37,7 +37,7 @@ jest.mock('../stores/tempFs', () => ({
   removeTempDownloadFile: jest.fn(),
 }))
 jest.mock('../stores/uploads', () => ({
-  cancelUpload: jest.fn(),
+  removeUpload: jest.fn(),
 }))
 jest.mock('../stores/appKey', () => ({
   getAppKeyForIndexer: jest.fn(),
@@ -114,7 +114,7 @@ const getSdkMock = jest.mocked(getSdk)
 const getIndexerURLMock = jest.mocked(getIndexerURL)
 const removeFsFileMock = jest.mocked(removeFsFile)
 const removeTempDownloadFileMock = jest.mocked(removeTempDownloadFile)
-const cancelUploadMock = jest.mocked(cancelUpload)
+const removeUploadMock = jest.mocked(removeUpload)
 const getAppKeyForIndexerMock = jest.mocked(getAppKeyForIndexer)
 const getIsConnectedMock = jest.mocked(getIsConnected)
 
@@ -132,7 +132,7 @@ describe('syncDownEvents', () => {
     getIndexerURLMock.mockResolvedValue(INDEXER_URL)
     removeFsFileMock.mockResolvedValue(undefined)
     removeTempDownloadFileMock.mockResolvedValue(undefined)
-    cancelUploadMock.mockReturnValue(undefined)
+    removeUploadMock.mockReturnValue(undefined)
     getAppKeyForIndexerMock.mockResolvedValue({} as any)
   })
 
@@ -354,7 +354,7 @@ describe('syncDownEvents', () => {
 
     await syncDownEvents()
 
-    expect(cancelUploadMock).toHaveBeenCalledWith('file-1')
+    expect(removeUploadMock).toHaveBeenCalledWith('file-1')
     const updatedFile = await readFileRecordByObjectId('obj-1')
     expect(updatedFile).not.toBeNull()
   })

--- a/src/managers/syncDownEvents.ts
+++ b/src/managers/syncDownEvents.ts
@@ -30,7 +30,7 @@ import { getIsConnected, getSdk } from '../stores/sdk'
 import { getAutoSyncDownEvents, getIndexerURL } from '../stores/settings'
 import { removeTempDownloadFile } from '../stores/tempFs'
 import { readThumbnailRecordByThumbForHashAndSize } from '../stores/thumbnails'
-import { cancelUpload } from '../stores/uploads'
+import { removeUpload } from '../stores/uploads'
 
 const batchSize = 100
 
@@ -225,7 +225,7 @@ async function handleFileRecord(
       { includeUpdatedAt: true },
     )
     // Cancel any inflight upload for this file since we now have a pinned object.
-    cancelUpload(existingFile.id)
+    removeUpload(existingFile.id)
     counts.existing++
   } else {
     if (type === 'file') {

--- a/src/managers/uploader.test.ts
+++ b/src/managers/uploader.test.ts
@@ -329,7 +329,33 @@ describe('UploadManager', () => {
     })
 
     it('keeps errored files in store when some files fail during save', async () => {
-      // file1 has a DB record (will succeed), file2 does not (will fail with FK error)
+      const entry1 = await createTestFile('file1')
+      const entry2 = await createTestFile('file2')
+
+      manager.initialize(mockSdk, TEST_INDEXER_URL)
+      mockPacker.finalize.mockResolvedValueOnce([
+        mockPinnedObject,
+        mockPinnedObject,
+      ])
+      // pinObject succeeds for file1, fails for file2
+      mockSdk.pinObject
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error('Pin failed'))
+
+      await manager.queueFiles([entry1, entry2])
+      await manager.flush()
+
+      // file1 should be removed (success)
+      expect(getUploadState('file1')).toBeUndefined()
+
+      // file2 should remain with error status (failed to save)
+      const upload2 = getUploadState('file2')
+      expect(upload2).toBeDefined()
+      expect(upload2?.status).toBe('error')
+    })
+
+    it('skips pinning for files deleted during upload', async () => {
+      // file1 has a DB record (will succeed), file2 does not (deleted during upload)
       const entry1 = await createTestFile('file1')
       const entry2 = createFileEntry('file2-no-db-record')
 
@@ -345,10 +371,11 @@ describe('UploadManager', () => {
       // file1 should be removed (success)
       expect(getUploadState('file1')).toBeUndefined()
 
-      // file2 should remain with error status (failed to save)
-      const upload2 = getUploadState('file2-no-db-record')
-      expect(upload2).toBeDefined()
-      expect(upload2?.status).toBe('error')
+      // file2 should be removed (skipped because file was deleted)
+      expect(getUploadState('file2-no-db-record')).toBeUndefined()
+
+      // pinObject should only be called once (for file1, not file2)
+      expect(mockSdk.pinObject).toHaveBeenCalledTimes(1)
     })
 
     it('sets error when pinObject fails and does not save to local DB', async () => {

--- a/src/managers/uploader.ts
+++ b/src/managers/uploader.ts
@@ -467,6 +467,17 @@ class UploadManager {
       }
 
       try {
+        // Check if file still exists (may have been deleted while batch was in-flight)
+        const fileRecord = await readFileRecord(entry.fileId)
+        if (!fileRecord) {
+          logger.warn(
+            'uploadManager',
+            `File ${entry.fileId} deleted during upload, skipping pin`,
+          )
+          successfulFileIds.push(entry.fileId)
+          continue
+        }
+
         // Update metadata on the pinned object
         pinnedObject.updateMetadata(encodeFileMetadata(entry.file))
 

--- a/src/stores/uploads.ts
+++ b/src/stores/uploads.ts
@@ -130,14 +130,9 @@ export function removeUploads(ids: string[]) {
   })
 }
 
-export function cancelAllUploads() {
+export function clearAllUploads() {
   logger.debug('uploads', 'cancelling all uploads')
   useUploadsStore.setState({ uploads: {} })
-}
-
-export function cancelUpload(id: string) {
-  logger.debug('uploads', 'cancelling upload', id)
-  removeUpload(id)
 }
 
 export type UploadCounts = {


### PR DESCRIPTION
- Remove cancelUpload which only cleared UI state without actually aborting in-flight uploads. Call sites now use removeUpload directly.
- Wire up cancel buttons and shutdown to call uploadManager.shutdown() so batches are actually aborted.
- Skip pinning files deleted during upload to prevent orphaned objects.