### PR TITLE
feat: upgrade SDK with parallel uploads and inflight cancellation

### DIFF
--- a/.changeset/upgrade-sdk.md
+++ b/.changeset/upgrade-sdk.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Improved upload parallelism and added proper cancellation for inflight uploads.

--- a/bun.lock
+++ b/bun.lock
@@ -50,7 +50,7 @@
         "react-native-safe-area-context": "^5.6.1",
         "react-native-screens": "~4.16.0",
         "react-native-share": "^12.2.0",
-        "react-native-sia": "^0.13.11",
+        "react-native-sia": "^0.13.12",
         "react-native-svg": "15.12.1",
         "react-native-webview": "13.15.0",
         "react-native-worklets": "0.7.2",
@@ -1504,7 +1504,7 @@
 
     "react-native-share": ["react-native-share@12.2.4", "", {}, "sha512-H9q9lXcB322jMMMQ3xAg2QFux2gznJzztcNnycK4iqL/XjDGULf/MWkdwBXUfEEhl6ydnGmhP6huRMRYiyIGng=="],
 
-    "react-native-sia": ["react-native-sia@0.13.11", "", { "dependencies": { "uniffi-bindgen-react-native": "^0.29.3-1" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-HpNvfBKEvfn10WVBqae2q3M2/To4eTBBAn7OB8Q+CW3cqecYFNOiiia+gdjm4wxeB3E6kq7vDa3olwYYmp5HxA=="],
+    "react-native-sia": ["react-native-sia@0.13.12", "", { "dependencies": { "uniffi-bindgen-react-native": "^0.29.3-1" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-FCnogk+FVrBPzcDX41Me0I3GoFZaXm+hnwccE/G/6+3HWvORarA8Y4JYw+Hrg2HU+6t5QwH5tRiunWrfhymBZQ=="],
 
     "react-native-svg": ["react-native-svg@15.12.1", "", { "dependencies": { "css-select": "^5.1.0", "css-tree": "^1.1.3", "warn-once": "0.1.1" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-vCuZJDf8a5aNC2dlMovEv4Z0jjEUET53lm/iILFnFewa15b4atjVxU6Wirm6O9y6dEsdjDZVD7Q3QM4T1wlI8g=="],
 

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "react-native-safe-area-context": "^5.6.1",
     "react-native-screens": "~4.16.0",
     "react-native-share": "^12.2.0",
-    "react-native-sia": "^0.13.11",
+    "react-native-sia": "^0.13.12",
     "react-native-svg": "15.12.1",
     "react-native-webview": "13.15.0",
     "react-native-worklets": "0.7.2",

--- a/src/components/SettingsAdvancedTransfers.tsx
+++ b/src/components/SettingsAdvancedTransfers.tsx
@@ -40,8 +40,8 @@ export function SettingsAdvancedTransfers() {
         <Button
           style={{ marginTop: 10 }}
           disabled={uploadCounts.total === 0}
-          onPress={() => {
-            getUploadManager().shutdown()
+          onPress={async () => {
+            await getUploadManager().shutdown()
             clearAllUploads()
           }}
         >

--- a/src/managers/app.ts
+++ b/src/managers/app.ts
@@ -106,21 +106,21 @@ export async function initApp(): Promise<void> {
   endInitState()
 }
 
-function cancelAllTransfers() {
-  getUploadManager().shutdown()
+async function cancelAllTransfers() {
+  await getUploadManager().shutdown()
   clearAllUploads()
   cancelAllDownloads()
 }
 
 export async function shutdownApp() {
-  cancelAllTransfers()
+  await cancelAllTransfers()
 }
 
 export async function resetData() {
   await deleteAllFileRecords()
   await resetDb()
   await resetSyncDownCursor()
-  cancelAllTransfers()
+  await cancelAllTransfers()
 }
 
 export async function resetApp() {

--- a/src/managers/uploader.test.ts
+++ b/src/managers/uploader.test.ts
@@ -173,6 +173,7 @@ function createMockPacker(
 ): jest.Mocked<PackedUploadInterface> {
   return {
     add: jest.fn().mockResolvedValue(BigInt(1000)),
+    cancel: jest.fn().mockResolvedValue(undefined),
     finalize: jest.fn().mockResolvedValue([pinnedObject]),
   } as unknown as jest.Mocked<PackedUploadInterface>
 }
@@ -243,15 +244,12 @@ describe('UploadManager', () => {
 
       await manager.__testProcessFiles([createFileEntry('file1')])
 
-      expect(mockSdk.uploadPacked).toHaveBeenCalledWith(
-        {
-          maxInflight: UPLOAD_MAX_INFLIGHT,
-          dataShards: UPLOAD_DATA_SHARDS,
-          parityShards: UPLOAD_PARITY_SHARDS,
-          progressCallback: expect.any(Object),
-        },
-        { signal: expect.any(AbortSignal) },
-      )
+      expect(mockSdk.uploadPacked).toHaveBeenCalledWith({
+        maxInflight: UPLOAD_MAX_INFLIGHT,
+        dataShards: UPLOAD_DATA_SHARDS,
+        parityShards: UPLOAD_PARITY_SHARDS,
+        progressCallback: expect.any(Object),
+      })
     })
 
     it('reuses packer for subsequent files in same batch', async () => {
@@ -605,7 +603,7 @@ describe('UploadManager', () => {
       // Before cancel, files should be in store
       expect(getActiveUploads()).toHaveLength(2)
 
-      manager.shutdown()
+      await manager.shutdown()
 
       // After cancel, all uploads should be removed
       expect(getActiveUploads()).toHaveLength(0)
@@ -617,36 +615,22 @@ describe('UploadManager', () => {
       manager.initialize(mockSdk, TEST_INDEXER_URL)
 
       await manager.__testProcessFiles([createFileEntry('file1')])
-      manager.shutdown()
+      await manager.shutdown()
 
       // Advancing timers should not trigger finalize since loop is stopped
       await jest.advanceTimersByTimeAsync(PACKER_IDLE_TIMEOUT + 1000)
       expect(mockPacker.finalize).not.toHaveBeenCalled()
     })
 
-    it('aborts batch operations via AbortSignal', async () => {
-      let capturedSignal: AbortSignal | undefined
-
-      // Capture the abort signal passed to uploadPacked
-      mockSdk.uploadPacked.mockImplementation(
-        async (_opts: any, asyncOpts: any) => {
-          capturedSignal = asyncOpts?.signal
-          return mockPacker
-        },
-      )
-
+    it('cancels inflight uploads via packer.cancel()', async () => {
       manager.initialize(mockSdk, TEST_INDEXER_URL)
       await manager.__testProcessFiles([createFileEntry('file1')])
 
-      // Signal should not be aborted yet
-      expect(capturedSignal).toBeDefined()
-      expect(capturedSignal?.aborted).toBe(false)
+      expect(mockPacker.cancel).not.toHaveBeenCalled()
 
-      // Cancel the batch
-      manager.shutdown()
+      await manager.shutdown()
 
-      // Signal should now be aborted
-      expect(capturedSignal?.aborted).toBe(true)
+      expect(mockPacker.cancel).toHaveBeenCalledTimes(1)
     })
 
     it('removes enqueued files from upload store', async () => {
@@ -658,7 +642,7 @@ describe('UploadManager', () => {
       // Before shutdown, file should be in store
       expect(getUploadState('queued-file')).toBeDefined()
 
-      manager.shutdown()
+      await manager.shutdown()
 
       // After shutdown, queued file should be removed
       expect(getUploadState('queued-file')).toBeUndefined()

--- a/src/managers/uploader.ts
+++ b/src/managers/uploader.ts
@@ -67,7 +67,6 @@ type BatchState = {
   startedAt: number
   /** Timestamp of last successful packer.add() — used to detect suspension gaps. */
   lastProcessedAt: number
-  abortController: AbortController
 }
 
 /** Recorded after each flush for efficiency analysis and testing. */
@@ -108,6 +107,8 @@ class UploadManager {
   private batch: BatchState | null = null
   /** The batch currently being finalized/uploaded (after flush, before pin). */
   private uploadingBatch: BatchState | null = null
+  /** Native packed upload handle for the batch being finalized; used by shutdown() to cancel. */
+  private uploadingPacker: PackedUploadInterface | null = null
   /** Base URL for the indexer service; used when saving pinned objects. */
   private indexerURL: string = ''
   /** Files added via enqueue() — processed before polled files. */
@@ -173,8 +174,9 @@ class UploadManager {
     const batch = this.batch
     const packer = this.packer
 
-    // Move batch to uploadingBatch so shutdown() can cancel it separately
+    // Move batch/packer to uploading* so shutdown() can cancel them separately
     this.uploadingBatch = batch
+    this.uploadingPacker = packer
     this.packer = null
     this.batch = null
 
@@ -210,9 +212,7 @@ class UploadManager {
       }
 
       const finalizeStart = Date.now()
-      const pinnedObjects = await packer.finalize({
-        signal: batch.abortController.signal,
-      })
+      const pinnedObjects = await packer.finalize()
       logger.info('uploadManager', 'batch_finalized', {
         batchId: batch.batchId,
         objects: pinnedObjects.length,
@@ -241,28 +241,33 @@ class UploadManager {
       }
     } finally {
       this.uploadingBatch = null
+      this.uploadingPacker = null
     }
   }
 
-  /** Stop the loop, abort in-flight batches, and clean up upload state. */
-  shutdown(): void {
+  /** Stop the loop, cancel in-flight uploads, and clean up upload state. */
+  async shutdown(): Promise<void> {
     this.active = false
 
-    if (this.batch) {
+    if (this.packer) {
       logger.info('uploadManager', 'batch_cancel', {
-        batchId: this.batch.batchId,
+        batchId: this.batch?.batchId,
       })
-      this.batch.abortController.abort()
+      await this.packer.cancel()
+    }
+    if (this.batch) {
       for (const entry of this.batch.files) {
         removeUpload(entry.fileId)
       }
     }
 
-    if (this.uploadingBatch) {
+    if (this.uploadingPacker) {
       logger.info('uploadManager', 'uploading_batch_cancel', {
-        batchId: this.uploadingBatch.batchId,
+        batchId: this.uploadingBatch?.batchId,
       })
-      this.uploadingBatch.abortController.abort()
+      await this.uploadingPacker.cancel()
+    }
+    if (this.uploadingBatch) {
       for (const entry of this.uploadingBatch.files) {
         removeUpload(entry.fileId)
       }
@@ -307,6 +312,7 @@ class UploadManager {
     this.packer = null
     this.batch = null
     this.uploadingBatch = null
+    this.uploadingPacker = null
     this.explicitQueue = []
     this.polledFiles = []
     this.sdk = null
@@ -434,21 +440,17 @@ class UploadManager {
           slabsFilled: 0,
           startedAt: Date.now(),
           lastProcessedAt: 0,
-          abortController: new AbortController(),
         }
         this.batch = batch
-        this.packer = await this.sdk.uploadPacked(
-          {
-            maxInflight: UPLOAD_MAX_INFLIGHT,
-            dataShards: UPLOAD_DATA_SHARDS,
-            parityShards: UPLOAD_PARITY_SHARDS,
-            progressCallback: {
-              progress: (uploaded, total) =>
-                this.onProgress(batch, uploaded, total),
-            },
+        this.packer = await this.sdk.uploadPacked({
+          maxInflight: UPLOAD_MAX_INFLIGHT,
+          dataShards: UPLOAD_DATA_SHARDS,
+          parityShards: UPLOAD_PARITY_SHARDS,
+          progressCallback: {
+            progress: (uploaded, total) =>
+              this.onProgress(batch, uploaded, total),
           },
-          { signal: batch.abortController.signal },
-        )
+        })
       }
 
       setUploadStatus(entry.fileId, 'packing')
@@ -460,9 +462,7 @@ class UploadManager {
       const t0 = Date.now()
       const reader = createFileReader(entry.fileUri)
       const t1 = Date.now()
-      await this.packer.add(reader, {
-        signal: this.batch!.abortController.signal,
-      })
+      await this.packer.add(reader)
       const t2 = Date.now()
       const slabsBefore = this.batch!.slabsFilled
       this.recordAdd(entry)
@@ -535,7 +535,6 @@ class UploadManager {
     end: number,
   ): Promise<void> {
     const packer = this.packer!
-    const signal = this.batch!.abortController.signal
 
     const inflight = []
     for (let j = from; j < end; j++) {
@@ -552,7 +551,7 @@ class UploadManager {
         entry,
         t0,
         readerMs: Date.now() - t0,
-        promise: packer.add(reader, { signal }),
+        promise: packer.add(reader),
       })
     }
 

--- a/src/stores/sdk.ts
+++ b/src/stores/sdk.ts
@@ -80,7 +80,7 @@ export async function setSdkWithUploader(
 ): Promise<void> {
   const currentSdk = getState().sdk
   if (currentSdk && currentSdk !== sdk) {
-    getUploadManager().shutdown()
+    await getUploadManager().shutdown()
   }
   setState({ sdk })
   if (sdk) {
@@ -551,7 +551,7 @@ export async function getPinnedObject(
  * Resets the SDK state and shuts down uploader.
  */
 export async function resetSdk() {
-  getUploadManager().shutdown()
+  await getUploadManager().shutdown()
   setState({
     sdk: null,
     isConnected: false,


### PR DESCRIPTION
Upgrade react-native-sia to 0.13.12 which adds improved upload parallelism and a cancel() method on PackedUpload. Replace the generic AbortController pattern with the new packer.cancel() API.