### PR TITLE
feat: switch upload stats and log scopes sheets to native modals

### DIFF
--- a/.changeset/improve-log-scopes-query.md
+++ b/.changeset/improve-log-scopes-query.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Refined log viewer with faster scopes query, limited log fetch to 500 entries, and improved new log detection.

--- a/.changeset/native-modal-sheets.md
+++ b/.changeset/native-modal-sheets.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Switched upload stats and log scopes sheets to native page sheet modals.

--- a/src/components/LibraryStatusSheet.tsx
+++ b/src/components/LibraryStatusSheet.tsx
@@ -1,5 +1,12 @@
-import { useState } from 'react'
-import { Platform, Pressable, StyleSheet, Text, View } from 'react-native'
+import { useCallback } from 'react'
+import {
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native'
 import useSWR from 'swr'
 import { useIsOnline } from '../hooks/useIsOnline'
 import { humanSize } from '../lib/humanSize'
@@ -8,12 +15,13 @@ import type { UploadCategoryStats } from '../stores/fileStats'
 import { getUploadStats } from '../stores/fileStats'
 import { useFileStatsLocal, useFileStatsLost } from '../stores/files'
 import { useIsConnected } from '../stores/sdk'
+import { setStatusDisplayMode, useStatusDisplayMode } from '../stores/settings'
 import { closeSheet, useSheetOpen } from '../stores/sheets'
 import { palette, whiteA } from '../styles/colors'
-import { ActionSheet } from './ActionSheet'
 import { RowGroup, RowSubGroup } from './Group'
 import { InfoCard } from './InfoCard'
 import { LabeledValueRow } from './LabeledValueRow'
+import { ModalSheet } from './ModalSheet'
 
 const refreshInterval = 5_000
 
@@ -52,7 +60,7 @@ export function LibraryStatusSheet() {
   const isConnected = useIsConnected()
   const isOnline = useIsOnline()
   const isOpen = useSheetOpen('libraryStatus')
-  const [displayMode, setDisplayMode] = useState<'count' | 'size'>('count')
+  const { data: displayMode = 'count' } = useStatusDisplayMode()
   const stats = useSWR(
     ['upload-stats', isOpen ?? null],
     () => getUploadStats(),
@@ -67,6 +75,10 @@ export function LibraryStatusSheet() {
   )
   const lost = useFileStatsLost({ refreshInterval })
 
+  const handleClose = useCallback(() => {
+    closeSheet()
+  }, [])
+
   const toggle = (
     <View style={styles.toggleTrack}>
       {(['count', 'size'] as const).map((mode) => (
@@ -76,7 +88,7 @@ export function LibraryStatusSheet() {
             styles.toggleSegment,
             displayMode === mode && styles.toggleSegmentSelected,
           ]}
-          onPress={() => setDisplayMode(mode)}
+          onPress={() => setStatusDisplayMode(mode)}
         >
           <Text
             style={[
@@ -92,13 +104,9 @@ export function LibraryStatusSheet() {
   )
 
   return (
-    <ActionSheet
-      visible={isOpen}
-      onRequestClose={() => closeSheet()}
-      contentStyle={styles.sheetContent}
-    >
-      <View style={styles.sheetInnerDark}>
-        <RowGroup title="App status" style={styles.groupSpacing}>
+    <ModalSheet visible={isOpen} onRequestClose={handleClose} title="Status">
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <RowGroup title="Connectivity" style={styles.groupSpacing}>
           <InfoCard>
             <LabeledValueRow
               label="Internet"
@@ -373,18 +381,15 @@ export function LibraryStatusSheet() {
             </InfoCard>
           </RowSubGroup>
         </RowGroup>
-      </View>
-    </ActionSheet>
+      </ScrollView>
+    </ModalSheet>
   )
 }
 
 const styles = StyleSheet.create({
-  sheetContent: {
-    paddingTop: 16,
-    paddingBottom: 48,
+  scrollContent: {
     paddingHorizontal: 12,
-  },
-  sheetInnerDark: {
+    paddingBottom: 48,
     gap: 14,
   },
   groupSpacing: { marginTop: 8 },

--- a/src/components/LogView.tsx
+++ b/src/components/LogView.tsx
@@ -16,23 +16,25 @@ import { palette } from '../styles/colors'
 
 type LogViewProps = {
   isFollowing?: boolean
-  onLogCountChange?: (count: number) => void
+  onTotalCountChange?: (count: number) => void
   onScrollAwayFromBottom?: () => void
 }
 
 export function LogView({
   isFollowing,
-  onLogCountChange,
+  onTotalCountChange,
   onScrollAwayFromBottom,
 }: LogViewProps) {
-  const { data: logs = [], isLoading, error } = useLogs()
+  const { data, isLoading, error } = useLogs()
+  const logs = data?.entries ?? []
+  const totalCount = data?.totalCount ?? 0
   const flatListRef = useRef<FlatList<LogEntry>>(null)
 
-  const logCount = logs.length
   useEffect(() => {
-    onLogCountChange?.(logCount)
-  }, [logCount, onLogCountChange])
+    onTotalCountChange?.(totalCount)
+  }, [totalCount, onTotalCountChange])
 
+  const logCount = logs.length
   useEffect(() => {
     if (isFollowing && logCount > 0) {
       flatListRef.current?.scrollToOffset({ offset: 0, animated: false })

--- a/src/components/ModalSheet.tsx
+++ b/src/components/ModalSheet.tsx
@@ -1,0 +1,94 @@
+import type { ReactNode } from 'react'
+import {
+  Modal,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { colors, palette } from '../styles/colors'
+
+type Props = {
+  visible: boolean
+  onRequestClose: () => void
+  title: string
+  headerRight?: ReactNode
+  children: ReactNode
+}
+
+export function ModalSheet({
+  visible,
+  onRequestClose,
+  title,
+  headerRight,
+  children,
+}: Props) {
+  const insets = useSafeAreaInsets()
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onRequestClose}
+    >
+      <View style={styles.container}>
+        <View
+          style={[
+            styles.header,
+            {
+              paddingTop:
+                Platform.OS === 'android' ? Math.max(20, insets.top) : 20,
+            },
+          ]}
+        >
+          <Text style={styles.title}>{title}</Text>
+          <View style={styles.headerRight}>
+            {headerRight ?? (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Done"
+                onPress={onRequestClose}
+                hitSlop={8}
+              >
+                <Text style={styles.doneText}>Done</Text>
+              </Pressable>
+            )}
+          </View>
+        </View>
+        {children}
+      </View>
+    </Modal>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.bgCanvas,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingBottom: 12,
+  },
+  headerRight: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 16,
+  },
+  title: {
+    color: palette.gray[50],
+    fontSize: 17,
+    fontWeight: '700',
+  },
+  doneText: {
+    color: palette.blue[400],
+    fontSize: 17,
+    fontWeight: '600',
+  },
+})

--- a/src/components/SettingsLogsControlBar.tsx
+++ b/src/components/SettingsLogsControlBar.tsx
@@ -8,7 +8,14 @@ import {
   Trash2Icon,
 } from 'lucide-react-native'
 import { useCallback, useMemo, useState } from 'react'
-import { Alert, Pressable, StyleSheet, Text, View } from 'react-native'
+import {
+  Alert,
+  FlatList,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native'
 import { logsSwr } from '../hooks/useLogs'
 import { exportLogs } from '../lib/exportLogs'
 import { type LogLevel, logger } from '../lib/logger'
@@ -26,9 +33,10 @@ import {
   useLogsStore,
 } from '../stores/logs'
 import { closeSheet, openSheet, useSheetOpen } from '../stores/sheets'
-import { palette } from '../styles/colors'
+import { palette, whiteA } from '../styles/colors'
 import { ActionSheet } from './ActionSheet'
 import { BottomControlBar, iconColors } from './BottomControlBar'
+import { ModalSheet } from './ModalSheet'
 import { type OverflowAction, OverflowActions } from './OverflowActions'
 import { SpinnerIcon } from './SpinnerIcon'
 
@@ -39,7 +47,7 @@ const LOG_LEVELS: LogLevel[] = ['debug', 'info', 'warn', 'error']
 export function SettingsLogsControlBar({ navigation }: Props) {
   const logLevel = useLogLevel()
   const logScopes = useLogScopes()
-  const availableScopes = useAvailableScopes()
+  const { data: availableScopes = [] } = useAvailableScopes()
   const levelSheetOpen = useSheetOpen('logLevel')
   const scopeSheetOpen = useSheetOpen('logScopes')
   const toast = useToast()
@@ -234,51 +242,53 @@ export function SettingsLogsControlBar({ navigation }: Props) {
         ))}
       </ActionSheet>
 
-      <ActionSheet
+      <ModalSheet
         visible={scopeSheetOpen}
         onRequestClose={closeSheet}
-        snapPoints={['70%']}
-      >
-        <View
-          style={{
-            flexDirection: 'row',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            marginBottom: 12,
-          }}
-        >
-          <Text style={styles.sheetTitle}>Scopes</Text>
-          {logScopes.length > 0 && (
-            <Pressable onPress={handleClearScopes}>
-              <Text style={styles.clearButton}>Clear</Text>
+        title="Scopes"
+        headerRight={
+          <>
+            {logScopes.length > 0 && (
+              <Pressable onPress={handleClearScopes} hitSlop={8}>
+                <Text style={styles.clearButton}>Clear</Text>
+              </Pressable>
+            )}
+            <Pressable onPress={() => closeSheet()} hitSlop={8}>
+              <Text style={styles.doneText}>Done</Text>
             </Pressable>
-          )}
-        </View>
+          </>
+        }
+      >
         {availableScopes.length === 0 ? (
           <Text style={styles.emptyText}>No scopes available yet</Text>
         ) : (
-          availableScopes.map((scope) => {
-            const isSelected = logScopes.includes(scope)
-            return (
-              <Pressable
-                key={scope}
-                style={styles.sheetRow}
-                onPress={() => handleScopeToggle(scope)}
-              >
-                <Text
-                  style={[
-                    styles.sheetRowText,
-                    isSelected && styles.sheetRowTextSelected,
-                  ]}
+          <FlatList
+            data={availableScopes}
+            keyExtractor={(item) => item}
+            keyboardShouldPersistTaps="handled"
+            contentContainerStyle={styles.scopeListContent}
+            renderItem={({ item: scope }) => {
+              const isSelected = logScopes.includes(scope)
+              return (
+                <Pressable
+                  style={styles.scopeRow}
+                  onPress={() => handleScopeToggle(scope)}
                 >
-                  {scope}
-                </Text>
-                {isSelected && <Text style={styles.sheetRowCheck}>✓</Text>}
-              </Pressable>
-            )
-          })
+                  <Text
+                    style={[
+                      styles.scopeRowText,
+                      isSelected && styles.scopeRowTextSelected,
+                    ]}
+                  >
+                    {scope}
+                  </Text>
+                  {isSelected && <Text style={styles.scopeRowCheck}>✓</Text>}
+                </Pressable>
+              )
+            }}
+          />
         )}
-      </ActionSheet>
+      </ModalSheet>
     </>
   )
 }
@@ -328,10 +338,40 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
   },
+  doneText: {
+    color: palette.blue[400],
+    fontSize: 17,
+    fontWeight: '600',
+  },
   emptyText: {
     color: palette.gray[400],
     fontSize: 14,
     textAlign: 'center',
     marginTop: 20,
+  },
+  scopeListContent: {
+    paddingBottom: 40,
+  },
+  scopeRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: whiteA.a08,
+  },
+  scopeRowText: {
+    color: palette.gray[200],
+    fontSize: 16,
+  },
+  scopeRowTextSelected: {
+    color: palette.gray[50],
+    fontWeight: '600',
+  },
+  scopeRowCheck: {
+    color: palette.blue[400],
+    fontSize: 18,
+    fontWeight: '600',
   },
 })

--- a/src/hooks/useLogs.ts
+++ b/src/hooks/useLogs.ts
@@ -1,4 +1,5 @@
 import useSWR from 'swr'
+import type { LogEntry } from '../lib/logger'
 import { buildSWRHelpers } from '../lib/swr'
 import { countLogs, readLogs, useLogLevel, useLogScopes } from '../stores/logs'
 
@@ -8,9 +9,15 @@ export function useLogs() {
   const logLevel = useLogLevel()
   const logScopes = useLogScopes()
 
-  return useSWR(
+  return useSWR<{ entries: LogEntry[]; totalCount: number }>(
     logsSwr.getKey(`${logLevel},${logScopes.join(',')}`),
-    () => readLogs(logLevel, logScopes),
+    async () => {
+      const [entries, totalCount] = await Promise.all([
+        readLogs(logLevel, logScopes),
+        countLogs(logLevel, logScopes),
+      ])
+      return { entries, totalCount }
+    },
     {
       revalidateOnFocus: false,
       revalidateOnReconnect: false,
@@ -19,7 +26,7 @@ export function useLogs() {
 }
 
 /** Returns true if there are new logs available for the current filter. */
-export function useHasNewLogs(displayedCount: number): boolean {
+export function useHasNewLogs(lastFetchedCount: number): boolean {
   const logLevel = useLogLevel()
   const logScopes = useLogScopes()
 
@@ -33,5 +40,5 @@ export function useHasNewLogs(displayedCount: number): boolean {
     },
   )
 
-  return dbCount > displayedCount
+  return dbCount > lastFetchedCount
 }

--- a/src/screens/SettingsLogsScreen.tsx
+++ b/src/screens/SettingsLogsScreen.tsx
@@ -14,9 +14,9 @@ type Props = NativeStackScreenProps<MenuStackParamList, 'Logs'>
 
 export function SettingsLogsScreen({ route, navigation }: Props) {
   useMenuHeader()
-  const [displayedCount, setDisplayedCount] = useState(0)
+  const [lastFetchedCount, setLastFetchedCount] = useState(0)
   const [isFollowing, setIsFollowing] = useState(true)
-  const hasNewLogs = useHasNewLogs(displayedCount)
+  const hasNewLogs = useHasNewLogs(lastFetchedCount)
 
   useEffect(() => {
     if (isFollowing && hasNewLogs) {
@@ -37,7 +37,7 @@ export function SettingsLogsScreen({ route, navigation }: Props) {
     <SettingsFullLayout>
       <LogView
         isFollowing={isFollowing}
-        onLogCountChange={setDisplayedCount}
+        onTotalCountChange={setLastFetchedCount}
         onScrollAwayFromBottom={handleScrollAwayFromBottom}
       />
       {!isFollowing && hasNewLogs && (

--- a/src/stores/logs.ts
+++ b/src/stores/logs.ts
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react'
 import { create } from 'zustand'
 import { useShallow } from 'zustand/react/shallow'
 import { db, dbInitialized } from '../db'
@@ -10,6 +9,8 @@ import {
   logger,
   serializeData,
 } from '../lib/logger'
+import { createGetterAndSWRHook } from '../lib/selectors'
+import { buildSWRHelpers } from '../lib/swr'
 import { getAsyncStorageString, setAsyncStorageString } from './asyncStore'
 
 export type LogsState = {
@@ -51,22 +52,25 @@ export async function initLogger(): Promise<void> {
   hasInit = true
 }
 
-// Get available scopes from log files.
-export async function getAvailableScopes(): Promise<string[]> {
-  const logs = await readLogs()
-  return extractScopes(logs)
+export const logsScopeSwr = buildSWRHelpers('logScopes')
+
+async function fetchAvailableScopes(): Promise<string[]> {
+  try {
+    if (!dbInitialized) return []
+    const rows = await db().getAllAsync<{ scope: string }>(
+      'SELECT DISTINCT scope FROM logs ORDER BY scope',
+    )
+    return rows.map((r) => r.scope)
+  } catch (error) {
+    console.error('[logs] Failed to get scopes:', error)
+    return []
+  }
 }
 
-// Hook to get available scopes (reads from files).
-export function useAvailableScopes(): string[] {
-  const [scopes, setScopes] = useState<string[]>([])
-
-  useEffect(() => {
-    getAvailableScopes().then(setScopes)
-  }, [])
-
-  return scopes
-}
+export const [getAvailableScopes, useAvailableScopes] = createGetterAndSWRHook(
+  logsScopeSwr.getKey('available'),
+  fetchAvailableScopes,
+)
 
 export function useLogLevel(): LogLevel {
   return useLogsStore(useShallow((s) => s.logLevel))
@@ -192,7 +196,7 @@ export async function readLogs(
     }
 
     const { whereClause, params } = buildLogFilterQuery(logLevel, logScopes)
-    const query = `SELECT timestamp, level, scope, message, data FROM logs ${whereClause} ORDER BY createdAt DESC, id DESC`
+    const query = `SELECT timestamp, level, scope, message, data FROM logs ${whereClause} ORDER BY createdAt DESC, id DESC LIMIT 500`
 
     const rows = await db().getAllAsync<{
       timestamp: string

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -101,3 +101,17 @@ export async function toggleLibraryViewMode() {
   const next = current === 'gallery' ? 'list' : 'gallery'
   await setLibraryViewMode(next)
 }
+
+// Status display mode (count vs size)
+
+export type StatusDisplayMode = 'count' | 'size'
+
+export const [getStatusDisplayMode, useStatusDisplayMode] =
+  createGetterAndSWRHook(settingsSwr.getKey('statusDisplayMode'), () =>
+    getAsyncStorageString<StatusDisplayMode>('statusDisplayMode', 'count'),
+  )
+
+export async function setStatusDisplayMode(value: StatusDisplayMode) {
+  await setAsyncStorageString<StatusDisplayMode>('statusDisplayMode', value)
+  settingsSwr.triggerChange('statusDisplayMode')
+}


### PR DESCRIPTION
- Switched upload stats and log scopes sheets to native iOS page sheet modals. The other sheet has some issues when the content is taller than the screen.
- Refined log viewer with faster scopes query, limited log fetch to 500 entries, and improved new log detection.