### PR TITLE
feat: add --release flag to dev builds for standalone phone usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "dev:ios:device": "bun scripts/dev.ts ios:device",
     "dev:android:emulator": "bun scripts/dev.ts android:emulator",
     "dev:android:device": "bun scripts/dev.ts android:device",
+    "dev:ios:device:release": "bun scripts/dev.ts ios:device --release",
+    "dev:android:device:release": "bun scripts/dev.ts android:device --release",
     "fastlane:ios:build-ipa": "fastlane ios build_ipa",
     "fastlane:android:distribute-play-store": "fastlane android distribute_play_store",
     "fastlane:android:distribute-internal": "fastlane android distribute_internal",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -22,6 +22,8 @@ export interface BuildOptions {
   target: BuildTarget
   /** Always clean and prebuild, even if platform dir exists */
   alwaysClean?: boolean
+  /** Build with Release configuration (bundles JS, no dev server needed) */
+  release?: boolean
 }
 
 /**
@@ -33,7 +35,9 @@ async function killExistingBuilds(platform: 'ios' | 'android'): Promise<void> {
     await $`pkill -f "xcodebuild.*SiaStorageDev" 2>/dev/null`.quiet().nothrow()
   } else {
     // Kill gradle processes for this project
-    await $`pkill -f "gradlew.*assembleDebug" 2>/dev/null`.quiet().nothrow()
+    await $`pkill -f "gradlew.*assemble(Debug|Release)" 2>/dev/null`
+      .quiet()
+      .nothrow()
   }
 }
 
@@ -125,7 +129,7 @@ export async function buildIosSim(options: BuildOptions): Promise<void> {
  * Note: Installation is handled separately in dev.ts using devicectl.
  */
 export async function buildIosDevice(options: BuildOptions): Promise<void> {
-  const { target, alwaysClean = false } = options
+  const { target, alwaysClean = false, release = false } = options
   const paths = getTargetPaths(target)
 
   console.log(`   Build log: ${paths.buildLog}`)
@@ -177,7 +181,8 @@ export async function buildIosDevice(options: BuildOptions): Promise<void> {
   }
 
   // Build for device using xcodebuild directly (no fastlane)
-  writeBuildLog(target, '=== XCODEBUILD (device) ===\n', true)
+  const configuration = release ? 'Release' : 'Debug'
+  writeBuildLog(target, `=== XCODEBUILD (device, ${configuration}) ===\n`, true)
 
   const result = await runProcess({
     command: [
@@ -187,7 +192,7 @@ export async function buildIosDevice(options: BuildOptions): Promise<void> {
       '-scheme',
       'SiaStorageDev',
       '-configuration',
-      'Debug',
+      configuration,
       '-sdk',
       'iphoneos',
       '-arch',
@@ -200,7 +205,7 @@ export async function buildIosDevice(options: BuildOptions): Promise<void> {
     ],
     cwd: PROJECT_ROOT,
     target,
-    label: 'Building iOS (device)',
+    label: `Building iOS (device, ${configuration})`,
   })
 
   if (!result.success) {
@@ -216,7 +221,7 @@ export async function buildIosDevice(options: BuildOptions): Promise<void> {
  * Build Android app
  */
 export async function buildAndroid(options: BuildOptions): Promise<void> {
-  const { target, alwaysClean = false } = options
+  const { target, alwaysClean = false, release = false } = options
   const paths = getTargetPaths(target)
 
   console.log(`   Build log: ${paths.buildLog}`)
@@ -246,14 +251,31 @@ export async function buildAndroid(options: BuildOptions): Promise<void> {
     }
   }
 
+  // Validate signing env vars for release builds
+  if (release) {
+    const requiredVars = [
+      'SIA_RELEASE_STORE_FILE',
+      'SIA_RELEASE_STORE_PASSWORD',
+      'SIA_RELEASE_KEY_ALIAS',
+      'SIA_RELEASE_KEY_PASSWORD',
+    ]
+    const missing = requiredVars.filter((v) => !process.env[v])
+    if (missing.length > 0) {
+      throw new Error(
+        `Android release build requires signing env vars: ${missing.join(', ')}`,
+      )
+    }
+  }
+
   // Build APK using unified process runner
-  writeBuildLog(target, '=== GRADLE ===\n', true)
+  const gradleTask = release ? 'assembleRelease' : 'assembleDebug'
+  writeBuildLog(target, `=== GRADLE (${gradleTask}) ===\n`, true)
 
   const result = await runProcess({
-    command: ['./gradlew', 'assembleDebug', '--no-daemon'],
+    command: ['./gradlew', gradleTask, '--no-daemon'],
     cwd: join(PROJECT_ROOT, 'android'),
     target,
-    label: 'Building Android',
+    label: `Building Android (${gradleTask})`,
   })
 
   if (!result.success) {
@@ -270,10 +292,12 @@ export async function buildAndroid(options: BuildOptions): Promise<void> {
  */
 export async function findIosDeviceApp(
   target: BuildTarget,
+  options: { release?: boolean } = {},
 ): Promise<string | null> {
   const paths = getTargetPaths(target)
+  const config = options.release ? 'Release' : 'Debug'
   const result =
-    await $`find ${paths.derivedData} -name "*.app" -path "*Debug-iphoneos*" -type d 2>/dev/null`
+    await $`find ${paths.derivedData} -name "*.app" -path "*${config}-iphoneos*" -type d 2>/dev/null`
       .quiet()
       .nothrow()
   const found = result.stdout.toString().trim().split('\n').filter(Boolean)[0]

--- a/scripts/buildCache.ts
+++ b/scripts/buildCache.ts
@@ -30,8 +30,10 @@ export const BUILD_CACHE_DIR = join(PROJECT_ROOT, '.build-cache')
 // Note: Android emulator and device share the same build (same APK works for both)
 export type BuildTarget =
   | 'ios-sim' // iOS Simulator builds (dev and e2e)
-  | 'ios-device' // iOS real device builds
-  | 'android' // Android builds (emulator and device share same APK)
+  | 'ios-device' // iOS real device builds (debug)
+  | 'ios-device-release' // iOS real device builds (release, standalone)
+  | 'android' // Android builds (emulator and device share same APK, debug)
+  | 'android-release' // Android release builds (standalone)
 
 // Get paths for a specific build target
 export function getTargetPaths(target: BuildTarget) {
@@ -110,7 +112,11 @@ export function needsRebuild(
     }
   } else {
     // Android: check for APK in standard location
-    const apkDir = join(PROJECT_ROOT, 'android/app/build/outputs/apk/debug')
+    const apkVariant = target === 'android-release' ? 'release' : 'debug'
+    const apkDir = join(
+      PROJECT_ROOT,
+      `android/app/build/outputs/apk/${apkVariant}`,
+    )
     if (!existsSync(apkDir)) {
       return [true, 'no Android APK found']
     }

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -12,6 +12,7 @@
  * Flags:
  *   --rebuild    Full clean build (delete platform dir, prebuild, build)
  *   --no-run     Build only, don't launch the app
+ *   --release    Build with Release config (bundles JS, no dev server needed)
  *
  * How caching works:
  *   - Computes hash from package.json, bun.lock, app.config.js, eas.json, plugins/*.js
@@ -19,9 +20,11 @@
  *   - Skips rebuild if hash matches and artifacts exist
  *
  * Cache locations:
- *   .build-cache/ios-sim/    - iOS Simulator builds
- *   .build-cache/ios-device/ - iOS device builds
- *   .build-cache/android/    - Android builds (shared by emulator and device)
+ *   .build-cache/ios-sim/            - iOS Simulator builds
+ *   .build-cache/ios-device/         - iOS device builds (debug)
+ *   .build-cache/ios-device-release/ - iOS device builds (release)
+ *   .build-cache/android/            - Android builds (debug, shared by emulator and device)
+ *   .build-cache/android-release/    - Android release builds
  */
 
 import { rmSync } from 'node:fs'
@@ -57,6 +60,7 @@ const args = process.argv.slice(2)
 const targetArg = args.find((a) => !a.startsWith('-'))
 const forceRebuild = args.includes('--rebuild')
 const noRun = args.includes('--no-run')
+const release = args.includes('--release')
 
 // Map CLI arg to build target
 function getTarget(): BuildTarget {
@@ -65,12 +69,12 @@ function getTarget(): BuildTarget {
     case 'ios:sim':
       return 'ios-sim'
     case 'ios:device':
-      return 'ios-device'
+      return release ? 'ios-device-release' : 'ios-device'
     case 'android:emulator':
     case 'android:emu':
-      return 'android'
+      return release ? 'android-release' : 'android'
     case 'android:device':
-      return 'android' // Same build as emulator, just different device selection
+      return release ? 'android-release' : 'android'
     default:
       console.error('Usage: bun scripts/dev.ts <target> [flags]')
       console.error('')
@@ -85,20 +89,26 @@ function getTarget(): BuildTarget {
         '  --rebuild    Full clean build (delete platform dir, prebuild, build)',
       )
       console.error("  --no-run     Build only, don't launch the app")
+      console.error(
+        '  --release    Build with Release config (standalone, no dev server)',
+      )
       process.exit(1)
   }
 }
 
 const target = getTarget()
 const platform = target.includes('ios') ? 'ios' : 'android'
-const isDevice = target === 'ios-device' || targetArg === 'android:device'
+const isDevice =
+  target === 'ios-device' ||
+  target === 'ios-device-release' ||
+  targetArg === 'android:device'
 const paths = getTargetPaths(target)
 
 // Print header
 console.log(`\n🚀 Smart Dev Build`)
 console.log(`   Target: ${targetArg}`)
 console.log(
-  `   Flags: ${[forceRebuild && '--rebuild', noRun && '--no-run'].filter(Boolean).join(' ') || 'none'}`,
+  `   Flags: ${[forceRebuild && '--rebuild', noRun && '--no-run', release && '--release'].filter(Boolean).join(' ') || 'none'}`,
 )
 console.log(`   Cache: .build-cache/${target}/`)
 console.log('')
@@ -117,7 +127,7 @@ if (forceRebuild) {
 
 // For iOS device builds, check for connected device first (before building)
 let selectedDevice: Device | null = null
-if (target === 'ios-device') {
+if (target === 'ios-device' || target === 'ios-device-release') {
   console.log('📱 Checking for iOS device...')
   selectedDevice = await selectDevice('ios', 'device')
 
@@ -136,8 +146,11 @@ if (target === 'ios-device') {
   console.log('')
 }
 
-// Check if rebuild needed
-const [rebuildNeeded, reason] = needsRebuild(target, { forceRebuild })
+// Release builds always rebuild to ensure the JS bundle is fresh.
+// Debug builds use the cache since JS loads from Metro.
+const [rebuildNeeded, reason] = release
+  ? [true, 'release build (always rebuilds)']
+  : needsRebuild(target, { forceRebuild })
 
 if (rebuildNeeded) {
   console.log(`🔨 Build needed: ${reason}`)
@@ -145,12 +158,12 @@ if (rebuildNeeded) {
   // Platform-specific build
   if (platform === 'ios') {
     if (isDevice) {
-      await buildIosDevice({ target })
+      await buildIosDevice({ target, release })
     } else {
       await buildIosSim({ target })
     }
   } else {
-    await buildAndroid({ target })
+    await buildAndroid({ target, release })
   }
 
   console.log('✅ Build complete')
@@ -182,7 +195,7 @@ async function runIosDevice(): Promise<void> {
   console.log('📱 Installing on iOS device...')
 
   // Find the built app
-  const appPath = await findIosDeviceApp(target)
+  const appPath = await findIosDeviceApp(target, { release })
   if (!appPath) {
     console.error('   Could not find built app')
     process.exit(1)
@@ -279,7 +292,11 @@ async function runAndroid(): Promise<void> {
 
 // Find Android APK
 async function findAndroidApk(): Promise<string> {
-  const apkDir = join(PROJECT_ROOT, 'android/app/build/outputs/apk/debug')
+  const apkVariant = release ? 'release' : 'debug'
+  const apkDir = join(
+    PROJECT_ROOT,
+    `android/app/build/outputs/apk/${apkVariant}`,
+  )
   const apkResult = await $`find ${apkDir} -name "*.apk" 2>/dev/null`
     .quiet()
     .nothrow()


### PR DESCRIPTION
- Adds `dev:ios:device:release` and `dev:android:device:release` which puts a sia.storage.dev release build on a device that can be used without a dev server.