### PR TITLE
fix: prevent carousel flickering, position shifts, and detail view issues

### DIFF
--- a/.changeset/fix-carousel-file-not-found-during-sync.md
+++ b/.changeset/fix-carousel-file-not-found-during-sync.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fixed file viewer flickering and showing wrong file during sync by using a frozen ID window for carousel positions.

--- a/.changeset/fix-detail-text-crash.md
+++ b/.changeset/fix-detail-text-crash.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fixed crash in file details view caused by rendering a number outside a Text component.

--- a/.changeset/fix-detail-toggle-persistence.md
+++ b/.changeset/fix-detail-toggle-persistence.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fixed image reloading when switching between viewer and detail view.

--- a/.changeset/fix-detail-view-scroll.md
+++ b/.changeset/fix-detail-view-scroll.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fixed file detail view not scrollable on Android by using gesture-handler-aware ScrollView.

--- a/.changeset/improve-drag-to-dismiss.md
+++ b/.changeset/improve-drag-to-dismiss.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Improved drag-to-dismiss gesture to feel more responsive with velocity-based flick detection and a lower distance threshold.

--- a/src/components/DragToDismiss.tsx
+++ b/src/components/DragToDismiss.tsx
@@ -17,6 +17,7 @@ type Props = {
   children: ReactNode
   onDismiss: () => void
   onDragStart?: () => void
+  onDragCancel?: () => void
   enabled?: boolean
   dismissThreshold?: number
 }
@@ -31,8 +32,9 @@ export function DragToDismiss({
   children,
   onDismiss,
   onDragStart,
+  onDragCancel,
   enabled = true,
-  dismissThreshold = 150,
+  dismissThreshold = 100,
 }: Props) {
   const { height: screenHeight } = useWindowDimensions()
   const translateY = useSharedValue(0)
@@ -89,11 +91,18 @@ export function DragToDismiss({
       }
     })
     .onEnd((event) => {
-      if (event.translationY > dismissThreshold) {
+      // Dismiss on sufficient drag distance OR a quick downward flick,
+      // similar to iOS Photos.
+      const isDragged = event.translationY > dismissThreshold
+      const isFlicked = event.velocityY > 800
+      if (isDragged || isFlicked) {
         translateY.value = withSpring(screenHeight, { damping: 20 })
         runOnJS(onDismiss)()
       } else {
         translateY.value = withSpring(0)
+        if (onDragCancel) {
+          runOnJS(onDragCancel)()
+        }
       }
     })
 
@@ -121,18 +130,24 @@ export function DragToDismiss({
     }
   })
 
-  // On Android, wrap content with a native gesture to allow children to receive touches
-  const nativeGesture = Gesture.Native()
-  const composedGesture =
+  // Android: Gesture.Native() lets child native components (e.g. buttons)
+  // receive touches alongside the pan gesture. Not needed on iOS.
+  const androidNativeGesture = Gesture.Native()
+  const dismissGesture =
     Platform.OS === 'android'
-      ? Gesture.Simultaneous(panGesture, nativeGesture)
+      ? Gesture.Simultaneous(panGesture, androidNativeGesture)
       : panGesture
 
+  // GestureDetector must always stay mounted to keep the React tree stable.
+  // Conditionally removing it causes children to unmount/remount, resetting
+  // all state. Scrollable children (e.g. FileDetails) must use ScrollView
+  // from react-native-gesture-handler so they can negotiate with this
+  // GestureDetector on Android.
   return (
     <DragToDismissGestureContext.Provider value={panGesture}>
       <View style={styles.container}>
         <Animated.View style={[styles.backdrop, backdropStyle]} />
-        <GestureDetector gesture={composedGesture}>
+        <GestureDetector gesture={dismissGesture}>
           <Animated.View style={[styles.content, contentStyle]}>
             {children}
           </Animated.View>

--- a/src/components/FileCarousel/index.tsx
+++ b/src/components/FileCarousel/index.tsx
@@ -8,7 +8,6 @@ import {
   Platform,
   Pressable,
   StyleSheet,
-  Text,
   View,
 } from 'react-native'
 import Carousel, {
@@ -24,7 +23,7 @@ import {
 import { logger } from '../../lib/logger'
 import { generateSiaShareUrl } from '../../lib/shareUrl'
 import { useToast } from '../../lib/toastContext'
-import { useVirtualFileList } from '../../stores/fileCarousel'
+import { useFileCarousel } from '../../stores/fileCarousel'
 import type { FileRecord } from '../../stores/files'
 import { useSdk } from '../../stores/sdk'
 import { palette } from '../../styles/colors'
@@ -41,6 +40,7 @@ type Props = {
   onClose: () => void
   onShowActionSheet?: () => void
   onZoomChange?: (isZoomed: boolean) => void
+  onViewStyleChange?: (viewStyle: 'consume' | 'detail') => void
   isDismissing?: boolean
 }
 
@@ -50,17 +50,24 @@ export function FileCarousel({
   onClose,
   onShowActionSheet,
   onZoomChange,
+  onViewStyleChange,
   isDismissing,
 }: Props) {
-  const [viewStyle, setViewStyle] = useState<'consume' | 'detail'>('consume')
-  const [showChrome, setShowChrome] = useState(false)
+  const [viewStyle, _setViewStyle] = useState<'consume' | 'detail'>('consume')
 
-  // Hide chrome during drag-to-dismiss
-  useEffect(() => {
-    if (isDismissing) {
-      setShowChrome(false)
-    }
-  }, [isDismissing])
+  const setViewStyle = useCallback(
+    (style: 'consume' | 'detail') => {
+      _setViewStyle(style)
+      onViewStyleChange?.(style)
+      // Keep controls visible when switching back from detail view,
+      // since the user just interacted with the control bar toggle.
+      if (style === 'consume') {
+        setShowChrome(true)
+      }
+    },
+    [onViewStyleChange],
+  )
+  const [showChrome, setShowChrome] = useState(false)
   const [isScreenReaderEnabled, setIsScreenReaderEnabled] = useState(false)
   const [isZoomed, setIsZoomed] = useState(false)
 
@@ -71,27 +78,18 @@ export function FileCarousel({
     onClose()
   }, [onClose, toast])
 
-  const handleFileUpdated = useCallback(
-    (message: string) => {
-      toast.show(message)
-    },
-    [toast],
-  )
-
   const {
     totalCount,
     currentIndex,
     currentFile,
     getFileAtIndex,
     setCurrentIndex,
-    isLoading,
-  } = useVirtualFileList({
+  } = useFileCarousel({
     initialId,
     initialFile,
     prefetchRadius: 3,
     maxCacheSize: 50,
     onDeleted: handleFileDeleted,
-    onUpdated: handleFileUpdated,
   })
 
   const [viewerSize, setViewerSize] = useState({ width: 0, height: 0 })
@@ -112,30 +110,27 @@ export function FileCarousel({
     return Array.from({ length: totalCount }, (_, i) => i)
   }, [totalCount])
 
-  // Scroll to the file's position once we know it. The carousel's defaultIndex
-  // only works on mount, but currentIndex is determined asynchronously after
-  // querying the DB for the file's position in the sorted list. Once totalCount
-  // transitions from placeholder (0 or 1) to the real count, scroll to position.
-  const hasScrolledToInitialPosition = useRef(false)
-  const previousTotalCount = useRef(totalCount)
+  const isDetailView = viewStyle === 'detail'
+
+  // Opacity swap: render the initial file directly while the carousel mounts
+  // invisibly behind it, then atomically swap after 2 animation frames. This
+  // avoids a flicker where the carousel briefly shows index 0 before scrolling
+  // to the correct defaultIndex position.
+  const showCarousel = carouselData.length > 1 && viewerSize.width > 0
+  const [carouselReady, setCarouselReady] = useState(false)
 
   useEffect(() => {
-    const wasInitial = previousTotalCount.current <= 1
-    const isNowReal = totalCount > 1
-    const carousel = carouselRef.current
-    const carouselReady = viewerSize.width > 0 && carousel
-
-    if (
-      wasInitial &&
-      isNowReal &&
-      carouselReady &&
-      !hasScrolledToInitialPosition.current
-    ) {
-      hasScrolledToInitialPosition.current = true
-      carousel.scrollTo({ index: currentIndex, animated: false })
+    if (!showCarousel) return
+    let cancelled = false
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        if (!cancelled) setCarouselReady(true)
+      })
+    })
+    return () => {
+      cancelled = true
     }
-    previousTotalCount.current = totalCount
-  }, [totalCount, currentIndex, viewerSize.width])
+  }, [showCarousel])
 
   // Unlock screen orientation.
   useEffect(() => {
@@ -241,25 +236,9 @@ export function FileCarousel({
 
       if (!file) {
         return (
-          <View style={styles.center}>
+          <Pressable style={styles.center} onPress={toggleControlsVisibility}>
             <BlocksLoader size={20} />
-          </View>
-        )
-      }
-
-      if (viewStyle === 'detail') {
-        return (
-          <FileDetails
-            file={file}
-            header={
-              <FileCarouselHeader
-                file={file}
-                title={file.name ?? 'Details'}
-                navigation={navigationProxy}
-                icon="close"
-              />
-            }
-          />
+          </Pressable>
         )
       }
 
@@ -281,14 +260,12 @@ export function FileCarousel({
       handleImageZoomChange,
       goToNext,
       goToPrev,
-      viewStyle,
-      navigationProxy,
     ],
   )
 
   return (
     <View style={styles.container}>
-      {showChrome && viewStyle === 'consume' ? (
+      {showChrome && !isDetailView && !isDismissing ? (
         <View style={styles.headerOverlay} pointerEvents="box-none">
           <FileCarouselHeader
             file={currentFile ?? undefined}
@@ -301,38 +278,80 @@ export function FileCarousel({
 
       {currentFile ? (
         <View style={styles.viewer} onLayout={handleViewerLayout}>
-          {carouselData.length > 0 && viewerSize.width > 0 && (
-            <Carousel
-              ref={carouselRef}
-              data={carouselData}
-              renderItem={renderItem}
-              width={viewerSize.width}
-              height={viewerSize.height}
-              defaultIndex={currentIndex}
-              onSnapToItem={handleSnapToItem}
-              loop={false}
-              enabled={!isZoomed}
-              windowSize={5}
-              onConfigurePanGesture={(gesture) => {
-                gesture.activeOffsetX([-10, 10])
-                // On Android, coordinate with DragToDismiss gesture to allow both to work
-                if (Platform.OS === 'android' && dragToDismissGesture) {
-                  gesture.simultaneousWithExternalGesture(dragToDismissGesture)
-                }
-              }}
+          {/* Both views stay mounted to preserve state across toggles.
+              The inactive view is hidden with opacity:0 + pointerEvents:none. */}
+          <View
+            style={isDetailView ? styles.hiddenLayer : styles.activeLayer}
+            pointerEvents={isDetailView ? 'none' : 'auto'}
+          >
+            {/* Base layer: renders the initial file directly so there's no
+                gap frame while the carousel mounts invisibly. Hidden once the
+                carousel is ready, to prevent it showing through during swipes
+                or zoom/pan. */}
+            <View
+              style={carouselReady ? styles.hiddenLayer : styles.activeLayer}
+              pointerEvents={carouselReady ? 'none' : 'auto'}
+            >
+              {renderItem({ item: currentIndex })}
+            </View>
+            {showCarousel && (
+              <View
+                style={[
+                  styles.absoluteFill,
+                  !carouselReady && styles.transparent,
+                ]}
+                pointerEvents={carouselReady ? 'auto' : 'none'}
+              >
+                <Carousel
+                  ref={carouselRef}
+                  data={carouselData}
+                  renderItem={renderItem}
+                  width={viewerSize.width}
+                  height={viewerSize.height}
+                  defaultIndex={currentIndex}
+                  onSnapToItem={handleSnapToItem}
+                  loop={false}
+                  enabled={!isZoomed && !isDismissing}
+                  windowSize={5}
+                  onConfigurePanGesture={(gesture) => {
+                    gesture.activeOffsetX([-10, 10])
+                    // Android: carousel waits for DragToDismiss to fail
+                    // (horizontal movement) before activating. Prevents
+                    // diagonal drags from swiping the carousel sideways
+                    // during drag-to-dismiss.
+                    if (Platform.OS === 'android' && dragToDismissGesture) {
+                      gesture.requireExternalGestureToFail(dragToDismissGesture)
+                    }
+                  }}
+                />
+              </View>
+            )}
+          </View>
+          {/* Detail view uses RNGH ScrollView so it can scroll within the
+              DragToDismiss GestureDetector hierarchy on Android. */}
+          <View
+            style={[styles.absoluteFill, !isDetailView && styles.hiddenLayer]}
+            pointerEvents={isDetailView ? 'auto' : 'none'}
+          >
+            <FileDetails
+              file={currentFile}
+              header={
+                <FileCarouselHeader
+                  file={currentFile}
+                  title={currentFile.name ?? 'Details'}
+                  navigation={navigationProxy}
+                  icon="close"
+                />
+              }
             />
-          )}
-        </View>
-      ) : isLoading ? (
-        <View style={styles.center}>
-          <BlocksLoader size={20} />
+          </View>
         </View>
       ) : (
-        <View style={styles.center}>
-          <Text style={styles.text}>File not found</Text>
-        </View>
+        <Pressable style={styles.center} onPress={toggleControlsVisibility}>
+          <BlocksLoader size={20} />
+        </Pressable>
       )}
-      {currentFile && (showChrome || viewStyle === 'detail') ? (
+      {currentFile && (showChrome || isDetailView) && !isDismissing ? (
         <View
           style={[
             styles.controlBarOverlay,
@@ -380,10 +399,11 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
-  text: {
-    color: palette.gray[50],
-  },
   viewer: { flex: 1 },
+  activeLayer: { flex: 1 },
+  hiddenLayer: { flex: 1, opacity: 0 },
+  absoluteFill: { position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 },
+  transparent: { opacity: 0 },
   headerOverlay: {
     position: 'absolute',
     top: 0,

--- a/src/components/FileDetails/FileMeta.tsx
+++ b/src/components/FileDetails/FileMeta.tsx
@@ -186,7 +186,7 @@ export function FileMeta({
                   />
                   <LabeledValueRow
                     label="Slabs"
-                    value={pinnedObject.slabs().length}
+                    value={String(pinnedObject.slabs().length)}
                     isMonospace
                     showDividerTop
                   />

--- a/src/components/FileDetails/index.tsx
+++ b/src/components/FileDetails/index.tsx
@@ -1,5 +1,9 @@
 import type React from 'react'
-import { ScrollView, StyleSheet, View } from 'react-native'
+import { StyleSheet, View } from 'react-native'
+// RNGH ScrollView instead of RN ScrollView so it can negotiate with other
+// gesture handlers in the tree. The standard RN ScrollView doesn't receive
+// scroll events on Android when nested inside a GestureHandlerRootView.
+import { ScrollView } from 'react-native-gesture-handler'
 import { useFileStatus } from '../../lib/file'
 import type { FileRecord } from '../../stores/files'
 import { colors, palette } from '../../styles/colors'
@@ -16,7 +20,10 @@ export function FileDetails({
 
   return (
     <View style={styles.container}>
-      <ScrollView contentContainerStyle={styles.scrollContent}>
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
         {header}
         <View style={styles.metaContainer}>
           {status.data ? <FileMeta file={file} status={status.data} /> : null}

--- a/src/managers/app.ts
+++ b/src/managers/app.ts
@@ -1,3 +1,4 @@
+import { mutate } from 'swr'
 import { initializeDB, resetDb } from '../db'
 import { shutdownAllServiceIntervals } from '../lib/serviceInterval'
 import { type InitStep, setAppState } from '../stores/app'
@@ -125,6 +126,7 @@ export async function resetApp() {
         await resetSdk()
         await resetPhotosNewCursor()
         await resetPhotosArchiveCursor()
+        await mutate(() => true, undefined, { revalidate: false })
       },
     },
   ])

--- a/src/screens/LibraryScreen.tsx
+++ b/src/screens/LibraryScreen.tsx
@@ -55,6 +55,7 @@ export function LibraryScreen({ route, navigation }: Props) {
     return files.data?.find((f) => f.id === openFileId) ?? null
   })
   const [isCarouselZoomed, setIsCarouselZoomed] = useState(false)
+  const [isCarouselDetail, setIsCarouselDetail] = useState(false)
   const [isDraggingToDismiss, setIsDraggingToDismiss] = useState(false)
   const fadeAnim = useRef(new Animated.Value(0)).current
   const scaleAnim = useRef(new Animated.Value(0.95)).current
@@ -262,13 +263,16 @@ export function LibraryScreen({ route, navigation }: Props) {
           ]}
           pointerEvents="box-none"
         >
+          {/* Disable drag-to-dismiss when zoomed into an image or viewing
+              file details, so the detail ScrollView can scroll freely. */}
           <DragToDismiss
             onDismiss={() => {
               setSelectedFile(null)
               setIsDraggingToDismiss(false)
             }}
             onDragStart={() => setIsDraggingToDismiss(true)}
-            enabled={!isCarouselZoomed}
+            onDragCancel={() => setIsDraggingToDismiss(false)}
+            enabled={!isCarouselZoomed && !isCarouselDetail}
           >
             <FileCarousel
               initialId={selectedFile.id}
@@ -276,6 +280,7 @@ export function LibraryScreen({ route, navigation }: Props) {
               onClose={() => setSelectedFile(null)}
               onShowActionSheet={handleShowCarouselActions}
               onZoomChange={setIsCarouselZoomed}
+              onViewStyleChange={(s) => setIsCarouselDetail(s === 'detail')}
               isDismissing={isDraggingToDismiss}
             />
           </DragToDismiss>

--- a/src/stores/fileCarousel.test.ts
+++ b/src/stores/fileCarousel.test.ts
@@ -2,9 +2,10 @@ import { act, renderHook, waitFor } from '@testing-library/react-native'
 import { db, initializeDB, resetDb } from '../db'
 import {
   fetchFilePosition,
-  fetchFilesAtIndices,
+  fetchFilesByIDs,
+  fetchSortedFileIds,
   fetchTotalCount,
-  useVirtualFileList,
+  useFileCarousel,
 } from './fileCarousel'
 import { createFileRecord } from './files'
 import type { Category } from './library'
@@ -327,85 +328,46 @@ describe('fileCarousel virtual list functions', () => {
     })
   })
 
-  describe('fetchFilesAtIndices', () => {
-    test('fetches files at specified indices', async () => {
+  describe('fetchSortedFileIds', () => {
+    test('returns IDs in sort order', async () => {
       await seedDateRecords()
-      // DESC order: file-e(0), file-d(1), file-c(2), file-b(3), file-a(4)
-
-      const files = await fetchFilesAtIndices([0, 2, 4], defaultParams)
-
-      expect(files.size).toBe(3)
-      expect(files.get(0)?.id).toBe('file-e')
-      expect(files.get(2)?.id).toBe('file-c')
-      expect(files.get(4)?.id).toBe('file-a')
+      // DESC order: file-e, file-d, file-c, file-b, file-a
+      const ids = await fetchSortedFileIds(defaultParams, 5, 0)
+      expect(ids).toEqual(['file-e', 'file-d', 'file-c', 'file-b', 'file-a'])
     })
 
-    test('returns empty map for empty indices array', async () => {
+    test('respects limit and offset', async () => {
       await seedDateRecords()
-      const files = await fetchFilesAtIndices([], defaultParams)
+      const ids = await fetchSortedFileIds(defaultParams, 2, 1)
+      expect(ids).toEqual(['file-d', 'file-c'])
+    })
+
+    test('returns empty array for empty database', async () => {
+      const ids = await fetchSortedFileIds(defaultParams, 10, 0)
+      expect(ids).toEqual([])
+    })
+  })
+
+  describe('fetchFilesByIDs', () => {
+    test('returns files keyed by ID', async () => {
+      await seedDateRecords()
+      const files = await fetchFilesByIDs(['file-a', 'file-c', 'file-e'])
+      expect(files.size).toBe(3)
+      expect(files.get('file-a')?.name).toBe('a.jpg')
+      expect(files.get('file-c')?.name).toBe('c.jpg')
+      expect(files.get('file-e')?.name).toBe('e.jpg')
+    })
+
+    test('returns empty map for empty ID list', async () => {
+      const files = await fetchFilesByIDs([])
       expect(files.size).toBe(0)
     })
 
-    test('skips out-of-bounds indices', async () => {
+    test('skips nonexistent IDs', async () => {
       await seedDateRecords()
-      const files = await fetchFilesAtIndices([0, 10, 100], defaultParams)
+      const files = await fetchFilesByIDs(['file-a', 'nonexistent'])
       expect(files.size).toBe(1)
-      expect(files.get(0)?.id).toBe('file-e')
-    })
-
-    test('fetches contiguous range', async () => {
-      await seedDateRecords()
-      const files = await fetchFilesAtIndices([1, 2, 3], defaultParams)
-
-      expect(files.size).toBe(3)
-      expect(files.get(1)?.id).toBe('file-d')
-      expect(files.get(2)?.id).toBe('file-c')
-      expect(files.get(3)?.id).toBe('file-b')
-    })
-
-    test('respects category filter', async () => {
-      await createRecord({
-        id: 'img-1',
-        name: 'photo1.jpg',
-        createdAt: base,
-        type: 'image/jpeg',
-      })
-      await createRecord({
-        id: 'vid-1',
-        name: 'video1.mp4',
-        createdAt: base + 10,
-        type: 'video/mp4',
-      })
-      await createRecord({
-        id: 'img-2',
-        name: 'photo2.jpg',
-        createdAt: base + 20,
-        type: 'image/jpeg',
-      })
-
-      const files = await fetchFilesAtIndices([0, 1], {
-        ...defaultParams,
-        categories: ['Image'],
-      })
-
-      // Images only DESC: img-2(0), img-1(1)
-      expect(files.size).toBe(2)
-      expect(files.get(0)?.id).toBe('img-2')
-      expect(files.get(1)?.id).toBe('img-1')
-    })
-
-    test('respects sort order', async () => {
-      await seedDateRecords()
-
-      const ascFiles = await fetchFilesAtIndices([0, 1, 2], {
-        ...defaultParams,
-        sortDir: 'ASC',
-      })
-
-      // ASC order: file-a(0), file-b(1), file-c(2)
-      expect(ascFiles.get(0)?.id).toBe('file-a')
-      expect(ascFiles.get(1)?.id).toBe('file-b')
-      expect(ascFiles.get(2)?.id).toBe('file-c')
+      expect(files.get('file-a')?.id).toBe('file-a')
     })
   })
 
@@ -415,11 +377,11 @@ describe('fileCarousel virtual list functions', () => {
 
       const count = await fetchTotalCount(defaultParams)
       const position = await fetchFilePosition('only-file', defaultParams)
-      const files = await fetchFilesAtIndices([0], defaultParams)
+      const files = await fetchFilesByIDs(['only-file'])
 
       expect(count).toBe(1)
       expect(position).toBe(0)
-      expect(files.get(0)?.id).toBe('only-file')
+      expect(files.get('only-file')?.id).toBe('only-file')
     })
 
     test('handles files with null names', async () => {
@@ -437,18 +399,13 @@ describe('fileCarousel virtual list functions', () => {
       })
       expect(count).toBe(2)
 
-      // NAME ASC: null names sort first (or last depending on impl), then alphabetical
-      const files = await fetchFilesAtIndices([0, 1], {
-        ...defaultParams,
-        sortBy: 'NAME',
-        sortDir: 'ASC',
-      })
+      const files = await fetchFilesByIDs(['file-null', 'file-named'])
       expect(files.size).toBe(2)
     })
   })
 })
 
-describe('useVirtualFileList hook', () => {
+describe('useFileCarousel hook', () => {
   const base = 2_000
 
   beforeEach(async () => {
@@ -484,27 +441,6 @@ describe('useVirtualFileList hook', () => {
     await db().runAsync('DELETE FROM files WHERE id = ?', id)
   }
 
-  async function updateRecord(
-    id: string,
-    updates: { name?: string; updatedAt?: number },
-  ) {
-    const setClauses: string[] = []
-    const params: (string | number)[] = []
-    if (updates.name !== undefined) {
-      setClauses.push('name = ?')
-      params.push(updates.name)
-    }
-    if (updates.updatedAt !== undefined) {
-      setClauses.push('updatedAt = ?')
-      params.push(updates.updatedAt)
-    }
-    params.push(id)
-    await db().runAsync(
-      `UPDATE files SET ${setClauses.join(', ')} WHERE id = ?`,
-      ...params,
-    )
-  }
-
   function triggerSyncChange() {
     mockChangeCallbacks.forEach((callback) => callback())
   }
@@ -516,7 +452,7 @@ describe('useVirtualFileList hook', () => {
 
       const onDeleted = jest.fn()
       const { result } = renderHook(() =>
-        useVirtualFileList({
+        useFileCarousel({
           initialId: 'file-2',
           onDeleted,
         }),
@@ -540,47 +476,13 @@ describe('useVirtualFileList hook', () => {
       expect(onDeleted).toHaveBeenCalled()
     })
 
-    test('calls onUpdated when file metadata changes', async () => {
-      await createRecord({
-        id: 'file-1',
-        name: 'original.jpg',
-        createdAt: base,
-      })
-
-      const onUpdated = jest.fn()
-      const { result } = renderHook(() =>
-        useVirtualFileList({
-          initialId: 'file-1',
-          onUpdated,
-        }),
-      )
-
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false)
-      })
-
-      expect(result.current.currentFile?.name).toBe('original.jpg')
-
-      // Update the file's name and trigger sync
-      await updateRecord('file-1', {
-        name: 'renamed.jpg',
-        updatedAt: base + 100,
-      })
-      await act(async () => {
-        triggerSyncChange()
-        await new Promise((r) => setTimeout(r, 50))
-      })
-
-      expect(onUpdated).toHaveBeenCalledWith('File renamed')
-    })
-
-    test('updates position when total count changes', async () => {
+    test('keeps frozen position when other files are deleted', async () => {
       await createRecord({ id: 'file-1', name: 'a.jpg', createdAt: base })
       await createRecord({ id: 'file-2', name: 'b.jpg', createdAt: base + 10 })
       await createRecord({ id: 'file-3', name: 'c.jpg', createdAt: base + 20 })
 
       const { result } = renderHook(() =>
-        useVirtualFileList({
+        useFileCarousel({
           initialId: 'file-2',
         }),
       )
@@ -594,20 +496,151 @@ describe('useVirtualFileList hook', () => {
       expect(result.current.currentIndex).toBe(1)
       expect(result.current.currentFile?.id).toBe('file-2')
 
-      // Delete file-3 (the one before file-2), so file-2 moves to position 0
+      // Delete file-3 — position map is frozen, so index stays at 1
       await deleteRecord('file-3')
       await act(async () => {
         triggerSyncChange()
         await new Promise((r) => setTimeout(r, 50))
       })
 
-      await waitFor(() => {
-        expect(result.current.totalCount).toBe(2)
-      })
-      expect(result.current.currentIndex).toBe(0)
-      // Current file should remain available (not null) after position change
+      // Position and count stay frozen
+      expect(result.current.currentIndex).toBe(1)
+      expect(result.current.totalCount).toBe(3)
       expect(result.current.currentFile).not.toBeNull()
       expect(result.current.currentFile?.id).toBe('file-2')
+    })
+
+    test('currentFile ID never changes during sync storm', async () => {
+      await createRecord({ id: 'file-1', name: 'a.jpg', createdAt: base })
+      await createRecord({ id: 'file-2', name: 'b.jpg', createdAt: base + 10 })
+      await createRecord({ id: 'file-3', name: 'c.jpg', createdAt: base + 20 })
+
+      const renders: {
+        currentFile: { id: string } | null
+        isLoading: boolean
+      }[] = []
+      const { result } = renderHook(() => {
+        const hook = useFileCarousel({ initialId: 'file-2' })
+        renders.push({
+          currentFile: hook.currentFile ? { id: hook.currentFile.id } : null,
+          isLoading: hook.isLoading,
+        })
+        return hook
+      })
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      const initDoneIndex = renders.findIndex((r) => !r.isLoading)
+      expect(initDoneIndex).toBeGreaterThanOrEqual(0)
+
+      // Add DB delays to simulate real async behavior
+      const database = db()
+      const origFirst = database.getFirstAsync.bind(database)
+      const origAll = database.getAllAsync.bind(database)
+      jest
+        .spyOn(database, 'getFirstAsync')
+        .mockImplementation(async (...args: Parameters<typeof origFirst>) => {
+          await new Promise((r) => setTimeout(r, 5))
+          return origFirst(...args)
+        })
+      jest
+        .spyOn(database, 'getAllAsync')
+        .mockImplementation(async (...args: Parameters<typeof origAll>) => {
+          await new Promise((r) => setTimeout(r, 5))
+          return origAll(...args)
+        })
+
+      // Simulate a sync storm: add files one at a time, firing sync after each
+      for (let i = 4; i <= 10; i++) {
+        await createRecord({
+          id: `file-${i}`,
+          name: `${String.fromCharCode(96 + i)}.jpg`,
+          createdAt: base + i * 10,
+        })
+        await act(async () => {
+          triggerSyncChange()
+          await new Promise((r) => setTimeout(r, 30))
+        })
+      }
+
+      // Wait for everything to settle
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 200))
+      })
+
+      // Every render after init completed must have currentFile non-null
+      // and always showing the same file ID (frozen positions)
+      const postInitRenders = renders.slice(initDoneIndex)
+      const nullRenders = postInitRenders.filter((r) => r.currentFile === null)
+      expect(nullRenders).toEqual([])
+
+      const wrongFileRenders = postInitRenders.filter(
+        (r) => r.currentFile?.id !== 'file-2',
+      )
+      expect(wrongFileRenders).toEqual([])
+
+      // Position and count stay frozen at init values
+      expect(result.current.currentFile?.id).toBe('file-2')
+      expect(result.current.currentIndex).toBe(1)
+      expect(result.current.totalCount).toBe(3)
+
+      jest.restoreAllMocks()
+    })
+
+    test('preserves current file when rapid sync events interleave', async () => {
+      await createRecord({ id: 'file-1', name: 'a.jpg', createdAt: base })
+      await createRecord({ id: 'file-2', name: 'b.jpg', createdAt: base + 10 })
+      await createRecord({ id: 'file-3', name: 'c.jpg', createdAt: base + 20 })
+
+      const { result } = renderHook(() =>
+        useFileCarousel({
+          initialId: 'file-2',
+        }),
+      )
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      expect(result.current.currentIndex).toBe(1)
+      expect(result.current.currentFile?.id).toBe('file-2')
+
+      // Add async delays to DB methods to simulate real expo-sqlite behavior.
+      const database = db()
+      const origFirst = database.getFirstAsync.bind(database)
+      const origAll = database.getAllAsync.bind(database)
+      jest
+        .spyOn(database, 'getFirstAsync')
+        .mockImplementation(async (...args: Parameters<typeof origFirst>) => {
+          await new Promise((r) => setTimeout(r, 5))
+          return origFirst(...args)
+        })
+      jest
+        .spyOn(database, 'getAllAsync')
+        .mockImplementation(async (...args: Parameters<typeof origAll>) => {
+          await new Promise((r) => setTimeout(r, 5))
+          return origAll(...args)
+        })
+
+      // Add two files that would shift file-2's position in DB, then fire
+      // two sync events. With frozen positions, nothing should change.
+      await createRecord({ id: 'file-4', name: 'd.jpg', createdAt: base + 30 })
+      await createRecord({ id: 'file-5', name: 'e.jpg', createdAt: base + 40 })
+      await act(async () => {
+        triggerSyncChange()
+        triggerSyncChange()
+        await new Promise((r) => setTimeout(r, 200))
+      })
+
+      // Position and count stay frozen
+      expect(result.current.currentIndex).toBe(1)
+      expect(result.current.totalCount).toBe(3)
+      expect(result.current.currentFile).not.toBeNull()
+      expect(result.current.currentFile?.id).toBe('file-2')
+
+      jest.restoreAllMocks()
     })
   })
 
@@ -639,7 +672,7 @@ describe('useVirtualFileList hook', () => {
 
       // file-3 is at position 3, prefetchRadius: 1 means positions 2-4 are fetched
       const { result } = renderHook(() =>
-        useVirtualFileList({
+        useFileCarousel({
           initialId: 'file-3',
           initialFile,
           prefetchRadius: 1,
@@ -669,7 +702,7 @@ describe('useVirtualFileList hook', () => {
 
       // User taps on file-2 (which is at position 4 in DESC order)
       const { result } = renderHook(() =>
-        useVirtualFileList({
+        useFileCarousel({
           initialId: 'file-2',
           prefetchRadius: 5,
         }),
@@ -707,7 +740,7 @@ describe('useVirtualFileList hook', () => {
 
       // User taps on file-3 (which is at position 0 in DESC order)
       const { result } = renderHook(() =>
-        useVirtualFileList({
+        useFileCarousel({
           initialId: 'file-3',
           prefetchRadius: 2,
         }),

--- a/src/stores/fileCarousel.ts
+++ b/src/stores/fileCarousel.ts
@@ -177,16 +177,11 @@ export async function fetchFilePosition(
   return result?.count ?? 0
 }
 
-// Fetches files at the given indices by querying the contiguous range they span.
-export async function fetchFilesAtIndices(
-  indices: number[],
+export async function fetchSortedFileIds(
   params: VirtualListQueryParams,
-): Promise<Map<number, FileRecord>> {
-  const result = new Map<number, FileRecord>()
-  if (indices.length === 0) {
-    return result
-  }
-
+  limit: number,
+  offset: number,
+): Promise<string[]> {
   const { where, params: queryParams } = buildLibraryQueryParts({
     sortBy: params.sortBy,
     sortDir: params.sortDir,
@@ -196,70 +191,42 @@ export async function fetchFilesAtIndices(
   })
 
   const orderExpr = buildOrderExpr(params.sortBy, params.sortDir)
-
-  // Find the range of indices we need
-  const minIndex = Math.min(...indices)
-  const maxIndex = Math.max(...indices)
-  const rangeSize = maxIndex - minIndex + 1
-
-  // Single query: fetch the entire range with one LIMIT/OFFSET
-  // This is O(n) instead of O(n*m) for m indices
-  const sql = `SELECT ${FILE_COLUMNS} FROM files f ${where ?? ''} ORDER BY ${orderExpr} LIMIT ? OFFSET ?`
-  const rows = await db().getAllAsync<FileRecordRow>(
-    sql,
+  const rows = await db().getAllAsync<{ id: string }>(
+    `SELECT f.id FROM files f ${where ?? ''} ORDER BY ${orderExpr} LIMIT ? OFFSET ?`,
     ...queryParams,
-    rangeSize,
-    minIndex,
+    limit,
+    offset,
   )
+  return rows.map((r) => r.id)
+}
 
-  // Hydrate all rows in one batch
-  const hydratedFiles = await hydrateRows(rows)
+export async function fetchFilesByIDs(
+  ids: string[],
+): Promise<Map<string, FileRecord>> {
+  const result = new Map<string, FileRecord>()
+  if (ids.length === 0) return result
 
-  // Map each file to its absolute index
-  const indicesSet = new Set(indices)
-  for (let i = 0; i < hydratedFiles.length; i++) {
-    const absoluteIndex = minIndex + i
-    if (indicesSet.has(absoluteIndex)) {
-      result.set(absoluteIndex, hydratedFiles[i])
-    }
+  const placeholders = ids.map(() => '?').join(',')
+  const rows = await db().getAllAsync<FileRecordRow>(
+    `SELECT ${FILE_COLUMNS} FROM files f WHERE f.id IN (${placeholders})`,
+    ...ids,
+  )
+  const hydrated = await hydrateRows(rows)
+  for (const file of hydrated) {
+    result.set(file.id, file)
   }
-
   return result
 }
 
-// The carousel can't hold thousands of files in memory, so we give it placeholder
-// indices and fetch the actual file data as the user swipes nearby.
-
-async function fetchFileByID(fileID: string): Promise<FileRecord | null> {
-  const row = await db().getFirstAsync<FileRecordRow>(
-    `SELECT ${FILE_COLUMNS} FROM files f WHERE f.id = ? LIMIT 1`,
-    fileID,
-  )
-
-  if (!row) return null
-
-  const [file] = await hydrateRows([row])
-  return file ?? null
-}
-
-async function fileExists(fileID: string): Promise<boolean> {
-  const result = await db().getFirstAsync<{ count: number }>(
-    `SELECT COUNT(*) as count FROM files WHERE id = ?`,
-    fileID,
-  )
-  return (result?.count ?? 0) > 0
-}
-
-type UseVirtualFileListParams = {
+type UseFileCarouselParams = {
   initialId: string
   initialFile?: FileRecord
   prefetchRadius?: number
   maxCacheSize?: number
   onDeleted?: () => void
-  onUpdated?: (message: string) => void
 }
 
-type UseVirtualFileListReturn = {
+type UseFileCarouselReturn = {
   totalCount: number
   currentIndex: number
   currentFile: FileRecord | null
@@ -268,39 +235,60 @@ type UseVirtualFileListReturn = {
   isLoading: boolean
 }
 
+function windowIndices(
+  center: number,
+  count: number,
+  radius: number,
+): number[] {
+  const indices: number[] = []
+  for (
+    let i = Math.max(0, center - radius);
+    i <= Math.min(count - 1, center + radius);
+    i++
+  ) {
+    indices.push(i)
+  }
+  return indices
+}
+
+const ID_WINDOW_SIZE = 201
+const ID_WINDOW_HALF = Math.floor(ID_WINDOW_SIZE / 2)
+
 /**
- * Hook for virtualized file browsing in the carousel.
+ * Hook for file browsing in the carousel.
  *
- * Instead of loading all files into memory, this maintains a sparse cache
- * and fetches files on-demand as the user swipes. The carousel receives
- * placeholder indices and calls getFileAtIndex to get actual file data.
- *
- * @param initialId - The file ID to start viewing
- * @param initialFile - Optional pre-loaded file to avoid a flash of loading state
- * @param prefetchRadius - How many files to prefetch in each direction (default: 3)
- * @param maxCacheSize - Maximum files to keep in memory (default: 50)
+ * Uses a frozen ID window to prevent flickering and position shifts during sync:
+ * 1. At open time, captures ~201 sorted file IDs centered on the opened file.
+ * 2. Index→ID mappings are immutable for the session (append-only, never cleared).
+ * 3. Sync only monitors the current file for deletion.
+ * 4. File cache preserves references when data is identical (updatedAt + object count).
  */
-export function useVirtualFileList({
+export function useFileCarousel({
   initialId,
   initialFile,
   prefetchRadius = 3,
   maxCacheSize = 50,
   onDeleted,
-  onUpdated,
-}: UseVirtualFileListParams): UseVirtualFileListReturn {
+}: UseFileCarouselParams): UseFileCarouselReturn {
   const { sortBy, sortDir, selectedCategories, searchQuery } = useLibrary()
   const sortingDir: SortDir = sortDir ?? (sortBy === 'NAME' ? 'ASC' : 'DESC')
 
-  const [currentIndex, setCurrentIndexState] = useState<number>(0)
-  const [totalCount, setTotalCount] = useState<number>(initialFile ? 1 : 0)
+  const [currentIndex, _setCurrentIndex] = useState(0)
+  const [totalCount, setTotalCount] = useState(initialFile ? 1 : 0)
   const [isLoading, setIsLoading] = useState(!initialFile)
-
-  const cacheRef = useRef<Map<number, FileRecord>>(
-    initialFile ? new Map([[0, initialFile]]) : new Map(),
-  )
-  const fetchingRef = useRef<Set<number>>(new Set())
   const [cacheVersion, setCacheVersion] = useState(0)
 
+  // File data keyed by ID — persists across position changes
+  const fileCacheRef = useRef<Map<string, FileRecord>>(
+    initialFile ? new Map([[initialFile.id, initialFile]]) : new Map(),
+  )
+
+  // Index → file ID mapping — frozen at open time, append-only
+  const positionMapRef = useRef<Map<number, string>>(
+    initialFile ? new Map([[0, initialFile.id]]) : new Map(),
+  )
+
+  const currentFileIdRef = useRef(initialId)
   const initialFileRef = useRef(initialFile)
 
   const categoriesKey = useMemo(
@@ -321,58 +309,107 @@ export function useVirtualFileList({
     [sortBy, sortingDir, categoriesKey, searchQuery],
   )
 
-  // Initialize: find the starting position and prefetch nearby files
+  const populateCaches = useCallback(
+    (indexToFile: Map<number, FileRecord>): boolean => {
+      let changed = false
+      indexToFile.forEach((file, index) => {
+        positionMapRef.current.set(index, file.id)
+        const existing = fileCacheRef.current.get(file.id)
+        if (
+          existing &&
+          existing.updatedAt === file.updatedAt &&
+          Object.keys(existing.objects).length ===
+            Object.keys(file.objects).length
+        ) {
+          return
+        }
+        fileCacheRef.current.set(file.id, file)
+        changed = true
+      })
+      return changed
+    },
+    [],
+  )
+
+  const evictDistant = useCallback(
+    (centerIndex: number) => {
+      if (fileCacheRef.current.size <= maxCacheSize) return
+
+      const posEntries = Array.from(positionMapRef.current.entries())
+      posEntries.sort(
+        (a, b) => Math.abs(a[0] - centerIndex) - Math.abs(b[0] - centerIndex),
+      )
+      const keepIds = new Set(
+        posEntries.slice(0, maxCacheSize).map(([, id]) => id),
+      )
+      keepIds.add(currentFileIdRef.current)
+      for (const id of [...fileCacheRef.current.keys()]) {
+        if (!keepIds.has(id)) {
+          fileCacheRef.current.delete(id)
+        }
+      }
+    },
+    [maxCacheSize],
+  )
+
+  // Initialize: capture frozen ID window centered on the opened file
   useEffect(() => {
     let cancelled = false
 
     async function init() {
-      // If we have initialFile, don't show loading state - render immediately
-      // while we fetch position/count in the background
       if (!initialFileRef.current) {
         setIsLoading(true)
-        cacheRef.current.clear()
       }
-      fetchingRef.current.clear()
 
       try {
-        const [count, position] = await Promise.all([
-          fetchTotalCount(queryParams),
-          fetchFilePosition(initialId, queryParams),
-        ])
-
+        const position = await fetchFilePosition(initialId, queryParams)
         if (cancelled) return
 
-        // Move initialFile from index 0 to its actual position.
-        if (initialFileRef.current) {
-          if (position !== 0) {
-            cacheRef.current.delete(0)
-          }
-          cacheRef.current.set(position, initialFileRef.current)
-        }
-
-        setTotalCount(count)
-        setCurrentIndexState(position)
-
-        const indicesToFetch: number[] = []
-        for (
-          let i = Math.max(0, position - prefetchRadius);
-          i <= Math.min(count - 1, position + prefetchRadius);
-          i++
-        ) {
-          indicesToFetch.push(i)
-        }
-
-        const fetched = await fetchFilesAtIndices(
-          indicesToFetch.filter((i) => !cacheRef.current.has(i)),
+        const windowOffset = Math.max(0, position - ID_WINDOW_HALF)
+        const ids = await fetchSortedFileIds(
           queryParams,
+          ID_WINDOW_SIZE,
+          windowOffset,
         )
 
         if (cancelled) return
 
-        fetched.forEach((file, index) => {
-          cacheRef.current.set(index, file)
-        })
+        const relativePosition = position - windowOffset
 
+        for (let i = 0; i < ids.length; i++) {
+          positionMapRef.current.set(i, ids[i])
+        }
+
+        // When initialFile is provided, skip fetching visible files here.
+        // The prefetch effect runs immediately after and handles it.
+        if (!initialFileRef.current) {
+          const visibleIndices = windowIndices(
+            relativePosition,
+            ids.length,
+            prefetchRadius,
+          )
+          const visibleIds = visibleIndices
+            .map((i) => positionMapRef.current.get(i))
+            .filter((id): id is string => !!id && !fileCacheRef.current.has(id))
+
+          if (visibleIds.length > 0) {
+            const fileMap = await fetchFilesByIDs(visibleIds)
+            if (cancelled) return
+            const indexToFile = new Map<number, FileRecord>()
+            for (const i of visibleIndices) {
+              const id = positionMapRef.current.get(i)
+              if (id) {
+                const file = fileMap.get(id)
+                if (file) indexToFile.set(i, file)
+              }
+            }
+            populateCaches(indexToFile)
+          }
+        }
+
+        currentFileIdRef.current = initialId
+        setTotalCount(ids.length)
+        _setCurrentIndex(relativePosition)
         setCacheVersion((v) => v + 1)
       } finally {
         if (!cancelled) {
@@ -386,59 +423,39 @@ export function useVirtualFileList({
     return () => {
       cancelled = true
     }
-  }, [initialId, queryParams, prefetchRadius])
+  }, [initialId, queryParams, prefetchRadius, populateCaches])
 
-  // Prefetch: as the user swipes, fetch nearby files and evict distant ones
+  // Prefetch: as the user swipes, fetch nearby files by ID
   useEffect(() => {
     if (isLoading || totalCount === 0) return
 
     let cancelled = false
 
     async function prefetch() {
-      const indicesToFetch: number[] = []
+      const indices = windowIndices(currentIndex, totalCount, prefetchRadius)
+      const idsToFetch = indices
+        .map((i) => positionMapRef.current.get(i))
+        .filter((id): id is string => !!id && !fileCacheRef.current.has(id))
 
-      for (
-        let i = Math.max(0, currentIndex - prefetchRadius);
-        i <= Math.min(totalCount - 1, currentIndex + prefetchRadius);
-        i++
-      ) {
-        if (!cacheRef.current.has(i) && !fetchingRef.current.has(i)) {
-          indicesToFetch.push(i)
-          fetchingRef.current.add(i)
+      if (idsToFetch.length === 0) return
+
+      const fileMap = await fetchFilesByIDs(idsToFetch)
+
+      if (cancelled) return
+
+      const indexToFile = new Map<number, FileRecord>()
+      for (const i of indices) {
+        const id = positionMapRef.current.get(i)
+        if (id) {
+          const file = fileMap.get(id)
+          if (file) indexToFile.set(i, file)
         }
       }
 
-      if (indicesToFetch.length === 0) return
-
-      try {
-        const fetched = await fetchFilesAtIndices(indicesToFetch, queryParams)
-
-        if (cancelled) return
-
-        fetched.forEach((file, index) => {
-          cacheRef.current.set(index, file)
-        })
-
-        // Evict files furthest from current position to stay under maxCacheSize
-        if (cacheRef.current.size > maxCacheSize) {
-          const entries = Array.from(cacheRef.current.entries())
-          entries.sort(
-            (a, b) =>
-              Math.abs(a[0] - currentIndex) - Math.abs(b[0] - currentIndex),
-          )
-          const toKeep = new Set(
-            entries.slice(0, maxCacheSize).map(([idx]) => idx),
-          )
-          for (const [idx] of entries) {
-            if (!toKeep.has(idx)) {
-              cacheRef.current.delete(idx)
-            }
-          }
-        }
-
+      const changed = populateCaches(indexToFile)
+      evictDistant(currentIndex)
+      if (changed) {
         setCacheVersion((v) => v + 1)
-      } finally {
-        indicesToFetch.forEach((i) => fetchingRef.current.delete(i))
       }
     }
 
@@ -451,104 +468,29 @@ export function useVirtualFileList({
     currentIndex,
     totalCount,
     isLoading,
-    queryParams,
     prefetchRadius,
-    maxCacheSize,
+    evictDistant,
+    populateCaches,
   ])
-
-  const currentFileIDRef = useRef<string | null>(null)
-  // biome-ignore lint/correctness/useExhaustiveDependencies: cacheVersion forces re-run when cache updates
-  useEffect(() => {
-    const file = cacheRef.current.get(currentIndex)
-    currentFileIDRef.current = file?.id ?? null
-  }, [currentIndex, cacheVersion])
 
   const handleLibraryChange = useCallback(async () => {
     if (isLoading) return
 
-    const currentFileID = currentFileIDRef.current
+    const currentFileID = currentFileIdRef.current
     if (!currentFileID) return
 
     try {
-      const exists = await fileExists(currentFileID)
-      if (!exists) {
+      const row = await db().getFirstAsync<{ id: string }>(
+        'SELECT id FROM files WHERE id = ? LIMIT 1',
+        currentFileID,
+      )
+      if (!row) {
         onDeleted?.()
-        return
-      }
-
-      const [newCount, newPosition] = await Promise.all([
-        fetchTotalCount(queryParams),
-        fetchFilePosition(currentFileID, queryParams),
-      ])
-
-      // Clear cache when position or count changes
-      const positionChanged =
-        newCount !== totalCount || newPosition !== currentIndex
-      if (positionChanged) {
-        // Preserve the current file to avoid a flash or loading state.
-        const currentFile = cacheRef.current.get(currentIndex)
-
-        setTotalCount(newCount)
-        setCurrentIndexState(newPosition)
-        cacheRef.current.clear()
-        fetchingRef.current.clear()
-
-        if (currentFile) {
-          cacheRef.current.set(newPosition, currentFile)
-        }
-
-        setCacheVersion((v) => v + 1)
-      }
-
-      // Use newPosition for cache lookups when position changed, since
-      // state updates are async and currentIndex is stale in this callback.
-      const effectiveIndex = positionChanged ? newPosition : currentIndex
-
-      const cachedFile = cacheRef.current.get(effectiveIndex)
-      if (cachedFile && cachedFile.id === currentFileID) {
-        const freshFile = await fetchFileByID(currentFileID)
-        if (freshFile) {
-          const nameChanged = cachedFile.name !== freshFile.name
-          const metadataChanged =
-            nameChanged ||
-            cachedFile.updatedAt !== freshFile.updatedAt ||
-            cachedFile.size !== freshFile.size ||
-            cachedFile.type !== freshFile.type
-
-          if (metadataChanged) {
-            cacheRef.current.set(effectiveIndex, freshFile)
-            setCacheVersion((v) => v + 1)
-
-            const message = nameChanged ? 'File renamed' : 'File info updated'
-            onUpdated?.(message)
-
-            if (nameChanged && sortBy === 'NAME') {
-              const updatedPosition = await fetchFilePosition(
-                currentFileID,
-                queryParams,
-              )
-              if (updatedPosition !== effectiveIndex) {
-                setCurrentIndexState(updatedPosition)
-                cacheRef.current.clear()
-                fetchingRef.current.clear()
-                setCacheVersion((v) => v + 1)
-              }
-            }
-          }
-        }
       }
     } catch (_e) {
       // Silently ignore errors during sync handling.
     }
-  }, [
-    isLoading,
-    onDeleted,
-    queryParams,
-    totalCount,
-    currentIndex,
-    sortBy,
-    onUpdated,
-  ])
+  }, [isLoading, onDeleted])
 
   useEffect(() => {
     librarySwr.addChangeCallback('carousel', handleLibraryChange)
@@ -557,10 +499,12 @@ export function useVirtualFileList({
     }
   }, [handleLibraryChange])
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: cacheVersion forces new function reference when cache updates
+  // biome-ignore lint/correctness/useExhaustiveDependencies: cacheVersion forces new function reference when caches update
   const getFileAtIndex = useCallback(
     (index: number): FileRecord | null => {
-      return cacheRef.current.get(index) ?? null
+      const fileId = positionMapRef.current.get(index)
+      if (!fileId) return null
+      return fileCacheRef.current.get(fileId) ?? null
     },
     [cacheVersion],
   )
@@ -568,7 +512,9 @@ export function useVirtualFileList({
   const setCurrentIndex = useCallback(
     (index: number) => {
       if (index >= 0 && index < totalCount) {
-        setCurrentIndexState(index)
+        _setCurrentIndex(index)
+        const fileId = positionMapRef.current.get(index)
+        if (fileId) currentFileIdRef.current = fileId
       }
     },
     [totalCount],


### PR DESCRIPTION
Carousel stability during sync:
- Freeze ~201 sorted file IDs at open time as an immutable position map
- Use window-relative indexing so positions never shift during sync
- Simplify sync handler to only check current file deletion
- Preserve cached file references when data is identical (updatedAt + object count)
- Use opacity swap pattern to avoid flicker on carousel init
- Hide base layer once carousel is ready to prevent show-through during swipes

Detail view fixes:
- Keep both carousel and detail views always mounted, toggle visibility with opacity + pointerEvents to avoid unmount/remount state loss
- Use RNGH ScrollView in FileDetails for Android gesture compatibility
- Disable DragToDismiss when viewing details so ScrollView can scroll
- Persist controls when toggling back from detail to viewer
- Hide scroll indicator in detail view
- Fix crash from rendering number outside Text component (slabs count)

DragToDismiss:
- GestureDetector always stays mounted to keep React tree stable
- Add onDragCancel callback so controls and carousel restore after a cancelled drag gesture
- Hide controls and disable carousel swiping during drag-to-dismiss
- Lower dismiss threshold and add velocity-based flick detection
- Android: Gesture.Simultaneous with Gesture.Native for child touch forwarding
- Android: carousel uses requireExternalGestureToFail to prevent diagonal drags from swiping the carousel sideways during drag-to-dismis