### PR TITLE
fix: pass Google Maps API key in Android release build and add error boundary

### DIFF
--- a/.changeset/add-error-boundary.md
+++ b/.changeset/add-error-boundary.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Added error boundary and global error logging to catch and log unexpected crashes.

--- a/.changeset/fix-android-maps-api-key.md
+++ b/.changeset/fix-android-maps-api-key.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fixed Android crash caused by missing Google Maps API key in CI release builds.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,7 @@ jobs:
           SIA_RELEASE_KEY_ALIAS: ${{ secrets.SIA_RELEASE_KEY_ALIAS }}
           SIA_RELEASE_KEY_PASSWORD: ${{ secrets.SIA_RELEASE_KEY_PASSWORD }}
           GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_JSON }}
+          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
           CI: true
         run: bun scripts/releaseAndroid.ts ${{ inputs.track || 'internal' }}
         shell: bash

--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,11 @@
 import { registerRootComponent } from 'expo'
 import './polyfills'
 import { initSia, setLogger } from 'react-native-sia'
+import { installGlobalErrorHandler } from './src/lib/globalErrorHandler'
 import { logger, rustLogger } from './src/lib/logger'
 import { Root } from './src/Root'
+
+installGlobalErrorHandler()
 
 logger.info('app', 'initSia and uniffi...')
 

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -18,6 +18,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context'
 import { AppSplash } from './components/AppSplash'
 import { AuthWebViewModal } from './components/AuthWebViewModal'
+import { ErrorBoundary } from './components/ErrorBoundary'
 import { ShareIntentConsumer } from './components/ShareIntentConsumer'
 import useLinkedURL from './hooks/useLinkedURL'
 import { useReconnectIndexer } from './hooks/useReconnectIndexer'
@@ -102,37 +103,39 @@ export function Root() {
 
   return (
     <GestureHandlerRootView style={styles.gestureRoot}>
-      <SafeAreaProvider>
-        <ToastProvider>
-          <SafeAreaView style={styles.safe} edges={['left', 'right']}>
-            <StatusBar
-              barStyle={Platform.select({
-                ios: 'light-content',
-                android: 'light-content',
-                default: 'light-content',
-              })}
-            />
-            <ShareIntentProvider>
-              <BottomSheetModalProvider>
-                {showSplash ? (
-                  <AppSplash />
-                ) : (
-                  <>
-                    <ShareIntentConsumer />
-                    <NavigationContainer
-                      ref={navigationRef}
-                      theme={darkNavigationTheme}
-                    >
-                      <RootTabs />
-                    </NavigationContainer>
-                  </>
-                )}
-              </BottomSheetModalProvider>
-              <AuthWebViewModal />
-            </ShareIntentProvider>
-          </SafeAreaView>
-        </ToastProvider>
-      </SafeAreaProvider>
+      <ErrorBoundary>
+        <SafeAreaProvider>
+          <ToastProvider>
+            <SafeAreaView style={styles.safe} edges={['left', 'right']}>
+              <StatusBar
+                barStyle={Platform.select({
+                  ios: 'light-content',
+                  android: 'light-content',
+                  default: 'light-content',
+                })}
+              />
+              <ShareIntentProvider>
+                <BottomSheetModalProvider>
+                  {showSplash ? (
+                    <AppSplash />
+                  ) : (
+                    <>
+                      <ShareIntentConsumer />
+                      <NavigationContainer
+                        ref={navigationRef}
+                        theme={darkNavigationTheme}
+                      >
+                        <RootTabs />
+                      </NavigationContainer>
+                    </>
+                  )}
+                </BottomSheetModalProvider>
+                <AuthWebViewModal />
+              </ShareIntentProvider>
+            </SafeAreaView>
+          </ToastProvider>
+        </SafeAreaProvider>
+      </ErrorBoundary>
     </GestureHandlerRootView>
   )
 }

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,128 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react'
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native'
+import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context'
+import { logger } from '../lib/logger'
+import { colors, palette, whiteA } from '../styles/colors'
+
+const MAX_DETAIL_LENGTH = 2000
+
+type Props = {
+  children: ReactNode
+}
+
+type State = {
+  error: Error | null
+}
+
+// Error boundaries require class components — there is no hook equivalent.
+// https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    logger.error('errorBoundary', 'uncaught_render_error', {
+      error,
+      componentStack: info.componentStack ?? undefined,
+    })
+  }
+
+  handleRetry = () => {
+    this.setState({ error: null })
+  }
+
+  render() {
+    const { error } = this.state
+    if (!error) return this.props.children
+
+    const detail = `${error.message}\n\n${error.stack ?? ''}`.slice(
+      0,
+      MAX_DETAIL_LENGTH,
+    )
+
+    return (
+      <SafeAreaProvider>
+        <SafeAreaView style={styles.container}>
+          <View style={styles.content}>
+            <Text style={styles.title}>Something went wrong</Text>
+            <Text style={styles.subtitle}>
+              The app encountered an unexpected error.
+            </Text>
+            <ScrollView
+              style={styles.detailScroll}
+              contentContainerStyle={styles.detailContent}
+            >
+              <Text style={styles.detailText} selectable>
+                {detail}
+              </Text>
+            </ScrollView>
+            <Pressable
+              style={styles.button}
+              onPress={this.handleRetry}
+              accessibilityRole="button"
+            >
+              <Text style={styles.buttonText}>Try again</Text>
+            </Pressable>
+          </View>
+        </SafeAreaView>
+      </SafeAreaProvider>
+    )
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.bgCanvas,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 24,
+  },
+  content: {
+    maxWidth: 400,
+    maxHeight: '80%',
+    width: '100%',
+    alignItems: 'center',
+    gap: 12,
+  },
+  title: {
+    color: palette.gray[100],
+    fontSize: 18,
+    fontWeight: '800',
+  },
+  subtitle: {
+    color: whiteA.a70,
+    fontSize: 14,
+    textAlign: 'center',
+    marginBottom: 4,
+  },
+  detailScroll: {
+    maxHeight: 300,
+    width: '100%',
+    backgroundColor: palette.gray[900],
+    borderRadius: 8,
+  },
+  detailContent: {
+    padding: 12,
+  },
+  detailText: {
+    color: palette.gray[400],
+    fontSize: 12,
+    fontFamily: 'monospace',
+  },
+  button: {
+    backgroundColor: colors.accentPrimary,
+    borderRadius: 10,
+    paddingVertical: 12,
+    paddingHorizontal: 32,
+    alignItems: 'center',
+    marginTop: 4,
+  },
+  buttonText: {
+    color: palette.gray[50],
+    fontWeight: '700',
+  },
+})

--- a/src/lib/globalErrorHandler.ts
+++ b/src/lib/globalErrorHandler.ts
@@ -1,0 +1,24 @@
+import { logger } from './logger'
+
+declare const ErrorUtils: {
+  getGlobalHandler(): (error: Error, isFatal?: boolean) => void
+  setGlobalHandler(handler: (error: Error, isFatal?: boolean) => void): void
+}
+
+let installed = false
+
+export function installGlobalErrorHandler() {
+  if (installed) return
+  if (typeof ErrorUtils === 'undefined') return
+  installed = true
+
+  const defaultHandler = ErrorUtils.getGlobalHandler()
+
+  ErrorUtils.setGlobalHandler((error, isFatal) => {
+    logger.error('app', 'uncaught_js_error', {
+      error,
+      isFatal: isFatal ?? false,
+    })
+    defaultHandler(error, isFatal)
+  })
+}


### PR DESCRIPTION
- The release workflow was missing the GOOGLE_MAPS_API_KEY env var for the Android build step, causing the Maps SDK to crash with an IllegalStateException when opening the viewer with map component.
- Also adds a root-level ErrorBoundary that catches React render errors with a recovery UI, and a global JS error handler that logs uncaught exceptions.