### PR TITLE
feat: redesign library status sheet

### DIFF
--- a/.changeset/redesign-library-status-sheet.md
+++ b/.changeset/redesign-library-status-sheet.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Redesigned library status sheet with organized sections, count/size toggle, and aligned monospace formatting.

--- a/src/components/LabeledValueRow.tsx
+++ b/src/components/LabeledValueRow.tsx
@@ -1,6 +1,13 @@
 import Clipboard from '@react-native-clipboard/clipboard'
 import { useCallback } from 'react'
-import { Platform, Pressable, StyleSheet, Text, View } from 'react-native'
+import {
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  type TextStyle,
+  View,
+} from 'react-native'
 import { useToast } from '../lib/toastContext'
 import { colors, palette } from '../styles/colors'
 
@@ -14,6 +21,7 @@ type Props = {
   ellipsizeMode?: 'head' | 'middle' | 'tail' | 'clip'
   align?: 'left' | 'right'
   labelWidth?: number
+  labelStyle?: TextStyle
 }
 
 const defaultLabelWidth = 96
@@ -28,6 +36,7 @@ export function LabeledValueRow({
   ellipsizeMode = 'tail',
   align = 'right',
   labelWidth,
+  labelStyle,
 }: Props) {
   const toast = useToast()
 
@@ -69,7 +78,11 @@ export function LabeledValueRow({
         ]}
       >
         <Text
-          style={[styles.rowLabel, { width: labelWidth || defaultLabelWidth }]}
+          style={[
+            styles.rowLabel,
+            { width: labelWidth || defaultLabelWidth },
+            labelStyle,
+          ]}
           numberOfLines={1}
           ellipsizeMode="tail"
         >
@@ -81,7 +94,11 @@ export function LabeledValueRow({
   ) : (
     <View style={[styles.row, showDividerTop && styles.rowDivider]}>
       <Text
-        style={[styles.rowLabel, { width: labelWidth || defaultLabelWidth }]}
+        style={[
+          styles.rowLabel,
+          { width: labelWidth || defaultLabelWidth },
+          labelStyle,
+        ]}
         numberOfLines={1}
         ellipsizeMode="tail"
       >

--- a/src/components/LibraryStatusSheet.tsx
+++ b/src/components/LibraryStatusSheet.tsx
@@ -1,23 +1,58 @@
-import { StyleSheet, Text, View } from 'react-native'
+import { useState } from 'react'
+import { Platform, Pressable, StyleSheet, Text, View } from 'react-native'
 import useSWR from 'swr'
 import { useIsOnline } from '../hooks/useIsOnline'
+import { humanSize } from '../lib/humanSize'
 import { humanUploadPercent } from '../lib/uploadPercent'
+import type { UploadCategoryStats } from '../stores/fileStats'
 import { getUploadStats } from '../stores/fileStats'
-import { useFileCountLocal, useFileCountLost } from '../stores/files'
+import { useFileStatsLocal, useFileStatsLost } from '../stores/files'
 import { useIsConnected } from '../stores/sdk'
 import { closeSheet, useSheetOpen } from '../stores/sheets'
-import { palette } from '../styles/colors'
+import { palette, whiteA } from '../styles/colors'
 import { ActionSheet } from './ActionSheet'
-import { RowGroup } from './Group'
+import { RowGroup, RowSubGroup } from './Group'
 import { InfoCard } from './InfoCard'
 import { LabeledValueRow } from './LabeledValueRow'
 
 const refreshInterval = 5_000
 
+function formatDeviceValue(
+  data: { count: number; totalBytes: number } | undefined,
+  overall: { total: number; totalBytes: number } | undefined,
+  mode: 'count' | 'size',
+): string {
+  if (!data || !overall) return mode === 'count' ? '0 / 0' : '0 B / 0 B'
+  if (mode === 'size') {
+    return `${humanSize(data.totalBytes) ?? '0 B'} / ${humanSize(overall.totalBytes) ?? '0 B'}`
+  }
+  return `${data.count.toLocaleString()} / ${overall.total.toLocaleString()}`
+}
+
+function devicePercent(
+  data: { count: number; totalBytes: number } | undefined,
+  overall: { totalBytes: number } | undefined,
+): number | undefined {
+  if (!data || !overall || !overall.totalBytes) return undefined
+  return data.totalBytes / overall.totalBytes
+}
+
+function formatCategoryValue(
+  cat: UploadCategoryStats | undefined,
+  mode: 'count' | 'size',
+): string {
+  if (!cat) return mode === 'count' ? '0 / 0' : '0 B / 0 B'
+  if (mode === 'size') {
+    return `${humanSize(cat.uploadedBytes) ?? '0 B'} / ${humanSize(cat.totalBytes) ?? '0 B'}`
+  }
+  return `${cat.uploaded.toLocaleString()} / ${cat.total.toLocaleString()}`
+}
+
 export function LibraryStatusSheet() {
   const isConnected = useIsConnected()
   const isOnline = useIsOnline()
   const isOpen = useSheetOpen('libraryStatus')
+  const [displayMode, setDisplayMode] = useState<'count' | 'size'>('count')
   const stats = useSWR(
     ['upload-stats', isOpen ?? null],
     () => getUploadStats(),
@@ -25,14 +60,35 @@ export function LibraryStatusSheet() {
       refreshInterval,
     },
   )
-  const lostCount = useFileCountLost({ refreshInterval })
-  const localCount = useFileCountLocal(
-    { localOnly: false },
-    { refreshInterval },
-  )
-  const localOnlyCount = useFileCountLocal(
+  const onDevice = useFileStatsLocal({ localOnly: false }, { refreshInterval })
+  const pendingBackup = useFileStatsLocal(
     { localOnly: true },
     { refreshInterval },
+  )
+  const lost = useFileStatsLost({ refreshInterval })
+
+  const toggle = (
+    <View style={styles.toggleTrack}>
+      {(['count', 'size'] as const).map((mode) => (
+        <Pressable
+          key={mode}
+          style={[
+            styles.toggleSegment,
+            displayMode === mode && styles.toggleSegmentSelected,
+          ]}
+          onPress={() => setDisplayMode(mode)}
+        >
+          <Text
+            style={[
+              styles.toggleLabel,
+              displayMode === mode && styles.toggleLabelSelected,
+            ]}
+          >
+            {mode === 'count' ? 'Count' : 'Size'}
+          </Text>
+        </Pressable>
+      ))}
+    </View>
   )
 
   return (
@@ -42,11 +98,7 @@ export function LibraryStatusSheet() {
       contentStyle={styles.sheetContent}
     >
       <View style={styles.sheetInnerDark}>
-        <View style={styles.sheetHeaderRow}>
-          <Text style={styles.sheetTitle}>App status</Text>
-        </View>
-
-        <RowGroup title="Connections" style={styles.groupSpacing}>
+        <RowGroup title="App status" style={styles.groupSpacing}>
           <InfoCard>
             <LabeledValueRow
               label="Internet"
@@ -87,183 +139,239 @@ export function LibraryStatusSheet() {
           </InfoCard>
         </RowGroup>
 
-        <RowGroup title="Uploads" style={styles.groupSpacing}>
-          <InfoCard>
-            <LabeledValueRow
-              label="Overall"
-              value={
-                <View style={styles.valueRight}>
-                  <Text style={styles.valueText}>
-                    {`${stats.data?.overall.uploaded ?? 0} / ${
-                      stats.data?.overall.total ?? 0
-                    }`}
-                  </Text>
-                  <Text style={styles.valuePercent}>
-                    {humanUploadPercent(
-                      stats.data?.overall.percentDecimal,
-                      stats.data?.overall.percent,
-                    )}
-                  </Text>
-                </View>
-              }
-              align="right"
-              canCopy={false}
-            />
-            <LabeledValueRow
-              label="Photos"
-              value={
-                <View style={styles.valueRight}>
-                  <Text style={styles.valueText}>
-                    {`${stats.data?.photos.uploaded ?? 0} / ${
-                      stats.data?.photos.total ?? 0
-                    }`}
-                  </Text>
-                  <Text style={styles.valuePercent}>
-                    {humanUploadPercent(
-                      stats.data?.photos.percentDecimal,
-                      stats.data?.photos.percent,
-                    )}
-                  </Text>
-                </View>
-              }
-              align="right"
-              canCopy={false}
-              showDividerTop
-            />
-            <LabeledValueRow
-              label="Videos"
-              value={
-                <View style={styles.valueRight}>
-                  <Text style={styles.valueText}>
-                    {`${stats.data?.videos.uploaded ?? 0} / ${
-                      stats.data?.videos.total ?? 0
-                    }`}
-                  </Text>
-                  <Text style={styles.valuePercent}>
-                    {humanUploadPercent(
-                      stats.data?.videos.percentDecimal,
-                      stats.data?.videos.percent,
-                    )}
-                  </Text>
-                </View>
-              }
-              align="right"
-              canCopy={false}
-              showDividerTop
-            />
-            <LabeledValueRow
-              label="Audio"
-              value={
-                <View style={styles.valueRight}>
-                  <Text style={styles.valueText}>
-                    {`${stats.data?.audio.uploaded ?? 0} / ${
-                      stats.data?.audio.total ?? 0
-                    }`}
-                  </Text>
-                  <Text style={styles.valuePercent}>
-                    {humanUploadPercent(
-                      stats.data?.audio.percentDecimal,
-                      stats.data?.audio.percent,
-                    )}
-                  </Text>
-                </View>
-              }
-              align="right"
-              canCopy={false}
-              showDividerTop
-            />
-            <LabeledValueRow
-              label="Docs"
-              value={
-                <View style={styles.valueRight}>
-                  <Text style={styles.valueText}>
-                    {`${stats.data?.docs.uploaded ?? 0} / ${
-                      stats.data?.docs.total ?? 0
-                    }`}
-                  </Text>
-                  <Text style={styles.valuePercent}>
-                    {humanUploadPercent(
-                      stats.data?.docs.percentDecimal,
-                      stats.data?.docs.percent,
-                    )}
-                  </Text>
-                </View>
-              }
-              align="right"
-              canCopy={false}
-              showDividerTop
-            />
-            <LabeledValueRow
-              label="Other"
-              value={
-                <View style={styles.valueRight}>
-                  <Text style={styles.valueText}>
-                    {`${stats.data?.other.uploaded ?? 0} / ${
-                      stats.data?.other.total ?? 0
-                    }`}
-                  </Text>
-                  <Text style={styles.valuePercent}>
-                    {humanUploadPercent(
-                      stats.data?.other.percentDecimal,
-                      stats.data?.other.percent,
-                    )}
-                  </Text>
-                </View>
-              }
-              align="right"
-              canCopy={false}
-              showDividerTop
-            />
-            <LabeledValueRow
-              label="Thumbnails"
-              value={
-                <View style={styles.valueRight}>
-                  <Text style={styles.valueText}>
-                    {`${stats.data?.thumbnails.uploaded ?? 0} / ${
-                      stats.data?.thumbnails.total ?? 0
-                    }`}
-                  </Text>
-                  <Text style={styles.valuePercent}>
-                    {humanUploadPercent(
-                      stats.data?.thumbnails.percentDecimal,
-                      stats.data?.thumbnails.percent,
-                    )}
-                  </Text>
-                </View>
-              }
-              align="right"
-              canCopy={false}
-              showDividerTop
-            />
-          </InfoCard>
-        </RowGroup>
-        <RowGroup title="Local storage" style={styles.groupSpacing}>
-          <InfoCard>
-            <LabeledValueRow
-              label="Local files"
-              value={
-                <Text style={styles.valueText}>{localCount.data ?? 0}</Text>
-              }
-              align="right"
-              canCopy={false}
-            />
-            <LabeledValueRow
-              label="Local only files"
-              value={
-                <Text style={styles.valueText}>{localOnlyCount.data ?? 0}</Text>
-              }
-              align="right"
-              canCopy={false}
-            />
-            <LabeledValueRow
-              label="Lost files"
-              value={
-                <Text style={styles.valueText}>{lostCount.data ?? 0}</Text>
-              }
-              align="right"
-              canCopy={false}
-            />
-          </InfoCard>
+        <RowGroup title="Files" indicator={toggle} style={styles.groupSpacing}>
+          <RowSubGroup title="Network" style={styles.subGroupSpacing}>
+            <InfoCard>
+              <LabeledValueRow
+                label="Files"
+                labelStyle={styles.boldLabel}
+                value={
+                  <View style={styles.valueRight}>
+                    <Text style={styles.valueText}>
+                      {formatCategoryValue(stats.data?.files, displayMode)}
+                    </Text>
+                    <Text style={styles.valuePercent}>
+                      {humanUploadPercent(
+                        stats.data?.files.percentDecimal,
+                        stats.data?.files.percent,
+                      )}
+                    </Text>
+                  </View>
+                }
+                align="right"
+                canCopy={false}
+              />
+              <LabeledValueRow
+                label="  Photos"
+                value={
+                  <View style={styles.valueRight}>
+                    <Text style={styles.valueText}>
+                      {formatCategoryValue(stats.data?.photos, displayMode)}
+                    </Text>
+                    <Text style={styles.valuePercent}>
+                      {humanUploadPercent(
+                        stats.data?.photos.percentDecimal,
+                        stats.data?.photos.percent,
+                      )}
+                    </Text>
+                  </View>
+                }
+                align="right"
+                canCopy={false}
+                showDividerTop
+              />
+              <LabeledValueRow
+                label="  Videos"
+                value={
+                  <View style={styles.valueRight}>
+                    <Text style={styles.valueText}>
+                      {formatCategoryValue(stats.data?.videos, displayMode)}
+                    </Text>
+                    <Text style={styles.valuePercent}>
+                      {humanUploadPercent(
+                        stats.data?.videos.percentDecimal,
+                        stats.data?.videos.percent,
+                      )}
+                    </Text>
+                  </View>
+                }
+                align="right"
+                canCopy={false}
+                showDividerTop
+              />
+              <LabeledValueRow
+                label="  Audio"
+                value={
+                  <View style={styles.valueRight}>
+                    <Text style={styles.valueText}>
+                      {formatCategoryValue(stats.data?.audio, displayMode)}
+                    </Text>
+                    <Text style={styles.valuePercent}>
+                      {humanUploadPercent(
+                        stats.data?.audio.percentDecimal,
+                        stats.data?.audio.percent,
+                      )}
+                    </Text>
+                  </View>
+                }
+                align="right"
+                canCopy={false}
+                showDividerTop
+              />
+              <LabeledValueRow
+                label="  Docs"
+                value={
+                  <View style={styles.valueRight}>
+                    <Text style={styles.valueText}>
+                      {formatCategoryValue(stats.data?.docs, displayMode)}
+                    </Text>
+                    <Text style={styles.valuePercent}>
+                      {humanUploadPercent(
+                        stats.data?.docs.percentDecimal,
+                        stats.data?.docs.percent,
+                      )}
+                    </Text>
+                  </View>
+                }
+                align="right"
+                canCopy={false}
+                showDividerTop
+              />
+              <LabeledValueRow
+                label="  Other"
+                value={
+                  <View style={styles.valueRight}>
+                    <Text style={styles.valueText}>
+                      {formatCategoryValue(stats.data?.other, displayMode)}
+                    </Text>
+                    <Text style={styles.valuePercent}>
+                      {humanUploadPercent(
+                        stats.data?.other.percentDecimal,
+                        stats.data?.other.percent,
+                      )}
+                    </Text>
+                  </View>
+                }
+                align="right"
+                canCopy={false}
+                showDividerTop
+              />
+            </InfoCard>
+            <View style={styles.networkGroupGap} />
+            <InfoCard>
+              <LabeledValueRow
+                label="Thumbnails"
+                value={
+                  <View style={styles.valueRight}>
+                    <Text style={styles.valueText}>
+                      {formatCategoryValue(stats.data?.thumbnails, displayMode)}
+                    </Text>
+                    <Text style={styles.valuePercent}>
+                      {humanUploadPercent(
+                        stats.data?.thumbnails.percentDecimal,
+                        stats.data?.thumbnails.percent,
+                      )}
+                    </Text>
+                  </View>
+                }
+                align="right"
+                canCopy={false}
+              />
+            </InfoCard>
+            <View style={styles.networkGroupGap} />
+            <InfoCard>
+              <LabeledValueRow
+                label="All"
+                value={
+                  <View style={styles.valueRight}>
+                    <Text style={styles.valueText}>
+                      {formatCategoryValue(stats.data?.overall, displayMode)}
+                    </Text>
+                    <Text style={styles.valuePercent}>
+                      {humanUploadPercent(
+                        stats.data?.overall.percentDecimal,
+                        stats.data?.overall.percent,
+                      )}
+                    </Text>
+                  </View>
+                }
+                align="right"
+                canCopy={false}
+              />
+            </InfoCard>
+          </RowSubGroup>
+          <RowSubGroup title="Device" style={styles.subGroupSpacing}>
+            <InfoCard>
+              <LabeledValueRow
+                label="On device"
+                labelWidth={120}
+                value={
+                  <View style={styles.valueRight}>
+                    <Text style={styles.valueText}>
+                      {formatDeviceValue(
+                        onDevice.data,
+                        stats.data?.overall,
+                        displayMode,
+                      )}
+                    </Text>
+                    <Text style={styles.valuePercent}>
+                      {humanUploadPercent(
+                        devicePercent(onDevice.data, stats.data?.overall),
+                      )}
+                    </Text>
+                  </View>
+                }
+                align="right"
+                canCopy={false}
+              />
+              <LabeledValueRow
+                label="Pending backup"
+                labelWidth={120}
+                value={
+                  <View style={styles.valueRight}>
+                    <Text style={styles.valueText}>
+                      {formatDeviceValue(
+                        pendingBackup.data,
+                        stats.data?.overall,
+                        displayMode,
+                      )}
+                    </Text>
+                    <Text style={styles.valuePercent}>
+                      {humanUploadPercent(
+                        devicePercent(pendingBackup.data, stats.data?.overall),
+                      )}
+                    </Text>
+                  </View>
+                }
+                align="right"
+                canCopy={false}
+                showDividerTop
+              />
+              <LabeledValueRow
+                label="Lost"
+                labelWidth={120}
+                value={
+                  <View style={styles.valueRight}>
+                    <Text style={styles.valueText}>
+                      {formatDeviceValue(
+                        lost.data,
+                        stats.data?.overall,
+                        displayMode,
+                      )}
+                    </Text>
+                    <Text style={styles.valuePercent}>
+                      {humanUploadPercent(
+                        devicePercent(lost.data, stats.data?.overall),
+                      )}
+                    </Text>
+                  </View>
+                }
+                align="right"
+                canCopy={false}
+                showDividerTop
+              />
+            </InfoCard>
+          </RowSubGroup>
         </RowGroup>
       </View>
     </ActionSheet>
@@ -279,20 +387,32 @@ const styles = StyleSheet.create({
   sheetInnerDark: {
     gap: 14,
   },
-  sheetHeaderRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    marginBottom: 10,
-  },
-  sheetTitle: {
-    color: palette.gray[50],
-    fontSize: 20,
-    fontWeight: '900',
-    letterSpacing: 0.2,
-  },
   groupSpacing: { marginTop: 8 },
-  groupIndicator: { color: palette.gray[300], fontSize: 12, fontWeight: '700' },
+  subGroupSpacing: { marginTop: 12 },
+  networkGroupGap: { height: 8 },
+  boldLabel: { fontWeight: '700' },
+  toggleTrack: {
+    flexDirection: 'row',
+    backgroundColor: whiteA.a08,
+    borderRadius: 8,
+    padding: 2,
+  },
+  toggleSegment: {
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 6,
+  },
+  toggleSegmentSelected: {
+    backgroundColor: whiteA.a10,
+  },
+  toggleLabel: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: palette.gray[400],
+  },
+  toggleLabelSelected: {
+    color: palette.gray[50],
+  },
   valueRight: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -301,8 +421,16 @@ const styles = StyleSheet.create({
     width: '100%',
     flex: 1,
   },
-  valueText: { color: palette.gray[100] },
-  valuePercent: { color: palette.gray[400] },
+  valueText: {
+    color: palette.gray[100],
+    fontFamily: Platform.select({ ios: 'Menlo', android: 'monospace' }),
+    fontSize: 13,
+  },
+  valuePercent: {
+    color: palette.gray[400],
+    fontFamily: Platform.select({ ios: 'Menlo', android: 'monospace' }),
+    fontSize: 13,
+  },
   dotOnline: {
     width: 8,
     height: 8,

--- a/src/hooks/useAppStatus.tsx
+++ b/src/hooks/useAppStatus.tsx
@@ -4,6 +4,7 @@ import {
   UploadCloudIcon,
 } from 'lucide-react-native'
 import type React from 'react'
+import { compactUploadPercent } from '../lib/uploadPercent'
 import { useIsInitializing } from '../stores/app'
 import { useIsConnected } from '../stores/sdk'
 import { useHasOnboarded } from '../stores/settings'
@@ -46,10 +47,11 @@ export function useAppStatus(): AppStatus {
   }
 
   if (uploadsProgress.show) {
+    const hint = compactUploadPercent(uploadsProgress.percentDecimal)
     return {
       visible: true,
       icon: <UploadCloudIcon size={14} color={palette.gray[50]} />,
-      hint: `${uploadsProgress.percentComplete}`,
+      hint: hint ?? undefined,
       level: 'info',
     }
   }

--- a/src/lib/uploadPercent.ts
+++ b/src/lib/uploadPercent.ts
@@ -1,12 +1,20 @@
 /**
- * Format a decimal upload percentage as a human-readable string.
- * If the decimal is between 0.99 and 1, it will be formatted to 1 decimal place.
- * @param decimal - The decimal upload percentage (0-1).
- * @param fallback - The fallback string to return if the decimal is null.
- * @returns The human-readable string.
+ * Format a decimal upload percentage as a fixed-width string.
+ * Always shows 1 decimal place and pads to 6 characters (e.g. " 99.3%").
+ * Used in the status sheet where alignment matters.
  */
 export function humanUploadPercent(decimal?: number, fallback?: string) {
-  if (decimal == null) return fallback ?? '100%'
-  if (decimal >= 0.99 && decimal < 1) return `${(decimal * 100).toFixed(1)}%`
+  if (decimal == null) return fallback ?? '100.0%'
+  const pct = (decimal * 100).toFixed(1)
+  return `${pct}%`.padStart(6)
+}
+
+/**
+ * Format a decimal upload percentage for compact display (e.g. header pill).
+ * Shows 0 decimal places. Returns null when >= 99% so the caller can
+ * show just a spinner instead.
+ */
+export function compactUploadPercent(decimal: number): string | null {
+  if (decimal >= 0.99) return null
   return `${Math.round(decimal * 100)}%`
 }

--- a/src/stores/fileStats.ts
+++ b/src/stores/fileStats.ts
@@ -13,6 +13,7 @@ export type UploadCategoryStats = {
 
 export type UploadStats = {
   overall: UploadCategoryStats
+  files: UploadCategoryStats
   photos: UploadCategoryStats
   videos: UploadCategoryStats
   audio: UploadCategoryStats
@@ -59,7 +60,7 @@ async function counts(
   const uploaded = Math.max(0, total - remaining)
   const uploadedBytes = Math.max(0, totalBytes - remainingBytes)
   const percentDecimal = totalBytes ? uploadedBytes / totalBytes : 1
-  const percent = `${Math.round(percentDecimal * 100)}%`
+  const percent = `${(percentDecimal * 100).toFixed(1)}%`.padStart(6)
   return {
     total,
     remaining,
@@ -90,19 +91,34 @@ export async function getUploadStats(): Promise<UploadStats> {
     counts(thumbsWhere, indexerURL),
   ])
 
-  const categories = [photosC, videosC, audioC, docsC, otherC, thumbsC]
-  const overallTotal = categories.reduce((s, c) => s + c.total, 0)
-  const overallUploaded = categories.reduce((s, c) => s + c.uploaded, 0)
-  const overallRemaining = categories.reduce((s, c) => s + c.remaining, 0)
-  const overallTotalBytes = categories.reduce((s, c) => s + c.totalBytes, 0)
-  const overallUploadedBytes = categories.reduce(
+  const fileCategories = [photosC, videosC, audioC, docsC, otherC]
+  const filesTotalCount = fileCategories.reduce((s, c) => s + c.total, 0)
+  const filesUploaded = fileCategories.reduce((s, c) => s + c.uploaded, 0)
+  const filesRemaining = fileCategories.reduce((s, c) => s + c.remaining, 0)
+  const filesTotalBytes = fileCategories.reduce((s, c) => s + c.totalBytes, 0)
+  const filesUploadedBytes = fileCategories.reduce(
+    (s, c) => s + c.uploadedBytes,
+    0,
+  )
+  const filesPercentDecimal = filesTotalBytes
+    ? filesUploadedBytes / filesTotalBytes
+    : 1
+  const filesPercent = `${(filesPercentDecimal * 100).toFixed(1)}%`.padStart(6)
+
+  const allCategories = [...fileCategories, thumbsC]
+  const overallTotal = allCategories.reduce((s, c) => s + c.total, 0)
+  const overallUploaded = allCategories.reduce((s, c) => s + c.uploaded, 0)
+  const overallRemaining = allCategories.reduce((s, c) => s + c.remaining, 0)
+  const overallTotalBytes = allCategories.reduce((s, c) => s + c.totalBytes, 0)
+  const overallUploadedBytes = allCategories.reduce(
     (s, c) => s + c.uploadedBytes,
     0,
   )
   const overallPercentDecimal = overallTotalBytes
     ? overallUploadedBytes / overallTotalBytes
     : 1
-  const overallPercent = `${Math.round(overallPercentDecimal * 100)}%`
+  const overallPercent =
+    `${(overallPercentDecimal * 100).toFixed(1)}%`.padStart(6)
 
   const stats: UploadStats = {
     overall: {
@@ -113,6 +129,15 @@ export async function getUploadStats(): Promise<UploadStats> {
       uploadedBytes: overallUploadedBytes,
       percent: overallPercent,
       percentDecimal: overallPercentDecimal,
+    },
+    files: {
+      uploaded: filesUploaded,
+      total: filesTotalCount,
+      remaining: filesRemaining,
+      totalBytes: filesTotalBytes,
+      uploadedBytes: filesUploadedBytes,
+      percent: filesPercent,
+      percentDecimal: filesPercentDecimal,
     },
     photos: photosC,
     videos: videosC,

--- a/src/stores/files.ts
+++ b/src/stores/files.ts
@@ -584,6 +584,21 @@ export const [getFileCountLost, useFileCountLost] = createGetterAndSWRHook(
   },
 )
 
+export const [getFileStatsLost, useFileStatsLost] = createGetterAndSWRHook(
+  librarySwr.getKey('lostStats'),
+  async () => {
+    const currentIndexerURL = await getIndexerURL()
+    return readAllFileRecordsStats({
+      order: 'ASC',
+      pinned: {
+        indexerURL: currentIndexerURL,
+        isPinned: false,
+      },
+      fileExistsLocally: false,
+    })
+  },
+)
+
 export const [getFileCountLocal, useFileCountLocal] = createGetterAndSWRHook(
   librarySwr.getKey('localCount'),
   async ({ localOnly }: { localOnly: boolean }) => {

--- a/src/stores/uploads.ts
+++ b/src/stores/uploads.ts
@@ -193,6 +193,7 @@ export function useUploadProgress(): {
   show: boolean
   enabled: boolean
   remaining: number
+  percentDecimal: number
   percentComplete: string
   total: number
 } {
@@ -211,7 +212,7 @@ export function useUploadProgress(): {
   const activeWeightedProgress = activeUploads
     .map((u) => u.progress * u.size)
     .reduce((a, b) => a + b, 0)
-  const percentComplete = totalBytes
+  const percentDecimal = totalBytes
     ? Math.min((activeWeightedProgress + uploadedBytes) / totalBytes, 1)
     : 0
 
@@ -219,7 +220,8 @@ export function useUploadProgress(): {
     show: isEnabled && !!localOnlyFiles,
     enabled: isEnabled,
     remaining: localOnlyFiles,
-    percentComplete: humanUploadPercent(percentComplete),
+    percentDecimal,
+    percentComplete: humanUploadPercent(percentDecimal),
     total: totalFiles,
   }
 }


### PR DESCRIPTION
Reorganize into App Status and Files sections with Network/Device sub-groups. Add count/size toggle, monospace-aligned values, locale formatting, and compact header percent display.

![Screenshot 2026-02-11 at 17.54.05.png](https://app.graphite.com/user-attachments/assets/e8274477-5eb2-471a-98d7-c8cdda629698.png)

![Screenshot 2026-02-11 at 17.53.44.png](https://app.graphite.com/user-attachments/assets/4712674d-7515-4bd8-888e-3c344c2acc20.png)

