### PR TITLE
fix: remove LIMIT from readLogs used by copy and export

### DIFF
--- a/.changeset/fix-copy-logs-limit.md
+++ b/.changeset/fix-copy-logs-limit.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fixed copy and export logs not including all log entries.

--- a/src/hooks/useLogs.ts
+++ b/src/hooks/useLogs.ts
@@ -13,7 +13,7 @@ export function useLogs() {
     logsSwr.getKey(`${logLevel},${logScopes.join(',')}`),
     async () => {
       const [entries, totalCount] = await Promise.all([
-        readLogs(logLevel, logScopes),
+        readLogs(logLevel, logScopes, 500),
         countLogs(logLevel, logScopes),
       ])
       return { entries, totalCount }

--- a/src/stores/logs.ts
+++ b/src/stores/logs.ts
@@ -189,6 +189,7 @@ function buildLogFilterQuery(
 export async function readLogs(
   logLevel?: LogLevel,
   logScopes?: string[],
+  limit?: number,
 ): Promise<LogEntry[]> {
   try {
     if (!dbInitialized) {
@@ -196,7 +197,8 @@ export async function readLogs(
     }
 
     const { whereClause, params } = buildLogFilterQuery(logLevel, logScopes)
-    const query = `SELECT timestamp, level, scope, message, data FROM logs ${whereClause} ORDER BY createdAt DESC, id DESC LIMIT 500`
+    const limitClause = limit ? ` LIMIT ${limit}` : ''
+    const query = `SELECT timestamp, level, scope, message, data FROM logs ${whereClause} ORDER BY createdAt DESC, id DESC${limitClause}`
 
     const rows = await db().getAllAsync<{
       timestamp: string


### PR DESCRIPTION
- Recent log screen optimizations mean the export is clipping at 500.