### PR TITLE
feat: structured logging with machine-readable JSONL export

### DIFF
--- a/.changeset/structured-logging.md
+++ b/.changeset/structured-logging.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Structured logging with machine-readable JSONL export.

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -58,15 +58,15 @@ export function Root() {
 
   // Log AppState changes.
   useEffect(() => {
-    logger.info('appState', `initial state: ${appStateRef.current}`)
+    logger.info('appState', 'initial_state', { state: appStateRef.current })
 
     const subscription = AppState.addEventListener(
       'change',
       (nextAppState: AppStateStatus) => {
-        logger.info(
-          'appState',
-          `state changed: ${appStateRef.current} -> ${nextAppState}`,
-        )
+        logger.info('appState', 'state_changed', {
+          from: appStateRef.current,
+          to: nextAppState,
+        })
         appStateRef.current = nextAppState
       },
     )

--- a/src/components/FileActionsSheet.tsx
+++ b/src/components/FileActionsSheet.tsx
@@ -106,7 +106,9 @@ function SingleFileActionsSheet({
       toast.show('Removed from device')
       onComplete?.()
     } catch (e) {
-      logger.error('FileActionsSheet', 'failed to remove local file', e)
+      logger.error('FileActionsSheet', 'remove_local_file_failed', {
+        error: e as Error,
+      })
       toast.show('Failed to remove from device')
     }
   }, [file?.id, file?.type, toast, onComplete, file])
@@ -119,7 +121,7 @@ function SingleFileActionsSheet({
       toast.show('Upload queued')
       onComplete?.()
     } catch (e) {
-      logger.error('FileActionsSheet', 'failed to reupload file', e)
+      logger.error('FileActionsSheet', 'reupload_failed', { error: e as Error })
       toast.show('Failed to reupload file')
     }
   }, [file?.id, toast, onComplete, file, reupload])
@@ -131,7 +133,9 @@ function SingleFileActionsSheet({
       toast.show('Removed from network')
       onComplete?.()
     } catch (e) {
-      logger.error('FileActionsSheet', 'failed to remove from network', e)
+      logger.error('FileActionsSheet', 'remove_from_network_failed', {
+        error: e as Error,
+      })
       toast.show('Failed to remove from network')
     }
   }, [file?.id, toast, onComplete, file])
@@ -144,7 +148,9 @@ function SingleFileActionsSheet({
       toast.show('File deleted')
       onComplete?.()
     } catch (e) {
-      logger.error('FileActionsSheet', 'failed to delete file', e)
+      logger.error('FileActionsSheet', 'delete_file_failed', {
+        error: e as Error,
+      })
       toast.show('Failed to delete file')
     }
   }, [file, navigation, toast, onComplete])
@@ -306,7 +312,9 @@ function BulkFileActionsSheet({
       }
       onComplete?.()
     } catch (e) {
-      logger.error('FileActionsSheet', 'failed to queue downloads', e)
+      logger.error('FileActionsSheet', 'queue_downloads_failed', {
+        error: e as Error,
+      })
       toast.show('Failed to start downloads')
     }
   }, [counts, toast, onComplete])
@@ -325,7 +333,9 @@ function BulkFileActionsSheet({
       toast.show(`Removed ${removed} files from device`)
       onComplete?.()
     } catch (e) {
-      logger.error('FileActionsSheet', 'failed to remove files from device', e)
+      logger.error('FileActionsSheet', 'remove_files_from_device_failed', {
+        error: e as Error,
+      })
       toast.show('Failed to remove files from device')
     }
   }, [counts, toast, onComplete])
@@ -343,7 +353,9 @@ function BulkFileActionsSheet({
       toast.show(`Removed ${removed} files from network`)
       onComplete?.()
     } catch (e) {
-      logger.error('FileActionsSheet', 'failed to remove files from network', e)
+      logger.error('FileActionsSheet', 'remove_files_from_network_failed', {
+        error: e as Error,
+      })
       toast.show('Failed to remove files from network')
     }
   }, [counts, toast, onComplete])
@@ -363,7 +375,9 @@ function BulkFileActionsSheet({
       toast.show(`Queued ${queued} uploads`)
       onComplete?.()
     } catch (e) {
-      logger.error('FileActionsSheet', 'failed to queue uploads', e)
+      logger.error('FileActionsSheet', 'queue_uploads_failed', {
+        error: e as Error,
+      })
       toast.show('Failed to start uploads')
     }
   }, [counts, toast, onComplete])
@@ -375,7 +389,9 @@ function BulkFileActionsSheet({
       toast.show(`Deleted ${counts.total} files`)
       onComplete?.()
     } catch (e) {
-      logger.error('FileActionsSheet', 'failed to delete files', e)
+      logger.error('FileActionsSheet', 'delete_files_failed', {
+        error: e as Error,
+      })
       toast.show('Failed to delete files')
     }
   }, [counts, toast, onComplete])

--- a/src/components/FileCarousel/index.tsx
+++ b/src/components/FileCarousel/index.tsx
@@ -171,7 +171,7 @@ export function FileCarousel({
       Clipboard.setString(shareUrl)
       toast.show('Share URL copied')
     } catch (e) {
-      logger.error('FileCarousel', 'Failed to share URL', e)
+      logger.error('FileCarousel', 'share_url_failed', { error: e as Error })
       toast.show('Failed to copy URL')
     }
   }, [currentFile, sdk, toast])
@@ -189,7 +189,7 @@ export function FileCarousel({
       const msg =
         typeof e === 'string' ? e : e instanceof Error ? e.message : ''
       if (!msg.includes('User did not share')) {
-        logger.error('FileCarousel', 'File sharing failed', e)
+        logger.error('FileCarousel', 'share_failed', { error: e as Error })
       }
     }
   }, [currentFile, status.data?.fileUri])

--- a/src/components/FileImport/index.tsx
+++ b/src/components/FileImport/index.tsx
@@ -48,10 +48,10 @@ async function detectFileType(
   sharedObject: PinnedObjectInterface,
   id: string,
 ): Promise<string> {
-  logger.debug(
-    'FileImport',
-    `Detecting type from first ${MAGIC_BYTES_LENGTH} bytes ${id}`,
-  )
+  logger.debug('FileImport', 'detecting_type', {
+    id,
+    byteCount: MAGIC_BYTES_LENGTH,
+  })
   try {
     if (!sdk || !sharedObject) {
       throw new Error('Missing required data for type detection')
@@ -64,15 +64,15 @@ async function detectFileType(
     )
 
     if (bytes.length === 0) {
-      logger.warn('FileImport', 'No bytes received for type detection')
+      logger.warn('FileImport', 'no_bytes_for_detection')
       return 'application/octet-stream'
     }
 
     const type = detectMimeTypeFromBytes(bytes)
-    logger.debug('FileImport', `Detected type: ${type}`)
+    logger.debug('FileImport', 'detected_type', { type })
     return type || 'application/octet-stream'
   } catch (e) {
-    logger.error('FileImport', 'Error detecting type', e)
+    logger.error('FileImport', 'type_detection_error', { error: e as Error })
     return 'application/octet-stream'
   }
 }
@@ -83,13 +83,13 @@ async function downloadAndProcessFile(
   shareUrl: string,
   downloadFromShareURL: ReturnType<typeof useDownloadFromShareURL>,
 ): Promise<FileRecord> {
-  logger.debug('FileImport', `SWR function starting for ${id}`)
+  logger.debug('FileImport', 'swr_start', { id })
   try {
     if (!shareUrl) throw new Error('Invalid share URL')
 
-    logger.debug('FileImport', `downloading to temp ${id} ${shareUrl}`)
+    logger.debug('FileImport', 'downloading', { id, shareUrl })
     await downloadFromShareURL(id, shareUrl)
-    logger.debug('FileImport', 'download complete')
+    logger.debug('FileImport', 'download_complete')
 
     const tempFsFileUri = await getFsFileUri({
       id,
@@ -99,13 +99,13 @@ async function downloadAndProcessFile(
       throw new Error('File not found in cache after download')
     }
 
-    logger.debug('FileImport', `sniffing type from ${tempFsFileUri}`)
+    logger.debug('FileImport', 'sniffing_type', { uri: tempFsFileUri })
     let type: string
     try {
       type = await getMimeType({ uri: tempFsFileUri })
-      logger.debug('FileImport', `detected type ${type}`)
+      logger.debug('FileImport', 'detected_type', { type })
     } catch (e) {
-      logger.error('FileImport', 'error detecting type', e)
+      logger.error('FileImport', 'type_detection_error', { error: e as Error })
       type = 'application/octet-stream'
     }
 
@@ -114,20 +114,17 @@ async function downloadAndProcessFile(
     const size = fileInfo.size ?? 0
 
     const finalFsFileUri = await copyFileToFs({ id, type }, tempFile)
-    logger.debug('FileImport', `copied to final location ${finalFsFileUri}`)
+    logger.debug('FileImport', 'copied_to_final', { uri: finalFsFileUri })
 
     if (finalFsFileUri !== tempFsFileUri) {
       tempFile.delete()
     }
 
-    logger.debug('FileImport', `calculating hash from ${finalFsFileUri}`)
+    logger.debug('FileImport', 'calculating_hash', { uri: finalFsFileUri })
     const hash = await calculateContentHash(finalFsFileUri)
-    logger.debug('FileImport', `hash calculated ${hash}`)
+    logger.debug('FileImport', 'hash_calculated', { hash })
 
-    logger.info(
-      'FileImport',
-      `file ready type=${type} size=${size} hash=${hash}`,
-    )
+    logger.info('FileImport', 'file_ready', { type, size, hash })
 
     return {
       id,
@@ -142,7 +139,7 @@ async function downloadAndProcessFile(
       objects: {},
     } satisfies FileRecord
   } catch (e) {
-    logger.error('FileImport', 'Error preparing file', e)
+    logger.error('FileImport', 'prepare_error', { error: e as Error })
     throw e
   }
 }
@@ -169,7 +166,7 @@ export function FileImport({
         if (!sdk || !shareUrl) return null
         return sdk.sharedObject(shareUrl)
       } catch (e) {
-        logger.error('FileImport', 'Error getting shared object', e)
+        logger.error('FileImport', 'shared_object_error', { error: e as Error })
         return null
       }
     },
@@ -268,7 +265,7 @@ export function FileImport({
 
     setIsAddingToDatabase(true)
     try {
-      logger.info('FileImport', `importing file ${sharedFile.data.id}`)
+      logger.info('FileImport', 'importing_file', { id: sharedFile.data.id })
 
       // Pin the shared object and create file record.
       const indexerURL = await getIndexerURL()
@@ -287,7 +284,7 @@ export function FileImport({
         params: { openFileId: sharedFile.data.id },
       })
     } catch (e) {
-      logger.error('FileImport', 'Error adding file to library', e)
+      logger.error('FileImport', 'add_to_library_error', { error: e as Error })
       toast.show('Error adding file to library')
     } finally {
       setIsAddingToDatabase(false)

--- a/src/components/LogView.tsx
+++ b/src/components/LogView.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react-native'
 import { useLogs } from '../hooks/useLogs'
 import { getLevelColorHex, getScopeColorHex } from '../lib/logColors'
-import type { LogEntry } from '../lib/logger'
+import { formatDataPairs, type LogEntry } from '../lib/logger'
 import { palette } from '../styles/colors'
 
 type LogViewProps = {
@@ -53,6 +53,7 @@ export function LogView({
     ({ item, index }: { item: LogEntry; index: number }) => {
       const scopeColor = getScopeColorHex(item.scope)
       const levelColor = getLevelColorHex(item.level) ?? palette.gray[50]
+      const dataPart = formatDataPairs(item.data)
 
       return (
         <Text
@@ -69,6 +70,7 @@ export function LogView({
             [{item.scope}]{' '}
           </Text>
           <Text style={styles.message}>{item.message}</Text>
+          {dataPart ? <Text style={styles.data}>{` ${dataPart}`}</Text> : null}
         </Text>
       )
     },
@@ -140,6 +142,9 @@ const styles = StyleSheet.create({
   },
   message: {
     color: palette.gray[50],
+  },
+  data: {
+    color: palette.gray[400],
   },
   empty: {
     color: palette.gray[300],

--- a/src/components/MediaConsumers/VideoPlayer.tsx
+++ b/src/components/MediaConsumers/VideoPlayer.tsx
@@ -25,7 +25,7 @@ export function VideoPlayer({
     try {
       await videoRef.current?.enterFullscreen()
     } catch (error) {
-      logger.error('VideoPlayer', 'Failed to enter fullscreen:', error)
+      logger.error('VideoPlayer', 'fullscreen_error', { error: error as Error })
     }
   }, [player])
 

--- a/src/components/SettingsLogsControlBar.tsx
+++ b/src/components/SettingsLogsControlBar.tsx
@@ -66,7 +66,7 @@ export function SettingsLogsControlBar({ navigation }: Props) {
         toast.show('No logs to export')
       }
     } catch (error) {
-      logger.error('logs', 'Failed to export logs', error)
+      logger.error('logs', 'export_failed', { error: error as Error })
       toast.show('Failed to export logs')
     } finally {
       setIsExporting(false)
@@ -112,7 +112,7 @@ export function SettingsLogsControlBar({ navigation }: Props) {
               await logsSwr.triggerChange()
               toast.show('Logs cleared')
             } catch (error) {
-              logger.error('logs', 'Failed to clear logs', error)
+              logger.error('logs', 'clear_failed', { error: error as Error })
               toast.show('Failed to clear logs')
             }
           },
@@ -130,15 +130,20 @@ export function SettingsLogsControlBar({ navigation }: Props) {
         return
       }
       const content = logs
-        .map(
-          (entry) =>
-            `${entry.timestamp} ${entry.level.toUpperCase()} [${entry.scope}] ${entry.message}`,
+        .map((entry) =>
+          JSON.stringify({
+            ts: entry.timestamp,
+            level: entry.level,
+            scope: entry.scope,
+            msg: entry.message,
+            ...entry.data,
+          }),
         )
         .join('\n')
       Clipboard.setString(content)
       toast.show('Logs copied')
     } catch (error) {
-      logger.error('logs', 'Failed to copy logs', error)
+      logger.error('logs', 'copy_failed', { error: error as Error })
       toast.show('Failed to copy logs')
     }
   }, [toast])

--- a/src/components/ShareIntentConsumer.tsx
+++ b/src/components/ShareIntentConsumer.tsx
@@ -24,7 +24,7 @@ export function ShareIntentConsumer() {
       try {
         const files = (shareIntent.files ?? []).filter((file) => file?.path)
         if (files.length === 0) {
-          logger.debug('shareIntent', 'no supported files in shared payload')
+          logger.debug('shareIntent', 'no_supported_files')
           toast.show('No shareable files found.')
           return
         }
@@ -46,7 +46,7 @@ export function ShareIntentConsumer() {
 
         await uploader(processedFiles)
       } catch (error) {
-        logger.error('shareIntent', 'failed to process shared content', error)
+        logger.error('shareIntent', 'process_failed', { error: error as Error })
         toast.show('Failed to import shared files.')
       } finally {
         resetShareIntent()

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -14,12 +14,12 @@ export async function initializeDB(options?: {
   databaseName?: string
 }): Promise<void> {
   const name = options?.databaseName ?? dbName
-  logger.info('db', `initializing database: ${name}`)
+  logger.info('db', 'initializing', { name })
   database = await SQLite.openDatabaseAsync(name)
   await runMigrations(database, options?.onProgress)
   dbInitialized = true
   dbName = name
-  logger.info('db', 'database initialized')
+  logger.info('db', 'initialized')
 }
 
 /** Close the database connection (for test cleanup) */
@@ -28,7 +28,7 @@ export async function closeDb(): Promise<void> {
     try {
       await database.closeAsync()
     } catch (e) {
-      logger.debug('db', 'error closing database', e)
+      logger.debug('db', 'close_error', { error: e as Error })
     }
     dbInitialized = false
   }
@@ -42,11 +42,9 @@ export async function resetDb() {
     const rows = await database.getAllAsync<{ name: string }>(
       `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'`,
     )
-    logger.debug(
-      'db',
-      'dropping tables',
-      rows.map((r) => r.name),
-    )
+    logger.debug('db', 'dropping_tables', {
+      tables: rows.map((r) => r.name),
+    })
     for (let i = 0; i < rows.length; i++) {
       const table = rows[i].name
       await database.execAsync(`DROP TABLE IF EXISTS "${table}"`)

--- a/src/db/migrations/0001_init_schema.ts
+++ b/src/db/migrations/0001_init_schema.ts
@@ -122,7 +122,10 @@ async function up(db: SQLite.SQLiteDatabase): Promise<void> {
       `CREATE INDEX IF NOT EXISTS idx_logs_createdAt ON logs(createdAt);`,
     )
   } catch (e) {
-    logger.error('db', 'error running migration 0001_init_schema', e)
+    logger.error('db', 'migration_error', {
+      id: '0001_init_schema',
+      error: e as Error,
+    })
     throw e
   }
 }

--- a/src/db/migrations/0002_keychain_accessibility.ts
+++ b/src/db/migrations/0002_keychain_accessibility.ts
@@ -55,13 +55,13 @@ export const migration_0002_keychain_accessibility: Migration = {
   id: '0002_keychain_accessibility',
   description: 'Migrate keychain to AFTER_FIRST_UNLOCK accessibility',
   up: async (_db: SQLite.SQLiteDatabase) => {
-    logger.info('db', 'Starting keychain accessibility migration...')
+    logger.info('db', 'keychain_migration_start')
 
     const appKeysMap = await getAppKeysMap()
     const keyCount = Object.keys(appKeysMap).length
 
     if (keyCount === 0) {
-      logger.info('db', 'No AppKeys to migrate')
+      logger.info('db', 'no_keys_to_migrate')
       return
     }
 
@@ -72,9 +72,6 @@ export const migration_0002_keychain_accessibility: Migration = {
     // Re-add with AFTER_FIRST_UNLOCK accessibility
     await setAppKeysMap(appKeysMap)
 
-    logger.info(
-      'db',
-      `Keychain accessibility migration complete: migrated ${keyCount} key(s)`,
-    )
+    logger.info('db', 'keychain_migration_complete', { keyCount })
   },
 }

--- a/src/db/migrations/0003_logs_data_column.ts
+++ b/src/db/migrations/0003_logs_data_column.ts
@@ -1,0 +1,12 @@
+import type * as SQLite from 'expo-sqlite'
+import type { Migration } from './types'
+
+async function up(db: SQLite.SQLiteDatabase): Promise<void> {
+  await db.execAsync('ALTER TABLE logs ADD COLUMN data TEXT;')
+}
+
+export const migration_0003_logs_data_column: Migration = {
+  id: '0003_logs_data_column',
+  description: 'Add data column to logs table for structured log data.',
+  up,
+}

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -20,18 +20,20 @@ import type * as SQLite from 'expo-sqlite'
 import { logger } from '../../lib/logger'
 import { migration_0001_init_schema } from './0001_init_schema'
 import { migration_0002_keychain_accessibility } from './0002_keychain_accessibility'
+import { migration_0003_logs_data_column } from './0003_logs_data_column'
 import type { Migration, MigrationProgressHandler } from './types'
 
 const migrations: Migration[] = [
   migration_0001_init_schema,
   migration_0002_keychain_accessibility,
+  migration_0003_logs_data_column,
 ]
 
 export async function runMigrations(
   db: SQLite.SQLiteDatabase,
   onProgress?: MigrationProgressHandler,
 ): Promise<void> {
-  logger.debug('db', 'checking migrations...')
+  logger.debug('db', 'checking_migrations')
   await db.execAsync(
     `CREATE TABLE IF NOT EXISTS migrations (
       id TEXT PRIMARY KEY,
@@ -46,18 +48,15 @@ export async function runMigrations(
 
   const needToApply = migrations.length - applied.size
   if (needToApply > 0) {
-    logger.info(
-      'db',
-      'need to apply',
-      migrations.length - applied.size,
-      'migrations',
-    )
+    logger.info('db', 'migrations_pending', {
+      count: migrations.length - applied.size,
+    })
   }
   for (const m of migrations) {
     if (applied.has(m.id)) {
       continue
     }
-    logger.info('db', 'applying migration', m.id)
+    logger.info('db', 'applying_migration', { id: m.id })
     onProgress?.({
       id: m.id,
       message: m.description,
@@ -71,5 +70,5 @@ export async function runMigrations(
       )
     })
   }
-  logger.info('db', 'all migrations applied')
+  logger.info('db', 'migrations_complete')
 }

--- a/src/encoding/fileMetadata.ts
+++ b/src/encoding/fileMetadata.ts
@@ -23,11 +23,7 @@ export function decodeFileMetadata(buffer?: ArrayBuffer): FileMetadata {
   try {
     return transformFileMetadata(JSON.parse(new TextDecoder().decode(buffer)))
   } catch (e) {
-    logger.error(
-      'fileMetadata',
-      'Error converting file metadata from buffer',
-      e,
-    )
+    logger.error('fileMetadata', 'decode_error', { error: e as Error })
     return {
       name: '',
       size: 0,

--- a/src/hooks/useAccount.tsx
+++ b/src/hooks/useAccount.tsx
@@ -9,7 +9,7 @@ export function useAccount() {
       const account = await sdk.account()
       return account
     } catch (e) {
-      logger.error('useAccount', 'error getting account', e)
+      logger.error('useAccount', 'error', { error: e as Error })
       throw e
     }
   })

--- a/src/hooks/useCameraCapture.ts
+++ b/src/hooks/useCameraCapture.ts
@@ -12,12 +12,12 @@ export function useCameraCapture() {
   const isCapturingRef = useRef<boolean>(false)
   return useCallback(async (): Promise<FileRecord[]> => {
     if (isCapturingRef.current) {
-      logger.debug('cameraCapture', 'already capturing, ignoring new request.')
+      logger.debug('cameraCapture', 'already_capturing')
       return []
     }
     isCapturingRef.current = true
     try {
-      logger.debug('cameraCapture', 'opening camera...')
+      logger.debug('cameraCapture', 'opening')
       const result = await ImagePicker.launchCamera({
         mediaType: 'mixed',
         saveToPhotos: false,
@@ -29,14 +29,14 @@ export function useCameraCapture() {
       })
 
       if (result.didCancel) {
-        logger.debug('cameraCapture', 'capture canceled.')
+        logger.debug('cameraCapture', 'canceled')
         return []
       }
       if (result.errorCode) {
-        logger.warn(
-          'cameraCapture',
-          `error: ${result.errorMessage ?? result.errorCode}`,
-        )
+        logger.warn('cameraCapture', 'picker_error', {
+          errorCode: result.errorCode,
+          errorMessage: result.errorMessage,
+        })
         return []
       }
 
@@ -71,7 +71,7 @@ export function useCameraCapture() {
 
       return files
     } catch (e) {
-      logger.error('cameraCapture', 'error', e)
+      logger.error('cameraCapture', 'error', { error: e as Error })
       return []
     } finally {
       isCapturingRef.current = false

--- a/src/hooks/useDocumentPicker.ts
+++ b/src/hooks/useDocumentPicker.ts
@@ -11,12 +11,12 @@ export function useDocumentPicker() {
   const isPickingRef = useRef<boolean>(false)
   return useCallback(async (): Promise<FileRecord[]> => {
     if (isPickingRef.current) {
-      logger.debug('documentPicker', 'already picking, ignoring new request.')
+      logger.debug('documentPicker', 'already_picking')
       return []
     }
     isPickingRef.current = true
     try {
-      logger.debug('documentPicker', 'opening document picker...')
+      logger.debug('documentPicker', 'opening')
       const result = await DocumentPicker.getDocumentAsync({
         multiple: true,
         type: '*/*',
@@ -24,7 +24,7 @@ export function useDocumentPicker() {
       })
 
       if (result.canceled) {
-        logger.debug('documentPicker', 'selection canceled.')
+        logger.debug('documentPicker', 'canceled')
         return []
       }
 
@@ -44,7 +44,7 @@ export function useDocumentPicker() {
 
       return files
     } catch (e) {
-      logger.error('documentPicker', 'error', e)
+      logger.error('documentPicker', 'error', { error: e as Error })
       return []
     } finally {
       isPickingRef.current = false

--- a/src/hooks/useImagePicker.ts
+++ b/src/hooks/useImagePicker.ts
@@ -11,12 +11,12 @@ export function useImagePicker() {
   const isPickingRef = useRef<boolean>(false)
   return useCallback(async (): Promise<FileRecord[]> => {
     if (isPickingRef.current) {
-      logger.debug('imagePicker', 'already picking, ignoring new request.')
+      logger.debug('imagePicker', 'already_picking')
       return []
     }
     isPickingRef.current = true
     try {
-      logger.debug('imagePicker', 'opening media picker...')
+      logger.debug('imagePicker', 'opening')
       const result = await ImagePicker.launchImageLibrary({
         mediaType: 'mixed',
         // 0 => unlimited on iOS; Android uses picker default multi-select UI if available.
@@ -29,14 +29,14 @@ export function useImagePicker() {
       })
 
       if (result.didCancel) {
-        logger.debug('imagePicker', 'media selection canceled.')
+        logger.debug('imagePicker', 'canceled')
         return []
       }
       if (result.errorCode) {
-        logger.warn(
-          'imagePicker',
-          `error: ${result.errorMessage ?? result.errorCode}`,
-        )
+        logger.warn('imagePicker', 'picker_error', {
+          errorCode: result.errorCode,
+          errorMessage: result.errorMessage,
+        })
         return []
       }
 
@@ -55,7 +55,7 @@ export function useImagePicker() {
       }
       return files
     } catch (e) {
-      logger.error('imagePicker', 'error', e)
+      logger.error('imagePicker', 'error', { error: e as Error })
       return []
     } finally {
       isPickingRef.current = false

--- a/src/hooks/useIsOnline.ts
+++ b/src/hooks/useIsOnline.ts
@@ -28,10 +28,9 @@ export function useIsOnline() {
     if (isOnline.isLoading) {
       return
     }
-    logger.debug(
-      'netinfo',
-      `app is now ${isOnline.data ? 'online' : 'offline'}`,
-    )
+    logger.debug('netinfo', 'connectivity_changed', {
+      online: isOnline.data,
+    })
   }, [isOnline.data, isOnline.isLoading])
 
   return isOnline

--- a/src/hooks/usePinnedObjects.tsx
+++ b/src/hooks/usePinnedObjects.tsx
@@ -14,10 +14,10 @@ export function usePinnedObjects(file: FileRecord) {
           const appKey = await getAppKeyForIndexer(indexerURL)
           if (!appKey) {
             // TODO: Figure out how to handle this situation.
-            logger.warn(
-              'usePinnedObjects',
-              `fileId=${file.id} indexerURL=${indexerURL} No AppKey found`,
-            )
+            logger.warn('usePinnedObjects', 'no_app_key', {
+              fileId: file.id,
+              indexerURL,
+            })
             return null
           }
           return {

--- a/src/hooks/useReconnectIndexer.ts
+++ b/src/hooks/useReconnectIndexer.ts
@@ -14,7 +14,7 @@ export function useReconnectIndexer() {
       const isInitializing = getIsInitializing()
 
       if (!isInitializing && !isIndexerConnected && isOnline) {
-        logger.info('netinfo', 'app is now online, reconnecting...')
+        logger.info('netinfo', 'online_reconnecting')
         await reconnectIndexer()
       }
     })
@@ -32,10 +32,7 @@ export function useReconnectIndexer() {
         const isOnline = await getIsOnline()
         const isIndexerConnected = getIsConnected()
         if (isOnline && !isIndexerConnected) {
-          logger.info(
-            'netinfo',
-            'app is online but not connected to indexer, reconnecting...',
-          )
+          logger.info('netinfo', 'indexer_disconnected_reconnecting')
           reconnectIndexer()
         }
       }, 5_000)

--- a/src/hooks/useRecoveryPhraseRegistration.ts
+++ b/src/hooks/useRecoveryPhraseRegistration.ts
@@ -13,10 +13,7 @@ export function useRecoveryPhraseRegistration() {
       indexerURL: string,
     ): Promise<{ success: boolean }> => {
       if (!phrase) {
-        logger.warn(
-          'recoveryPhraseRegistration',
-          'No recovery phrase available',
-        )
+        logger.warn('recoveryPhraseRegistration', 'no_phrase_available')
         return { success: false }
       }
 
@@ -28,11 +25,9 @@ export function useRecoveryPhraseRegistration() {
         return { success: true }
       }
 
-      logger.error(
-        'recoveryPhraseRegistration',
-        'Failed to register with mnemonic:',
-        error,
-      )
+      logger.error('recoveryPhraseRegistration', 'registration_failed', {
+        error: error as unknown as Error,
+      })
       switch (error.type) {
         case 'cancelled':
           toast.show('Authorization cancelled')

--- a/src/hooks/useRecoveryPhraseValidation.ts
+++ b/src/hooks/useRecoveryPhraseValidation.ts
@@ -22,11 +22,9 @@ export function useRecoveryPhraseValidation(manualPhrase: string) {
         return { isValid: true, error: null }
       } catch (e) {
         if (__DEV__)
-          logger.debug(
-            'recoveryPhraseValidation',
-            'Recovery phrase validation failed:',
-            e,
-          )
+          logger.debug('recoveryPhraseValidation', 'validation_failed', {
+            error: e as Error,
+          })
 
         const message =
           e instanceof Error

--- a/src/hooks/useShareAction.tsx
+++ b/src/hooks/useShareAction.tsx
@@ -54,7 +54,7 @@ export function useShareAction({ fileId }: { fileId: string }) {
       const msg =
         typeof e === 'string' ? e : e instanceof Error ? e.message : ''
       if (!msg.includes('User did not share')) {
-        logger.error('shareAction', 'File sharing failed:', e)
+        logger.error('shareAction', 'share_failed', { error: e as Error })
       }
     }
   }, [file, status.data?.fileUri])

--- a/src/lib/deleteFile.tsx
+++ b/src/lib/deleteFile.tsx
@@ -22,7 +22,7 @@ async function tryStep<T>(
 ): Promise<void> {
   const [, err] = await tryCatch(fn)
   if (err) {
-    logger.error('deleteFile', `${step} failed for ${id}`, err)
+    logger.error('deleteFile', 'step_failed', { step, id, error: err as Error })
   }
 }
 

--- a/src/lib/detectMimeType.ts
+++ b/src/lib/detectMimeType.ts
@@ -20,7 +20,7 @@ export async function detectMimeType(
     }
     return detectMimeTypeFromBytes(bytes)
   } catch (e) {
-    logger.error('detectMimeType', 'error:', e)
+    logger.error('detectMimeType', 'error', { error: e as Error })
     return null
   }
 }

--- a/src/lib/exportLogs.ts
+++ b/src/lib/exportLogs.ts
@@ -18,18 +18,21 @@ export async function exportLogs(): Promise<string | null> {
       return null
     }
 
-    // Format logs as text file.
+    // Format logs as JSONL.
     const content = logs
-      .map(
-        (entry) =>
-          `${entry.timestamp} ${entry.level.toUpperCase()} [${entry.scope}] ${
-            entry.message
-          }`,
+      .map((entry) =>
+        JSON.stringify({
+          ...entry.data,
+          ts: entry.timestamp,
+          level: entry.level,
+          scope: entry.scope,
+          msg: entry.message,
+        }),
       )
       .join('\n')
 
     // Write to temporary file.
-    const tempFileName = `logs-export-${Date.now()}.txt`
+    const tempFileName = `logs-export-${Date.now()}.jsonl`
     const tempFile = new File(Paths.document, tempFileName)
     const contentBytes = new TextEncoder().encode(content)
 
@@ -47,11 +50,11 @@ export async function exportLogs(): Promise<string | null> {
     const fileId = uniqueId()
     const size = contentBytes.length
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
-    const fileName = `logs-${timestamp}.txt`
+    const fileName = `logs-${timestamp}.jsonl`
 
     // Copy temp file to FS storage.
     const fsFileUri = await copyFileToFs(
-      { id: fileId, type: 'text/plain' },
+      { id: fileId, type: 'application/x-ndjson' },
       tempFile,
     )
 
@@ -75,7 +78,7 @@ export async function exportLogs(): Promise<string | null> {
     await createFileRecord({
       id: fileId,
       name: fileName,
-      type: 'text/plain',
+      type: 'application/x-ndjson',
       size,
       hash,
       createdAt: now,
@@ -90,7 +93,7 @@ export async function exportLogs(): Promise<string | null> {
 
     return fileId
   } catch (error) {
-    logger.error('logExport', 'Failed to export logs', error)
+    logger.error('logExport', 'export_failed', { error: error as Error })
     throw error
   }
 }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -6,10 +6,8 @@ import {
   getScopeColorAnsi,
 } from './logColors'
 
-// Log levels in order of severity.
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
 
-// Parse log level from env var.
 function getLogLevelFromEnv(): LogLevel {
   if (typeof process !== 'undefined' && process.env) {
     const level = process.env.EXPO_PUBLIC_LOG_LEVEL?.toLowerCase()
@@ -22,10 +20,9 @@ function getLogLevelFromEnv(): LogLevel {
       return level
     }
   }
-  return 'debug' // Default to debug in dev.
+  return 'debug'
 }
 
-/** Parse scope filter from env var (comma-separated). */
 function getScopeFilterFromEnv(): string[] | null {
   if (typeof process !== 'undefined' && process.env) {
     const filter = process.env.EXPO_PUBLIC_LOG_SCOPES
@@ -36,66 +33,6 @@ function getScopeFilterFromEnv(): string[] | null {
   return null
 }
 
-/** Serialize a value to a string, converting objects/errors to JSON. */
-function serializeValue(value: unknown): string {
-  // Handle primitives.
-  if (value === null || value === undefined) {
-    return String(value)
-  }
-  if (
-    typeof value === 'string' ||
-    typeof value === 'number' ||
-    typeof value === 'boolean'
-  ) {
-    return String(value)
-  }
-
-  // Handle Error objects specially to capture message, stack, and other properties.
-  if (value instanceof Error) {
-    const errorObj: Record<string, unknown> = {
-      name: value.name,
-      message: value.message,
-    }
-    // Truncate stack trace to prevent extremely long log messages.
-    if (value.stack) {
-      const stack = value.stack
-      // Limit stack trace to first 500 characters to prevent UI issues.
-      errorObj.stack = stack.length > 500 ? `${stack.slice(0, 500)}...` : stack
-    }
-    // Include any additional properties on the error.
-    Object.keys(value).forEach((key) => {
-      if (!['name', 'message', 'stack'].includes(key)) {
-        errorObj[key] = (value as unknown as Record<string, unknown>)[key]
-      }
-    })
-    try {
-      const json = JSON.stringify(errorObj)
-      // Also limit total JSON size to prevent issues.
-      return json.length > 1000 ? `${json.slice(0, 1000)}...` : json
-    } catch {
-      return `Error: ${value.name} - ${value.message}`
-    }
-  }
-
-  // Handle objects and arrays - serialize to one-line JSON.
-  if (typeof value === 'object') {
-    try {
-      const json = JSON.stringify(value)
-      // Limit total JSON size to prevent extremely long log messages.
-      return json.length > 1000 ? `${json.slice(0, 1000)}...` : json
-    } catch {
-      // If JSON.stringify fails (circular reference, etc.), fall back to string representation.
-      return String(value)
-    }
-  }
-
-  // Fallback for anything else.
-  return String(value)
-}
-
-/** Format timestamp with full date and time for better log analysis.
- * Format: "2026-01-05 07:56:03.123" (ISO-like, local time)
- */
 function formatTimestamp(): string {
   const now = new Date()
   const year = now.getFullYear()
@@ -108,19 +45,16 @@ function formatTimestamp(): string {
   return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}.${millis}`
 }
 
-/** Check if a log should be output to terminal based on level and scope filters. */
 function shouldLogToTerminal(level: LogLevel, scope: string): boolean {
   const envLevel = getLogLevelFromEnv()
   const levelOrder: LogLevel[] = ['debug', 'info', 'warn', 'error']
   const envLevelIndex = levelOrder.indexOf(envLevel)
   const logLevelIndex = levelOrder.indexOf(level)
 
-  // Filter by level.
   if (logLevelIndex < envLevelIndex) {
     return false
   }
 
-  // Filter by scope.
   const scopeFilter = getScopeFilterFromEnv()
   if (scopeFilter && scopeFilter.length > 0) {
     return scopeFilter.includes(scope)
@@ -129,52 +63,123 @@ function shouldLogToTerminal(level: LogLevel, scope: string): boolean {
   return true
 }
 
-/** Format log message for terminal. */
+/** Serialize a data value for storage, converting Errors to plain objects. */
+function serializeDataValue(value: unknown): unknown {
+  if (value instanceof Error) {
+    const obj: Record<string, unknown> = {
+      name: value.name,
+      message: value.message,
+    }
+    if (value.stack) {
+      obj.stack =
+        value.stack.length > 500
+          ? `${value.stack.slice(0, 500)}...`
+          : value.stack
+    }
+    for (const key of Object.keys(value)) {
+      if (!['name', 'message', 'stack'].includes(key)) {
+        obj[key] = (value as unknown as Record<string, unknown>)[key]
+      }
+    }
+    return obj
+  }
+  return value
+}
+
+const MAX_STRING_VALUE_LENGTH = 2000
+
+/** Serialize a data value for storage, truncating large strings. */
+function truncateDataValue(value: unknown): unknown {
+  if (typeof value === 'string' && value.length > MAX_STRING_VALUE_LENGTH) {
+    return `${value.slice(0, MAX_STRING_VALUE_LENGTH)}...`
+  }
+  return value
+}
+
+/** Serialize data record for DB storage. Converts Error values to plain objects. */
+export function serializeData(data: LogData | undefined): string | null {
+  if (!data) return null
+  const serialized: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(data)) {
+    serialized[key] = truncateDataValue(serializeDataValue(value))
+  }
+  try {
+    return JSON.stringify(serialized)
+  } catch {
+    return null
+  }
+}
+
+/** Format data as key=value pairs for terminal/display. */
+export function formatDataPairs(data?: LogData): string {
+  if (!data) return ''
+  const pairs: string[] = []
+  for (const [key, value] of Object.entries(data)) {
+    if (value instanceof Error) {
+      pairs.push(`${key}=${value.name}: ${value.message}`)
+    } else if (typeof value === 'string') {
+      pairs.push(`${key}=${value}`)
+    } else if (value === null || value === undefined) {
+      pairs.push(`${key}=${String(value)}`)
+    } else {
+      try {
+        pairs.push(`${key}=${JSON.stringify(value)}`)
+      } catch {
+        pairs.push(`${key}=${String(value)}`)
+      }
+    }
+  }
+  return pairs.join(' ')
+}
+
 function formatTerminalLog(
   level: LogLevel,
   scope: string,
   timestamp: string,
-  ...args: unknown[]
+  msg: string,
+  data?: LogData,
 ): string {
   const levelColor = getLevelColorAnsi(level)
   const scopeColor = getScopeColorAnsi(scope)
   const levelUpper = level.toUpperCase().padEnd(5)
-
-  const message = args.map(serializeValue).join(' ')
-  return `${timestamp} ${levelColor}${ANSI_BOLD}${levelUpper}${ANSI_RESET} ${scopeColor}${ANSI_BOLD}[${scope}]${ANSI_RESET} ${message}`
+  const dataPart = formatDataPairs(data)
+  const messagePart = dataPart ? `${msg} ${dataPart}` : msg
+  return `${timestamp} ${levelColor}${ANSI_BOLD}${levelUpper}${ANSI_RESET} ${scopeColor}${ANSI_BOLD}[${scope}]${ANSI_RESET} ${messagePart}`
 }
 
-/** Create a logger function for a specific level. */
 function createLogger(level: LogLevel) {
-  return (scope: string, ...args: unknown[]) => {
+  return (scope: string, msg: string, data?: LogData) => {
     const timestamp = formatTimestamp()
-    const message = args.map(serializeValue).join(' ')
     const entry: LogEntry = {
       timestamp,
       level,
       scope,
-      message,
+      message: msg,
+      data,
     }
 
     appendLog(entry)
 
-    const terminalMessage = formatTerminalLog(level, scope, timestamp, ...args)
-
     if (shouldLogToTerminal(level, scope)) {
-      console.log(terminalMessage)
+      console.log(formatTerminalLog(level, scope, timestamp, msg, data))
     }
   }
 }
 
-/** Structured log entry type. */
+type ReservedLogKeys = 'ts' | 'level' | 'scope' | 'msg'
+
+export type LogData = { [K in ReservedLogKeys]?: never } & {
+  [key: string]: unknown
+}
+
 export type LogEntry = {
   timestamp: string
   level: LogLevel
   scope: string
   message: string
+  data?: LogData
 }
 
-/** Logger interface. */
 export const logger = {
   debug: createLogger('debug'),
   info: createLogger('info'),
@@ -183,7 +188,6 @@ export const logger = {
   clear: () => {},
 }
 
-/** Rust logger using the rust scope. */
 export const rustLogger = {
   hasInitialized: false,
   debug: (message: string) => {

--- a/src/lib/processAssets.ts
+++ b/src/lib/processAssets.ts
@@ -209,10 +209,12 @@ export async function processAssets(
   const warnings: string[] = []
   const existingFilesByLocalIdCount = existingLocalIds.length
   const existingFilesByContentHashCount = existingContentHashes.length
-  logger.debug(
-    'processAssets',
-    `result: picked=${candidateFiles.length}, new=${newFiles.length}, incomplete=${incompleteFiles.length}, existing=${existingFiles.length}`,
-  )
+  logger.debug('processAssets', 'result', {
+    picked: candidateFiles.length,
+    new: newFiles.length,
+    incomplete: incompleteFiles.length,
+    existing: existingFiles.length,
+  })
   if (existingFilesByLocalIdCount > 0 || existingFilesByContentHashCount > 0) {
     warnings.push('Some files were duplicates and were not included.')
   }
@@ -221,10 +223,9 @@ export async function processAssets(
   await createManyFileRecords(newFiles)
 
   // Generate thumbnails for new image and video files.
-  logger.debug(
-    'processAssets',
-    `generating thumbnails for ${newFiles.length} new files`,
-  )
+  logger.debug('processAssets', 'generating_thumbnails', {
+    count: newFiles.length,
+  })
 
   // Generate thumbnails for new files, this will run in the background.
   generateThumbnails(newFiles)

--- a/src/lib/readFileBytes.ts
+++ b/src/lib/readFileBytes.ts
@@ -47,7 +47,7 @@ export async function readFileBytes(
       reader.releaseLock()
     }
   } catch (e) {
-    logger.error('readFileBytes', 'error:', e)
+    logger.error('readFileBytes', 'error', { error: e as Error })
     return null
   }
 }

--- a/src/lib/retry.ts
+++ b/src/lib/retry.ts
@@ -33,12 +33,13 @@ export async function retry<T>(
         0,
         Math.round(exponentialDelay + jitterOffset),
       )
-      logger.warn(
-        'retry',
-        `${name} failed (attempt ${attempt}/${maxAttempts}), retrying in ${delayWithJitter}ms... error: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      )
+      logger.warn('retry', 'attempt_failed', {
+        name,
+        attempt,
+        maxAttempts,
+        delayMs: delayWithJitter,
+        error: error instanceof Error ? error : new Error(String(error)),
+      })
 
       // If this was the last attempt, do not delay, just throw.
       if (attempt === maxAttempts) {

--- a/src/lib/serviceInterval.ts
+++ b/src/lib/serviceInterval.ts
@@ -18,7 +18,7 @@ const pausedCallbacks: Array<() => void> = []
  */
 export function pauseAllServiceIntervals(): void {
   paused = true
-  logger.debug('serviceInterval', 'all services paused')
+  logger.debug('serviceInterval', 'all_paused')
 }
 
 /**
@@ -26,7 +26,7 @@ export function pauseAllServiceIntervals(): void {
  */
 export function resumeAllServiceIntervals(): void {
   paused = false
-  logger.debug('serviceInterval', 'all services resumed')
+  logger.debug('serviceInterval', 'all_resumed')
   const callbacks = [...pausedCallbacks]
   pausedCallbacks.length = 0
   for (const cb of callbacks) {

--- a/src/lib/shareLink.ts
+++ b/src/lib/shareLink.ts
@@ -8,7 +8,9 @@ export default async function shareLink({ url }: { url: string }) {
     })
     if (result.action === Share.sharedAction) {
       if (result.activityType) {
-        logger.debug('shareLink', result.activityType)
+        logger.debug('shareLink', 'shared', {
+          activityType: result.activityType,
+        })
         // shared with activity type of result.activityType
       } else {
         // shared

--- a/src/lib/slotPool.ts
+++ b/src/lib/slotPool.ts
@@ -43,12 +43,11 @@ export class SlotPool {
   /** Acquire a slot. Resolves with a release function to free the slot. */
   async acquire(): Promise<() => void> {
     if (this.inUseCount < this.maxSlots) {
-      logger.debug(
-        'slotPool',
-        `acquired: inUse=${this.inUseCount + 1}/${
-          this.maxSlots
-        } queued=${Math.max(0, this.waitQueue.length - 1)}`,
-      )
+      logger.debug('slotPool', 'acquired', {
+        inUse: this.inUseCount + 1,
+        maxSlots: this.maxSlots,
+        queued: Math.max(0, this.waitQueue.length - 1),
+      })
       // Immediate acquisition.
       this.inUseCount += 1
       let released = false
@@ -61,28 +60,29 @@ export class SlotPool {
     }
 
     // Wait for a slot to free up.
-    logger.debug(
-      'slotPool',
-      `waiting: inUse=${this.inUseCount}/${this.maxSlots} queued=${this.waitQueue.length}`,
-    )
+    logger.debug('slotPool', 'waiting', {
+      inUse: this.inUseCount,
+      maxSlots: this.maxSlots,
+      queued: this.waitQueue.length,
+    })
     return await new Promise<() => void>((resolve) => {
       const grant = () => {
-        logger.debug(
-          'slotPool',
-          `acquired: inUse=${this.inUseCount + 1}/${
-            this.maxSlots
-          } queued=${Math.max(0, this.waitQueue.length - 1)}`,
-        )
+        logger.debug('slotPool', 'acquired', {
+          inUse: this.inUseCount + 1,
+          maxSlots: this.maxSlots,
+          queued: Math.max(0, this.waitQueue.length - 1),
+        })
         this.inUseCount += 1
         let released = false
         const release = () => {
           if (released) return
           released = true
           this.inUseCount -= 1
-          logger.debug(
-            'slotPool',
-            `released: inUse=${this.inUseCount}/${this.maxSlots} queued=${this.waitQueue.length}`,
-          )
+          logger.debug('slotPool', 'released', {
+            inUse: this.inUseCount,
+            maxSlots: this.maxSlots,
+            queued: this.waitQueue.length,
+          })
           this.drain()
         }
         resolve(release)

--- a/src/managers/backgroundTasks.ts
+++ b/src/managers/backgroundTasks.ts
@@ -137,7 +137,7 @@ export async function initBackgroundTasks() {
       const config = taskConfigs[taskId as TaskId]
       const state = taskStates[taskId as TaskId]
       if (!config || !state) {
-        logger.warn('backgroundTask', `unknown task id: ${taskId}`)
+        logger.warn('backgroundTask', 'unknown_task_id', { taskId })
         BackgroundFetch.finish(taskId)
         return
       }
@@ -155,26 +155,24 @@ export async function initBackgroundTasks() {
       const config = taskConfigs[taskId as TaskId]
       const state = taskStates[taskId as TaskId]
       if (!config || !state) {
-        logger.warn('backgroundTask', `unknown task id: ${taskId}`)
+        logger.warn('backgroundTask', 'unknown_task_id', { taskId })
         BackgroundFetch.finish(taskId)
         return
       }
       const log = logTask(config, state)
 
-      log(`timeout callback fired, aborting delay and finishing task`)
+      log('timeout')
 
       // Abort any pending delay BEFORE setting status, so the while loop
       // can exit cleanly when the Promise resolves.
       state.abort?.()
       transitionTaskState(state, 'finished')
       BackgroundFetch.finish(config.id)
-      log(
-        `finished, reason: timeout, elapsed ${formatElapsedTime(state.startTime)}`,
-      )
+      log('timeout_finished', { elapsedMs: Date.now() - state.startTime })
     },
   )
 
-  logger.info('backgroundTask', `configure status: ${status}`)
+  logger.info('backgroundTask', 'configured', { status })
 
   // Schedule custom background processing task on iOS.
   if (Platform.OS === 'ios') {
@@ -186,16 +184,15 @@ export async function initBackgroundTasks() {
         delay: minutesInMs(31),
         ...sharedConfig,
       })
-      logger.info(
-        'backgroundTask',
-        `scheduleTask status for ${bgProcessingTaskConfig.id}: ${scheduled}`,
-      )
+      logger.info('backgroundTask', 'task_scheduled', {
+        taskId: bgProcessingTaskConfig.id,
+        scheduled,
+      })
     } catch (error) {
-      logger.error(
-        'backgroundTask',
-        `scheduleTask failed for ${bgProcessingTaskConfig.id}:`,
-        error,
-      )
+      logger.error('backgroundTask', 'schedule_failed', {
+        taskId: bgProcessingTaskConfig.id,
+        error: error as Error,
+      })
     }
   }
 }
@@ -250,7 +247,7 @@ async function runBackgroundWork(config: TaskConfig, state: TaskState) {
   // Check if user has onboarded - if not, there's nothing to do
   const hasOnboarded = await getHasOnboarded()
   if (!hasOnboarded) {
-    log('not onboarded, exiting')
+    log('skipped', { reason: 'not_onboarded' })
     return
   }
 
@@ -259,14 +256,14 @@ async function runBackgroundWork(config: TaskConfig, state: TaskState) {
   // initialization sequence including reconnectIndexer().
   const isInitializing = getIsInitializing()
   if (isInitializing) {
-    log('waiting for app initialization to complete...')
+    log('waiting_for_init')
     const initResult = await waitForInitialization(delayFn)
     if (initResult === 'timeout') {
-      log('initialization timed out, exiting')
+      log('skipped', { reason: 'init_timeout' })
       return
     }
     if (initResult === 'aborted') {
-      log('wait aborted, exiting')
+      log('skipped', { reason: 'aborted' })
       return
     }
   }
@@ -274,12 +271,12 @@ async function runBackgroundWork(config: TaskConfig, state: TaskState) {
   // Check if initialization failed
   const initError = getInitializationError()
   if (initError) {
-    log(`initialization failed: ${initError}, exiting`)
+    log('skipped', { reason: 'init_failed', initError })
     return
   }
 
   const isConnected = getIsConnected()
-  log(`app ready (connected=${isConnected})`)
+  log('app_ready', { connected: isConnected })
 
   await runFsOrphanScanner()
   await runFsEvictionScanner()
@@ -292,15 +289,17 @@ async function runBackgroundWork(config: TaskConfig, state: TaskState) {
     uploaded: manager.uploadedCount,
     uploadedBytes: manager.uploadedBytes,
   }
-  log(
-    `files awaiting upload: ${initialStats.count} (${formatBytes(initialStats.totalBytes)} total)`,
-  )
+  log('awaiting_upload', {
+    count: initialStats.count,
+    totalBytes: initialStats.totalBytes,
+  })
 
   while (true) {
     if (state.status === 'finished') {
       const finalStats = await getFileStatsLocal({ localOnly: true })
       log(
-        logSummary(
+        'finished',
+        buildSummaryData(
           'timed out',
           initialStats,
           finalStats,
@@ -312,12 +311,15 @@ async function runBackgroundWork(config: TaskConfig, state: TaskState) {
       return
     }
     const stats = await getFileStatsLocal({ localOnly: true })
-    log(
-      `still uploading: ${stats.count} files remaining (${formatBytes(stats.totalBytes)}), elapsed ${formatElapsedTime(state.startTime)}`,
-    )
+    log('still_uploading', {
+      filesRemaining: stats.count,
+      bytesRemaining: stats.totalBytes,
+      elapsedMs: Date.now() - state.startTime,
+    })
     if (stats.count === 0) {
       log(
-        logSummary(
+        'finished',
+        buildSummaryData(
           'all uploaded',
           initialStats,
           { count: 0, totalBytes: 0 },
@@ -332,7 +334,8 @@ async function runBackgroundWork(config: TaskConfig, state: TaskState) {
     if (result === 'aborted') {
       const finalStats = await getFileStatsLocal({ localOnly: true })
       log(
-        logSummary(
+        'finished',
+        buildSummaryData(
           'aborted',
           initialStats,
           finalStats,
@@ -353,7 +356,7 @@ type UploadSnapshot = {
   uploadedBytes: number
 }
 
-function logSummary(
+function buildSummaryData(
   reason: string,
   initialStats: { count: number; totalBytes: number },
   finalStats: { count: number; totalBytes: number },
@@ -365,51 +368,33 @@ function logSummary(
     uploadedBytes: number
   },
   state: TaskState,
-): string {
+): Record<string, unknown> {
   const filesPacked = manager.packedCount - initial.packed
   const bytesPacked = manager.packedBytes - initial.packedBytes
   const filesUploaded = manager.uploadedCount - initial.uploaded
   const bytesUploaded = manager.uploadedBytes - initial.uploadedBytes
   const filesAdded = finalStats.count - initialStats.count + filesUploaded
-  const parts = [
-    `finished (${reason})`,
-    `packed ${filesPacked} files (${formatBytes(bytesPacked)})`,
-    `uploaded ${filesUploaded} files (${formatBytes(bytesUploaded)})`,
-    `${filesAdded} new files added to library`,
-    `${finalStats.count} files remaining (${formatBytes(finalStats.totalBytes)})`,
-    `elapsed ${formatElapsedTime(state.startTime)}`,
-  ]
-  return parts.join(', ')
-}
-
-function formatElapsedTime(startTime: number): string {
-  const ms = Date.now() - startTime
-  const totalSeconds = Math.floor(ms / 1000)
-  const minutes = Math.floor(totalSeconds / 60)
-  const seconds = totalSeconds % 60
-  if (minutes > 0) {
-    return `${minutes}m ${seconds}s`
+  return {
+    reason,
+    filesPacked,
+    bytesPacked,
+    filesUploaded,
+    bytesUploaded,
+    filesAdded,
+    filesRemaining: finalStats.count,
+    bytesRemaining: finalStats.totalBytes,
+    elapsedMs: Date.now() - state.startTime,
   }
-  return `${seconds}s`
-}
-
-function formatBytes(bytes: number): string {
-  if (bytes <= 0) return '0 B'
-  const units = ['B', 'KB', 'MB', 'GB']
-  const i = Math.min(
-    Math.floor(Math.log(bytes) / Math.log(1024)),
-    units.length - 1,
-  )
-  const value = bytes / 1024 ** i
-  return `${value.toFixed(i === 0 ? 0 : 1)} ${units[i]}`
 }
 
 function logTask(config: TaskConfig, state: TaskState) {
-  const prefix = state.invocationId
-    ? `[${config.type}][${config.id}][${state.invocationId}]`
-    : `[${config.type}][${config.id}]`
-  return (message: string) => {
-    logger.debug('backgroundTask', `${prefix} ${message}`)
+  return (msg: string, data?: Record<string, unknown>) => {
+    logger.debug('backgroundTask', msg, {
+      taskType: config.type,
+      taskId: config.id,
+      invocationId: state.invocationId,
+      ...data,
+    })
   }
 }
 

--- a/src/managers/downloader.ts
+++ b/src/managers/downloader.ts
@@ -102,11 +102,7 @@ export function useDownloadFromShareURL() {
         downloadState?.status === 'running' ||
         downloadState?.status === 'queued'
       ) {
-        logger.debug(
-          'useDownloadFromShareURL',
-          'download already in progress',
-          id,
-        )
+        logger.debug('useDownloadFromShareURL', 'already_in_progress', { id })
         return id
       }
 
@@ -187,12 +183,7 @@ function createFileWriter(params: {
       }
 
       if (chunks % 10 === 0) {
-        logger.debug(
-          'streamToCache',
-          'downloaded',
-          bytesWritten,
-          'bytes so far',
-        )
+        logger.debug('streamToCache', 'progress', { bytesWritten })
       }
     },
   }
@@ -208,14 +199,14 @@ async function streamToCache(params: {
 }): Promise<void> {
   const { file, totalSize, download, onAfterClose, signal } = params
   const targetFile = await getOrCreateTempDownloadFile(file)
-  logger.debug('streamToCache', 'writing to cache path:', targetFile.uri)
+  logger.debug('streamToCache', 'write_start', { uri: targetFile.uri })
 
   const fileWriter = targetFile.writableStream().getWriter()
 
   try {
     // Check for abort before starting
     if (signal.aborted) {
-      logger.debug('streamToCache', 'abort received before download started')
+      logger.debug('streamToCache', 'abort_before_start')
       await targetFile.delete()
       return
     }
@@ -230,10 +221,10 @@ async function streamToCache(params: {
     // Download writes chunks to our writer
     await download(writer)
 
-    logger.debug('streamToCache', 'download stream ended')
+    logger.debug('streamToCache', 'stream_ended')
   } finally {
     await fileWriter.close()
-    logger.debug('streamToCache', 'writer closed')
+    logger.debug('streamToCache', 'writer_closed')
   }
 
   if (onAfterClose) {
@@ -254,10 +245,7 @@ export async function downloadFirstBytesFromShared(
     throw new Error('SDK not initialized')
   }
 
-  logger.debug(
-    'downloadFirstBytesFromShared',
-    `Downloading first ${byteCount} bytes`,
-  )
+  logger.debug('downloadFirstBytesFromShared', 'downloading', { byteCount })
 
   // Collect bytes into an array
   const chunks: Uint8Array[] = []
@@ -305,9 +293,8 @@ export async function downloadFirstBytesFromShared(
     if (offset >= byteCount) break
   }
 
-  logger.debug(
-    'downloadFirstBytesFromShared',
-    `Downloaded ${bytes.length} bytes`,
-  )
+  logger.debug('downloadFirstBytesFromShared', 'downloaded', {
+    bytes: bytes.length,
+  })
   return bytes
 }

--- a/src/managers/downloadsPool.ts
+++ b/src/managers/downloadsPool.ts
@@ -37,7 +37,7 @@ export async function acquireDownloadSlot(): Promise<() => void> {
 
 export async function setMaxDownloads(value: number) {
   if (!value) {
-    logger.warn('settings', 'setMaxDownloads: value must be 1 or greater')
+    logger.warn('settings', 'invalid_max_downloads')
   }
   const clamped = Math.max(1, Math.floor(Number(value) || 1))
   await setAsyncStorageNumber('maxDownloads', clamped)

--- a/src/managers/fsEvictionScanner.ts
+++ b/src/managers/fsEvictionScanner.ts
@@ -42,10 +42,7 @@ export async function runFsEvictionScanner(): Promise<
     }
 
     let currentSize = totalSize
-    logger.warn(
-      'fsEvictionScanner',
-      `total size over limit totalSize=${totalSize}`,
-    )
+    logger.warn('fsEvictionScanner', 'over_limit', { totalSize })
 
     let processedRows = 0
     let evicted = 0
@@ -71,10 +68,10 @@ export async function runFsEvictionScanner(): Promise<
           currentSize -= row.size
           evicted += 1
         } catch (error) {
-          logger.error(
-            'fsEvictionScanner',
-            `failed to remove file fileId=${row.fileId} error=${error}`,
-          )
+          logger.error('fsEvictionScanner', 'remove_failed', {
+            fileId: row.fileId,
+            error: error as Error,
+          })
         }
       }
 
@@ -90,13 +87,14 @@ export async function runFsEvictionScanner(): Promise<
       evicted,
       currentSize,
     }
-    logger.info(
-      'fsEvictionScanner',
-      `summary processedRows=${processedRows} evicted=${evicted} currentSize=${currentSize}`,
-    )
+    logger.info('fsEvictionScanner', 'summary', {
+      processedRows,
+      evicted,
+      currentSize,
+    })
     return results
   } catch (error) {
-    logger.error('fsEvictionScanner', 'error during scan', error)
+    logger.error('fsEvictionScanner', 'scan_error', { error: error as Error })
   } finally {
     await setFsEvictionLastRun()
   }

--- a/src/managers/fsOrphanScanner.ts
+++ b/src/managers/fsOrphanScanner.ts
@@ -56,15 +56,16 @@ export async function runFsOrphanScanner(options?: {
         try {
           entry.file.delete()
           removed++
-          logger.info(
-            'fsOrphanScanner',
-            `removed unindexed file fileId=${entry.fileId} uri=${entry.file.uri}`,
-          )
+          logger.info('fsOrphanScanner', 'file_removed', {
+            fileId: entry.fileId,
+            uri: entry.file.uri,
+          })
         } catch (error) {
-          logger.error(
-            'fsOrphanScanner',
-            `failed to delete file fileId=${entry.fileId} uri=${entry.file.uri} error=${error}`,
-          )
+          logger.error('fsOrphanScanner', 'delete_failed', {
+            fileId: entry.fileId,
+            uri: entry.file.uri,
+            error: error as Error,
+          })
         }
       }
 
@@ -80,11 +81,11 @@ export async function runFsOrphanScanner(options?: {
 
     if (removed > 0) {
       await fsTriggerRefresh()
-      logger.info('fsOrphanScanner', `summary removed=${removed}`)
+      logger.info('fsOrphanScanner', 'summary', { removed })
     }
     return { removed }
   } catch (error) {
-    logger.error('fsOrphanScanner', 'error during scan', error)
+    logger.error('fsOrphanScanner', 'scan_error', { error: error as Error })
   } finally {
     await setFsOrphanLastRun()
   }

--- a/src/managers/logRotation.ts
+++ b/src/managers/logRotation.ts
@@ -32,9 +32,9 @@ export async function runLogRotation(): Promise<void> {
       )`,
       toDelete,
     )
-    logger.debug('logRotation', `Rotated ${toDelete} log entries`)
+    logger.debug('logRotation', 'rotated', { deleted: toDelete })
   } catch (error) {
-    logger.error('logRotation', 'Failed to rotate logs', error)
+    logger.error('logRotation', 'rotation_failed', { error: error as Error })
   }
 }
 

--- a/src/managers/perfMonitor.ts
+++ b/src/managers/perfMonitor.ts
@@ -8,7 +8,7 @@ export const initPerfMonitor = createServiceInterval({
   worker: () => {
     const cpu = getCpuUsage()
     const mem = getMemoryUsage()
-    logger.info('perfMonitor', `cpu=${cpu}% mem=${mem}MB`)
+    logger.info('perfMonitor', 'tick', { cpu, mem })
   },
   getState: async () => true,
   interval: PERF_MONITOR_INTERVAL,

--- a/src/managers/syncDownEvents.ts
+++ b/src/managers/syncDownEvents.ts
@@ -47,14 +47,15 @@ type Counts = {
  * The service runs again every SYNC_EVENTS_INTERVAL milliseconds.
  */
 export async function syncDownEvents(): Promise<void> {
+  logger.debug('syncDownEvents', 'tick')
   const isConnected = getIsConnected()
   if (!isConnected) {
-    logger.debug('syncDownEvents', 'not connected to indexer, skipping sync')
+    logger.debug('syncDownEvents', 'skipped', { reason: 'not_connected' })
     return
   }
   const sdk = getSdk()
   if (!sdk) {
-    logger.debug('syncDownEvents', 'no sdk, skipping sync')
+    logger.debug('syncDownEvents', 'skipped', { reason: 'no_sdk' })
     return
   }
 
@@ -67,21 +68,18 @@ export async function syncDownEvents(): Promise<void> {
   while (true) {
     try {
       const cursor = await getSyncDownCursor()
-      logger.debug(
-        'syncDownEvents',
-        `syncing from id=${cursor?.id} after=${cursor?.after}`,
-      )
+      logger.debug('syncDownEvents', 'syncing', {
+        id: cursor?.id,
+        after: cursor?.after,
+      })
 
       const events = await sdk.objectEvents(cursor, batchSize)
 
       // If the batch size is 1, we are probably synced and repeatedly polling the last event.
       if (events.length === 1) {
-        logger.debug(
-          'syncDownEvents',
-          `batch size=${events.length}, no new events found`,
-        )
+        logger.debug('syncDownEvents', 'batch', { size: events.length })
       } else {
-        logger.info('syncDownEvents', `batch size=${events.length}`)
+        logger.info('syncDownEvents', 'batch', { size: events.length })
       }
 
       await processBatch(events, counts)
@@ -101,15 +99,16 @@ export async function syncDownEvents(): Promise<void> {
         break
       }
     } catch (e) {
-      logger.error('syncDownEvents', 'sync error', e)
+      logger.error('syncDownEvents', 'sync_error', { error: e as Error })
       break
     }
   }
 
-  logger.info(
-    'syncDownEvents',
-    `synced, existingCount=${counts.existing}, addedCount=${counts.added}, deletedCount=${counts.deleted}`,
-  )
+  logger.info('syncDownEvents', 'synced', {
+    existing: counts.existing,
+    added: counts.added,
+    deleted: counts.deleted,
+  })
 }
 
 async function processBatch(events: ObjectEvent[], counts: Counts) {
@@ -130,7 +129,9 @@ async function handleDeleteEvent(id: string, counts: Counts): Promise<void> {
   try {
     const existingFileRecord = await readFileRecordByObjectId(id)
     if (existingFileRecord) {
-      logger.info('syncDownEvents', `deleting file id=${existingFileRecord.id}`)
+      logger.info('syncDownEvents', 'file_delete', {
+        fileId: existingFileRecord.id,
+      })
       await Promise.all([
         // Remove the file from the file system.
         removeFsFile(existingFileRecord),
@@ -141,13 +142,13 @@ async function handleDeleteEvent(id: string, counts: Counts): Promise<void> {
       ])
       counts.deleted++
     } else {
-      logger.debug(
-        'syncDownEvents',
-        `no file record found for object id=${id}, skipping delete`,
-      )
+      logger.debug('syncDownEvents', 'skipped', {
+        reason: 'no_file_record',
+        objectId: id,
+      })
     }
   } catch (e) {
-    logger.error('syncDownEvents', `error handling delete for id=${id}`, e)
+    logger.error('syncDownEvents', 'delete_error', { id, error: e as Error })
     throw e
   }
 }
@@ -187,9 +188,9 @@ async function handleUpdateEvent(
       )
       return
     }
-    logger.debug('syncDownEvents', 'incomplete metadata, skipping update')
+    logger.debug('syncDownEvents', 'skipped', { reason: 'incomplete_metadata' })
   } catch (e) {
-    logger.error('syncDownEvents', `error handling update for id=${id}`, e)
+    logger.error('syncDownEvents', 'update_error', { id, error: e as Error })
     throw e
   }
 }
@@ -204,12 +205,11 @@ async function handleFileRecord(
 ) {
   if (existingFile) {
     if (type === 'file') {
-      logger.debug('syncDownEvents', `updating file hash=${existingFile.hash}`)
+      logger.debug('syncDownEvents', 'file_update', { hash: existingFile.hash })
     } else {
-      logger.debug(
-        'syncDownEvents',
-        `updating thumbnail thumbForHash=${existingFile.thumbForHash}`,
-      )
+      logger.debug('syncDownEvents', 'thumbnail_update', {
+        thumbForHash: existingFile.thumbForHash,
+      })
     }
     const localObject = await pinnedObjectToLocalObject(
       existingFile.id,
@@ -229,12 +229,11 @@ async function handleFileRecord(
     counts.existing++
   } else {
     if (type === 'file') {
-      logger.info('syncDownEvents', `creating file hash=${metadata.hash}`)
+      logger.info('syncDownEvents', 'file_create', { hash: metadata.hash })
     } else {
-      logger.info(
-        'syncDownEvents',
-        `creating thumbnail thumbForHash=${metadata.thumbForHash}`,
-      )
+      logger.info('syncDownEvents', 'thumbnail_create', {
+        thumbForHash: metadata.thumbForHash,
+      })
     }
     const fileId = uniqueId()
     const localObject = await pinnedObjectToLocalObject(
@@ -302,6 +301,6 @@ export async function setSyncDownCursor(value: ObjectsCursor | undefined) {
 }
 
 export async function resetSyncDownCursor() {
-  logger.info('syncDownEvents', 'resetting sync down cursor')
+  logger.info('syncDownEvents', 'cursor_reset')
   await setSyncDownCursor(undefined)
 }

--- a/src/managers/syncNewPhotos.ts
+++ b/src/managers/syncNewPhotos.ts
@@ -21,6 +21,7 @@ import { settingsSwr } from '../stores/settings'
 const PAGE_SIZE = 200
 
 async function workForward(): Promise<void> {
+  logger.debug('syncNewPhotos', 'tick')
   if (!(await getMediaLibraryPermissions())) return
   const cursor = await getPhotosNewCursor()
 
@@ -35,10 +36,10 @@ async function workForward(): Promise<void> {
       resolveWithFullInfo: true,
     })
     if (page.assets.length === 0) {
-      logger.debug('syncNewPhotos', 'no new photos found')
+      logger.debug('syncNewPhotos', 'no_new_photos')
       return
     }
-    logger.info('syncNewPhotos', `batch size=${page.assets.length}`)
+    logger.info('syncNewPhotos', 'batch', { size: page.assets.length })
     const lastAssetCreationTime =
       page.assets[page.assets.length - 1].creationTime
     const nextTimestamp = lastAssetCreationTime ? lastAssetCreationTime + 1 : 0
@@ -55,7 +56,7 @@ async function workForward(): Promise<void> {
     )
     if (files.length > 0) await librarySwr.triggerChange()
   } catch (e) {
-    logger.error('syncNewPhotos', 'batch error', e)
+    logger.error('syncNewPhotos', 'batch_error', { error: e as Error })
   }
 }
 
@@ -101,6 +102,6 @@ export async function setPhotosNewCursor(value: number) {
 }
 
 export async function resetPhotosNewCursor() {
-  logger.info('syncNewPhotos', 'resetting photos new sync cursor')
+  logger.info('syncNewPhotos', 'cursor_reset')
   await setPhotosNewCursor(defaultValue)
 }

--- a/src/managers/syncPhotosArchive.ts
+++ b/src/managers/syncPhotosArchive.ts
@@ -22,13 +22,14 @@ import { settingsSwr } from '../stores/settings'
 const PAGE_SIZE = 50
 
 export async function workBackward() {
+  logger.debug('syncPhotosArchive', 'tick')
   if (!(await getMediaLibraryPermissions())) return
   const localOnlyCount = await getFileCountLocal({ localOnly: true })
   if (localOnlyCount > 0) {
-    logger.info(
-      'syncPhotosArchive',
-      `waiting for ${localOnlyCount} local-only files to sync`,
-    )
+    logger.info('syncPhotosArchive', 'skipped', {
+      reason: 'local_only_pending',
+      localOnlyCount,
+    })
     return
   }
   const cursor = await getPhotosArchiveCursor()
@@ -44,11 +45,11 @@ export async function workBackward() {
       resolveWithFullInfo: true,
     })
     if (page.assets.length === 0) {
-      logger.info('syncPhotosArchive', 'archive is fully synced')
+      logger.info('syncPhotosArchive', 'fully_synced')
       await setPhotosArchiveCursor(0)
       return
     }
-    logger.info('syncPhotosArchive', `batch size=${page.assets.length}`)
+    logger.info('syncPhotosArchive', 'batch', { size: page.assets.length })
     const lastAssetCreationTime =
       page.assets[page.assets.length - 1].creationTime ?? 0
     const nextTimestamp = lastAssetCreationTime ? lastAssetCreationTime - 1 : 0
@@ -70,7 +71,7 @@ export async function workBackward() {
       return 0
     }
   } catch (e) {
-    logger.error('syncPhotosArchive', 'batch error', e)
+    logger.error('syncPhotosArchive', 'batch_error', { error: e as Error })
   }
 }
 
@@ -114,11 +115,11 @@ export async function setPhotosArchiveCursor(value: number) {
 }
 
 export async function restartPhotosArchiveCursor() {
-  logger.info('syncPhotosArchive', 'restarting photos archive sync cursor')
+  logger.info('syncPhotosArchive', 'cursor_restart')
   await setPhotosArchiveCursor(Date.now())
 }
 
 export async function resetPhotosArchiveCursor() {
-  logger.info('syncPhotosArchive', 'disabling photos archive sync cursor')
+  logger.info('syncPhotosArchive', 'cursor_disable')
   await setPhotosArchiveCursor(defaultValue)
 }

--- a/src/managers/syncUpMetadata.ts
+++ b/src/managers/syncUpMetadata.ts
@@ -36,70 +36,6 @@ export function diffFileMetadata(
   return diffs
 }
 
-/**
- * Format field-level metadata diffs as git-style +/- lines.
- * '+' denotes the newer value, '-' denotes the older value. Side labels: 'l' = local, 'r' = remote.
- *
- * Example (newerSide = 'local'):
- * -r name: "old.jpg"
- * +l name: "new.jpg"
- * -r updatedAt: 1700000000000
- * +l updatedAt: 1700005000000
- */
-export function formatMetadataDiff(
-  diffs: Partial<DiffResult>,
-  isLocalNewer: boolean,
-): string {
-  const lines: string[] = []
-  const keys = Object.keys(diffs) as (keyof FileMetadata)[]
-  for (const key of keys) {
-    const entry = diffs[key]
-    if (!entry) continue
-    const oldVal = isLocalNewer ? entry.remote : entry.local
-    const newVal = isLocalNewer ? entry.local : entry.remote
-    const oldStr = JSON.stringify(oldVal)
-    const newStr = JSON.stringify(newVal)
-    const oldSide = isLocalNewer ? 'r' : 'l'
-    const newSide = isLocalNewer ? 'l' : 'r'
-    lines.push(`-${oldSide} ${String(key)}: ${oldStr}`)
-    lines.push(`+${newSide} ${String(key)}: ${newStr}`)
-  }
-  return lines.join('\n')
-}
-
-function formatTimestamp(ts?: number): string {
-  if (!ts || ts <= 0) return 'n/a'
-  return new Intl.DateTimeFormat('en-US', {
-    month: 'short',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-    hour12: false,
-  }).format(new Date(ts))
-}
-
-function formatDiff(params: {
-  fileId: string
-  objectId: string
-  localMeta: FileMetadata
-  remoteMeta: FileMetadata
-  diffs: Partial<DiffResult>
-  isLocalNewer: boolean
-}): string {
-  const { fileId, objectId, localMeta, remoteMeta, diffs, isLocalNewer } =
-    params
-  const headerLeft = `local (l) updated at ${formatTimestamp(
-    localMeta.updatedAt,
-  )}`
-  const headerRight = `remote (r) updated at ${formatTimestamp(
-    remoteMeta.updatedAt,
-  )}`
-  const status = isLocalNewer ? 'local newer' : 'remote newer'
-  const diff = formatMetadataDiff(diffs, isLocalNewer)
-  return `[syncUpMetadata] fileId=${fileId} objectId=${objectId}\n${headerLeft}    ${headerRight}\n${status} • ${diff}`
-}
-
 export type MetadataSyncResult = {
   scanned: number
   withDiffs: number
@@ -118,7 +54,10 @@ async function tryWithLog<T>(
   try {
     return await fn()
   } catch (e) {
-    logger.error('syncUpMetadata', `${operation} failed`, { ...ctx, error: e })
+    logger.error('syncUpMetadata', `${operation}_failed`, {
+      ...ctx,
+      error: e as Error,
+    })
     return null
   }
 }
@@ -162,15 +101,15 @@ export async function setSyncUpCursor(
  */
 export async function runSyncUpMetadata(batchSize: number): Promise<void> {
   if (!getIsConnected()) {
-    logger.debug('syncUpMetadata', 'not connected to indexer, skipping')
+    logger.debug('syncUpMetadata', 'skipped', { reason: 'not_connected' })
     return
   }
   const indexerURL = await getIndexerURL()
   const after = await getSyncUpCursor()
-  logger.debug(
-    'syncUpMetadata',
-    `service tick: from ${after?.id ?? 'begin'} after=${after?.updatedAt}`,
-  )
+  logger.debug('syncUpMetadata', 'tick', {
+    fromId: after?.id ?? 'begin',
+    afterUpdatedAt: after?.updatedAt,
+  })
   const batch = await readAllFileRecords({
     order: 'ASC',
     orderBy: 'updatedAt',
@@ -184,7 +123,7 @@ export async function runSyncUpMetadata(batchSize: number): Promise<void> {
       : undefined,
   })
   if (batch.length === 0) {
-    logger.debug('syncUpMetadata', 'no new updates')
+    logger.debug('syncUpMetadata', 'no_updates')
     return
   }
   for (const f of batch) {
@@ -211,17 +150,14 @@ export async function runSyncUpMetadata(batchSize: number): Promise<void> {
     if (Object.keys(diffs).length === 0) continue
 
     const isLocalNewer = (f.updatedAt || 0) >= (remoteMeta.updatedAt || 0)
-    logger.info(
-      'syncUpMetadata',
-      formatDiff({
-        fileId: f.id,
-        objectId: obj.id,
-        localMeta: f,
-        remoteMeta,
-        diffs,
-        isLocalNewer,
-      }),
-    )
+    logger.info('syncUpMetadata', 'metadata_diff', {
+      fileId: f.id,
+      objectId: obj.id,
+      localUpdatedAt: f.updatedAt,
+      remoteUpdatedAt: remoteMeta.updatedAt,
+      newerSide: isLocalNewer ? 'local' : 'remote',
+      diffs,
+    })
 
     if (isLocalNewer) {
       await tryWithLog(
@@ -237,7 +173,7 @@ export async function runSyncUpMetadata(batchSize: number): Promise<void> {
       updatedAt: last.updatedAt + 1,
       id: last.id,
     })
-    logger.debug('syncUpMetadata', 'end reached')
+    logger.debug('syncUpMetadata', 'end_reached')
   } else {
     await setSyncUpCursor({
       updatedAt: last.updatedAt,

--- a/src/managers/thumbnailScanner.ts
+++ b/src/managers/thumbnailScanner.ts
@@ -57,14 +57,15 @@ async function logOverallProgress() {
     const targetThumbs = originals * ThumbSizes.length
     const remaining = Math.max(targetThumbs - thumbs, 0)
     const percent = targetThumbs > 0 ? Math.min(1, thumbs / targetThumbs) : 1
-    logger.debug(
-      'thumbnailScanner',
-      `overall originals=${originals} thumbs=${thumbs}/${targetThumbs} remaining=${remaining} percent=${Math.round(
-        percent * 100,
-      )}%`,
-    )
+    logger.debug('thumbnailScanner', 'progress', {
+      originals,
+      thumbs,
+      targetThumbs,
+      remaining,
+      percent: Math.round(percent * 100),
+    })
   } catch (e) {
-    logger.error('thumbnailScanner', 'progress error', e)
+    logger.error('thumbnailScanner', 'progress_error', { error: e as Error })
   }
 }
 
@@ -152,7 +153,7 @@ export async function runThumbnailScanner(): Promise<ThumbnailScannerResult> {
   }
   let producedCount = 0
   try {
-    logger.debug('thumbnailScanner', 'scanning...')
+    logger.debug('thumbnailScanner', 'tick')
     const skippedNoSourceUri = new Set<string>()
     const processedThisRun = new Set<string>()
 
@@ -201,21 +202,16 @@ export async function runThumbnailScanner(): Promise<ThumbnailScannerResult> {
           continue
         }
 
-        logger.debug(
-          'thumbnailScanner',
-          `candidate id=${c.id} hash=${
-            c.hash
-          } existingSizes=${existingSizes.join(
-            ',',
-          )} missingSizes=${missingSizes.join(',')}`,
-        )
+        logger.debug('thumbnailScanner', 'candidate', {
+          id: c.id,
+          hash: c.hash,
+          existingSizes: existingSizes.join(','),
+          missingSizes: missingSizes.join(','),
+        })
 
         for (const size of missingSizes) {
           if (producedCount >= MAX_THUMBS_PER_TICK) break
-          logger.debug(
-            'thumbnailScanner',
-            `attempt size id=${c.id} size=${size}`,
-          )
+          logger.debug('thumbnailScanner', 'attempt', { id: c.id, size })
           summary.attempts.push({
             originalId: c.id,
             originalHash: c.hash,
@@ -237,7 +233,7 @@ export async function runThumbnailScanner(): Promise<ThumbnailScannerResult> {
               size,
               thumbId: outcome.thumbId,
             })
-            logger.info('thumbnailScanner', `produced id=${c.id} size=${size}`)
+            logger.info('thumbnailScanner', 'produced', { id: c.id, size })
           } else if (outcome.status === 'duplicate') {
             summary.deduplicated.push({
               originalId: c.id,
@@ -256,7 +252,7 @@ export async function runThumbnailScanner(): Promise<ThumbnailScannerResult> {
         }
       }
     }
-    logger.info('thumbnailScanner', 'batch complete', {
+    logger.info('thumbnailScanner', 'batch_complete', {
       produced: summary.produced.length,
       skippedNoSource: summary.skippedNoSource.length,
       skippedFullyCovered: summary.skippedFullyCovered.length,
@@ -267,7 +263,7 @@ export async function runThumbnailScanner(): Promise<ThumbnailScannerResult> {
     })
     await logOverallProgress()
   } catch (e) {
-    logger.error('thumbnailScanner', 'scan error', e)
+    logger.error('thumbnailScanner', 'scan_error', { error: e as Error })
   }
   return summary
 }

--- a/src/managers/thumbnailer.ts
+++ b/src/managers/thumbnailer.ts
@@ -74,7 +74,7 @@ export async function generateThumbnailsForFile(
       type: fileRecord.type,
     })
     if (!sourceUri) {
-      logger.warn('generateThumbnailsForFile', 'no source URI', {
+      logger.warn('generateThumbnailsForFile', 'no_source_uri', {
         fileId: fileRecord.id,
       })
       return
@@ -85,18 +85,14 @@ export async function generateThumbnailsForFile(
     const missingSizes = ThumbSizes.filter((s) => !existingSizes.includes(s))
 
     if (missingSizes.length === 0) {
-      logger.debug(
-        'generateThumbnailsForFile',
-        'all thumbnails already exist',
-        {
-          fileId: fileRecord.id,
-        },
-      )
+      logger.debug('generateThumbnailsForFile', 'all_exist', {
+        fileId: fileRecord.id,
+      })
       return
     }
 
     // Generate missing thumbnails.
-    logger.debug('generateThumbnailsForFile', 'generating thumbnails', {
+    logger.debug('generateThumbnailsForFile', 'generating', {
       fileId: fileRecord.id,
       missingSizes,
     })
@@ -121,9 +117,9 @@ export async function generateThumbnails(files: FileRecord[]) {
     try {
       await generateThumbnailsForFile(file)
     } catch (error) {
-      logger.error('generateThumbnails', 'thumbnail generation error', {
+      logger.error('generateThumbnails', 'generation_error', {
         fileId: file.id,
-        error,
+        error: error as Error,
       })
     }
   }
@@ -162,7 +158,7 @@ export async function ensureThumbnailForSize(params: {
 
   // Log if there's a mismatch between stored and detected types.
   if (detectedType && detectedType !== fileType) {
-    logger.warn('thumbnailer', 'type mismatch detected', {
+    logger.warn('thumbnailer', 'type_mismatch', {
       fileId,
       storedType: fileType,
       detectedType,
@@ -172,7 +168,7 @@ export async function ensureThumbnailForSize(params: {
 
   // Skip unsupported formats early.
   if (!actualType?.startsWith('image/') && !actualType?.startsWith('video/')) {
-    logger.error('thumbnailer', 'unsupported format', {
+    logger.error('thumbnailer', 'unsupported_format', {
       fileId,
       fileHash,
       size,
@@ -184,7 +180,7 @@ export async function ensureThumbnailForSize(params: {
     return { status: 'error', error: new Error('Unsupported format') }
   }
 
-  logger.debug('thumbnailer', 'source uri', {
+  logger.debug('thumbnailer', 'source_uri', {
     fileId,
     uri: sourceUri,
     storedType: fileType,
@@ -196,28 +192,28 @@ export async function ensureThumbnailForSize(params: {
   try {
     if (actualType?.startsWith('video/')) {
       info = await prepareVideoThumbnail(sourceUri, size)
-      logger.debug('thumbnailer', 'video base frame prepared', {
+      logger.debug('thumbnailer', 'video_frame_prepared', {
         fileId,
         size,
         info,
       })
     } else {
       info = await prepareImageThumbnail(sourceUri, size)
-      logger.debug('thumbnailer', 'image target size prepared', {
+      logger.debug('thumbnailer', 'image_resized', {
         fileId,
         size,
         info,
       })
     }
   } catch (e) {
-    logger.error('thumbnailer', 'error preparing source', {
+    logger.error('thumbnailer', 'source_prepare_error', {
       fileId,
       fileHash,
       size,
       storedType: fileType,
       detectedType,
       sourceUri,
-      error: e,
+      error: e as Error,
     })
     markFileErrored(fileId)
     return { status: 'error', error: e }
@@ -250,7 +246,7 @@ export async function ensureThumbnailForSize(params: {
     const fileUri = await copyFileToFs(thumbFileInfo, new File(result.uri))
     const thumbHash = await calculateContentHash(fileUri)
     if (!thumbHash) {
-      logger.error('thumbnailer', 'failed to calculate hash', { fileId, size })
+      logger.error('thumbnailer', 'hash_error', { fileId, size })
       markFileErrored(fileId)
       return { status: 'error', error: new Error('Missing thumbnail hash') }
     }
@@ -258,7 +254,7 @@ export async function ensureThumbnailForSize(params: {
     // Check if a thumbnail with this hash already exists (dedupe by content hash).
     const existingThumb = await readFileRecordByContentHash(thumbHash)
     if (existingThumb) {
-      logger.debug('thumbnailer', 'thumbnail already exists by hash', {
+      logger.debug('thumbnailer', 'hash_exists', {
         thumbId: existingThumb.id,
         hash: fileHash,
         size,
@@ -285,7 +281,7 @@ export async function ensureThumbnailForSize(params: {
       },
       true,
     )
-    logger.debug('thumbnailer', 'created thumbnail record', {
+    logger.debug('thumbnailer', 'record_created', {
       thumbId,
       hash: fileHash,
       size,
@@ -302,7 +298,7 @@ export async function ensureThumbnailForSize(params: {
       height: result.height ?? null,
     }
   } catch (e) {
-    logger.error('thumbnailer', 'error generating thumbnail', {
+    logger.error('thumbnailer', 'generation_error', {
       fileId,
       fileHash,
       size,
@@ -310,7 +306,7 @@ export async function ensureThumbnailForSize(params: {
       detectedType,
       sourceUri,
       inputUri: info.inputUri,
-      error: e,
+      error: e as Error,
     })
     markFileErrored(fileId)
     return { status: 'error', error: e }

--- a/src/managers/uploader.ts
+++ b/src/managers/uploader.ts
@@ -167,7 +167,7 @@ class UploadManager {
       | 'manual' = 'manual',
   ): Promise<void> {
     if (!this.packer || !this.batch) {
-      logger.debug('uploadManager', 'No packer to flush')
+      logger.debug('uploadManager', 'no_packer_to_flush')
       return
     }
 
@@ -193,7 +193,7 @@ class UploadManager {
       fillPercent,
     })
 
-    logger.info('uploadManager', 'Flushing batch', {
+    logger.info('uploadManager', 'batch_flush', {
       reason,
       batchId: batch.batchId,
       files: batch.files.length,
@@ -233,11 +233,10 @@ class UploadManager {
       })
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e)
-      logger.error(
-        'uploadManager',
-        `Error finalizing batch ${batch.batchId}`,
-        e,
-      )
+      logger.error('uploadManager', 'batch_finalize_error', {
+        batchId: batch.batchId,
+        error: e as Error,
+      })
 
       for (const entry of batch.files) {
         setUploadError(entry.fileId, message)
@@ -252,7 +251,9 @@ class UploadManager {
     this.active = false
 
     if (this.batch) {
-      logger.info('uploadManager', `Cancelling batch ${this.batch.batchId}`)
+      logger.info('uploadManager', 'batch_cancel', {
+        batchId: this.batch.batchId,
+      })
       this.batch.abortController.abort()
       for (const entry of this.batch.files) {
         removeUpload(entry.fileId)
@@ -260,10 +261,9 @@ class UploadManager {
     }
 
     if (this.uploadingBatch) {
-      logger.info(
-        'uploadManager',
-        `Cancelling uploading batch ${this.uploadingBatch.batchId}`,
-      )
+      logger.info('uploadManager', 'uploading_batch_cancel', {
+        batchId: this.uploadingBatch.batchId,
+      })
       this.uploadingBatch.abortController.abort()
       for (const entry of this.uploadingBatch.files) {
         removeUpload(entry.fileId)
@@ -405,7 +405,7 @@ class UploadManager {
    */
   private async processEntry(entry: FileEntry): Promise<void> {
     if (!this.sdk) {
-      logger.error('uploadManager', 'SDK not initialized')
+      logger.error('uploadManager', 'sdk_not_initialized')
       setUploadError(entry.fileId, 'SDK not initialized')
       return
     }
@@ -428,7 +428,7 @@ class UploadManager {
       }
 
       if (!this.packer) {
-        logger.info('uploadManager', 'Creating new packer')
+        logger.info('uploadManager', 'packer_create')
         const batch: BatchState = {
           batchId: uniqueId(),
           files: [],
@@ -454,10 +454,10 @@ class UploadManager {
       }
 
       setUploadStatus(entry.fileId, 'packing')
-      logger.debug(
-        'uploadManager',
-        `Adding file ${entry.fileId} to packer (${entry.size} bytes)`,
-      )
+      logger.debug('uploadManager', 'file_packing', {
+        fileId: entry.fileId,
+        size: entry.size,
+      })
 
       const t0 = Date.now()
       const reader = createFileReader(entry.fileUri)
@@ -483,7 +483,10 @@ class UploadManager {
       }
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e)
-      logger.error('uploadManager', `Error processing file ${entry.fileId}`, e)
+      logger.error('uploadManager', 'file_process_error', {
+        fileId: entry.fileId,
+        error: e as Error,
+      })
       setUploadError(entry.fileId, message)
     }
   }
@@ -541,10 +544,10 @@ class UploadManager {
       if (!this.active) break
       const entry = entries[j]
       setUploadStatus(entry.fileId, 'packing')
-      logger.debug(
-        'uploadManager',
-        `Adding file ${entry.fileId} to packer (${entry.size} bytes)`,
-      )
+      logger.debug('uploadManager', 'file_packing', {
+        fileId: entry.fileId,
+        size: entry.size,
+      })
       const t0 = Date.now()
       const reader = createFileReader(entry.fileUri)
       inflight.push({
@@ -581,11 +584,10 @@ class UploadManager {
       } catch (e) {
         if (!this.active) break
         const message = e instanceof Error ? e.message : String(e)
-        logger.error(
-          'uploadManager',
-          `Error processing file ${entry.fileId}`,
-          e,
-        )
+        logger.error('uploadManager', 'file_process_error', {
+          fileId: entry.fileId,
+          error: e as Error,
+        })
         setUploadError(entry.fileId, message)
       }
     }
@@ -664,7 +666,7 @@ class UploadManager {
 
       return this.polledFiles.length
     } catch (e) {
-      logger.error('uploadManager', 'DB poll error', e)
+      logger.error('uploadManager', 'db_poll_error', { error: e as Error })
       return 0
     }
   }
@@ -790,10 +792,10 @@ class UploadManager {
     const successfulFileIds: string[] = []
 
     if (pinnedObjects.length !== batch.files.length) {
-      logger.warn(
-        'uploadManager',
-        `Object count mismatch: ${pinnedObjects.length} objects for ${batch.files.length} files`,
-      )
+      logger.warn('uploadManager', 'object_count_mismatch', {
+        objects: pinnedObjects.length,
+        files: batch.files.length,
+      })
     }
 
     for (let i = 0; i < batch.files.length; i++) {
@@ -801,10 +803,10 @@ class UploadManager {
       const pinnedObject = pinnedObjects[i]
 
       if (!pinnedObject) {
-        logger.error(
-          'uploadManager',
-          `No pinned object for file ${entry.fileId} at index ${i}`,
-        )
+        logger.error('uploadManager', 'no_pinned_object', {
+          fileId: entry.fileId,
+          index: i,
+        })
         setUploadError(entry.fileId, 'No pinned object returned')
         continue
       }
@@ -812,10 +814,9 @@ class UploadManager {
       try {
         const fileRecord = await readFileRecord(entry.fileId)
         if (!fileRecord) {
-          logger.warn(
-            'uploadManager',
-            `File ${entry.fileId} deleted during upload, skipping pin`,
-          )
+          logger.warn('uploadManager', 'file_deleted_during_upload', {
+            fileId: entry.fileId,
+          })
           successfulFileIds.push(entry.fileId)
           continue
         }
@@ -830,17 +831,16 @@ class UploadManager {
         )
         await upsertLocalObject(localObject)
 
-        logger.debug('uploadManager', `Saved object for file ${entry.fileId}`)
+        logger.debug('uploadManager', 'object_saved', { fileId: entry.fileId })
         this._uploadedCount++
         this._uploadedBytes += entry.size
         successfulFileIds.push(entry.fileId)
       } catch (e) {
         const message = e instanceof Error ? e.message : String(e)
-        logger.error(
-          'uploadManager',
-          `Error saving object for file ${entry.fileId}`,
-          e,
-        )
+        logger.error('uploadManager', 'object_save_error', {
+          fileId: entry.fileId,
+          error: e as Error,
+        })
         setUploadError(entry.fileId, message)
       }
     }
@@ -866,7 +866,7 @@ export function useUploader() {
   return useCallback(
     async (files: FileRecordRow[]) => {
       if (!sdk) {
-        logger.warn('useUploader', 'SDK not initialized')
+        logger.warn('useUploader', 'sdk_not_initialized')
         return
       }
 
@@ -874,7 +874,7 @@ export function useUploader() {
       for (const file of files) {
         const fileUri = await getFsFileUri(file)
         if (!fileUri) {
-          logger.warn('useUploader', `File not available locally: ${file.id}`)
+          logger.warn('useUploader', 'file_not_local', { fileId: file.id })
           continue
         }
         entries.push({ fileId: file.id, fileUri, file, size: file.size })

--- a/src/screens/OnboardingRecoveryPhraseScreen.tsx
+++ b/src/screens/OnboardingRecoveryPhraseScreen.tsx
@@ -52,7 +52,9 @@ export default function OnboardingRecoveryPhraseScreen() {
         nav.navigate('FinishedOnboarding', { indexerURL })
       }
     } catch (err) {
-      logger.error('onboarding', 'Error completing recovery phrase setup', err)
+      logger.error('onboarding', 'recovery_phrase_error', {
+        error: err as Error,
+      })
     }
   }
 

--- a/src/stores/appKey.ts
+++ b/src/stores/appKey.ts
@@ -46,20 +46,20 @@ export async function getAppKeyForIndexer(
   // Check cache first.
   const cached = cachedAppKeys.get(indexerURL)
   if (cached) {
-    logger.debug('appKey', 'cache hit, using cached AppKey')
+    logger.debug('appKey', 'cache_hit')
     return new AppKey(cached)
   }
 
   // Load from storage.
-  logger.debug('appKey', 'cache miss, loading from SecureStore...')
+  logger.debug('appKey', 'cache_miss')
   const appKeysMap = await getAppKeysMap()
   const keyBuffer = appKeysMap[indexerURL]
   if (!keyBuffer) {
-    logger.debug('appKey', 'AppKey not found in SecureStore')
+    logger.debug('appKey', 'not_found')
     return undefined
   }
 
-  logger.debug('appKey', 'AppKey loaded from SecureStore, caching')
+  logger.debug('appKey', 'loaded')
   cachedAppKeys.set(indexerURL, keyBuffer)
   return new AppKey(keyBuffer)
 }

--- a/src/stores/downloads.ts
+++ b/src/stores/downloads.ts
@@ -86,10 +86,10 @@ export function cancelAllDownloads() {
   const current = getState().downloads
   Object.values(current).forEach((r) => {
     try {
-      logger.debug('downloads', 'aborting download', r.id)
+      logger.debug('downloads', 'aborting', { id: r.id })
       r.controller?.abort()
     } catch (e) {
-      logger.error('downloads', 'error aborting download', r.id, e)
+      logger.error('downloads', 'abort_error', { id: r.id, error: e as Error })
     }
   })
   useDownloadsStore.setState({ downloads: {} })
@@ -123,17 +123,17 @@ export async function runDownloadWithSlot<T>(params: {
   setDownloadState(id, 'queued', 0)
   const release = await acquireDownloadSlot()
   try {
-    logger.debug('downloads', 'download running', id)
+    logger.debug('downloads', 'running', { id })
     setDownloadState(id, 'running', 0)
     const result = await task(controller.signal)
-    logger.debug('downloads', 'download success', id)
+    logger.debug('downloads', 'success', { id })
     // Set 'done' status and delay removal to prevent re-triggering downloads
     // while components may not have fetched the new file uri yet.
     setDownloadState(id, 'done', 1)
     setTimeout(() => removeDownload(id), 5000)
     return result
   } catch (e) {
-    logger.error('downloads', 'download error', id, e)
+    logger.error('downloads', 'error', { id, error: e as Error })
     const message = e instanceof Error ? e.message : String(e)
     setDownloadState(id, 'error', 0, message)
     throw e

--- a/src/stores/files.ts
+++ b/src/stores/files.ts
@@ -327,7 +327,7 @@ export async function readFileRecordByContentHash(hash: string) {
     hash,
   )
   if (!row) {
-    logger.debug('db', 'file not found by hash', hash)
+    logger.debug('db', 'file_not_found_by_hash', { hash })
     return null
   }
   const objects = await readLocalObjectsForFile(row.id)
@@ -340,7 +340,7 @@ export async function readFileRecord(id: string): Promise<FileRecord | null> {
     id,
   )
   if (!row) {
-    logger.debug('db', 'file not found', id)
+    logger.debug('db', 'file_not_found', { id })
     return null
   }
   const objects = await readLocalObjectsForFile(id)
@@ -473,7 +473,7 @@ export async function createFileRecordWithLocalObject(
     })
     await librarySwr.triggerChange()
   } catch (e) {
-    logger.error('db', 'createFileRecordWithLocalObject error', e)
+    logger.error('db', 'create_file_record_error', { error: e as Error })
     throw e
   }
 }
@@ -491,7 +491,7 @@ export async function updateFileRecordWithLocalObject(
     })
     await librarySwr.triggerChange()
   } catch (e) {
-    logger.error('db', 'updateFileRecordWithLocalObject error', e)
+    logger.error('db', 'update_file_record_error', { error: e as Error })
     throw e
   }
 }

--- a/src/stores/fs.ts
+++ b/src/stores/fs.ts
@@ -110,7 +110,7 @@ export async function copyFileToFs(
   file: FsFileInfo,
   sourceFile: File,
 ): Promise<string> {
-  logger.debug('fs', `copyFile ${file.id} from ${sourceFile.uri}`)
+  logger.debug('fs', 'copy_file', { fileId: file.id, uri: sourceFile.uri })
   const target = getFsFileForId(file)
   const targetInfo = target.info()
   if (targetInfo.exists) {

--- a/src/stores/logs.ts
+++ b/src/stores/logs.ts
@@ -4,7 +4,12 @@ import { useShallow } from 'zustand/react/shallow'
 import { db, dbInitialized } from '../db'
 import { sqlInsert } from '../db/sql'
 import { setLogAppender } from '../lib/logAppender'
-import { type LogEntry, type LogLevel, logger } from '../lib/logger'
+import {
+  type LogEntry,
+  type LogLevel,
+  logger,
+  serializeData,
+} from '../lib/logger'
 import { getAsyncStorageString, setAsyncStorageString } from './asyncStore'
 
 export type LogsState = {
@@ -30,7 +35,7 @@ export async function initLogger(): Promise<void> {
   setLogAppender(appendLogToDb)
 
   // Now we can log.
-  logger.info('logs', 'initLogger called')
+  logger.info('logs', 'init')
 
   // Init state with stored values.
   const storedLevel = await getLogLevel()
@@ -127,8 +132,6 @@ export async function toggleLogScope(scope: string): Promise<void> {
 async function appendLogToDb(entry: LogEntry): Promise<void> {
   try {
     if (!dbInitialized) {
-      // Database not fully initialized (migrations not run), skip DB write.
-      // Early logs still go to console via logger.ts.
       return
     }
     await sqlInsert('logs', {
@@ -136,6 +139,7 @@ async function appendLogToDb(entry: LogEntry): Promise<void> {
       level: entry.level,
       scope: entry.scope,
       message: entry.message,
+      data: serializeData(entry.data),
       createdAt: Date.now(),
     })
   } catch (error) {
@@ -188,21 +192,31 @@ export async function readLogs(
     }
 
     const { whereClause, params } = buildLogFilterQuery(logLevel, logScopes)
-    const query = `SELECT timestamp, level, scope, message FROM logs ${whereClause} ORDER BY createdAt DESC, id DESC`
+    const query = `SELECT timestamp, level, scope, message, data FROM logs ${whereClause} ORDER BY createdAt DESC, id DESC`
 
     const rows = await db().getAllAsync<{
       timestamp: string
       level: string
       scope: string
       message: string
+      data: string | null
     }>(query, ...params)
 
-    return rows.map((row) => ({
-      timestamp: row.timestamp,
-      level: row.level as LogEntry['level'],
-      scope: row.scope,
-      message: row.message,
-    }))
+    return rows.map((row) => {
+      let data: Record<string, unknown> | undefined
+      if (row.data) {
+        try {
+          data = JSON.parse(row.data)
+        } catch {}
+      }
+      return {
+        timestamp: row.timestamp,
+        level: row.level as LogEntry['level'],
+        scope: row.scope,
+        message: row.message,
+        data,
+      }
+    })
   } catch (error) {
     console.error('[logs] Failed to read logs:', error)
     return []

--- a/src/stores/sdk.ts
+++ b/src/stores/sdk.ts
@@ -102,7 +102,7 @@ export async function connectSdk(): Promise<SdkInterface | null> {
 
     const [sdk, err] = await builderConnected(builder, appKey)
     if (err) {
-      logger.error('sdk', 'Error connecting', err)
+      logger.error('sdk', 'connect_error', { error: err as Error })
       return null
     }
 
@@ -111,10 +111,10 @@ export async function connectSdk(): Promise<SdkInterface | null> {
       return sdk
     }
 
-    logger.warn('sdk', 'SDK not connected, auth required')
+    logger.warn('sdk', 'auth_required')
     return null
   } catch (err) {
-    logger.error('sdk', 'Error initializing SDK', err)
+    logger.error('sdk', 'init_error', { error: err as Error })
     return null
   }
 }
@@ -126,15 +126,15 @@ export async function connectSdk(): Promise<SdkInterface | null> {
  */
 export async function reconnectIndexer(): Promise<boolean> {
   if (getState().isReconnecting) {
-    logger.debug('sdk', 'already reconnecting, skipping')
+    logger.debug('sdk', 'reconnect_skipped')
     return false
   }
   setState({ isReconnecting: true })
 
-  logger.info('sdk', 'reconnecting...')
+  logger.info('sdk', 'reconnecting')
   const isAuthing = getState().isAuthing
   if (isAuthing) {
-    logger.debug('sdk', 'already authing, skipping')
+    logger.debug('sdk', 'auth_skipped')
     setState({ isReconnecting: false })
     return false
   }
@@ -200,7 +200,7 @@ export type SwitchResult = Result<void, SwitchError>
 export async function authenticateIndexer(
   indexerURL: string,
 ): Promise<AuthenticateResult> {
-  logger.info('sdk', `Authenticating with ${indexerURL}...`)
+  logger.info('sdk', 'authenticating', { indexerURL })
 
   // Check if we have an AppKey for this indexer (returning user).
   const appKey = await getAppKeyForIndexer(indexerURL)
@@ -210,11 +210,11 @@ export async function authenticateIndexer(
     const [sdk, connectedErr] = await builderConnected(builder, appKey)
     if (connectedErr) {
       setState({ isAuthing: false })
-      logger.error('sdk', 'Connection error', connectedErr)
+      logger.error('sdk', 'connect_error', { error: connectedErr as Error })
       return err({ type: 'error', message: connectedErr.message })
     }
     if (sdk) {
-      logger.info('sdk', 'Already registered, connected.')
+      logger.info('sdk', 'already_registered')
       setIndexerURL(indexerURL)
       await setSdkWithUploader(sdk)
       setState({ isAuthing: false, isConnected: true })
@@ -224,7 +224,7 @@ export async function authenticateIndexer(
   }
 
   // New user - run browser auth and save approved builder for registerWithIndexer.
-  logger.info('sdk', 'New user, running browser auth...')
+  logger.info('sdk', 'browser_auth_start')
   setState({ isAuthing: true, pendingApproval: null })
 
   const builder = new Builder(indexerURL)
@@ -246,7 +246,7 @@ export async function authenticateIndexer(
       : null,
   })
 
-  logger.info('sdk', 'Browser auth completed.')
+  logger.info('sdk', 'browser_auth_complete')
   return ok({ alreadyConnected: false })
 }
 
@@ -271,7 +271,7 @@ export function setSdk(sdk: SdkInterface | null) {
 export async function switchIndexer(
   newIndexerURL: string,
 ): Promise<SwitchResult> {
-  logger.info('sdk', `Attempting to switch to ${newIndexerURL}...`)
+  logger.info('sdk', 'indexer_switch', { indexerURL: newIndexerURL })
 
   // First, check if we have an AppKey specifically for this indexer.
   const appKeyForIndexer = await getAppKeyForIndexer(newIndexerURL)
@@ -283,12 +283,14 @@ export async function switchIndexer(
     )
 
     if (connectedErr) {
-      logger.error('sdk', 'Connection error with stored AppKey', connectedErr)
+      logger.error('sdk', 'stored_key_connect_error', {
+        error: connectedErr as Error,
+      })
       return err({ type: 'error', message: connectedErr.message })
     }
 
     if (sdk) {
-      logger.info('sdk', 'Connected using stored AppKey for this indexer.')
+      logger.info('sdk', 'stored_key_connected')
       setIndexerURL(newIndexerURL)
       await setSdkWithUploader(sdk)
       setState({ isConnected: true })
@@ -297,7 +299,7 @@ export async function switchIndexer(
   }
 
   // No stored AppKey for this indexer - user needs to enter mnemonic.
-  logger.info('sdk', 'No stored AppKey for this indexer, needs reauth')
+  logger.info('sdk', 'no_stored_key')
   return err({ type: 'needsReauth' })
 }
 
@@ -319,7 +321,7 @@ export async function registerWithIndexer(
   // Validate mnemonic against stored hash if one exists.
   const mnemonicValid = await validateMnemonic(mnemonic)
   if (mnemonicValid === 'invalid') {
-    logger.warn('sdk', 'Mnemonic does not match stored hash')
+    logger.warn('sdk', 'mnemonic_hash_mismatch')
     // Keep pendingApproval so user can fix mnemonic and retry.
     setState({ isAuthing: false })
     return err({ type: 'mnemonicMismatch' })
@@ -330,11 +332,11 @@ export async function registerWithIndexer(
   let approvedBuilder: BuilderInterface | null = null
 
   if (pendingApproval && pendingApproval.indexerURL === indexerURL) {
-    logger.debug('sdk', 'Using pending approval from authenticateIndexer')
+    logger.debug('sdk', 'using_pending_approval')
     approvedBuilder = pendingApproval.builder
   } else {
     // No pending approval - run browser auth (fallback for edge cases).
-    logger.info('sdk', 'No pending approval, running browser auth...')
+    logger.info('sdk', 'browser_auth_start')
     const builder = new Builder(indexerURL)
     const [result, authErr] = await runBrowserAuthFlow(builder)
     if (authErr) {
@@ -353,7 +355,7 @@ export async function registerWithIndexer(
   const [sdk, registerErr] = await builderRegister(approvedBuilder, mnemonic)
   if (registerErr) {
     setState({ isAuthing: false, pendingApproval: null })
-    logger.error('sdk', 'Error registering with mnemonic', registerErr)
+    logger.error('sdk', 'register_error', { error: registerErr as Error })
     return err({ type: 'error', message: registerErr.message })
   }
 
@@ -376,7 +378,7 @@ async function builderConnected(
   appKey: AppKey,
 ): Promise<Result<SdkInterface | null>> {
   try {
-    logger.debug('sdk', 'Attempting builder.connected...')
+    logger.debug('sdk', 'builder_connected_attempt')
     const sdk = await withTimeout(
       builder.connected(appKey),
       CONNECTION_TIMEOUT_MS,
@@ -394,7 +396,7 @@ async function builderRequestConnection(
   builder: Builder,
 ): Promise<Result<BuilderInterface>> {
   try {
-    logger.debug('sdk', 'Requesting app connection...')
+    logger.debug('sdk', 'connection_request')
     const result = await withTimeout(
       builder.requestConnection({
         id: hexToUint8(APP_KEY).buffer,
@@ -419,7 +421,7 @@ async function builderWaitForApproval(
   builder: BuilderInterface,
 ): Promise<Result<BuilderInterface>> {
   try {
-    logger.debug('sdk', 'Waiting for approval...')
+    logger.debug('sdk', 'waiting_for_approval')
     const result = await withTimeout(
       builder.waitForApproval(),
       CONNECTION_TIMEOUT_MS,
@@ -438,7 +440,7 @@ async function builderRegister(
   mnemonic: string,
 ): Promise<Result<SdkInterface>> {
   try {
-    logger.info('sdk', 'Registering with mnemonic...')
+    logger.info('sdk', 'registering')
     const result = await withTimeout(
       builder.register(mnemonic),
       CONNECTION_TIMEOUT_MS,
@@ -480,7 +482,9 @@ async function runBrowserAuthFlow(
   const [builderAfterRequest, requestErr] =
     await builderRequestConnection(builder)
   if (requestErr) {
-    logger.error('sdk', 'Error requesting connection', requestErr)
+    logger.error('sdk', 'connection_request_error', {
+      error: requestErr as Error,
+    })
     return err({ type: 'error', message: requestErr.message })
   }
 
@@ -488,9 +492,11 @@ async function runBrowserAuthFlow(
     await waitForUserApproval(builderAfterRequest)
   if (approvalErr) {
     if (approvalErr.type === 'cancelled') {
-      logger.info('sdk', 'App authorization cancelled by user')
+      logger.info('sdk', 'auth_cancelled')
     } else {
-      logger.error('sdk', 'Error during approval', approvalErr)
+      logger.error('sdk', 'approval_error', {
+        error: new Error(approvalErr.message),
+      })
     }
     return err(approvalErr)
   }

--- a/src/stores/uploads.ts
+++ b/src/stores/uploads.ts
@@ -134,7 +134,7 @@ export function removeUploads(ids: string[]) {
 }
 
 export function clearAllUploads() {
-  logger.debug('uploads', 'cancelling all uploads')
+  logger.debug('uploads', 'cancel_all')
   useUploadsStore.setState({ uploads: {} })
 }
 


### PR DESCRIPTION
- Store structured data alongside log messages so exports are machine-readable (JSONL) while keeping in-app display human-readable.
- Our logging was a mix of JSON data and pre-formatted human readable messages, this PR makes our logging fully consistent and structured.
- Every log has a scope and now a msg that is a short key, the rest of the data is stored as json.
- JSON data is nicely formatted in the console and log screen but logs are downloaded/exported as JSONL.

```
 LOG  2026-02-10 17:29:01.579 INFO  [syncPhotosArchive] skipped reason=local_only_pending localOnlyCount=57
 LOG  2026-02-10 17:29:01.925 INFO  [thumbnailScanner] batch_complete produced=0 skippedNoSource=1173 skippedFullyCovered=0 skippedErrorCooldown=0 errors=0 deduplicated=3 total=1175
 LOG  2026-02-10 17:29:01.936 DEBUG [thumbnailScanner] progress originals=2325 thumbs=4152 targetThumbs=4650 remaining=498 percent=89
 LOG  2026-02-10 17:29:02.796 INFO  [appState] state_changed from=inactive to=active
 LOG  2026-02-10 17:29:03.368 DEBUG [syncUpMetadata] tick fromId=jn7b58ulxq afterUpdatedAt=1770772692805
 LOG  2026-02-10 17:29:03.372 DEBUG [syncUpMetadata] no_updates
 LOG  2026-02-10 17:29:05.484 INFO  [appState] state_changed from=active to=inactive
 LOG  2026-02-10 17:29:05.492 INFO  [appState] state_changed from=inactive to=background
```