### PR TITLE
feat: resume archive sync when pending bytes drop below 4 slabs

### DIFF
--- a/.changeset/archive-sync-threshold.md
+++ b/.changeset/archive-sync-threshold.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Resume fetching archive photos when pending upload data drops below 4 slabs instead of waiting for 0 files.

--- a/src/components/SettingsSyncPhotos.tsx
+++ b/src/components/SettingsSyncPhotos.tsx
@@ -1,4 +1,6 @@
 import { Linking, StyleSheet, Switch, Text } from 'react-native'
+import { SYNC_ARCHIVE_RESUME_THRESHOLD } from '../config'
+import { humanSize } from '../lib/humanSize'
 import { useMediaLibraryPermissions } from '../lib/mediaLibraryPermissions'
 import {
   toggleAutoSyncNewPhotos,
@@ -10,7 +12,7 @@ import {
   useAutoSyncPhotosArchive,
   usePhotosArchiveCursor,
 } from '../managers/syncPhotosArchive'
-import { useFileCountLocal } from '../stores/files'
+import { useFileStatsLocal } from '../stores/files'
 import { colors } from '../styles/colors'
 import { Button } from './Button'
 import { RowGroup } from './Group'
@@ -21,7 +23,7 @@ export function SettingsSyncPhotos() {
   const autoSyncNew = useAutoSyncNewPhotos()
   const autoSyncPhotosArchive = useAutoSyncPhotosArchive()
   const photosArchiveCursor = usePhotosArchiveCursor()
-  const localOnlyCount = useFileCountLocal({ localOnly: true })
+  const localOnlyStats = useFileStatsLocal({ localOnly: true })
   const cursorValue = photosArchiveCursor.data ?? 0
   const photosArchiveInProgress = cursorValue > 0
   const { isSomeAccess, accessLabel, color } = useMediaLibraryPermissions()
@@ -90,10 +92,11 @@ export function SettingsSyncPhotos() {
         : null}
       {autoSyncPhotosArchive.data &&
       photosArchiveInProgress &&
-      (localOnlyCount.data ?? 0) > 0 ? (
+      (localOnlyStats.data?.totalBytes ?? 0) >=
+        SYNC_ARCHIVE_RESUME_THRESHOLD ? (
         <Text
           style={styles.info}
-        >{`Waiting for ${localOnlyCount.data} files to upload before continuing archive sync`}</Text>
+        >{`Waiting for ${humanSize(localOnlyStats.data?.totalBytes ?? 0) ?? '0 B'} to upload before continuing archive sync`}</Text>
       ) : null}
       <Button
         style={{ marginTop: 10 }}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -38,6 +38,8 @@ export const SYNC_EVENTS_INTERVAL = secondsInMs(10) // 10 seconds
 export const SYNC_NEW_PHOTOS_INTERVAL = secondsInMs(5) // 5 seconds
 // Sync archive photos interval.
 export const SYNC_PHOTOS_ARCHIVE_INTERVAL = secondsInMs(5) // 5 seconds
+// Resume fetching archive photos when pending local-only bytes drop below this threshold.
+export const SYNC_ARCHIVE_RESUME_THRESHOLD = 4 * SLAB_SIZE
 // Thumbnail scanner interval.
 export const THUMBNAIL_SCANNER_INTERVAL = secondsInMs(5) // 5 seconds
 // Maximum number of bytes to retain in the local file system before evicting.

--- a/src/managers/syncPhotosArchive.test.ts
+++ b/src/managers/syncPhotosArchive.test.ts
@@ -34,7 +34,7 @@ jest.mock('../lib/processAssets', () => ({
 }))
 jest.mock('../stores/files', () => ({
   __esModule: true,
-  getFileCountLocal: jest.fn().mockResolvedValue(0),
+  getFileStatsLocal: jest.fn().mockResolvedValue({ count: 0, totalBytes: 0 }),
 }))
 jest.mock('../stores/library', () => ({
   __esModule: true,

--- a/src/managers/syncPhotosArchive.ts
+++ b/src/managers/syncPhotosArchive.ts
@@ -1,5 +1,8 @@
 import * as MediaLibrary from 'expo-media-library'
-import { SYNC_PHOTOS_ARCHIVE_INTERVAL } from '../config'
+import {
+  SYNC_ARCHIVE_RESUME_THRESHOLD,
+  SYNC_PHOTOS_ARCHIVE_INTERVAL,
+} from '../config'
 import { logger } from '../lib/logger'
 import {
   ensureMediaLibraryPermission,
@@ -15,7 +18,7 @@ import {
   setAsyncStorageBoolean,
   setAsyncStorageNumber,
 } from '../stores/asyncStore'
-import { getFileCountLocal } from '../stores/files'
+import { getFileStatsLocal } from '../stores/files'
 import { librarySwr } from '../stores/library'
 import { settingsSwr } from '../stores/settings'
 
@@ -24,11 +27,12 @@ const PAGE_SIZE = 50
 export async function workBackward() {
   logger.debug('syncPhotosArchive', 'tick')
   if (!(await getMediaLibraryPermissions())) return
-  const localOnlyCount = await getFileCountLocal({ localOnly: true })
-  if (localOnlyCount > 0) {
+  const { count, totalBytes } = await getFileStatsLocal({ localOnly: true })
+  if (totalBytes >= SYNC_ARCHIVE_RESUME_THRESHOLD) {
     logger.info('syncPhotosArchive', 'skipped', {
       reason: 'local_only_pending',
-      localOnlyCount,
+      count,
+      totalBytes,
     })
     return
   }


### PR DESCRIPTION
- Resume fetching archive photos when pending upload data drops below 4 slabs instead of waiting for 0 files.
- We recently changed the photos archive sync feature to pause until all existing files are synced. This worked and reduced resource usage and overload, but creating some inefficient gaps where the upload packer would often flush partial slabs because it would not queue more files until the left overs were fully uploaded.