### PR TITLE
fix: eliminate filesystem race causing download loop on Android

### DIFF
--- a/.changeset/fix-android-download-loop.md
+++ b/.changeset/fix-android-download-loop.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fixed a bug on Android where downloaded files would loop back to downloading.

--- a/src/lib/file.ts
+++ b/src/lib/file.ts
@@ -56,8 +56,7 @@ function computeFileStatus({
   const isDownloading =
     downloadState?.status === 'running' || downloadState?.status === 'queued'
   const hasSealedObject = fileHasASealedObject(file)
-  // Treat as downloaded if we have the URI OR download just finished ('done')
-  const isDownloaded = !!fileUri || downloadState?.status === 'done'
+  const isDownloaded = !!fileUri
   return {
     isUploading,
     isDownloading,

--- a/src/managers/downloader.ts
+++ b/src/managers/downloader.ts
@@ -34,8 +34,7 @@ export async function downloadFile(file: FileRecord): Promise<void> {
   const downloadState = getDownloadState(file.id)
   if (
     downloadState?.status === 'running' ||
-    downloadState?.status === 'queued' ||
-    downloadState?.status === 'done'
+    downloadState?.status === 'queued'
   ) {
     return // Already downloading or just completed
   }

--- a/src/stores/appKey.ts
+++ b/src/stores/appKey.ts
@@ -46,7 +46,6 @@ export async function getAppKeyForIndexer(
   // Check cache first.
   const cached = cachedAppKeys.get(indexerURL)
   if (cached) {
-    logger.debug('appKey', 'cache_hit')
     return new AppKey(cached)
   }
 

--- a/src/stores/downloads.ts
+++ b/src/stores/downloads.ts
@@ -3,7 +3,7 @@ import { logger } from '../lib/logger'
 import { createGetterAndSelector } from '../lib/selectors'
 import { acquireDownloadSlot } from '../managers/downloadsPool'
 
-export type DownloadStatus = 'queued' | 'running' | 'done' | 'error'
+export type DownloadStatus = 'queued' | 'running' | 'error'
 
 export type DownloadState = {
   id: string
@@ -127,10 +127,7 @@ export async function runDownloadWithSlot<T>(params: {
     setDownloadState(id, 'running', 0)
     const result = await task(controller.signal)
     logger.debug('downloads', 'success', { id })
-    // Set 'done' status and delay removal to prevent re-triggering downloads
-    // while components may not have fetched the new file uri yet.
-    setDownloadState(id, 'done', 1)
-    setTimeout(() => removeDownload(id), 5000)
+    removeDownload(id)
     return result
   } catch (e) {
     logger.error('downloads', 'error', { id, error: e as Error })

--- a/src/stores/fs.ts
+++ b/src/stores/fs.ts
@@ -1,5 +1,5 @@
 import { Directory, File, Paths } from 'expo-file-system'
-import useSWR from 'swr'
+import useSWR, { mutate } from 'swr'
 import { db } from '../db'
 import { sqlDelete, sqlInsert, sqlUpdate } from '../db/sql'
 import { extFromMime } from '../lib/fileTypes'
@@ -11,6 +11,10 @@ import { buildSWRHelpers } from '../lib/swr'
  */
 
 const { getKey, triggerChange } = buildSWRHelpers('fs/files')
+
+function swrKeyFsFileUri(fileId?: string) {
+  return [...getKey(fileId), 'uri']
+}
 
 export type FsFileInfo = {
   id: string
@@ -127,12 +131,12 @@ export async function copyFileToFs(
     addedAt: previous?.addedAt ?? Date.now(),
     usedAt: Date.now(),
   })
-  await fsTriggerRefresh(file.id)
+  await mutate(swrKeyFsFileUri(file.id), target.uri, { revalidate: false })
   return target.uri
 }
 
 export function useFsFileUri(file?: FsFileInfo) {
-  return useSWR([...getKey(file?.id), 'uri'], () => {
+  return useSWR(swrKeyFsFileUri(file?.id), () => {
     return file ? getFsFileUri(file) : null
   })
 }


### PR DESCRIPTION
- iOS was working fine but it seems like on Android sometimes there is a race condition. This change should completely remove the **possibility** by setting the swr value directly.
- Set the SWR cache directly in copyFileToFs with the known URI instead of re-fetching from the filesystem, where Android's [File.info](http://File.info)() can return exists: false immediately after File.copy().
- Remove the 'done' download status and 5s timer workaround that this makes unnecessary.