### PR TITLE
fix: queue logs emitted before logger initializes

### DIFF
--- a/.changeset/queue-early-logs.md
+++ b/.changeset/queue-early-logs.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Logs emitted before the database is ready are now queued and flushed once the logger initializes.

--- a/src/lib/logAppender.ts
+++ b/src/lib/logAppender.ts
@@ -3,13 +3,22 @@ import type { LogEntry } from './logger'
 type LogAppender = (entry: LogEntry) => void
 
 let appender: LogAppender | null = null
+const queue: LogEntry[] = []
 
-/** Append a log entry. No-op if no appender is registered. */
+/** Append a log entry. Queues if no appender is registered yet. */
 export function appendLog(entry: LogEntry): void {
-  appender?.(entry)
+  if (!appender) {
+    queue.push(entry)
+    return
+  }
+  appender(entry)
 }
 
-/** Register the log appender function. */
+/** Register the log appender function and flush any queued entries. */
 export function setLogAppender(fn: LogAppender): void {
   appender = fn
+  for (const entry of queue) {
+    fn(entry)
+  }
+  queue.length = 0
 }


### PR DESCRIPTION
- Logs emitted before the database and logger are ready (e.g. during cold background starts) were silently dropped. Now they are queued in memory and flushed once the log appender is registered.