### PR TITLE
refactor: fine-grained cache invalidation for SWR layer

### DIFF
--- a/.changeset/refactor-swr-cache.md
+++ b/.changeset/refactor-swr-cache.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Improved responsiveness of library updates by refining how cached data is refreshed.

--- a/src/components/FileDetails/FileMeta.tsx
+++ b/src/components/FileDetails/FileMeta.tsx
@@ -9,7 +9,10 @@ import { humanSize } from '../../lib/humanSize'
 import { type FileRecord, updateFileRecord } from '../../stores/files'
 import { getFsFileUri } from '../../stores/fs'
 import { useShowAdvanced } from '../../stores/settings'
-import { readThumbnailsByHash, thumbnailSwr } from '../../stores/thumbnails'
+import {
+  readThumbnailsByHash,
+  thumbnailsByHashCache,
+} from '../../stores/thumbnails'
 import { colors, palette } from '../../styles/colors'
 import { RowGroup } from '../Group'
 import { InfoCard } from '../InfoCard'
@@ -37,7 +40,7 @@ export function FileMeta({
   })
   const pinnedObjects = usePinnedObjects(file)
   const thumbnails = useSWR(
-    showAdvanced.data ? thumbnailSwr.getKey(`${file.hash}/all`) : null,
+    showAdvanced.data ? thumbnailsByHashCache.key(file.hash) : null,
     async () => {
       const records = await readThumbnailsByHash(file.hash)
       return Promise.all(

--- a/src/components/HostsList.tsx
+++ b/src/components/HostsList.tsx
@@ -1,7 +1,6 @@
 import { ChevronRightIcon } from 'lucide-react-native'
 import { Platform, Pressable, StyleSheet, Text, View } from 'react-native'
-import useSWR from 'swr'
-import { useSdk } from '../stores/sdk'
+import { useHosts } from '../stores/hosts'
 import { colors, palette } from '../styles/colors'
 import { SWRList } from './SWRList'
 
@@ -10,8 +9,7 @@ export function HostsList({
 }: {
   onSelectHost: (host: string) => void
 }) {
-  const sdk = useSdk()
-  const response = useSWR(sdk ? ['hosts', sdk] : null, () => sdk!.hosts())
+  const response = useHosts()
 
   return (
     <SWRList

--- a/src/components/LibraryLocalResetButton.tsx
+++ b/src/components/LibraryLocalResetButton.tsx
@@ -1,6 +1,9 @@
 import { Alert } from 'react-native'
 import { resetData } from '../managers/app'
-import { librarySwr } from '../stores/library'
+import {
+  invalidateCacheLibraryAllStats,
+  invalidateCacheLibraryLists,
+} from '../stores/librarySwr'
 import { Button } from './Button'
 
 /**
@@ -25,7 +28,8 @@ export function LibraryLocalResetButton() {
               style: 'destructive',
               onPress: async () => {
                 await resetData()
-                librarySwr.triggerChange()
+                await invalidateCacheLibraryAllStats()
+                invalidateCacheLibraryLists()
               },
             },
           ],

--- a/src/components/SettingsLogsControlBar.tsx
+++ b/src/components/SettingsLogsControlBar.tsx
@@ -16,7 +16,7 @@ import {
   Text,
   View,
 } from 'react-native'
-import { logsSwr } from '../hooks/useLogs'
+import { logsCache } from '../hooks/useLogs'
 import { exportLogs } from '../lib/exportLogs'
 import { type LogLevel, logger } from '../lib/logger'
 import { useToast } from '../lib/toastContext'
@@ -117,7 +117,7 @@ export function SettingsLogsControlBar({ navigation }: Props) {
           onPress: async () => {
             try {
               await clearLogs()
-              await logsSwr.triggerChange()
+              await logsCache.invalidateAll()
               toast.show('Logs cleared')
             } catch (error) {
               logger.error('logs', 'clear_failed', { error: error as Error })

--- a/src/hooks/useBestThumbnail.ts
+++ b/src/hooks/useBestThumbnail.ts
@@ -4,9 +4,12 @@ import { useFileStatus } from '../lib/file'
 import { useDownload } from '../managers/downloader'
 import { useIsInitializing } from '../stores/app'
 import type { FileRecord, ThumbSize } from '../stores/files'
-import { getFsFileUri } from '../stores/fs'
+import { useFsFileUri } from '../stores/fs'
 import { useIsConnected } from '../stores/sdk'
-import { readBestThumbnailByHash, thumbnailSwr } from '../stores/thumbnails'
+import {
+  bestThumbnailCache,
+  readBestThumbnailByHash,
+} from '../stores/thumbnails'
 
 /**
  * useBestThumbnailUri returns the local URI of the best available thumbnail for a file.
@@ -24,7 +27,7 @@ export function useBestThumbnailUri(
 ) {
   // Fetch the best thumbnail record.
   const thumbRecord = useSWR(
-    file ? thumbnailSwr.getKey(`${file.hash}/${thumbSize}/record`) : null,
+    file ? bestThumbnailCache.key(file.hash, String(thumbSize)) : null,
     () => (file ? readBestThumbnailByHash(file.hash, thumbSize) : null),
   )
 
@@ -43,18 +46,7 @@ export function useBestThumbnailUri(
     download()
   }, [isInitializing, isConnected, thumbRecord.data, status.data, download])
 
-  // Get the URI for the thumbnail.
-  const response = useSWR(
-    file ? thumbnailSwr.getKey(`${file.hash}/${thumbSize}/uri`) : null,
-    async () => {
-      if (!thumbRecord.data) return null
-      return await getFsFileUri(thumbRecord.data)
-    },
-  )
-  // Update when status changes so the thumbnail is re-rendered when the uri becomes available.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: status.data triggers mutate intentionally
-  useEffect(() => {
-    response.mutate()
-  }, [status.data])
-  return response
+  // Get the URI via fsFileUriCache which receives synchronous pushes from
+  // copyFileToFs — no async gap between download completing and URI appearing.
+  return useFsFileUri(thumbRecord.data ?? undefined)
 }

--- a/src/hooks/useLogs.ts
+++ b/src/hooks/useLogs.ts
@@ -1,16 +1,17 @@
 import useSWR from 'swr'
 import type { LogEntry } from '../lib/logger'
-import { buildSWRHelpers } from '../lib/swr'
+import { swrCacheBy } from '../lib/swr'
 import { countLogs, readLogs, useLogLevel, useLogScopes } from '../stores/logs'
 
-export const logsSwr = buildSWRHelpers('logs')
+/** Filtered log entries, keyed by (level, scopes). */
+export const logsCache = swrCacheBy()
 
 export function useLogs() {
   const logLevel = useLogLevel()
   const logScopes = useLogScopes()
 
   return useSWR<{ entries: LogEntry[]; totalCount: number }>(
-    logsSwr.getKey(`${logLevel},${logScopes.join(',')}`),
+    logsCache.key(logLevel, logScopes.join(',')),
     async () => {
       const [entries, totalCount] = await Promise.all([
         readLogs(logLevel, logScopes, 500),

--- a/src/lib/file.ts
+++ b/src/lib/file.ts
@@ -1,10 +1,9 @@
-import { useEffect } from 'react'
+import { useMemo } from 'react'
 import {
   PinnedObject,
   type PinnedObjectInterface,
   type SealedObject,
 } from 'react-native-sia'
-import useSWR, { type SWRResponse } from 'swr'
 import type { LocalObject } from '../encoding/localObject'
 import { getAppKeyForIndexer } from '../stores/appKey'
 import { type DownloadState, useDownloadState } from '../stores/downloads'
@@ -75,29 +74,39 @@ function computeFileStatus({
   }
 }
 
+export type FileStatusResponse = {
+  data: FileStatus | undefined
+  isLoading: boolean
+}
+
 export function useFileStatus(
   file?: FileRecord,
   isShared?: boolean,
-): SWRResponse<FileStatus, Error> {
+): FileStatusResponse {
   const uploadState = useUploadState(file?.id || '')
   const downloadState = useDownloadState(file?.id || '')
   const fileUri = useFsFileUri(file)
-  const response = useSWR(fileUri.isLoading ? null : [file?.id, 'status'], () =>
-    computeFileStatus({
+
+  const data = useMemo(() => {
+    if (fileUri.isLoading) return undefined
+    return computeFileStatus({
       file,
       isShared,
       uploadState,
       downloadState,
       fileUri: fileUri.data ?? null,
       errorText: uploadState?.error || downloadState?.error || null,
-    }),
-  )
-  // Immediately update when there are changes to data or transfer progress.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: these deps trigger mutate intentionally
-  useEffect(() => {
-    response.mutate()
-  }, [file, uploadState, downloadState, fileUri.data])
-  return response
+    })
+  }, [
+    file,
+    isShared,
+    uploadState,
+    downloadState,
+    fileUri.data,
+    fileUri.isLoading,
+  ])
+
+  return { data, isLoading: fileUri.isLoading }
 }
 
 export function getFileTypeName(

--- a/src/lib/mediaLibraryPermissions.ts
+++ b/src/lib/mediaLibraryPermissions.ts
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from 'react'
 import { Linking, Platform } from 'react-native'
 import useSWR from 'swr'
 import { palette } from '../styles/colors'
-import { buildSWRHelpers } from './swr'
+import { swrCache } from './swr'
 
 export async function ensureMediaLibraryPermission(): Promise<boolean> {
   const res = await MediaLibrary.requestPermissionsAsync()
@@ -16,12 +16,11 @@ export async function getMediaLibraryPermissions(): Promise<boolean> {
   return res.granted === true
 }
 
-export const mediaLibraryPermissionsSwr = buildSWRHelpers(
-  'mediaLibraryPermissions',
-)
+/** Device media library permission status. */
+export const mediaLibraryPermissionsCache = swrCache()
 
 export function useMediaLibraryPermissions() {
-  const perms = useSWR(mediaLibraryPermissionsSwr.getKey(), () =>
+  const perms = useSWR(mediaLibraryPermissionsCache.key(), () =>
     MediaLibrary.getPermissionsAsync(),
   )
 

--- a/src/lib/selectors.ts
+++ b/src/lib/selectors.ts
@@ -1,6 +1,7 @@
 import useSWR, { type SWRConfiguration, type SWRResponse } from 'swr'
 import type { StoreApi, UseBoundStore } from 'zustand'
 import { useShallow } from 'zustand/react/shallow'
+import { type SwrCache, swrCache } from './swr'
 
 /**
  * Creates getter and hook selectors for a state transform function.
@@ -30,28 +31,51 @@ export function createGetterAndSelector<T, R, Args extends any[] = []>(
 }
 
 /**
- * Creates getter and swr hook selectors for a state transform function.
- * @param key - The key to use for the selector.
- * @param fetcher - The fetcher function.
- * @returns [getData, useData]
+ * Creates a getter function, SWR hook, and cache entry for async data.
  *
- * Example:
- * ```
- * const [getFileList, useFileList] = createGetterAndSWRHook(
- *   'key',
- *   (data) => data
- * )
- * ```
+ * Standalone (creates its own cache):
+ *   const [get, use, cache] = createGetterAndSWRHook(fetcher)
+ *
+ * With external key (for shared caches like libraryStats):
+ *   const [get, use] = createGetterAndSWRHook(sharedCache.key('x'), fetcher)
  */
+export function createGetterAndSWRHook<T, Args extends any[] = []>(
+  fetcher: (...args: Args) => Promise<T>,
+): [
+  (...args: Args) => Promise<T>,
+  (...args: [...Args, SWRConfiguration?]) => SWRResponse<T, any, any>,
+  SwrCache<T>,
+]
 export function createGetterAndSWRHook<T, Args extends any[] = []>(
   key: string[],
   fetcher: (...args: Args) => Promise<T>,
 ): [
   (...args: Args) => Promise<T>,
   (...args: [...Args, SWRConfiguration?]) => SWRResponse<T, any, any>,
-] {
+]
+export function createGetterAndSWRHook<T, Args extends any[] = []>(
+  keyOrFetcher: string[] | ((...args: Args) => Promise<T>),
+  maybeFetcher?: (...args: Args) => Promise<T>,
+) {
+  let key: string[]
+  let fetcher: (...args: Args) => Promise<T>
+  let cache: SwrCache<T> | undefined
+
+  if (Array.isArray(keyOrFetcher)) {
+    key = keyOrFetcher
+    fetcher = maybeFetcher!
+  } else {
+    cache = swrCache<T>()
+    key = cache.key()
+    fetcher = keyOrFetcher
+  }
+
   const argCount = fetcher.length
-  return [
+  const result: [
+    (...args: Args) => Promise<T>,
+    (...args: [...Args, SWRConfiguration?]) => SWRResponse<T, any, any>,
+    SwrCache<T>?,
+  ] = [
     (...args: Args) => fetcher(...args),
     (...argsAndConfig: [...Args, SWRConfiguration?]) => {
       const args = argsAndConfig.slice(0, argCount) as unknown as Args
@@ -59,4 +83,7 @@ export function createGetterAndSWRHook<T, Args extends any[] = []>(
       return useSWR([...key, ...args], () => fetcher(...args), config)
     },
   ]
+
+  if (cache) result.push(cache)
+  return result
 }

--- a/src/lib/swr.ts
+++ b/src/lib/swr.ts
@@ -1,43 +1,51 @@
 import { mutate } from 'swr'
 
+let nextId = 0
+
+export type SwrCache<T = unknown> = ReturnType<typeof swrCache<T>>
+
 /**
- * Builds SWR helpers for a given base key.
+ * SWR cache entry with no parameters.
  *
- * Example:
- * ```
- * const { getKey, triggerChange } = buildSWRHelpers('key')
- * ```
+ *   const allHostsCache = swrCache()
+ *   useSWR(allHostsCache.key(), fetcher)
+ *   allHostsCache.invalidate()
+ *   allHostsCache.set(newData)
  */
-export function buildSWRHelpers(baseKey: string) {
-  const changeCallbacks = new Map<string, () => void>()
-
-  const addChangeCallback = (key: string, callback: () => void) => {
-    changeCallbacks.set(key, callback)
-  }
-
-  const removeChangeCallback = (key: string) => {
-    changeCallbacks.delete(key)
-  }
-
-  const getKey = (id?: string) => {
-    return id ? [`${baseKey}/${id}`] : [`${baseKey}`]
-  }
-
-  const triggerChange = async (keyPath?: string) => {
-    await mutate((key: string[]) => {
-      if (!Array.isArray(key) || typeof key[0] !== 'string') {
-        return false
-      }
-      const first = key[0]
-      return first.startsWith(getKey(keyPath)[0])
-    })
-    changeCallbacks.forEach((callback) => callback())
-  }
-
+export function swrCache<T = unknown>() {
+  const key = [`swr/${nextId++}`]
   return {
-    getKey,
-    triggerChange,
-    addChangeCallback,
-    removeChangeCallback,
+    key: () => key,
+    invalidate: () => mutate(key),
+    set: (data: T) => mutate(key, data ?? undefined, { revalidate: false }),
+  }
+}
+
+/**
+ * SWR cache entry parameterized by one or more string key parts.
+ *
+ *   const hostByKeyCache = swrCacheBy()
+ *   useSWR(hostByKeyCache.key(publicKey), fetcher)
+ *   hostByKeyCache.invalidate(publicKey)
+ *   hostByKeyCache.set(newData, publicKey)
+ *   hostByKeyCache.invalidateAll()
+ */
+export function swrCacheBy<T = unknown>() {
+  const prefix = `swr/${nextId++}`
+  return {
+    key: (...parts: string[]) => [`${prefix}/${parts.join('/')}`],
+    invalidate: (...parts: string[]) =>
+      mutate([`${prefix}/${parts.join('/')}`]),
+    invalidateAll: () =>
+      mutate(
+        (key: unknown) =>
+          Array.isArray(key) &&
+          typeof key[0] === 'string' &&
+          key[0].startsWith(`${prefix}/`),
+      ),
+    set: (data: T, ...parts: string[]) =>
+      mutate([`${prefix}/${parts.join('/')}`], data ?? undefined, {
+        revalidate: false,
+      }),
   }
 }

--- a/src/managers/downloadsPool.ts
+++ b/src/managers/downloadsPool.ts
@@ -7,7 +7,6 @@ import {
   getAsyncStorageNumber,
   setAsyncStorageNumber,
 } from '../stores/asyncStore'
-import { settingsSwr } from '../stores/settings'
 
 let downloadPool: SlotPool | null = null
 const initDownloadOnce = new SingleInit()
@@ -42,10 +41,10 @@ export async function setMaxDownloads(value: number) {
   const clamped = Math.max(1, Math.floor(Number(value) || 1))
   await setAsyncStorageNumber('maxDownloads', clamped)
   setDownloadMaxSlots(clamped)
-  settingsSwr.triggerChange('maxDownloads')
+  await maxDownloadsCache.set(clamped)
 }
 
-export const [getMaxDownloads, useMaxDownloads] = createGetterAndSWRHook(
-  settingsSwr.getKey('maxDownloads'),
-  () => getAsyncStorageNumber('maxDownloads', DEFAULT_MAX_DOWNLOADS),
-)
+export const [getMaxDownloads, useMaxDownloads, maxDownloadsCache] =
+  createGetterAndSWRHook<number>(() =>
+    getAsyncStorageNumber('maxDownloads', DEFAULT_MAX_DOWNLOADS),
+  )

--- a/src/managers/fsOrphanScanner.ts
+++ b/src/managers/fsOrphanScanner.ts
@@ -8,7 +8,7 @@ import {
 } from '../stores/asyncStore'
 import {
   deleteFsFileMetadataBatch,
-  fsTriggerRefresh,
+  fsFileUriCache,
   listFilesInFsStorageDirectory,
 } from '../stores/fs'
 
@@ -80,7 +80,7 @@ export async function runFsOrphanScanner(options?: {
     }
 
     if (removed > 0) {
-      await fsTriggerRefresh()
+      await fsFileUriCache.invalidateAll()
       logger.info('fsOrphanScanner', 'summary', { removed })
     }
     return { removed }

--- a/src/managers/syncDownEvents.ts
+++ b/src/managers/syncDownEvents.ts
@@ -26,6 +26,10 @@ import {
   updateFileRecordWithLocalObject,
 } from '../stores/files'
 import { removeFsFile } from '../stores/fs'
+import {
+  invalidateCacheLibraryAllStats,
+  invalidateCacheLibraryLists,
+} from '../stores/librarySwr'
 import { getIsConnected, getSdk } from '../stores/sdk'
 import { getAutoSyncDownEvents, getIndexerURL } from '../stores/settings'
 import { removeTempDownloadFile } from '../stores/tempFs'
@@ -104,6 +108,11 @@ export async function syncDownEvents(): Promise<void> {
     }
   }
 
+  if (counts.added > 0 || counts.deleted > 0 || counts.existing > 0) {
+    await invalidateCacheLibraryAllStats()
+    invalidateCacheLibraryLists()
+  }
+
   logger.info('syncDownEvents', 'synced', {
     existing: counts.existing,
     added: counts.added,
@@ -137,8 +146,8 @@ async function handleDeleteEvent(id: string, counts: Counts): Promise<void> {
         removeFsFile(existingFileRecord),
         // Remove any temporary download file.
         removeTempDownloadFile(existingFileRecord),
-        // Remove the file from the database.
-        deleteFileRecord(existingFileRecord.id),
+        // Remove the file from the database (deferred invalidation).
+        deleteFileRecord(existingFileRecord.id, false),
       ])
       counts.deleted++
     } else {
@@ -223,6 +232,7 @@ async function handleFileRecord(
       },
       localObject,
       { includeUpdatedAt: true },
+      false,
     )
     // Cancel any inflight upload for this file since we now have a pinned object.
     removeUpload(existingFile.id)
@@ -249,6 +259,7 @@ async function handleFileRecord(
         addedAt: Date.now(),
       },
       localObject,
+      false,
     )
     counts.added++
   }

--- a/src/managers/syncNewPhotos.test.ts
+++ b/src/managers/syncNewPhotos.test.ts
@@ -14,21 +14,18 @@ jest.mock('expo-media-library', () => ({
 jest.mock('../lib/mediaLibraryPermissions', () => ({
   ensureMediaLibraryPermission: jest.fn(),
   getMediaLibraryPermissions: jest.fn().mockResolvedValue(true),
-  mediaLibraryPermissionsSwr: {
-    getKey: jest.fn((k: string) => [k]),
-    triggerChange: jest.fn(),
-    addChangeCallback: jest.fn(),
+  mediaLibraryPermissionsCache: {
+    key: jest.fn(() => ['mediaLibraryPermissions']),
+    invalidate: jest.fn(),
+    set: jest.fn(),
   },
 }))
 jest.mock('../lib/processAssets', () => ({
   processAssets: jest.fn(),
 }))
-jest.mock('../stores/library', () => ({
-  librarySwr: {
-    triggerChange: jest.fn(),
-    addChangeCallback: jest.fn(),
-    getKey: jest.fn((k: string) => [k]),
-  },
+jest.mock('../stores/librarySwr', () => ({
+  invalidateCacheLibraryAllStats: jest.fn(),
+  invalidateCacheLibraryLists: jest.fn(),
 }))
 
 async function runTick() {

--- a/src/managers/syncNewPhotos.ts
+++ b/src/managers/syncNewPhotos.ts
@@ -4,7 +4,7 @@ import { logger } from '../lib/logger'
 import {
   ensureMediaLibraryPermission,
   getMediaLibraryPermissions,
-  mediaLibraryPermissionsSwr,
+  mediaLibraryPermissionsCache,
 } from '../lib/mediaLibraryPermissions'
 import { processAssets } from '../lib/processAssets'
 import { createGetterAndSWRHook } from '../lib/selectors'
@@ -15,8 +15,10 @@ import {
   setAsyncStorageBoolean,
   setAsyncStorageNumber,
 } from '../stores/asyncStore'
-import { librarySwr } from '../stores/library'
-import { settingsSwr } from '../stores/settings'
+import {
+  invalidateCacheLibraryAllStats,
+  invalidateCacheLibraryLists,
+} from '../stores/librarySwr'
 
 const PAGE_SIZE = 200
 
@@ -54,7 +56,10 @@ async function workForward(): Promise<void> {
         timestamp: new Date(asset.creationTime).toISOString(),
       })),
     )
-    if (files.length > 0) await librarySwr.triggerChange()
+    if (files.length > 0) {
+      await invalidateCacheLibraryAllStats()
+      invalidateCacheLibraryLists()
+    }
   } catch (e) {
     logger.error('syncNewPhotos', 'batch_error', { error: e as Error })
   }
@@ -69,18 +74,21 @@ export const initSyncNewPhotos = createServiceInterval({
 
 // Photos sync - new photos forward cursor and toggle.
 
-export const [getAutoSyncNewPhotos, useAutoSyncNewPhotos] =
-  createGetterAndSWRHook(settingsSwr.getKey('autoSyncNewPhotos'), () =>
-    getAsyncStorageBoolean('autoSyncNewPhotos', false),
-  )
+export const [
+  getAutoSyncNewPhotos,
+  useAutoSyncNewPhotos,
+  autoSyncNewPhotosCache,
+] = createGetterAndSWRHook<boolean>(() =>
+  getAsyncStorageBoolean('autoSyncNewPhotos', false),
+)
 
 export async function setAutoSyncNewPhotos(value: boolean) {
   await setAsyncStorageBoolean('autoSyncNewPhotos', value)
-  settingsSwr.triggerChange('autoSyncNewPhotos')
+  await autoSyncNewPhotosCache.set(value)
   if (value) {
     ensureMediaLibraryPermission()
   }
-  mediaLibraryPermissionsSwr.triggerChange()
+  mediaLibraryPermissionsCache.invalidate()
 }
 
 export async function toggleAutoSyncNewPhotos() {
@@ -91,14 +99,14 @@ export async function toggleAutoSyncNewPhotos() {
 
 const defaultValue = Date.now()
 
-export const [getPhotosNewCursor, usePhotosNewCursor] = createGetterAndSWRHook(
-  settingsSwr.getKey('photosNewCursor'),
-  () => getAsyncStorageNumber('photosNewCursor', defaultValue),
-)
+export const [getPhotosNewCursor, usePhotosNewCursor, photosNewCursorCache] =
+  createGetterAndSWRHook<number>(() =>
+    getAsyncStorageNumber('photosNewCursor', defaultValue),
+  )
 
 export async function setPhotosNewCursor(value: number) {
   await setAsyncStorageNumber('photosNewCursor', value)
-  settingsSwr.triggerChange('photosNewCursor')
+  await photosNewCursorCache.set(value)
 }
 
 export async function resetPhotosNewCursor() {

--- a/src/managers/syncPhotosArchive.test.ts
+++ b/src/managers/syncPhotosArchive.test.ts
@@ -22,10 +22,10 @@ jest.mock('../lib/mediaLibraryPermissions', () => ({
   __esModule: true,
   ensureMediaLibraryPermission: jest.fn(),
   getMediaLibraryPermissions: jest.fn().mockResolvedValue(true),
-  mediaLibraryPermissionsSwr: {
-    getKey: jest.fn((k: string) => [k]),
-    triggerChange: jest.fn(),
-    addChangeCallback: jest.fn(),
+  mediaLibraryPermissionsCache: {
+    key: jest.fn(() => ['mediaLibraryPermissions']),
+    invalidate: jest.fn(),
+    set: jest.fn(),
   },
 }))
 jest.mock('../lib/processAssets', () => ({
@@ -36,13 +36,10 @@ jest.mock('../stores/files', () => ({
   __esModule: true,
   getFileStatsLocal: jest.fn().mockResolvedValue({ count: 0, totalBytes: 0 }),
 }))
-jest.mock('../stores/library', () => ({
+jest.mock('../stores/librarySwr', () => ({
   __esModule: true,
-  librarySwr: {
-    triggerChange: jest.fn(),
-    addChangeCallback: jest.fn(),
-    getKey: jest.fn((k: string) => [k]),
-  },
+  invalidateCacheLibraryAllStats: jest.fn(),
+  invalidateCacheLibraryLists: jest.fn(),
 }))
 
 async function runTick() {

--- a/src/managers/syncPhotosArchive.ts
+++ b/src/managers/syncPhotosArchive.ts
@@ -7,7 +7,7 @@ import { logger } from '../lib/logger'
 import {
   ensureMediaLibraryPermission,
   getMediaLibraryPermissions,
-  mediaLibraryPermissionsSwr,
+  mediaLibraryPermissionsCache,
 } from '../lib/mediaLibraryPermissions'
 import { processAssets } from '../lib/processAssets'
 import { createGetterAndSWRHook } from '../lib/selectors'
@@ -19,8 +19,10 @@ import {
   setAsyncStorageNumber,
 } from '../stores/asyncStore'
 import { getFileStatsLocal } from '../stores/files'
-import { librarySwr } from '../stores/library'
-import { settingsSwr } from '../stores/settings'
+import {
+  invalidateCacheLibraryAllStats,
+  invalidateCacheLibraryLists,
+} from '../stores/librarySwr'
 
 const PAGE_SIZE = 50
 
@@ -69,7 +71,8 @@ export async function workBackward() {
       })),
     )
     if (files.length > 0) {
-      await librarySwr.triggerChange()
+      await invalidateCacheLibraryAllStats()
+      invalidateCacheLibraryLists()
     } else {
       // Nothing was found so immediately start next interval.
       return 0
@@ -88,18 +91,21 @@ export const initSyncPhotosArchive = createServiceInterval({
 
 const defaultValue = 0
 
-export const [getAutoSyncPhotosArchive, useAutoSyncPhotosArchive] =
-  createGetterAndSWRHook(settingsSwr.getKey('autoSyncPhotosArchive'), () =>
-    getAsyncStorageBoolean('autoSyncPhotosArchive', false),
-  )
+export const [
+  getAutoSyncPhotosArchive,
+  useAutoSyncPhotosArchive,
+  autoSyncPhotosArchiveCache,
+] = createGetterAndSWRHook<boolean>(() =>
+  getAsyncStorageBoolean('autoSyncPhotosArchive', false),
+)
 
 export async function setAutoSyncPhotosArchive(value: boolean) {
   await setAsyncStorageBoolean('autoSyncPhotosArchive', value)
-  settingsSwr.triggerChange('autoSyncPhotosArchive')
+  await autoSyncPhotosArchiveCache.set(value)
   if (value) {
     ensureMediaLibraryPermission()
   }
-  mediaLibraryPermissionsSwr.triggerChange()
+  mediaLibraryPermissionsCache.invalidate()
 }
 
 export async function toggleAutoSyncPhotosArchive() {
@@ -108,14 +114,17 @@ export async function toggleAutoSyncPhotosArchive() {
   await setAutoSyncPhotosArchive(next)
 }
 
-export const [getPhotosArchiveCursor, usePhotosArchiveCursor] =
-  createGetterAndSWRHook(settingsSwr.getKey('photosArchiveCursor'), () =>
-    getAsyncStorageNumber('photosArchiveCursor', defaultValue),
-  )
+export const [
+  getPhotosArchiveCursor,
+  usePhotosArchiveCursor,
+  photosArchiveCursorCache,
+] = createGetterAndSWRHook<number>(() =>
+  getAsyncStorageNumber('photosArchiveCursor', defaultValue),
+)
 
 export async function setPhotosArchiveCursor(value: number) {
   await setAsyncStorageNumber('photosArchiveCursor', value)
-  settingsSwr.triggerChange('photosArchiveCursor')
+  await photosArchiveCursorCache.set(value)
 }
 
 export async function restartPhotosArchiveCursor() {

--- a/src/managers/thumbnailer.ts
+++ b/src/managers/thumbnailer.ts
@@ -16,9 +16,9 @@ import {
 } from '../stores/files'
 import { copyFileToFs, getFsFileUri } from '../stores/fs'
 import {
+  invalidateThumbnailsForHash,
   readThumbnailSizesForHash,
   thumbnailExistsForHashAndSize,
-  thumbnailSwr,
 } from '../stores/thumbnails'
 
 // Track files currently being processed to prevent race conditions
@@ -289,7 +289,7 @@ export async function ensureThumbnailForSize(params: {
 
     // Invalidate thumbnail cache for this original file so gallery items update.
     // This will revalidate all thumb sizes for this hash.
-    await thumbnailSwr.triggerChange(fileHash)
+    await invalidateThumbnailsForHash(fileHash)
 
     return {
       status: 'produced',

--- a/src/managers/uploader.test.ts
+++ b/src/managers/uploader.test.ts
@@ -106,14 +106,6 @@ jest.mock('../encoding/fileMetadata', () => ({
   encodeFileMetadata: jest.fn(() => new Uint8Array()),
 }))
 
-jest.mock('../stores/library', () => ({
-  librarySwr: {
-    triggerChange: jest.fn(),
-    addChangeCallback: jest.fn(),
-    getKey: jest.fn((key: string) => key),
-  },
-}))
-
 const TEST_INDEXER_URL = 'https://test.indexer'
 
 async function createTestFile(id: string, size = 1000): Promise<FileEntry> {

--- a/src/managers/uploaderEfficiency.test.ts
+++ b/src/managers/uploaderEfficiency.test.ts
@@ -83,14 +83,6 @@ jest.mock('../encoding/fileMetadata', () => ({
   encodeFileMetadata: jest.fn(() => new Uint8Array()),
 }))
 
-jest.mock('../stores/library', () => ({
-  librarySwr: {
-    triggerChange: jest.fn(),
-    addChangeCallback: jest.fn(),
-    getKey: jest.fn((key: string) => key),
-  },
-}))
-
 const MB = 1024 * 1024
 const KB = 1024
 const TEST_INDEXER_URL = 'https://test.indexer'

--- a/src/screens/SettingsLogsScreen.tsx
+++ b/src/screens/SettingsLogsScreen.tsx
@@ -5,7 +5,7 @@ import { Pressable, StyleSheet, Text, View } from 'react-native'
 import { LogView } from '../components/LogView'
 import { SettingsFullLayout } from '../components/SettingsLayout'
 import { SettingsLogsControlBar } from '../components/SettingsLogsControlBar'
-import { logsSwr, useHasNewLogs } from '../hooks/useLogs'
+import { logsCache, useHasNewLogs } from '../hooks/useLogs'
 import { useMenuHeader } from '../hooks/useMenuHeader'
 import type { MenuStackParamList } from '../stacks/types'
 import { palette } from '../styles/colors'
@@ -20,7 +20,7 @@ export function SettingsLogsScreen({ route, navigation }: Props) {
 
   useEffect(() => {
     if (isFollowing && hasNewLogs) {
-      logsSwr.triggerChange()
+      logsCache.invalidateAll()
     }
   }, [isFollowing, hasNewLogs])
 
@@ -30,7 +30,7 @@ export function SettingsLogsScreen({ route, navigation }: Props) {
 
   const handleShowNewLogs = () => {
     setIsFollowing(true)
-    logsSwr.triggerChange()
+    logsCache.invalidateAll()
   }
 
   return (

--- a/src/stores/appKey.ts
+++ b/src/stores/appKey.ts
@@ -2,11 +2,8 @@ import { AppKey, type AppKeyInterface } from 'react-native-sia'
 import { hexArrayBufferCodec } from '../encoding/arrayBuffer'
 import { logger } from '../lib/logger'
 import { createGetterAndSWRHook } from '../lib/selectors'
-import { buildSWRHelpers } from '../lib/swr'
 import { getSecureStoreJSON, setSecureStoreJSON } from './secureStore'
 import { getIndexerURL } from './settings'
-
-const appKeySwr = buildSWRHelpers('appKey')
 
 /**
  * AppKeys are stored per indexer URL. Each indexer has its own AppKey derived
@@ -66,17 +63,15 @@ export async function getAppKeyForIndexer(
 /**
  * Get the AppKey for the currently active indexer.
  */
-export const [getAppKey, useAppKey] = createGetterAndSWRHook<AppKey>(
-  appKeySwr.getKey(),
-  async () => {
+export const [getAppKey, useAppKey, appKeyCache] =
+  createGetterAndSWRHook<AppKey>(async () => {
     const indexerURL = await getIndexerURL()
     const appKey = await getAppKeyForIndexer(indexerURL)
     if (!appKey) {
       throw new Error('AppKey not found for active indexer')
     }
     return appKey
-  },
-)
+  })
 
 /**
  * Set the AppKey for a specific indexer URL.
@@ -91,7 +86,7 @@ export async function setAppKeyForIndexer(
   const appKeysMap = await getAppKeysMap()
   appKeysMap[indexerURL] = exported
   await setAppKeysMap(appKeysMap)
-  appKeySwr.triggerChange()
+  appKeyCache.invalidate()
 }
 
 /**
@@ -151,5 +146,5 @@ async function setAppKeysMap(map: AppKeysMap): Promise<void> {
 export async function clearAppKeys(): Promise<void> {
   await setSecureStoreJSON(APP_KEYS_SECURE_STORE_KEY, undefined, appKeysCodec)
   cachedAppKeys.clear()
-  appKeySwr.triggerChange()
+  appKeyCache.invalidate()
 }

--- a/src/stores/fileCarousel.test.ts
+++ b/src/stores/fileCarousel.test.ts
@@ -10,22 +10,7 @@ import {
 import { createFileRecord } from './files'
 import type { Category } from './library'
 
-const mockChangeCallbacks = new Map<string, () => void>()
-
-jest.mock('./librarySwr', () => ({
-  librarySwr: {
-    triggerChange: jest.fn(() => {
-      mockChangeCallbacks.forEach((callback) => callback())
-    }),
-    addChangeCallback: jest.fn((key: string, callback: () => void) => {
-      mockChangeCallbacks.set(key, callback)
-    }),
-    removeChangeCallback: jest.fn((key: string) => {
-      mockChangeCallbacks.delete(key)
-    }),
-    getKey: jest.fn((key: string) => key),
-  },
-}))
+import { invalidateCacheLibraryLists } from './librarySwr'
 
 jest.mock('./library', () => {
   const actual = jest.requireActual('./library')
@@ -410,13 +395,11 @@ describe('useFileCarousel hook', () => {
 
   beforeEach(async () => {
     await initializeDB()
-    mockChangeCallbacks.clear()
   })
 
   afterEach(async () => {
     await resetDb()
     jest.clearAllMocks()
-    mockChangeCallbacks.clear()
   })
 
   async function createRecord(params: {
@@ -442,7 +425,7 @@ describe('useFileCarousel hook', () => {
   }
 
   function triggerSyncChange() {
-    mockChangeCallbacks.forEach((callback) => callback())
+    invalidateCacheLibraryLists()
   }
 
   describe('sync event handling', () => {

--- a/src/stores/fileCarousel.ts
+++ b/src/stores/fileCarousel.ts
@@ -9,7 +9,7 @@ import {
   type SortDir,
   useLibrary,
 } from './library'
-import { librarySwr } from './librarySwr'
+import { useOnLibraryListChange } from './librarySwr'
 import { readLocalObjectsForFiles } from './localObjects'
 
 const FILE_COLUMNS =
@@ -473,31 +473,23 @@ export function useFileCarousel({
     populateCaches,
   ])
 
-  const handleLibraryChange = useCallback(async () => {
+  useOnLibraryListChange(() => {
     if (isLoading) return
-
     const currentFileID = currentFileIdRef.current
     if (!currentFileID) return
 
-    try {
-      const row = await db().getFirstAsync<{ id: string }>(
+    db()
+      .getFirstAsync<{ id: string }>(
         'SELECT id FROM files WHERE id = ? LIMIT 1',
         currentFileID,
       )
-      if (!row) {
-        onDeleted?.()
-      }
-    } catch (_e) {
-      // Silently ignore errors during sync handling.
-    }
-  }, [isLoading, onDeleted])
-
-  useEffect(() => {
-    librarySwr.addChangeCallback('carousel', handleLibraryChange)
-    return () => {
-      librarySwr.removeChangeCallback('carousel')
-    }
-  }, [handleLibraryChange])
+      .then((row) => {
+        if (!row) {
+          onDeleted?.()
+        }
+      })
+      .catch(() => {})
+  })
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: cacheVersion forces new function reference when caches update
   const getFileAtIndex = useCallback(

--- a/src/stores/files.test.ts
+++ b/src/stores/files.test.ts
@@ -8,14 +8,6 @@ import {
 } from './files'
 import { upsertFsFileMetadata } from './fs'
 
-jest.mock('./library', () => ({
-  librarySwr: {
-    triggerChange: jest.fn(),
-    addChangeCallback: jest.fn(),
-    getKey: jest.fn((key: string) => key),
-  },
-}))
-
 describe('files store queries', () => {
   const base = 1_000
 

--- a/src/stores/files.ts
+++ b/src/stores/files.ts
@@ -8,10 +8,18 @@ import {
 } from '../encoding/localObject'
 import { logger } from '../lib/logger'
 import { createGetterAndSWRHook } from '../lib/selectors'
+import { swrCacheBy } from '../lib/swr'
 import { keysOf } from '../lib/types'
-import { librarySwr } from './librarySwr'
+import {
+  invalidateCacheLibraryAllStats,
+  invalidateCacheLibraryLists,
+  libraryStats,
+} from './librarySwr'
 import { readLocalObjectsForFile, upsertLocalObject } from './localObjects'
 import { getIndexerURL } from './settings'
+
+/** Single file record keyed by file ID. */
+const fileByIdCache = swrCacheBy()
 
 /** Valid thumbnail sizes in pixels. */
 export type ThumbSize = 64 | 512
@@ -97,7 +105,8 @@ export async function createFileRecord(
     thumbSize,
   })
   if (triggerUpdate) {
-    await librarySwr.triggerChange()
+    await invalidateCacheLibraryAllStats()
+    invalidateCacheLibraryLists()
   }
 }
 
@@ -110,7 +119,8 @@ export async function createManyFileRecords(
     }
   })
   if (files.length > 0) {
-    await librarySwr.triggerChange()
+    await invalidateCacheLibraryAllStats()
+    invalidateCacheLibraryLists()
   }
 }
 
@@ -386,7 +396,7 @@ export async function updateFileRecord(
 
   await sqlUpdate('files', assignments, { id })
   if (triggerUpdate) {
-    await librarySwr.triggerChange()
+    invalidateCacheLibraryLists()
   }
 }
 
@@ -400,7 +410,7 @@ export async function updateManyFileRecords(
     }
   })
   if (updates.length > 0) {
-    await librarySwr.triggerChange()
+    invalidateCacheLibraryLists()
   }
 }
 
@@ -410,7 +420,8 @@ export async function deleteFileRecord(
 ): Promise<void> {
   await sqlDelete('files', { id })
   if (triggerUpdate) {
-    await librarySwr.triggerChange()
+    await invalidateCacheLibraryAllStats()
+    invalidateCacheLibraryLists()
   }
 }
 
@@ -421,7 +432,8 @@ export async function deleteManyFileRecords(ids: string[]): Promise<void> {
       await deleteFileRecord(id, false)
     }
   })
-  await librarySwr.triggerChange()
+  await invalidateCacheLibraryAllStats()
+  invalidateCacheLibraryLists()
 }
 
 /** Delete an original file and all its associated thumbnails. */
@@ -433,7 +445,8 @@ export async function deleteFileRecordAndThumbnails(id: string): Promise<void> {
     await sqlDelete('files', { thumbForHash: hash })
     await sqlDelete('files', { id })
   })
-  await librarySwr.triggerChange()
+  await invalidateCacheLibraryAllStats()
+  invalidateCacheLibraryLists()
 }
 
 /** Delete multiple files and all their associated thumbnails. */
@@ -454,7 +467,8 @@ export async function deleteManyFileRecordsAndThumbnails(
       await sqlDelete('files', { id })
     }
   })
-  await librarySwr.triggerChange()
+  await invalidateCacheLibraryAllStats()
+  invalidateCacheLibraryLists()
 }
 
 export async function deleteAllFileRecords(): Promise<void> {
@@ -465,13 +479,17 @@ export async function deleteAllFileRecords(): Promise<void> {
 export async function createFileRecordWithLocalObject(
   fileRecord: Omit<FileRecord, 'objects'>,
   localObject: LocalObject,
+  triggerUpdate: boolean = true,
 ): Promise<void> {
   try {
     await withTransactionLock(async () => {
       await createFileRecord(fileRecord, false)
       await upsertLocalObject(localObject, false)
     })
-    await librarySwr.triggerChange()
+    if (triggerUpdate) {
+      await invalidateCacheLibraryAllStats()
+      invalidateCacheLibraryLists()
+    }
   } catch (e) {
     logger.error('db', 'create_file_record_error', { error: e as Error })
     throw e
@@ -483,13 +501,17 @@ export async function updateFileRecordWithLocalObject(
   fileRecord: Omit<FileRecord, 'objects'>,
   localObject: LocalObject,
   options: { includeUpdatedAt?: boolean } = { includeUpdatedAt: false },
+  triggerUpdate: boolean = true,
 ): Promise<void> {
   try {
     await withTransactionLock(async () => {
       await updateFileRecord(fileRecord, false, options)
       await upsertLocalObject(localObject, false)
     })
-    await librarySwr.triggerChange()
+    if (triggerUpdate) {
+      await invalidateCacheLibraryAllStats()
+      invalidateCacheLibraryLists()
+    }
   } catch (e) {
     logger.error('db', 'update_file_record_error', { error: e as Error })
     throw e
@@ -521,7 +543,7 @@ export function transformRow(
 }
 
 export function useFileCountAll() {
-  return useSWR(librarySwr.getKey('count'), () =>
+  return useSWR(libraryStats.key('count'), () =>
     readAllFileRecordsCount({
       limit: undefined,
       after: undefined,
@@ -531,7 +553,7 @@ export function useFileCountAll() {
 }
 
 export function useFileStatsAll() {
-  return useSWR(librarySwr.getKey('stats'), () =>
+  return useSWR(libraryStats.key('stats'), () =>
     readAllFileRecordsStats({
       limit: undefined,
       after: undefined,
@@ -541,7 +563,7 @@ export function useFileStatsAll() {
 }
 
 export const [getFilesLocalOnly, useFilesLocalOnly] = createGetterAndSWRHook(
-  librarySwr.getKey('localOnly'),
+  libraryStats.key('localOnly'),
   async ({
     limit,
     order,
@@ -570,7 +592,7 @@ export const [getFilesLocalOnly, useFilesLocalOnly] = createGetterAndSWRHook(
 )
 
 export const [getFileCountLost, useFileCountLost] = createGetterAndSWRHook(
-  librarySwr.getKey('lostFiles'),
+  libraryStats.key('lostCount'),
   async () => {
     const currentIndexerURL = await getIndexerURL()
     return readAllFileRecordsCount({
@@ -585,7 +607,7 @@ export const [getFileCountLost, useFileCountLost] = createGetterAndSWRHook(
 )
 
 export const [getFileStatsLost, useFileStatsLost] = createGetterAndSWRHook(
-  librarySwr.getKey('lostStats'),
+  libraryStats.key('lostStats'),
   async () => {
     const currentIndexerURL = await getIndexerURL()
     return readAllFileRecordsStats({
@@ -600,7 +622,7 @@ export const [getFileStatsLost, useFileStatsLost] = createGetterAndSWRHook(
 )
 
 export const [getFileCountLocal, useFileCountLocal] = createGetterAndSWRHook(
-  librarySwr.getKey('localCount'),
+  libraryStats.key('localCount'),
   async ({ localOnly }: { localOnly: boolean }) => {
     const currentIndexerURL = await getIndexerURL()
     return readAllFileRecordsCount({
@@ -615,7 +637,7 @@ export const [getFileCountLocal, useFileCountLocal] = createGetterAndSWRHook(
 )
 
 export const [getFileStatsLocal, useFileStatsLocal] = createGetterAndSWRHook(
-  librarySwr.getKey('localStats'),
+  libraryStats.key('localStats'),
   async ({ localOnly }: { localOnly: boolean }) => {
     const currentIndexerURL = await getIndexerURL()
     return readAllFileRecordsStats({
@@ -630,5 +652,5 @@ export const [getFileStatsLocal, useFileStatsLocal] = createGetterAndSWRHook(
 )
 
 export function useFileDetails(id: string) {
-  return useSWR(librarySwr.getKey(id), () => readFileRecord(id))
+  return useSWR(fileByIdCache.key(id), () => readFileRecord(id))
 }

--- a/src/stores/fs.ts
+++ b/src/stores/fs.ts
@@ -1,20 +1,17 @@
 import { Directory, File, Paths } from 'expo-file-system'
-import useSWR, { mutate } from 'swr'
+import useSWR from 'swr'
 import { db } from '../db'
 import { sqlDelete, sqlInsert, sqlUpdate } from '../db/sql'
 import { extFromMime } from '../lib/fileTypes'
 import { logger } from '../lib/logger'
-import { buildSWRHelpers } from '../lib/swr'
+import { swrCacheBy } from '../lib/swr'
 
 /**
  * Persistent file system used for storing local copies of files.
  */
 
-const { getKey, triggerChange } = buildSWRHelpers('fs/files')
-
-function swrKeyFsFileUri(fileId?: string) {
-  return [...getKey(fileId), 'uri']
-}
+/** Local filesystem URI for a file, keyed by file ID. */
+export const fsFileUriCache = swrCacheBy<string | null>()
 
 export type FsFileInfo = {
   id: string
@@ -29,10 +26,6 @@ export type FsMetaRow = {
 }
 
 export const fsStorageDirectory = new Directory(Paths.document, 'files')
-
-export function fsTriggerRefresh(fileId?: string): Promise<void> {
-  return triggerChange(fileId)
-}
 
 export function listFilesInFsStorageDirectory(): File[] {
   const info = fsStorageDirectory.info()
@@ -95,18 +88,18 @@ export async function getFsFileUri(file: FsFileInfo): Promise<string | null> {
 export async function removeFsFile(file: FsFileInfo): Promise<void> {
   const fsFile = getFsFileForId(file)
   const info = fsFile.info()
-  let mutated = false
+  let changed = false
   if (info.exists) {
     fsFile.delete()
-    mutated = true
+    changed = true
   }
   const meta = await readFsFileMetadata(file.id)
   if (meta) {
     await deleteFsFileMetadata(file.id)
-    mutated = true
+    changed = true
   }
-  if (mutated) {
-    fsTriggerRefresh(file.id)
+  if (changed) {
+    await fsFileUriCache.set(null, file.id)
   }
 }
 
@@ -131,12 +124,12 @@ export async function copyFileToFs(
     addedAt: previous?.addedAt ?? Date.now(),
     usedAt: Date.now(),
   })
-  await mutate(swrKeyFsFileUri(file.id), target.uri, { revalidate: false })
+  await fsFileUriCache.set(target.uri, file.id)
   return target.uri
 }
 
 export function useFsFileUri(file?: FsFileInfo) {
-  return useSWR(swrKeyFsFileUri(file?.id), () => {
+  return useSWR(fsFileUriCache.key(file?.id ?? ''), () => {
     return file ? getFsFileUri(file) : null
   })
 }

--- a/src/stores/hosts.tsx
+++ b/src/stores/hosts.tsx
@@ -1,11 +1,16 @@
 import useSWR from 'swr'
+import { swrCache, swrCacheBy } from '../lib/swr'
 import { useSdk } from './sdk'
 
-const KEY = 'sdk/hosts'
+/** Full list of all hosts. */
+const allHostsCache = swrCache()
+
+/** Single host keyed by public key. */
+const hostByKeyCache = swrCacheBy()
 
 export function useHosts() {
   const sdk = useSdk()
-  return useSWR(sdk ? [KEY] : null, async () => sdk?.hosts(), {
+  return useSWR(sdk ? allHostsCache.key() : null, () => sdk!.hosts(), {
     revalidateOnFocus: false,
     refreshInterval: 20_000,
   })
@@ -13,7 +18,7 @@ export function useHosts() {
 
 export function useHost(publicKey: string) {
   const hosts = useHosts()
-  return useSWR(hosts.data ? [KEY, publicKey] : null, () =>
+  return useSWR(hosts.data ? hostByKeyCache.key(publicKey) : null, () =>
     hosts.data?.find((h) => h.publicKey === publicKey),
   )
 }

--- a/src/stores/library.ts
+++ b/src/stores/library.ts
@@ -1,14 +1,11 @@
-import { useEffect, useMemo } from 'react'
+import { useMemo } from 'react'
 import useSWR from 'swr'
 import useSWRInfinite from 'swr/infinite'
 import { create } from 'zustand'
 import { db } from '../db'
-import { useDebouncedCallback } from '../hooks/useDebouncedCallback'
 import { type FileRecord, type FileRecordRow, transformRow } from './files'
-import { librarySwr } from './librarySwr'
+import { libraryStats, useOnLibraryListChange } from './librarySwr'
 import { readLocalObjectsForFiles } from './localObjects'
-
-export { librarySwr }
 
 type MediaCategory = 'Video' | 'Image' | 'Audio'
 const MEDIA_PREFIXES: Record<MediaCategory, string> = {
@@ -70,15 +67,12 @@ const PAGE_SIZE = 40
 export function useFileList() {
   const { sortBy, sortDir, selectedCategories, searchQuery } = useLibrary()
   const sortingDir = sortDir ?? (sortBy === 'NAME' ? 'ASC' : 'DESC')
-
   const categories = Array.from(selectedCategories ?? new Set())
   const categoriesKey = categories.length
     ? categories.slice().sort().join(',')
     : ''
 
-  const base = librarySwr.getKey(
-    `list:${sortBy}:${sortingDir}:${categoriesKey}:${searchQuery ?? ''}`,
-  )
+  const base = `library/list:${sortBy}:${sortingDir}:${categoriesKey}:${searchQuery ?? ''}`
 
   const fetcher = async (key: string) => {
     const pageIndex = Number(key.split('|page=').pop() ?? '0')
@@ -103,14 +97,7 @@ export function useFileList() {
     { revalidateOnFocus: false, revalidateAll: true },
   )
 
-  const debouncedMutate = useDebouncedCallback(() => swr.mutate(), 100)
-
-  useEffect(() => {
-    librarySwr.addChangeCallback('infiniteList', debouncedMutate)
-    return () => {
-      librarySwr.removeChangeCallback('infiniteList')
-    }
-  }, [debouncedMutate])
+  useOnLibraryListChange(() => swr.mutate())
 
   const pages = swr.data
 
@@ -130,7 +117,7 @@ export function useFileList() {
 
 // Count of library files excluding thumbnails.
 export function useLibraryCount() {
-  return useSWR(librarySwr.getKey('countWithoutThumbs'), async () => {
+  return useSWR(libraryStats.key('countNoThumbs'), async () => {
     const row = await db().getFirstAsync<{ count: number }>(
       `SELECT COUNT(*) as count FROM files WHERE thumbForHash IS NULL`,
     )

--- a/src/stores/librarySwr.ts
+++ b/src/stores/librarySwr.ts
@@ -1,3 +1,33 @@
-import { buildSWRHelpers } from '../lib/swr'
+import { useEffect, useRef } from 'react'
+import { create } from 'zustand'
+import { swrCacheBy } from '../lib/swr'
 
-export const librarySwr = buildSWRHelpers('library')
+/** Library stat queries (count, stats, localOnly, etc.), keyed by stat name. invalidateAll() clears them together. */
+export const libraryStats = swrCacheBy()
+
+export const invalidateCacheLibraryAllStats = () => libraryStats.invalidateAll()
+
+// Version counter for signaling library list changes. Subscribers use
+// useOnLibraryListChange to run a callback when the version bumps.
+type LibraryVersionState = { version: number }
+
+const useLibraryVersion = create<LibraryVersionState>(() => ({
+  version: 0,
+}))
+
+export function invalidateCacheLibraryLists() {
+  useLibraryVersion.setState((s) => ({ version: s.version + 1 }))
+}
+
+/** Runs `callback` whenever the library list version bumps. */
+export function useOnLibraryListChange(callback: () => void) {
+  const { version } = useLibraryVersion()
+  const versionRef = useRef(version)
+  const callbackRef = useRef(callback)
+  callbackRef.current = callback
+  useEffect(() => {
+    if (version === versionRef.current) return
+    versionRef.current = version
+    callbackRef.current()
+  }, [version])
+}

--- a/src/stores/localObjects.ts
+++ b/src/stores/localObjects.ts
@@ -6,7 +6,10 @@ import {
   localObjectFromStorageRow,
   localObjectToStorageRow,
 } from '../encoding/localObject'
-import { librarySwr } from './librarySwr'
+import {
+  invalidateCacheLibraryAllStats,
+  invalidateCacheLibraryLists,
+} from './librarySwr'
 
 export async function readLocalObjectsForFile(
   fileId: string,
@@ -42,7 +45,8 @@ export async function upsertLocalObject(
     { conflictClause: 'OR REPLACE' },
   )
   if (triggerUpdate) {
-    await librarySwr.triggerChange()
+    await invalidateCacheLibraryAllStats()
+    invalidateCacheLibraryLists()
   }
 }
 
@@ -52,7 +56,8 @@ export async function deleteLocalObjects(
 ): Promise<void> {
   await sqlDelete('objects', { fileId })
   if (triggerUpdate) {
-    await librarySwr.triggerChange()
+    await invalidateCacheLibraryAllStats()
+    invalidateCacheLibraryLists()
   }
 }
 
@@ -61,7 +66,8 @@ export async function deleteManyLocalObjects(fileIds: string[]): Promise<void> {
   for (const fileId of fileIds) {
     await deleteLocalObjects(fileId, false)
   }
-  await librarySwr.triggerChange()
+  await invalidateCacheLibraryAllStats()
+  invalidateCacheLibraryLists()
 }
 
 export async function readLocalObjectsForFiles(

--- a/src/stores/logs.ts
+++ b/src/stores/logs.ts
@@ -10,7 +10,6 @@ import {
   serializeData,
 } from '../lib/logger'
 import { createGetterAndSWRHook } from '../lib/selectors'
-import { buildSWRHelpers } from '../lib/swr'
 import { getAsyncStorageString, setAsyncStorageString } from './asyncStore'
 
 export type LogsState = {
@@ -52,8 +51,6 @@ export async function initLogger(): Promise<void> {
   hasInit = true
 }
 
-export const logsScopeSwr = buildSWRHelpers('logScopes')
-
 async function fetchAvailableScopes(): Promise<string[]> {
   try {
     if (!dbInitialized) return []
@@ -67,10 +64,8 @@ async function fetchAvailableScopes(): Promise<string[]> {
   }
 }
 
-export const [getAvailableScopes, useAvailableScopes] = createGetterAndSWRHook(
-  logsScopeSwr.getKey('available'),
-  fetchAvailableScopes,
-)
+export const [getAvailableScopes, useAvailableScopes] =
+  createGetterAndSWRHook<string[]>(fetchAvailableScopes)
 
 export function useLogLevel(): LogLevel {
   return useLogsStore(useShallow((s) => s.logLevel))

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -1,6 +1,5 @@
 import { DEFAULT_INDEXER_URL } from '../config'
 import { createGetterAndSWRHook } from '../lib/selectors'
-import { buildSWRHelpers } from '../lib/swr'
 import {
   getAsyncStorageBoolean,
   getAsyncStorageString,
@@ -8,54 +7,48 @@ import {
   setAsyncStorageString,
 } from './asyncStore'
 
-export const settingsSwr = buildSWRHelpers('settings')
-
 // Active Indexer URL
 
-export const [getIndexerURL, useIndexerURL] = createGetterAndSWRHook(
-  settingsSwr.getKey('indexerURL'),
-  () => getAsyncStorageString<string>('indexerURL', DEFAULT_INDEXER_URL),
-)
+export const [getIndexerURL, useIndexerURL, indexerURLCache] =
+  createGetterAndSWRHook<string>(() =>
+    getAsyncStorageString<string>('indexerURL', DEFAULT_INDEXER_URL),
+  )
 
 export async function setIndexerURL(value: string) {
   await setAsyncStorageString('indexerURL', value)
-  settingsSwr.triggerChange('indexerURL')
+  await indexerURLCache.set(value)
 }
 
 // Has Onboarded
 
-export const [getHasOnboarded, useHasOnboarded] = createGetterAndSWRHook(
-  settingsSwr.getKey('hasOnboarded'),
-  () => getAsyncStorageBoolean('hasOnboarded'),
-)
+export const [getHasOnboarded, useHasOnboarded, hasOnboardedCache] =
+  createGetterAndSWRHook<boolean>(() => getAsyncStorageBoolean('hasOnboarded'))
 
 export async function setHasOnboarded(value: boolean) {
   await setAsyncStorageBoolean('hasOnboarded', value)
-  settingsSwr.triggerChange('hasOnboarded')
+  await hasOnboardedCache.set(value)
 }
 
 // Show Advanced
 
+export const [getShowAdvanced, useShowAdvanced, showAdvancedCache] =
+  createGetterAndSWRHook<boolean>(() => getAsyncStorageBoolean('showAdvanced'))
+
 export async function setShowAdvanced(value: boolean) {
   await setAsyncStorageBoolean('showAdvanced', value)
-  settingsSwr.triggerChange('showAdvanced')
+  await showAdvancedCache.set(value)
 }
-
-export const [getShowAdvanced, useShowAdvanced] = createGetterAndSWRHook(
-  settingsSwr.getKey('showAdvanced'),
-  () => getAsyncStorageBoolean('showAdvanced'),
-)
 
 // Auto Scan Uploads
 
-export const [getAutoScanUploads, useAutoScanUploads] = createGetterAndSWRHook(
-  settingsSwr.getKey('autoScanUploads'),
-  () => getAsyncStorageBoolean('autoScanUploads', true),
-)
+export const [getAutoScanUploads, useAutoScanUploads, autoScanUploadsCache] =
+  createGetterAndSWRHook<boolean>(() =>
+    getAsyncStorageBoolean('autoScanUploads', true),
+  )
 
 export async function setAutoScanUploads(value: boolean) {
   await setAsyncStorageBoolean('autoScanUploads', value)
-  settingsSwr.triggerChange('autoScanUploads')
+  await autoScanUploadsCache.set(value)
 }
 
 export async function toggleAutoScanUploads() {
@@ -66,14 +59,17 @@ export async function toggleAutoScanUploads() {
 
 // Auto Sync Down Events
 
-export const [getAutoSyncDownEvents, useAutoSyncDownEvents] =
-  createGetterAndSWRHook(settingsSwr.getKey('autoSyncDownEvents'), () =>
-    getAsyncStorageBoolean('autoSyncDownEvents', true),
-  )
+export const [
+  getAutoSyncDownEvents,
+  useAutoSyncDownEvents,
+  autoSyncDownEventsCache,
+] = createGetterAndSWRHook<boolean>(() =>
+  getAsyncStorageBoolean('autoSyncDownEvents', true),
+)
 
 export async function setAutoSyncDownEvents(value: boolean) {
   await setAsyncStorageBoolean('autoSyncDownEvents', value)
-  settingsSwr.triggerChange('autoSyncDownEvents')
+  await autoSyncDownEventsCache.set(value)
 }
 
 export async function toggleAutoSyncDownEvents() {
@@ -86,14 +82,14 @@ export async function toggleAutoSyncDownEvents() {
 
 export type LibraryViewMode = 'gallery' | 'list'
 
-export const [getLibraryViewMode, useLibraryViewMode] = createGetterAndSWRHook(
-  settingsSwr.getKey('libraryViewMode'),
-  () => getAsyncStorageString<LibraryViewMode>('libraryViewMode', 'gallery'),
-)
+export const [getLibraryViewMode, useLibraryViewMode, libraryViewModeCache] =
+  createGetterAndSWRHook<LibraryViewMode>(() =>
+    getAsyncStorageString<LibraryViewMode>('libraryViewMode', 'gallery'),
+  )
 
 export async function setLibraryViewMode(value: LibraryViewMode) {
   await setAsyncStorageString<LibraryViewMode>('libraryViewMode', value)
-  settingsSwr.triggerChange('libraryViewMode')
+  await libraryViewModeCache.set(value)
 }
 
 export async function toggleLibraryViewMode() {
@@ -106,12 +102,15 @@ export async function toggleLibraryViewMode() {
 
 export type StatusDisplayMode = 'count' | 'size'
 
-export const [getStatusDisplayMode, useStatusDisplayMode] =
-  createGetterAndSWRHook(settingsSwr.getKey('statusDisplayMode'), () =>
-    getAsyncStorageString<StatusDisplayMode>('statusDisplayMode', 'count'),
-  )
+export const [
+  getStatusDisplayMode,
+  useStatusDisplayMode,
+  statusDisplayModeCache,
+] = createGetterAndSWRHook<StatusDisplayMode>(() =>
+  getAsyncStorageString<StatusDisplayMode>('statusDisplayMode', 'count'),
+)
 
 export async function setStatusDisplayMode(value: StatusDisplayMode) {
   await setAsyncStorageString<StatusDisplayMode>('statusDisplayMode', value)
-  settingsSwr.triggerChange('statusDisplayMode')
+  await statusDisplayModeCache.set(value)
 }

--- a/src/stores/thumbnails.ts
+++ b/src/stores/thumbnails.ts
@@ -1,5 +1,5 @@
 import { db } from '../db'
-import { buildSWRHelpers } from '../lib/swr'
+import { swrCacheBy } from '../lib/swr'
 import {
   type FileRecord,
   type FileRecordRow,
@@ -9,7 +9,20 @@ import {
 } from './files'
 import { readLocalObjectsForFile } from './localObjects'
 
-export const thumbnailSwr = buildSWRHelpers('thumbnails')
+/** Single best thumbnail for a given (hash, thumbSize) pair. */
+export const bestThumbnailCache = swrCacheBy()
+
+/** All thumbnails associated with an original file hash. */
+export const thumbnailsByHashCache = swrCacheBy()
+
+export async function invalidateThumbnailsForHash(hash: string) {
+  await Promise.all([
+    ...ThumbSizes.map((size) =>
+      bestThumbnailCache.invalidate(hash, String(size)),
+    ),
+    thumbnailsByHashCache.invalidate(hash),
+  ])
+}
 
 /** Read all thumbnails associated with an original file content hash. */
 export async function readThumbnailsByHash(
@@ -72,7 +85,7 @@ export async function readBestThumbnailByHash(
     `SELECT id, name, size, createdAt, updatedAt, type, localId, hash, addedAt, thumbForHash, thumbSize
      FROM files
      WHERE thumbForHash = ? AND COALESCE(thumbSize, 0) <= ?
-     ORDER BY 
+     ORDER BY
        COALESCE(thumbSize, 0) DESC,
        id ASC
      LIMIT 1`,

--- a/test/utils/setup.ts
+++ b/test/utils/setup.ts
@@ -210,16 +210,6 @@ jest.mock('../../src/lib/fileReader', () => ({
   }),
 }))
 
-// Library SWR - keep as mock for simplicity, but include real query building functions
-jest.mock('../../src/stores/library', () => ({
-  ...jest.requireActual('../../src/stores/library'),
-  librarySwr: {
-    triggerChange: jest.fn(),
-    addChangeCallback: jest.fn(),
-    getKey: jest.fn((key: string) => key),
-  },
-}))
-
 // Suppress expected warnings from Expo modules
 const suppressedWarnings = [
   'EXNativeModulesProxy',


### PR DESCRIPTION
This and the next PR aim to reduce unnecessary re-rendering / revalidation. Right now the swr keys revalidate everything constantly. And the sync service triggers these updates for every event. The changes in this PR also move to setting new values into the swr cache whenever possible rather than triggering a general mutate and letting hooks revalidate which can cause some intermediate state issues.

Replace blanket cache invalidation with targeted updates scoped to exactly what changed. Mutations now only refresh the specific stats, lists, or records they affect instead of triggering full reloads.

- Typed cache factories with auto-generated keys replace shared mutable helpers
- Sync loops batch invalidation once after the loop instead of per-event
- Gallery list revalidates pages in place instead of full key swap
- useFileStatus uses useMemo instead of unnecessary SWR async layer