### PR TITLE
fix: prevent upload percentage from exceeding 100%

### DIFF
--- a/.changeset/fix-upload-percent-over-100.md
+++ b/.changeset/fix-upload-percent-over-100.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fixed upload percentage exceeding 100% due to double-counting completed files.

--- a/src/managers/uploader.ts
+++ b/src/managers/uploader.ts
@@ -34,7 +34,6 @@ import {
   getActiveUploads,
   registerUpload,
   removeUpload,
-  removeUploads,
   setUploadBatchInfo,
   setUploadError,
   setUploadStatus,
@@ -225,7 +224,6 @@ class UploadManager {
         batch,
         pinnedObjects,
       )
-      removeUploads(successfulFileIds)
       logger.info('uploadManager', 'batch_completed', {
         batchId: batch.batchId,
         files: successfulFileIds.length,
@@ -817,6 +815,7 @@ class UploadManager {
           logger.warn('uploadManager', 'file_deleted_during_upload', {
             fileId: entry.fileId,
           })
+          removeUpload(entry.fileId)
           successfulFileIds.push(entry.fileId)
           continue
         }
@@ -830,6 +829,7 @@ class UploadManager {
           pinnedObject,
         )
         await upsertLocalObject(localObject)
+        removeUpload(entry.fileId)
 
         logger.debug('uploadManager', 'object_saved', { fileId: entry.fileId })
         this._uploadedCount++

--- a/src/stores/uploads.ts
+++ b/src/stores/uploads.ts
@@ -201,7 +201,7 @@ export function useUploadProgress(): {
     .map((u) => u.progress)
     .reduce((a, b) => a + b, 0)
   const percentComplete = totalCount
-    ? (activeProgress + uploadedCount) / totalCount
+    ? Math.min((activeProgress + uploadedCount) / totalCount, 1)
     : 0
 
   return {


### PR DESCRIPTION
Remove uploads from the store per-file immediately after saving to the DB, rather than in a batch after the loop. This eliminates the window where a completed file is counted in both the DB (uploadedCount) and the in-memory upload store (activeProgress). Also clamp the percentage to 100% as an extra defense.