### PR TITLE
fix: android file sharing failing with null URI

### DIFF
--- a/.changeset/fix-android-share.md
+++ b/.changeset/fix-android-share.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fixed file sharing not working on Android.

--- a/app.config.js
+++ b/app.config.js
@@ -108,6 +108,7 @@ export default {
           ],
         },
       ],
+      './plugins/android-share-file-provider',
       [
         './plugins/android-release-signing',
         {

--- a/plugins/android-share-file-provider.js
+++ b/plugins/android-share-file-provider.js
@@ -1,0 +1,37 @@
+const { withDangerousMod } = require('@expo/config-plugins')
+const fs = require('fs/promises')
+const path = require('path')
+
+// Override react-native-share's default FileProvider paths to include
+// <files-path>, allowing sharing of files from Context.getFilesDir().
+// Without this, Share.open() fails on Android with a null URI error
+// because the library's default only covers Download/ and cache/.
+function withShareFileProvider(config) {
+  return withDangerousMod(config, [
+    'android',
+    async (config) => {
+      const xmlDir = path.join(
+        config.modRequest.platformProjectRoot,
+        'app/src/main/res/xml',
+      )
+      await fs.mkdir(xmlDir, { recursive: true })
+
+      const xmlContent = `<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path name="rnshare1" path="Download/" />
+    <cache-path name="rnshare2" path="/" />
+    <files-path name="internal_files" path="." />
+</paths>
+`
+      await fs.writeFile(
+        path.join(xmlDir, 'share_download_paths.xml'),
+        xmlContent,
+        'utf-8',
+      )
+
+      return config
+    },
+  ])
+}
+
+module.exports = withShareFileProvider

--- a/src/components/FileCarousel/index.tsx
+++ b/src/components/FileCarousel/index.tsx
@@ -191,7 +191,9 @@ export function FileCarousel({
         subject: `Sia Storage - ${currentFile.type}`,
       })
     } catch (e) {
-      if (typeof e === 'string' && !e.includes('User did not share')) {
+      const msg =
+        typeof e === 'string' ? e : e instanceof Error ? e.message : ''
+      if (!msg.includes('User did not share')) {
         logger.error('FileCarousel', 'File sharing failed', e)
       }
     }

--- a/src/hooks/useShareAction.tsx
+++ b/src/hooks/useShareAction.tsx
@@ -51,7 +51,9 @@ export function useShareAction({ fileId }: { fileId: string }) {
         subject: `Sia Storage - ${file.type}`,
       })
     } catch (e) {
-      if (typeof e === 'string' && !e.includes('User did not share')) {
+      const msg =
+        typeof e === 'string' ? e : e instanceof Error ? e.message : ''
+      if (!msg.includes('User did not share')) {
         logger.error('shareAction', 'File sharing failed:', e)
       }
     }


### PR DESCRIPTION
- This fixes the reported issue with the share button on Android.
- react-native-share's FileProvider only covers Download/ and cache/, but app files live in getFilesDir(). Add config plugin to extend the FileProvider paths.
- Also fix share error handler swallowing non-string errors.
