### PR TITLE
fix: gate archive sync on fully-synced state and show waiting message

### DIFF
--- a/.changeset/gate-archive-sync-on-uploads.md
+++ b/.changeset/gate-archive-sync-on-uploads.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Archive sync now waits for all files to finish uploading before continuing.

--- a/src/components/SettingsSyncPhotos.tsx
+++ b/src/components/SettingsSyncPhotos.tsx
@@ -10,6 +10,7 @@ import {
   useAutoSyncPhotosArchive,
   usePhotosArchiveCursor,
 } from '../managers/syncPhotosArchive'
+import { useFileCountLocal } from '../stores/files'
 import { colors } from '../styles/colors'
 import { Button } from './Button'
 import { RowGroup } from './Group'
@@ -20,6 +21,7 @@ export function SettingsSyncPhotos() {
   const autoSyncNew = useAutoSyncNewPhotos()
   const autoSyncPhotosArchive = useAutoSyncPhotosArchive()
   const photosArchiveCursor = usePhotosArchiveCursor()
+  const localOnlyCount = useFileCountLocal({ localOnly: true })
   const cursorValue = photosArchiveCursor.data ?? 0
   const photosArchiveInProgress = cursorValue > 0
   const { isSomeAccess, accessLabel, color } = useMediaLibraryPermissions()
@@ -86,6 +88,13 @@ export function SettingsSyncPhotos() {
             }`}</Text>
           )
         : null}
+      {autoSyncPhotosArchive.data &&
+      photosArchiveInProgress &&
+      (localOnlyCount.data ?? 0) > 0 ? (
+        <Text
+          style={styles.info}
+        >{`Waiting for ${localOnlyCount.data} files to upload before continuing archive sync`}</Text>
+      ) : null}
       <Button
         style={{ marginTop: 10 }}
         disabled={syncPhotosArchiveControlsDisabled}

--- a/src/managers/syncPhotosArchive.test.ts
+++ b/src/managers/syncPhotosArchive.test.ts
@@ -32,6 +32,10 @@ jest.mock('../lib/processAssets', () => ({
   __esModule: true,
   processAssets: jest.fn(),
 }))
+jest.mock('../stores/files', () => ({
+  __esModule: true,
+  getFileCountLocal: jest.fn().mockResolvedValue(0),
+}))
 jest.mock('../stores/library', () => ({
   __esModule: true,
   librarySwr: {

--- a/src/managers/syncPhotosArchive.ts
+++ b/src/managers/syncPhotosArchive.ts
@@ -15,6 +15,7 @@ import {
   setAsyncStorageBoolean,
   setAsyncStorageNumber,
 } from '../stores/asyncStore'
+import { getFileCountLocal } from '../stores/files'
 import { librarySwr } from '../stores/library'
 import { settingsSwr } from '../stores/settings'
 
@@ -22,6 +23,14 @@ const PAGE_SIZE = 50
 
 export async function workBackward() {
   if (!(await getMediaLibraryPermissions())) return
+  const localOnlyCount = await getFileCountLocal({ localOnly: true })
+  if (localOnlyCount > 0) {
+    logger.info(
+      'syncPhotosArchive',
+      `waiting for ${localOnlyCount} local-only files to sync`,
+    )
+    return
+  }
   const cursor = await getPhotosArchiveCursor()
 
   try {


### PR DESCRIPTION
- Archive sync now waits for all files to finish uploading before continuing. This should reduce the memory pressure on the app and also give the user a better sense of library upload/sync progress.