### PR TITLE
feat: refine photo sync architecture

### DIFF
--- a/.changeset/archive-sync-ui.md
+++ b/.changeset/archive-sync-ui.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Updated archive sync settings UI to show progress date from displayDate instead of numeric cursor.

--- a/.changeset/two-worker-photo-sync.md
+++ b/.changeset/two-worker-photo-sync.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Fixed photo sync missing photos without EXIF creation timestamps by switching to modificationTime sorting, and added periodic background re-scans to catch cross-device synced photos arriving with old timestamps.

--- a/src/components/SettingsSyncPhotos.tsx
+++ b/src/components/SettingsSyncPhotos.tsx
@@ -12,6 +12,7 @@ import {
   toggleAutoSyncPhotosArchive,
   useAutoSyncPhotosArchive,
   usePhotosArchiveCursor,
+  usePhotosArchiveDisplayDate,
 } from '../managers/syncPhotosArchive'
 import { useFileStatsLocal } from '../stores/files'
 import {
@@ -30,14 +31,15 @@ export function SettingsSyncPhotos() {
   const autoSyncNew = useAutoSyncNewPhotos()
   const autoSyncPhotosArchive = useAutoSyncPhotosArchive()
   const photosArchiveCursor = usePhotosArchiveCursor()
+  const photosArchiveDisplayDate = usePhotosArchiveDisplayDate()
   const localOnlyStats = useFileStatsLocal({ localOnly: true })
-  const cursorValue = photosArchiveCursor.data ?? 0
-  const photosArchiveInProgress = cursorValue > 0
+  const cursorValue = photosArchiveCursor.data ?? 'done'
+  const photosArchiveInProgress = cursorValue !== 'done'
   const { isSomeAccess, accessLabel, color } = useMediaLibraryPermissions()
   const photoImportDir = usePhotoImportDirectory()
 
   const isPhotosAccessDisabled = !isSomeAccess
-  const archiveDateLabel = formatArchiveCursor(cursorValue)
+  const archiveDateLabel = formatDisplayDate(photosArchiveDisplayDate.data ?? 0)
   const syncPhotosArchiveControlsDisabled =
     isPhotosAccessDisabled || !autoSyncPhotosArchive.data
 
@@ -108,24 +110,22 @@ export function SettingsSyncPhotos() {
           }
         />
       </InfoCard>
-      {photosArchiveCursor.data && photosArchiveCursor.data > 0
-        ? archiveDateLabel && (
-            <Text
-              style={[
-                styles.info,
-                syncPhotosArchiveControlsDisabled
-                  ? styles.infoDisabled
-                  : undefined,
-              ]}
-            >{`Currently synced back to: ${archiveDateLabel} ${
-              !autoSyncPhotosArchive.data
-                ? '(paused)'
-                : photosArchiveInProgress
-                  ? '(in progress)'
-                  : ''
-            }`}</Text>
-          )
-        : null}
+      {photosArchiveInProgress ? (
+        <Text
+          style={[
+            styles.info,
+            syncPhotosArchiveControlsDisabled ? styles.infoDisabled : undefined,
+          ]}
+        >
+          {archiveDateLabel
+            ? `Currently synced back to: ${archiveDateLabel} ${
+                !autoSyncPhotosArchive.data ? '(paused)' : '(in progress)'
+              }`
+            : `Archive sync ${
+                !autoSyncPhotosArchive.data ? '(paused)' : '(in progress)'
+              }`}
+        </Text>
+      ) : null}
       {autoSyncPhotosArchive.data &&
       photosArchiveInProgress &&
       (localOnlyStats.data?.totalBytes ?? 0) >=
@@ -141,7 +141,7 @@ export function SettingsSyncPhotos() {
           void restartPhotosArchiveCursor()
         }}
       >
-        {photosArchiveCursor.data && photosArchiveCursor.data > 0
+        {photosArchiveInProgress
           ? 'Restart archive sync'
           : 'Start archive sync'}
       </Button>
@@ -162,11 +162,9 @@ const styles = StyleSheet.create({
   },
 })
 
-function formatArchiveCursor(value: number): string | null {
-  // Always show a date; if value is not set or <= 0, use current time.
-  const ts = Number.isFinite(value) && value > 0 ? value : Date.now()
-  if (!Number.isFinite(ts)) return null
-  const d = new Date(ts)
+function formatDisplayDate(displayDate: number): string | null {
+  if (displayDate <= 0) return null
+  const d = new Date(displayDate)
   if (Number.isNaN(d.getTime())) return null
   try {
     return new Intl.DateTimeFormat(undefined, {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -35,11 +35,15 @@ export const PACKER_POLL_INTERVAL = secondsInMs(5) // 5 seconds
 // Sync events interval.
 export const SYNC_EVENTS_INTERVAL = secondsInMs(10) // 10 seconds
 // Sync new photos interval.
-export const SYNC_NEW_PHOTOS_INTERVAL = secondsInMs(5) // 5 seconds
+export const SYNC_NEW_PHOTOS_INTERVAL = secondsInMs(10) // 10 seconds
 // Sync archive photos interval.
 export const SYNC_PHOTOS_ARCHIVE_INTERVAL = secondsInMs(5) // 5 seconds
 // Resume fetching archive photos when pending local-only bytes drop below this threshold.
 export const SYNC_ARCHIVE_RESUME_THRESHOLD = 4 * SLAB_SIZE
+// Minimum interval between bounded recent re-scans of the archive.
+export const SYNC_ARCHIVE_RECENT_SCAN_INTERVAL = minutesInMs(180) // 3 hours
+// How far back the bounded recent re-scan walks.
+export const SYNC_ARCHIVE_RECENT_SCAN_LOOKBACK = daysInMs(14) // 14 days
 // Thumbnail scanner interval.
 export const THUMBNAIL_SCANNER_INTERVAL = secondsInMs(5) // 5 seconds
 // Maximum number of bytes to retain in the local file system before evicting.

--- a/src/db/migrations/0003_logs_data_column.ts
+++ b/src/db/migrations/0003_logs_data_column.ts
@@ -2,7 +2,12 @@ import type * as SQLite from 'expo-sqlite'
 import type { Migration } from './types'
 
 async function up(db: SQLite.SQLiteDatabase): Promise<void> {
-  await db.execAsync('ALTER TABLE logs ADD COLUMN data TEXT;')
+  const cols = await db.getAllAsync<{ name: string }>(
+    `SELECT name FROM pragma_table_info('logs') WHERE name='data'`,
+  )
+  if (cols.length === 0) {
+    await db.execAsync('ALTER TABLE logs ADD COLUMN data TEXT;')
+  }
 }
 
 export const migration_0003_logs_data_column: Migration = {

--- a/src/db/migrations/0006_add_tags_and_directories.ts
+++ b/src/db/migrations/0006_add_tags_and_directories.ts
@@ -45,10 +45,17 @@ async function up(db: SQLite.SQLiteDatabase): Promise<void> {
       );`,
     )
 
-    // Add directoryId column to files table.
-    await db.execAsync(
-      `ALTER TABLE files ADD COLUMN directoryId TEXT REFERENCES directories(id) ON DELETE SET NULL;`,
+    // Add directoryId column to files table (idempotent: ALTER TABLE ADD COLUMN
+    // is not transactional in SQLite, so the column may already exist from a
+    // previously failed run).
+    const cols = await db.getAllAsync<{ name: string }>(
+      `SELECT name FROM pragma_table_info('files') WHERE name='directoryId'`,
     )
+    if (cols.length === 0) {
+      await db.execAsync(
+        `ALTER TABLE files ADD COLUMN directoryId TEXT REFERENCES directories(id) ON DELETE SET NULL;`,
+      )
+    }
 
     // Index for looking up files by directory.
     await db.execAsync(

--- a/src/managers/app.ts
+++ b/src/managers/app.ts
@@ -26,7 +26,10 @@ import { initLogRotation } from './logRotation'
 import { initPerfMonitor } from './perfMonitor'
 import { initSyncDownEvents, resetSyncDownCursor } from './syncDownEvents'
 import { initSyncNewPhotos } from './syncNewPhotos'
-import { initSyncPhotosArchive } from './syncPhotosArchive'
+import {
+  initSyncPhotosArchive,
+  resetPhotosArchiveCursor,
+} from './syncPhotosArchive'
 import { initSyncUpMetadata, resetSyncUpCursor } from './syncUpMetadata'
 import { initThumbnailScanner } from './thumbnailScanner'
 import { getUploadManager } from './uploader'
@@ -113,9 +116,10 @@ export async function initApp(): Promise<void> {
     },
   })
 
-  await runSteps(steps)
-
-  endInitState()
+  const success = await runSteps(steps)
+  if (success) {
+    endInitState()
+  }
 }
 
 async function cancelAllTransfers() {
@@ -142,7 +146,7 @@ export async function resetApp() {
   // 2. Stop all service intervals and wait for in-flight workers to finish.
   await shutdownAllServiceIntervals()
 
-  await runSteps([
+  const success = await runSteps([
     {
       id: 'reset',
       label: 'Resetting application',
@@ -162,13 +166,20 @@ export async function resetApp() {
         // 6. Reset all in-memory state (zustand stores).
         resetAllStores()
 
-        // 7. Clear SWR cache (must come after store resets to avoid races).
+        // 7. Reset cursor caches.
+        await resetPhotosArchiveCursor()
+
+        // 8. Clear SWR cache (must come after store resets to avoid races).
         await mutate(() => true, undefined, { revalidate: false })
       },
     },
   ])
 
-  // 8. Re-initialize the app from clean state.
+  if (!success) {
+    return
+  }
+
+  // 9. Re-initialize the app from clean state.
   await initApp()
 }
 
@@ -244,7 +255,7 @@ type StepDefinition = {
   runner: (updateMessage: (message: string) => void) => Promise<void>
 }
 
-async function runSteps(steps: StepDefinition[]): Promise<void> {
+async function runSteps(steps: StepDefinition[]): Promise<boolean> {
   for (const stepDef of steps) {
     nextInitStep({
       id: stepDef.id,
@@ -265,7 +276,8 @@ async function runSteps(steps: StepDefinition[]): Promise<void> {
       const message = error instanceof Error ? error.message : String(error)
       updateMessage(message)
       setAppState((state) => ({ ...state, initializationError: message }))
-      return // Stop execution on error
+      return false
     }
   }
+  return true
 }

--- a/src/managers/backgroundTasks.test.ts
+++ b/src/managers/backgroundTasks.test.ts
@@ -71,6 +71,10 @@ jest.mock('./fsOrphanScanner', () => ({
   runFsOrphanScanner: () => mockRunFsOrphanScanner(),
 }))
 
+jest.mock('./syncPhotosArchive', () => ({
+  triggerRecentScanIfNeeded: jest.fn(() => Promise.resolve(false)),
+}))
+
 jest.mock('./uploader', () => ({
   getUploadManager: jest.fn(() => ({
     packedCount: 0,

--- a/src/managers/backgroundTasks.ts
+++ b/src/managers/backgroundTasks.ts
@@ -11,6 +11,7 @@ import { getIsConnected } from '../stores/sdk'
 import { getHasOnboarded } from '../stores/settings'
 import { runFsEvictionScanner } from './fsEvictionScanner'
 import { runFsOrphanScanner } from './fsOrphanScanner'
+import { triggerRecentScanIfNeeded } from './syncPhotosArchive'
 import { getUploadManager } from './uploader'
 
 /**
@@ -90,6 +91,10 @@ const taskStates: Record<TaskId, TaskState> = {
     invocationId: '',
     abort: undefined,
   },
+}
+
+export function getIsBackgroundTaskRunning(): boolean {
+  return Object.values(taskStates).some((s) => s.status === 'running')
 }
 
 function createFreshTaskState(): TaskState {
@@ -280,6 +285,7 @@ async function runBackgroundWork(config: TaskConfig, state: TaskState) {
 
   await runFsOrphanScanner()
   await runFsEvictionScanner()
+  await triggerRecentScanIfNeeded()
 
   const manager = getUploadManager()
   const initialStats = await getFileStatsLocal({ localOnly: true })

--- a/src/managers/syncNewPhotos.test.ts
+++ b/src/managers/syncNewPhotos.test.ts
@@ -1,15 +1,23 @@
 import * as MediaLibrary from 'expo-media-library'
 import { SYNC_NEW_PHOTOS_INTERVAL } from '../config'
-import { ensureMediaLibraryPermission } from '../lib/mediaLibraryPermissions'
 import { processAssets } from '../lib/processAssets'
 import { shutdownAllServiceIntervals } from '../lib/serviceInterval'
-import { initSyncNewPhotos, setAutoSyncNewPhotos } from './syncNewPhotos'
+import { getAsyncStorageNumber } from '../stores/asyncStore'
+import {
+  initSyncNewPhotos,
+  setAutoSyncNewPhotos,
+  setSyncNewPhotosEnabledAt,
+  workNew,
+} from './syncNewPhotos'
 
 jest.useFakeTimers()
 
 jest.mock('expo-media-library', () => ({
   getAssetsAsync: jest.fn(),
-  SortBy: { creationTime: 'creationTime' },
+  SortBy: {
+    creationTime: 'creationTime',
+    modificationTime: 'modificationTime',
+  },
   MediaType: { photo: 'photo', video: 'video' },
 }))
 jest.mock('../lib/mediaLibraryPermissions', () => ({
@@ -29,23 +37,21 @@ jest.mock('../stores/librarySwr', () => ({
   invalidateCacheLibraryLists: jest.fn(),
 }))
 
-async function runTick() {
-  await jest.advanceTimersByTimeAsync(SYNC_NEW_PHOTOS_INTERVAL)
-}
+const getAssetsAsyncMock = jest.mocked(MediaLibrary.getAssetsAsync)
+const processAssetsMock = jest.mocked(processAssets)
 
-function getTime(t: number | Date | undefined): number {
-  if (!t) return 0
-  return typeof t === 'number' ? t : t.getTime()
-}
-
-function asset(id: string, name: string, time: number): MediaLibrary.Asset {
+function asset(
+  id: string,
+  name: string,
+  opts: { creationTime?: number; modificationTime?: number },
+): MediaLibrary.Asset {
   return {
     id,
     filename: name,
     uri: `file://${id}`,
     mediaType: MediaLibrary.MediaType.photo,
-    creationTime: time,
-    modificationTime: time,
+    creationTime: opts.creationTime ?? 0,
+    modificationTime: opts.modificationTime ?? 0,
     width: 1,
     height: 1,
     duration: 0,
@@ -53,67 +59,124 @@ function asset(id: string, name: string, time: number): MediaLibrary.Asset {
 }
 
 function page(
-  a: MediaLibrary.Asset[],
+  assets: MediaLibrary.Asset[],
+  endCursor = '',
 ): MediaLibrary.PagedInfo<MediaLibrary.Asset> {
   return {
-    assets: a,
-    endCursor: '',
+    assets,
+    endCursor,
     hasNextPage: false,
-    totalCount: a.length,
+    totalCount: assets.length,
   }
 }
 
+function mockProcessAssetsSuccess() {
+  processAssetsMock.mockResolvedValue({
+    files: [{ id: '1' }] as never,
+    updatedFiles: [],
+    warnings: [],
+  })
+}
+
 describe('syncNewPhotos', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     jest.clearAllMocks()
+    getAssetsAsyncMock.mockReset()
+    await setSyncNewPhotosEnabledAt(0)
+    mockProcessAssetsSuccess()
   })
 
-  it('iterates forward adding all new files', async () => {
-    const ensureMediaLibraryPermissionMock = jest.mocked(
-      ensureMediaLibraryPermission,
+  it('sorts by modificationTime DESC', async () => {
+    getAssetsAsyncMock.mockResolvedValueOnce(
+      page([asset('a1', '1.jpg', { modificationTime: 5_000 })]),
     )
-    const getAssetsAsyncMock = jest.mocked(MediaLibrary.getAssetsAsync)
-    const processAssetsMock = jest.mocked(processAssets)
+    await workNew()
+    expect(getAssetsAsyncMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sortBy: [['modificationTime', false]],
+      }),
+    )
+  })
 
-    ensureMediaLibraryPermissionMock.mockResolvedValue(true)
+  it('does not pass createdBefore or createdAfter', async () => {
+    getAssetsAsyncMock.mockResolvedValueOnce(
+      page([asset('a1', '1.jpg', { modificationTime: 5_000 })]),
+    )
+    await workNew()
+    const opts = getAssetsAsyncMock.mock.calls[0][0]
+    expect(opts).not.toHaveProperty('createdAfter')
+    expect(opts).not.toHaveProperty('createdBefore')
+  })
+
+  it('only processes assets with modificationTime >= enabledAt', async () => {
+    await setSyncNewPhotosEnabledAt(3_000)
+    getAssetsAsyncMock.mockResolvedValueOnce(
+      page([
+        asset('a1', 'new1.jpg', { modificationTime: 5_000 }),
+        asset('a2', 'new2.jpg', { modificationTime: 4_000 }),
+        asset('a3', 'exact.jpg', { modificationTime: 3_000 }),
+        asset('a4', 'old.jpg', { modificationTime: 2_000 }),
+      ]),
+    )
+    await workNew()
+    expect(processAssetsMock).toHaveBeenCalledWith([
+      expect.objectContaining({ id: 'a1', name: 'new1.jpg' }),
+      expect.objectContaining({ id: 'a2', name: 'new2.jpg' }),
+      expect.objectContaining({ id: 'a3', name: 'exact.jpg' }),
+    ])
+  })
+
+  it('skips processing when all photos are before enabledAt', async () => {
+    await setSyncNewPhotosEnabledAt(10_000)
+    getAssetsAsyncMock.mockResolvedValueOnce(
+      page([
+        asset('a1', '1.jpg', { modificationTime: 5_000 }),
+        asset('a2', '2.jpg', { modificationTime: 3_000 }),
+      ]),
+    )
+    await workNew()
+    expect(processAssetsMock).not.toHaveBeenCalled()
+  })
+
+  it('no photos returns early without processing', async () => {
+    getAssetsAsyncMock.mockResolvedValueOnce(page([]))
+    await workNew()
+    expect(processAssetsMock).not.toHaveBeenCalled()
+  })
+
+  it('does not paginate even when page is full', async () => {
+    const fullPage = Array.from({ length: 50 }, (_, i) =>
+      asset(`a${i}`, `${i}.jpg`, { modificationTime: 10_000 - i }),
+    )
+    getAssetsAsyncMock.mockResolvedValueOnce(page(fullPage, 'cursor-page-1'))
+    await workNew()
+    expect(getAssetsAsyncMock).toHaveBeenCalledTimes(1)
+    expect(processAssetsMock).toHaveBeenCalledTimes(1)
+    expect(processAssetsMock.mock.calls[0][0]).toHaveLength(50)
+  })
+
+  it('falls back to modificationTime for timestamp when creationTime is 0', async () => {
+    getAssetsAsyncMock.mockResolvedValueOnce(
+      page([
+        asset('a1', 'downloaded.jpg', {
+          creationTime: 0,
+          modificationTime: 5_000,
+        }),
+      ]),
+    )
+    await workNew()
+    expect(processAssetsMock).toHaveBeenCalledWith([
+      expect.objectContaining({
+        timestamp: new Date(5_000).toISOString(),
+      }),
+    ])
+  })
+
+  it('setAutoSyncNewPhotos saves enablement timestamp', async () => {
+    jest.setSystemTime(new Date(1_700_000_000_000))
     await setAutoSyncNewPhotos(true)
-    getAssetsAsyncMock
-      .mockResolvedValueOnce(
-        page([asset('a1', '1.jpg', 1000), asset('a2', '2.jpg', 2000)]),
-      )
-      .mockResolvedValueOnce(page([asset('a3', '3.jpg', 2500)]))
-      .mockResolvedValueOnce(page([]))
-      .mockResolvedValueOnce(page([asset('a4', '4.jpg', 3000)]))
-
-    initSyncNewPhotos()
-    await runTick()
-    await runTick()
-    await runTick()
-    await runTick()
-
-    const opts0 = getAssetsAsyncMock.mock.calls[0][0]
-    const opts1 = getAssetsAsyncMock.mock.calls[1][0]
-    const opts2 = getAssetsAsyncMock.mock.calls[2][0]
-    const opts3 = getAssetsAsyncMock.mock.calls[3][0]
-    // createdAfter is set to current time on first init.
-    expect(getTime(opts0?.createdAfter)).toBeGreaterThan(0)
-    // First tick had two assets, two process calls.
-    expect(getTime(opts1?.createdAfter)).toBe(2001)
-    // Third tick had no assets, no further processing.
-    expect(getTime(opts2?.createdAfter)).toBe(2501)
-    // Fourth tick had one asset, one process call.
-    expect(getTime(opts3?.createdAfter)).toBe(2501)
-    expect(processAssetsMock).toHaveBeenCalledTimes(3)
-    expect(processAssetsMock).toHaveBeenNthCalledWith(1, [
-      expect.objectContaining({ id: 'a1', name: '1.jpg' }),
-      expect.objectContaining({ id: 'a2', name: '2.jpg' }),
-    ])
-    expect(processAssetsMock).toHaveBeenNthCalledWith(2, [
-      expect.objectContaining({ id: 'a3', name: '3.jpg' }),
-    ])
-    expect(processAssetsMock).toHaveBeenNthCalledWith(3, [
-      expect.objectContaining({ id: 'a4', name: '4.jpg' }),
-    ])
+    const enabledAt = await getAsyncStorageNumber('syncNewPhotosEnabledAt', 0)
+    expect(enabledAt).toBe(1_700_000_000_000)
   })
 
   it('aborts before processAssets when shutdown is called mid-tick', async () => {
@@ -136,7 +199,7 @@ describe('syncNewPhotos', () => {
     const shutdownPromise = shutdownAllServiceIntervals()
 
     // Resolve getAssetsAsync — worker will see signal.aborted and return.
-    resolveGetAssets!(page([asset('a1', '1.jpg', 1000)]))
+    resolveGetAssets!(page([asset('a1', '1.jpg', { modificationTime: 1000 })]))
     await jest.advanceTimersByTimeAsync(0)
     await shutdownPromise
 

--- a/src/managers/syncNewPhotos.ts
+++ b/src/managers/syncNewPhotos.ts
@@ -1,3 +1,25 @@
+/*
+ * syncNewPhotos — polls every 10s, fetches 1 page of 50 photos.
+ *
+ * Runs in the foreground while the user is active. Kept lightweight
+ * (small page, longer interval) to minimize jank. Only processes
+ * photos with modificationTime >= enabledAt so that historic photos
+ * don't appear unexpectedly — the archive handles the backfill.
+ * As time passes, the enabledAt floor stays fixed so the window of
+ * "new" photos grows naturally.
+ *
+ * Catches: newly taken photos and recently modified photos near the
+ * top of the sorted list. The deep historical tail and periodic
+ * re-scans for cross-device synced photos are handled by
+ * syncPhotosArchive (which runs its bounded re-scan during background
+ * tasks where heavier DB work is free).
+ *
+ * Sorts by modificationTime DESC because:
+ * - Android: DATE_TAKEN can be NULL for imported/downloaded photos,
+ *   silently excluding them from createdAfter/createdBefore queries.
+ * - iOS: creationDate can be an old EXIF date; modificationDate is the
+ *   iCloud-synced metadata timestamp (not local arrival time).
+ */
 import * as MediaLibrary from 'expo-media-library'
 import { SYNC_NEW_PHOTOS_INTERVAL } from '../config'
 import { logger } from '../lib/logger'
@@ -20,43 +42,42 @@ import {
   invalidateCacheLibraryLists,
 } from '../stores/librarySwr'
 
-const PAGE_SIZE = 200
+const PAGE_SIZE = 50
 
-async function workForward(signal: AbortSignal): Promise<void> {
+export async function workNew(signal?: AbortSignal): Promise<void> {
   logger.debug('syncNewPhotos', 'tick')
   if (!(await getMediaLibraryPermissions())) return
-  if (signal.aborted) return
-  const cursor = await getPhotosNewCursor()
+  if (signal?.aborted) return
+  const enabledAt = await getSyncNewPhotosEnabledAt()
 
   try {
     const page = await MediaLibrary.getAssetsAsync({
       first: PAGE_SIZE,
-      createdAfter: new Date(cursor),
-      // Ascending order.
-      sortBy: [[MediaLibrary.SortBy.creationTime, true]],
+      sortBy: [[MediaLibrary.SortBy.modificationTime, false]],
       mediaType: [MediaLibrary.MediaType.photo, MediaLibrary.MediaType.video],
-      // Resolve full info. For images this gets the full EXIF data and can fix the orientation.
-      resolveWithFullInfo: true,
     })
-    if (signal.aborted) return
-    if (page.assets.length === 0) {
+    if (signal?.aborted) return
+    const assets = page.assets.filter((a) => a.modificationTime >= enabledAt)
+    if (assets.length === 0) {
       logger.debug('syncNewPhotos', 'no_new_photos')
       return
     }
-    logger.info('syncNewPhotos', 'batch', { size: page.assets.length })
-    const lastAssetCreationTime =
-      page.assets[page.assets.length - 1].creationTime
-    const nextTimestamp = lastAssetCreationTime ? lastAssetCreationTime + 1 : 0
-    await setPhotosNewCursor(nextTimestamp)
-    if (signal.aborted) return
+
+    logger.info('syncNewPhotos', 'batch', {
+      assets: assets.length,
+      totalOnPage: page.assets.length,
+    })
+    if (signal?.aborted) return
     const { files } = await processAssets(
-      page.assets.map((asset) => ({
+      assets.map((asset) => ({
         id: asset.id,
         sourceUri: asset.uri,
         name: asset.filename,
         type: undefined,
         size: undefined,
-        timestamp: new Date(asset.creationTime).toISOString(),
+        timestamp: new Date(
+          asset.creationTime || asset.modificationTime,
+        ).toISOString(),
       })),
     )
     if (files.length > 0) {
@@ -64,18 +85,18 @@ async function workForward(signal: AbortSignal): Promise<void> {
       invalidateCacheLibraryLists()
     }
   } catch (e) {
-    logger.error('syncNewPhotos', 'batch_error', { error: e as Error })
+    logger.error('syncNewPhotos', 'batch_error', {
+      error: e as Error,
+    })
   }
 }
 
 export const { init: initSyncNewPhotos } = createServiceInterval({
   name: 'syncNewPhotos',
-  worker: workForward,
+  worker: workNew,
   getState: () => getAutoSyncNewPhotos(),
   interval: SYNC_NEW_PHOTOS_INTERVAL,
 })
-
-// Photos sync - new photos forward cursor and toggle.
 
 export const [
   getAutoSyncNewPhotos,
@@ -89,6 +110,7 @@ export async function setAutoSyncNewPhotos(value: boolean) {
   await setAsyncStorageBoolean('autoSyncNewPhotos', value)
   await autoSyncNewPhotosCache.set(value)
   if (value) {
+    await setSyncNewPhotosEnabledAt(Date.now())
     ensureMediaLibraryPermission()
   }
   mediaLibraryPermissionsCache.invalidate()
@@ -100,19 +122,12 @@ export async function toggleAutoSyncNewPhotos() {
   await setAutoSyncNewPhotos(next)
 }
 
-const defaultValue = Date.now()
-
-export const [getPhotosNewCursor, usePhotosNewCursor, photosNewCursorCache] =
+export const [getSyncNewPhotosEnabledAt, , syncNewPhotosEnabledAtCache] =
   createGetterAndSWRHook<number>(() =>
-    getAsyncStorageNumber('photosNewCursor', defaultValue),
+    getAsyncStorageNumber('syncNewPhotosEnabledAt', 0),
   )
 
-export async function setPhotosNewCursor(value: number) {
-  await setAsyncStorageNumber('photosNewCursor', value)
-  await photosNewCursorCache.set(value)
-}
-
-export async function resetPhotosNewCursor() {
-  logger.info('syncNewPhotos', 'cursor_reset')
-  await setPhotosNewCursor(defaultValue)
+export async function setSyncNewPhotosEnabledAt(value: number) {
+  await setAsyncStorageNumber('syncNewPhotosEnabledAt', value)
+  await syncNewPhotosEnabledAtCache.set(value)
 }

--- a/src/managers/syncPhotosArchive.test.ts
+++ b/src/managers/syncPhotosArchive.test.ts
@@ -1,26 +1,32 @@
 import * as MediaLibrary from 'expo-media-library'
-import { SYNC_PHOTOS_ARCHIVE_INTERVAL } from '../config'
-import { ensureMediaLibraryPermission } from '../lib/mediaLibraryPermissions'
+import {
+  SYNC_ARCHIVE_RECENT_SCAN_INTERVAL,
+  SYNC_ARCHIVE_RECENT_SCAN_LOOKBACK,
+} from '../config'
 import { processAssets } from '../lib/processAssets'
 import {
+  getLastRecentScanAt,
   getPhotosArchiveCursor,
-  initSyncPhotosArchive,
+  getPhotosArchiveDisplayDate,
   restartPhotosArchiveCursor,
   setAutoSyncPhotosArchive,
+  setLastRecentScanAt,
+  setPhotosArchiveCursor,
+  triggerRecentScanIfNeeded,
   workBackward,
 } from './syncPhotosArchive'
 
 jest.useFakeTimers()
 
-// Mocks
 jest.mock('expo-media-library', () => ({
-  __esModule: true,
   getAssetsAsync: jest.fn(),
-  SortBy: { creationTime: 'creationTime' },
+  SortBy: {
+    creationTime: 'creationTime',
+    modificationTime: 'modificationTime',
+  },
   MediaType: { photo: 'photo', video: 'video' },
 }))
 jest.mock('../lib/mediaLibraryPermissions', () => ({
-  __esModule: true,
   ensureMediaLibraryPermission: jest.fn(),
   getMediaLibraryPermissions: jest.fn().mockResolvedValue(true),
   mediaLibraryPermissionsCache: {
@@ -30,11 +36,9 @@ jest.mock('../lib/mediaLibraryPermissions', () => ({
   },
 }))
 jest.mock('../lib/processAssets', () => ({
-  __esModule: true,
   processAssets: jest.fn(),
 }))
 jest.mock('../stores/files', () => ({
-  __esModule: true,
   getFileStatsLocal: jest.fn().mockResolvedValue({ count: 0, totalBytes: 0 }),
 }))
 jest.mock('../stores/librarySwr', () => ({
@@ -43,18 +47,21 @@ jest.mock('../stores/librarySwr', () => ({
   invalidateCacheLibraryLists: jest.fn(),
 }))
 
-async function runTick() {
-  await jest.advanceTimersByTimeAsync(SYNC_PHOTOS_ARCHIVE_INTERVAL)
-}
+const getAssetsAsyncMock = jest.mocked(MediaLibrary.getAssetsAsync)
+const processAssetsMock = jest.mocked(processAssets)
 
-function asset(id: string, name: string, time: number): MediaLibrary.Asset {
+function asset(
+  id: string,
+  name: string,
+  opts: { creationTime?: number; modificationTime?: number },
+): MediaLibrary.Asset {
   return {
     id,
     filename: name,
     uri: `file://${id}`,
     mediaType: MediaLibrary.MediaType.photo,
-    creationTime: time,
-    modificationTime: time,
+    creationTime: opts.creationTime ?? 0,
+    modificationTime: opts.modificationTime ?? 0,
     width: 1,
     height: 1,
     duration: 0,
@@ -62,126 +69,171 @@ function asset(id: string, name: string, time: number): MediaLibrary.Asset {
 }
 
 function page(
-  a: MediaLibrary.Asset[],
+  assets: MediaLibrary.Asset[],
+  endCursor = '',
 ): MediaLibrary.PagedInfo<MediaLibrary.Asset> {
   return {
-    assets: a,
-    endCursor: '',
+    assets,
+    endCursor,
     hasNextPage: false,
-    totalCount: a.length,
+    totalCount: assets.length,
   }
 }
 
+function mockProcessAssetsSuccess() {
+  processAssetsMock.mockResolvedValue({
+    files: [{ id: '1' }] as never,
+    updatedFiles: [],
+    warnings: [],
+  })
+}
+
+const NOW = 1_700_000_000_000
+
 describe('syncPhotosArchive', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     jest.clearAllMocks()
+    jest.setSystemTime(new Date(NOW))
+    getAssetsAsyncMock.mockReset()
+    await setAutoSyncPhotosArchive(true)
+    await setLastRecentScanAt(0)
+    await restartPhotosArchiveCursor()
+    mockProcessAssetsSuccess()
   })
 
-  it('iterates backward adding files until exhausting the archive', async () => {
-    const ensureMediaLibraryPermissionMock = jest.mocked(
-      ensureMediaLibraryPermission,
+  it('sorts by modificationTime DESC', async () => {
+    await setPhotosArchiveCursor('start')
+    getAssetsAsyncMock.mockResolvedValueOnce(
+      page([asset('a1', '1.jpg', { modificationTime: 50_000 })], 'ref1'),
     )
-    const getAssetsAsyncMock = jest.mocked(MediaLibrary.getAssetsAsync)
-    const processAssetsMock = jest.mocked(processAssets)
-
-    ensureMediaLibraryPermissionMock.mockResolvedValue(true)
-    await setAutoSyncPhotosArchive(true)
-
-    getAssetsAsyncMock.mockImplementation(
-      async (
-        opts?: MediaLibrary.AssetsOptions,
-      ): Promise<MediaLibrary.PagedInfo<MediaLibrary.Asset>> => {
-        const t = opts?.createdBefore
-          ? new Date(opts.createdBefore).getTime()
-          : Number.MAX_SAFE_INTEGER
-        if (t >= 1_000_000)
-          return page([
-            asset('b1', 'one.jpg', 10_000),
-            asset('b2', 'two.jpg', 5_000),
-          ])
-        if (t >= 4_999) return page([asset('b3', 'three.jpg', 1_000)])
-        return page([])
-      },
+    await workBackward()
+    expect(getAssetsAsyncMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sortBy: [['modificationTime', false]],
+      }),
     )
+  })
 
-    processAssetsMock
-      .mockResolvedValueOnce({
-        files: [
-          {
-            id: 'b1',
-            name: 'one.jpg',
-            type: 'image/jpeg',
-            kind: 'file',
-            size: 100,
-            hash: 'hash1',
-            createdAt: 10_000,
-            updatedAt: 10_000,
-            localId: 'b1',
-            addedAt: 10_000,
-            objects: {},
-          },
-          {
-            id: 'b2',
-            name: 'two.jpg',
-            type: 'image/jpeg',
-            kind: 'file',
-            size: 100,
-            hash: 'hash2',
-            createdAt: 5_000,
-            updatedAt: 5_000,
-            localId: 'b2',
-            addedAt: 10_000,
-            objects: {},
-          },
-        ],
-        updatedFiles: [],
-        warnings: [],
-      })
-      .mockResolvedValueOnce({
-        files: [
-          {
-            id: 'b3',
-            name: 'three.jpg',
-            type: 'image/jpeg',
-            kind: 'file',
-            size: 100,
-            hash: 'hash3',
-            createdAt: 1_000,
-            updatedAt: 1_000,
-            localId: 'b3',
-            addedAt: 10_000,
-            objects: {},
-          },
-        ],
-        updatedFiles: [],
-        warnings: [],
-      })
-      .mockResolvedValueOnce({ files: [], updatedFiles: [], warnings: [] })
+  it('does not pass createdBefore or createdAfter', async () => {
+    await setPhotosArchiveCursor('start')
+    getAssetsAsyncMock.mockResolvedValueOnce(
+      page([asset('a1', '1.jpg', { modificationTime: 50_000 })], 'ref1'),
+    )
+    await workBackward()
+    const opts = getAssetsAsyncMock.mock.calls[0][0]
+    expect(opts).not.toHaveProperty('createdBefore')
+    expect(opts).not.toHaveProperty('createdAfter')
+  })
 
-    // Seed initial cursor so service is enabled.
+  it('cursor "start" fetches from beginning (no after param)', async () => {
+    await setPhotosArchiveCursor('start')
+    getAssetsAsyncMock.mockResolvedValueOnce(
+      page([asset('a1', '1.jpg', { modificationTime: 50_000 })], 'ref1'),
+    )
+    await workBackward()
+    expect(getAssetsAsyncMock.mock.calls[0][0]?.after).toBeUndefined()
+  })
+
+  it('passes endCursor as after param to resume', async () => {
+    await setPhotosArchiveCursor('some-asset-ref')
+    getAssetsAsyncMock.mockResolvedValueOnce(
+      page([asset('a1', '1.jpg', { modificationTime: 30_000 })], 'next-ref'),
+    )
+    await workBackward()
+    expect(getAssetsAsyncMock.mock.calls[0][0]?.after).toBe('some-asset-ref')
+  })
+
+  it('advances cursor to endCursor from page result', async () => {
+    await setPhotosArchiveCursor('start')
+    getAssetsAsyncMock.mockResolvedValueOnce(
+      page(
+        [
+          asset('a1', '1.jpg', { modificationTime: 90_000 }),
+          asset('a2', '2.jpg', { modificationTime: 80_000 }),
+        ],
+        'page-end-ref',
+      ),
+    )
+    await workBackward()
+    expect(await getPhotosArchiveCursor()).toBe('page-end-ref')
+  })
+
+  it('cursor "done" means fully synced — returns early', async () => {
+    await setPhotosArchiveCursor('done')
+    await workBackward()
+    expect(getAssetsAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('sets cursor to "done" when no assets remain', async () => {
+    await setPhotosArchiveCursor('some-ref')
+    getAssetsAsyncMock.mockResolvedValueOnce(page([]))
+    await workBackward()
+    expect(await getPhotosArchiveCursor()).toBe('done')
+    expect(processAssetsMock).not.toHaveBeenCalled()
+  })
+
+  it('stores displayDate from oldest modificationTime in batch', async () => {
+    await setPhotosArchiveCursor('start')
+    getAssetsAsyncMock.mockResolvedValueOnce(
+      page(
+        [
+          asset('a1', '1.jpg', { modificationTime: 90_000 }),
+          asset('a2', '2.jpg', { modificationTime: 40_000 }),
+          asset('a3', '3.jpg', { modificationTime: 70_000 }),
+        ],
+        'ref3',
+      ),
+    )
+    await workBackward()
+    expect(await getPhotosArchiveDisplayDate()).toBe(40_000)
+  })
+
+  it('restartPhotosArchiveCursor sets cursor to "start" and clears displayDate', async () => {
+    await setPhotosArchiveCursor('some-ref')
     await restartPhotosArchiveCursor()
+    expect(await getPhotosArchiveCursor()).toBe('start')
+    expect(await getPhotosArchiveDisplayDate()).toBe(0)
+  })
 
-    initSyncPhotosArchive()
-
-    // Tick 1: createdBefore 1_000_000 -> returns [10_000, 5_000], cursor -> 5_000
-    await runTick()
-    expect(processAssetsMock).toHaveBeenNthCalledWith(1, [
-      expect.objectContaining({ id: 'b1', name: 'one.jpg' }),
-      expect.objectContaining({ id: 'b2', name: 'two.jpg' }),
+  it('falls back to modificationTime for timestamp when creationTime is 0', async () => {
+    await setPhotosArchiveCursor('start')
+    getAssetsAsyncMock.mockResolvedValueOnce(
+      page(
+        [
+          asset('a1', 'downloaded.jpg', {
+            creationTime: 0,
+            modificationTime: 50_000,
+          }),
+        ],
+        'ref1',
+      ),
+    )
+    await workBackward()
+    expect(processAssetsMock).toHaveBeenCalledWith([
+      expect.objectContaining({
+        timestamp: new Date(50_000).toISOString(),
+      }),
     ])
-    expect(await getPhotosArchiveCursor()).toBe(4_999)
+  })
 
-    // Tick 2: createdBefore 4_999 -> returns [1_000], cursor -> 999
-    await runTick()
-    expect(processAssetsMock).toHaveBeenNthCalledWith(2, [
-      expect.objectContaining({ id: 'b3', name: 'three.jpg' }),
+  it('processes all assets on the page without filtering', async () => {
+    await setPhotosArchiveCursor('start')
+    getAssetsAsyncMock.mockResolvedValueOnce(
+      page(
+        [
+          asset('a1', '1.jpg', { modificationTime: 100_000 }),
+          asset('a2', '2.jpg', { modificationTime: 1_000 }),
+          asset('a3', '3.jpg', { modificationTime: 50_000 }),
+        ],
+        'ref3',
+      ),
+    )
+    await workBackward()
+    expect(processAssetsMock).toHaveBeenCalledWith([
+      expect.objectContaining({ id: 'a1' }),
+      expect.objectContaining({ id: 'a2' }),
+      expect.objectContaining({ id: 'a3' }),
     ])
-    expect(await getPhotosArchiveCursor()).toBe(999)
-
-    // Tick 3: createdBefore 1_000 -> returns [], cursor -> 0
-    await runTick()
-    expect(await getPhotosArchiveCursor()).toBe(0)
-    expect(processAssetsMock).toHaveBeenCalledTimes(2)
   })
 
   it('aborts before processAssets when signal is aborted during getAssetsAsync', async () => {
@@ -191,12 +243,106 @@ describe('syncPhotosArchive', () => {
     const ac = new AbortController()
     getAssetsAsyncMock.mockImplementation(async () => {
       ac.abort()
-      return page([asset('b1', 'one.jpg', 10_000)])
+      return page([asset('b1', 'one.jpg', { modificationTime: 10_000 })])
     })
 
     await restartPhotosArchiveCursor()
     await workBackward(ac.signal)
 
     expect(processAssetsMock).not.toHaveBeenCalled()
+  })
+
+  describe('triggerRecentScanIfNeeded', () => {
+    it('triggers when archive is done and interval elapsed', async () => {
+      await setPhotosArchiveCursor('done')
+      await setLastRecentScanAt(0)
+      const triggered = await triggerRecentScanIfNeeded()
+      expect(triggered).toBe(true)
+      expect(await getPhotosArchiveCursor()).toBe('start')
+    })
+
+    it('skips when archive is mid-walk', async () => {
+      await setPhotosArchiveCursor('some-ref')
+      await setLastRecentScanAt(0)
+      const triggered = await triggerRecentScanIfNeeded()
+      expect(triggered).toBe(false)
+      expect(await getPhotosArchiveCursor()).toBe('some-ref')
+    })
+
+    it('skips when last scan was recent', async () => {
+      await setPhotosArchiveCursor('done')
+      await setLastRecentScanAt(NOW - SYNC_ARCHIVE_RECENT_SCAN_INTERVAL + 1_000)
+      const triggered = await triggerRecentScanIfNeeded()
+      expect(triggered).toBe(false)
+      expect(await getPhotosArchiveCursor()).toBe('done')
+    })
+  })
+
+  describe('bounded recent scan', () => {
+    it('stops at boundary during recent scan', async () => {
+      await setPhotosArchiveCursor('done')
+      await setLastRecentScanAt(0)
+      await triggerRecentScanIfNeeded()
+
+      const boundary = NOW - SYNC_ARCHIVE_RECENT_SCAN_LOOKBACK
+
+      getAssetsAsyncMock.mockResolvedValueOnce(
+        page(
+          [
+            asset('a1', '1.jpg', { modificationTime: NOW - 1_000 }),
+            asset('a2', '2.jpg', { modificationTime: boundary - 1_000 }),
+          ],
+          'ref1',
+        ),
+      )
+      await workBackward()
+
+      expect(processAssetsMock).toHaveBeenCalledTimes(1)
+      expect(await getPhotosArchiveCursor()).toBe('done')
+      expect(await getPhotosArchiveDisplayDate()).toBe(0)
+      expect(await getLastRecentScanAt()).toBe(NOW)
+    })
+
+    it('continues normally when not in recent scan mode', async () => {
+      await setPhotosArchiveCursor('start')
+
+      getAssetsAsyncMock.mockResolvedValueOnce(
+        page(
+          [
+            asset('a1', '1.jpg', { modificationTime: 100_000 }),
+            asset('a2', '2.jpg', { modificationTime: 1_000 }),
+          ],
+          'ref2',
+        ),
+      )
+      await workBackward()
+
+      expect(await getPhotosArchiveCursor()).toBe('ref2')
+      expect(await getPhotosArchiveDisplayDate()).toBe(1_000)
+    })
+
+    it('processes the boundary-crossing batch before stopping', async () => {
+      await setPhotosArchiveCursor('done')
+      await setLastRecentScanAt(0)
+      await triggerRecentScanIfNeeded()
+
+      const boundary = NOW - SYNC_ARCHIVE_RECENT_SCAN_LOOKBACK
+
+      getAssetsAsyncMock.mockResolvedValueOnce(
+        page(
+          [
+            asset('a1', '1.jpg', { modificationTime: boundary + 5_000 }),
+            asset('a2', '2.jpg', { modificationTime: boundary - 5_000 }),
+          ],
+          'ref1',
+        ),
+      )
+      await workBackward()
+
+      expect(processAssetsMock).toHaveBeenCalledWith([
+        expect.objectContaining({ id: 'a1' }),
+        expect.objectContaining({ id: 'a2' }),
+      ])
+    })
   })
 })

--- a/src/managers/syncPhotosArchive.ts
+++ b/src/managers/syncPhotosArchive.ts
@@ -1,5 +1,36 @@
+/*
+ * syncPhotosArchive — polls every 5s, fetches 1 page of 50 photos.
+ *
+ * Two modes of operation:
+ *
+ * 1. Initial walk: walks the entire photo library from newest to oldest
+ *    by endCursor, stopping when all photos have been visited
+ *    (cursor = 'done'). Pauses when pending local-only bytes exceed
+ *    4 slabs to avoid overwhelming the upload pipeline.
+ *
+ * 2. Bounded recent re-scan: after the initial walk completes, a
+ *    periodic re-scan is triggered during background tasks (every ~3h)
+ *    to catch photos synced from other devices (e.g. iCloud) that
+ *    appear with old timestamps in the middle of the sorted list where
+ *    syncNewPhotos (which only sees the top 50) misses them. The
+ *    re-scan walks from the top and stops when it crosses a 14-day
+ *    boundary. This runs during background tasks where the device is
+ *    idle and heavier DB work is free.
+ *
+ * Sorts by modificationTime DESC because:
+ * - Android: DATE_TAKEN can be NULL for imported/downloaded photos,
+ *   silently excluding them from createdAfter/createdBefore queries.
+ * - iOS: creationDate can be an old EXIF date; modificationDate is the
+ *   iCloud-synced metadata timestamp (not local arrival time).
+ *
+ * Catches: the full historical tail plus periodic re-scans of the
+ * recent window for cross-device synced photos.
+ * Misses: newly taken photos (covered by syncNewPhotos).
+ */
 import * as MediaLibrary from 'expo-media-library'
 import {
+  SYNC_ARCHIVE_RECENT_SCAN_INTERVAL,
+  SYNC_ARCHIVE_RECENT_SCAN_LOOKBACK,
   SYNC_ARCHIVE_RESUME_THRESHOLD,
   SYNC_PHOTOS_ARCHIVE_INTERVAL,
 } from '../config'
@@ -15,8 +46,10 @@ import { createServiceInterval } from '../lib/serviceInterval'
 import {
   getAsyncStorageBoolean,
   getAsyncStorageNumber,
+  getAsyncStorageString,
   setAsyncStorageBoolean,
   setAsyncStorageNumber,
+  setAsyncStorageString,
 } from '../stores/asyncStore'
 import { getFileStatsLocal } from '../stores/files'
 import {
@@ -25,11 +58,15 @@ import {
 } from '../stores/librarySwr'
 
 const PAGE_SIZE = 50
+const CURSOR_DONE = 'done'
+const CURSOR_START = 'start'
 
-export async function workBackward(signal: AbortSignal) {
+let recentScanBoundary = 0
+
+export async function workBackward(signal?: AbortSignal) {
   logger.debug('syncPhotosArchive', 'tick')
   if (!(await getMediaLibraryPermissions())) return
-  if (signal.aborted) return
+  if (signal?.aborted) return
   const { count, totalBytes } = await getFileStatsLocal({ localOnly: true })
   if (totalBytes >= SYNC_ARCHIVE_RESUME_THRESHOLD) {
     logger.info('syncPhotosArchive', 'skipped', {
@@ -40,48 +77,93 @@ export async function workBackward(signal: AbortSignal) {
     return
   }
   const cursor = await getPhotosArchiveCursor()
+  if (cursor === CURSOR_DONE) return
+
+  logger.info('syncPhotosArchive', 'query', {
+    cursor: cursor === CURSOR_START ? 'start' : cursor,
+  })
 
   try {
     const page = await MediaLibrary.getAssetsAsync({
       first: PAGE_SIZE,
-      createdBefore: new Date(cursor),
-      // Descending order.
-      sortBy: [[MediaLibrary.SortBy.creationTime, false]],
+      after: cursor !== CURSOR_START ? cursor : undefined,
+      sortBy: [[MediaLibrary.SortBy.modificationTime, false]],
       mediaType: [MediaLibrary.MediaType.photo, MediaLibrary.MediaType.video],
-      // Resolve full info. For images this gets the full EXIF data and can fix the orientation.
-      resolveWithFullInfo: true,
     })
-    if (signal.aborted) return
+    if (signal?.aborted) return
     if (page.assets.length === 0) {
+      if (cursor !== CURSOR_START) {
+        logger.info('syncPhotosArchive', 'cursor_reached_end', {
+          cursor,
+        })
+      }
       logger.info('syncPhotosArchive', 'fully_synced')
-      await setPhotosArchiveCursor(0)
+      await setPhotosArchiveCursor(CURSOR_DONE)
       return
     }
-    logger.info('syncPhotosArchive', 'batch', { size: page.assets.length })
-    const lastAssetCreationTime =
-      page.assets[page.assets.length - 1].creationTime ?? 0
-    const nextTimestamp = lastAssetCreationTime ? lastAssetCreationTime - 1 : 0
-    await setPhotosArchiveCursor(nextTimestamp)
-    if (signal.aborted) return
+    const assets = page.assets
+    const prevCursor = cursor
+    await setPhotosArchiveCursor(page.endCursor)
+
+    const oldestModTime = Math.min(...assets.map((a) => a.modificationTime))
+    await setPhotosArchiveDisplayDate(oldestModTime)
+
+    logger.info('syncPhotosArchive', 'batch', {
+      size: assets.length,
+      oldestModTime: new Date(oldestModTime).toISOString(),
+      prevCursor: prevCursor === CURSOR_START ? 'start' : prevCursor,
+      nextCursor: page.endCursor,
+    })
+    if (signal?.aborted) return
     const { files } = await processAssets(
-      page.assets.map((asset) => ({
+      assets.map((asset) => ({
         id: asset.id,
         sourceUri: asset.uri,
         name: asset.filename,
         type: undefined,
         size: undefined,
-        timestamp: new Date(asset.creationTime).toISOString(),
+        timestamp: new Date(
+          asset.creationTime || asset.modificationTime,
+        ).toISOString(),
       })),
     )
     if (files.length > 0) {
+      logger.info('syncPhotosArchive', 'batch_processed', {
+        newFiles: files.length,
+        totalAssets: assets.length,
+      })
       await invalidateCacheLibraryAllStats()
       invalidateCacheLibraryLists()
     } else {
-      // Nothing was found so immediately start next interval.
-      return 0
+      logger.info('syncPhotosArchive', 'batch_all_duplicates', {
+        totalAssets: assets.length,
+      })
+    }
+
+    if (recentScanBoundary > 0 && oldestModTime < recentScanBoundary) {
+      logger.info('syncPhotosArchive', 'recent_scan_boundary_reached', {
+        oldestModTime: new Date(oldestModTime).toISOString(),
+        boundary: new Date(recentScanBoundary).toISOString(),
+      })
+      recentScanBoundary = 0
+      await setPhotosArchiveCursor(CURSOR_DONE)
+      await setPhotosArchiveDisplayDate(0)
+      await setLastRecentScanAt(Date.now())
     }
   } catch (e) {
-    logger.error('syncPhotosArchive', 'batch_error', { error: e as Error })
+    const msg = e instanceof Error ? e.message : String(e)
+    if (cursor !== CURSOR_START && msg.includes('cursor')) {
+      logger.warn('syncPhotosArchive', 'cursor_invalid_restarting', {
+        cursor,
+        error: msg,
+      })
+      await restartPhotosArchiveCursor()
+      return
+    }
+    logger.error('syncPhotosArchive', 'batch_error', {
+      error: e as Error,
+      cursor,
+    })
   }
 }
 
@@ -91,8 +173,6 @@ export const { init: initSyncPhotosArchive } = createServiceInterval({
   getState: async () => getAutoSyncPhotosArchive(),
   interval: SYNC_PHOTOS_ARCHIVE_INTERVAL,
 })
-
-const defaultValue = 0
 
 export const [
   getAutoSyncPhotosArchive,
@@ -121,21 +201,59 @@ export const [
   getPhotosArchiveCursor,
   usePhotosArchiveCursor,
   photosArchiveCursorCache,
-] = createGetterAndSWRHook<number>(() =>
-  getAsyncStorageNumber('photosArchiveCursor', defaultValue),
+] = createGetterAndSWRHook<string>(() =>
+  getAsyncStorageString('archiveSyncCursor', CURSOR_DONE),
 )
 
-export async function setPhotosArchiveCursor(value: number) {
-  await setAsyncStorageNumber('photosArchiveCursor', value)
+export async function setPhotosArchiveCursor(value: string) {
+  await setAsyncStorageString('archiveSyncCursor', value)
   await photosArchiveCursorCache.set(value)
 }
 
 export async function restartPhotosArchiveCursor() {
+  recentScanBoundary = 0
   logger.info('syncPhotosArchive', 'cursor_restart')
-  await setPhotosArchiveCursor(Date.now())
+  await setPhotosArchiveCursor(CURSOR_START)
+  await setPhotosArchiveDisplayDate(0)
 }
 
 export async function resetPhotosArchiveCursor() {
   logger.info('syncPhotosArchive', 'cursor_disable')
-  await setPhotosArchiveCursor(defaultValue)
+  await setPhotosArchiveCursor(CURSOR_DONE)
+  await setPhotosArchiveDisplayDate(0)
+}
+
+export const [
+  getPhotosArchiveDisplayDate,
+  usePhotosArchiveDisplayDate,
+  photosArchiveDisplayDateCache,
+] = createGetterAndSWRHook<number>(() =>
+  getAsyncStorageNumber('photosArchiveDisplayDate', 0),
+)
+
+export async function setPhotosArchiveDisplayDate(value: number) {
+  await setAsyncStorageNumber('photosArchiveDisplayDate', value)
+  await photosArchiveDisplayDateCache.set(value)
+}
+
+export const [getLastRecentScanAt, , lastRecentScanAtCache] =
+  createGetterAndSWRHook<number>(() =>
+    getAsyncStorageNumber('lastRecentScanAt', 0),
+  )
+
+export async function setLastRecentScanAt(value: number) {
+  await setAsyncStorageNumber('lastRecentScanAt', value)
+  await lastRecentScanAtCache.set(value)
+}
+
+export async function triggerRecentScanIfNeeded(): Promise<boolean> {
+  const cursor = await getPhotosArchiveCursor()
+  if (cursor !== CURSOR_DONE) return false
+
+  const lastScan = await getLastRecentScanAt()
+  if (Date.now() - lastScan < SYNC_ARCHIVE_RECENT_SCAN_INTERVAL) return false
+
+  await restartPhotosArchiveCursor()
+  recentScanBoundary = Date.now() - SYNC_ARCHIVE_RECENT_SCAN_LOOKBACK
+  return true
 }

--- a/src/stacks/MainStack.tsx
+++ b/src/stacks/MainStack.tsx
@@ -27,7 +27,11 @@ export function MainStack() {
       />
       <Stack.Screen
         name="Search"
-        options={{ headerShown: false, animation: 'fade', animationDuration: 100 }}
+        options={{
+          headerShown: false,
+          animation: 'fade',
+          animationDuration: 100,
+        }}
         component={SearchScreen}
       />
     </Stack.Navigator>


### PR DESCRIPTION
- Noticed the sync features were not syncing photos missing exif / created timestamps.
- Noticed that if a photo was adding on another device, the primary device would often update its cursor and miss the asset before it was visible to the local photo library.
- The media library APIs do not make it very easy to reliable sync.
- This switches to modificationTime sorting and adds a periodic background re-scan to catch both cases.
    - syncNewPhotos polls every 10s in the foreground, fetching the top 50 photos and only processing ones modified after sync was enabled.
    - syncPhotosArchive walks the full library once, then re-scans the last 14 days every ~3h during background tasks to pick up cross-device arrivals.