### PR TITLE
perf: batch DB transactions and add adaptive interval in syncDownEvents

### DIFF
--- a/.changeset/batch-sync-down.md
+++ b/.changeset/batch-sync-down.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Improved sync performance with batched database writes and adaptive polling intervals.

--- a/.changeset/syncing-indicator-empty.md
+++ b/.changeset/syncing-indicator-empty.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Added a syncing indicator on the empty library screen so new users can see progress.

--- a/src/managers/syncDownEvents.test.ts
+++ b/src/managers/syncDownEvents.test.ts
@@ -565,7 +565,7 @@ describe('syncDownEvents', () => {
     expect(file).toBeNull()
   })
 
-  test('error in delete event breaks loop without advancing cursor', async () => {
+  test('FS error in delete cleanup does not prevent cursor advancement', async () => {
     // Create existing file.
     const file: Omit<FileRecord, 'objects'> = {
       id: 'file-1',
@@ -591,7 +591,6 @@ describe('syncDownEvents', () => {
       }),
     )
 
-    // First event will fail during delete.
     const events: ObjectEvent[] = [
       makeObjectEvent({
         id: 'obj-1',
@@ -609,16 +608,23 @@ describe('syncDownEvents', () => {
       objectEvents: jest.fn().mockResolvedValueOnce(events),
     } as any)
 
-    // Simulate error during file system removal.
+    // Simulate error during file system removal (cleanup phase).
     jest.mocked(removeFsFile).mockRejectedValueOnce(new Error('FS error'))
 
     await syncDownEvents()
 
-    // Cursor should not have advanced because error broke the loop.
+    // Cursor should have advanced because DB commit succeeded (FS cleanup is non-fatal).
     const cursor = await getSyncDownCursor()
-    expect(cursor).toBeUndefined()
+    expect(cursor).toEqual({
+      id: 'obj-2',
+      after: new Date(NOW_BASE + 2 + cursorIncrement),
+    })
 
-    // Verify that removeFsFile was called, indicating the delete was attempted.
+    // File should be deleted from DB.
+    const deletedFile = await readFileRecordByObjectId('obj-1')
+    expect(deletedFile).toBeNull()
+
+    // Verify that removeFsFile was still called.
     expect(removeFsFile).toHaveBeenCalled()
   })
 
@@ -712,6 +718,66 @@ describe('syncDownEvents', () => {
     expect(thumb).not.toBeNull()
   })
 
+  test('deduplicates thumbnail events with same thumbForHash+thumbSize in batch', async () => {
+    const thumb1: FileMetadata = {
+      thumbForHash: 'hash-original',
+      thumbSize: 512,
+      name: 'thumb1.jpg',
+      type: 'image/jpeg',
+      size: 50,
+      hash: 'hash-thumb-1',
+      createdAt: NOW_BASE,
+      updatedAt: NOW_BASE,
+    }
+
+    const thumb2: FileMetadata = {
+      thumbForHash: 'hash-original',
+      thumbSize: 512,
+      name: 'thumb2.jpg',
+      type: 'image/jpeg',
+      size: 55,
+      hash: 'hash-thumb-2',
+      createdAt: NOW_BASE + 1,
+      updatedAt: NOW_BASE + 1,
+    }
+
+    const events: ObjectEvent[] = [
+      makeObjectEvent({
+        id: 'obj-thumb-1',
+        updatedAt: new Date(NOW_BASE),
+        object: makeMockPinnedObject(thumb1, 'obj-thumb-1'),
+      }),
+      makeObjectEvent({
+        id: 'obj-thumb-2',
+        updatedAt: new Date(NOW_BASE + 1),
+        object: makeMockPinnedObject(thumb2, 'obj-thumb-2'),
+      }),
+    ]
+
+    getSdkMock.mockReturnValue({
+      objectEvents: jest.fn().mockResolvedValueOnce(events),
+    } as any)
+
+    await syncDownEvents()
+
+    // First event creates the thumbnail.
+    const t1 = await readFileRecordByObjectId('obj-thumb-1')
+    expect(t1).not.toBeNull()
+
+    // Second event with same thumbForHash+thumbSize is treated as an update
+    // (deduped), not a create that would violate the UNIQUE constraint.
+    const t2 = await readFileRecordByObjectId('obj-thumb-2')
+    expect(t2).not.toBeNull()
+    expect(t2!.id).toBe(t1!.id)
+
+    // Cursor should have advanced past both events.
+    const cursor = await getSyncDownCursor()
+    expect(cursor).toEqual({
+      id: 'obj-thumb-2',
+      after: new Date(NOW_BASE + 1 + cursorIncrement),
+    })
+  })
+
   test('cursor persists across multiple runs', async () => {
     // First run events.
     const metadata1: FileMetadata = {
@@ -789,5 +855,86 @@ describe('syncDownEvents', () => {
 
     cursor = await getSyncDownCursor()
     expect(cursor).toBeUndefined()
+  })
+
+  test('returns 0 interval (poll immediately) when multiple events found', async () => {
+    const metadata1: FileMetadata = {
+      name: 'test1.jpg',
+      type: 'image/jpeg',
+      size: 100,
+      hash: 'hash-1',
+      createdAt: NOW_BASE,
+      updatedAt: NOW_BASE,
+      thumbForHash: undefined,
+      thumbSize: undefined,
+    }
+
+    const metadata2: FileMetadata = {
+      name: 'test2.jpg',
+      type: 'image/jpeg',
+      size: 200,
+      hash: 'hash-2',
+      createdAt: NOW_BASE + 1,
+      updatedAt: NOW_BASE + 1,
+      thumbForHash: undefined,
+      thumbSize: undefined,
+    }
+
+    const events: ObjectEvent[] = [
+      makeObjectEvent({
+        id: 'obj-1',
+        updatedAt: new Date(NOW_BASE),
+        object: makeMockPinnedObject(metadata1, 'obj-1'),
+      }),
+      makeObjectEvent({
+        id: 'obj-2',
+        updatedAt: new Date(NOW_BASE + 1),
+        object: makeMockPinnedObject(metadata2, 'obj-2'),
+      }),
+    ]
+
+    getSdkMock.mockReturnValue({
+      objectEvents: jest.fn().mockResolvedValueOnce(events),
+    } as any)
+
+    const result = await syncDownEvents()
+    expect(result).toBe(0)
+  })
+
+  test('returns undefined (use default interval) when 0-1 events found', async () => {
+    const metadata: FileMetadata = {
+      name: 'test.jpg',
+      type: 'image/jpeg',
+      size: 100,
+      hash: 'hash-1',
+      createdAt: NOW_BASE,
+      updatedAt: NOW_BASE,
+      thumbForHash: undefined,
+      thumbSize: undefined,
+    }
+
+    const events: ObjectEvent[] = [
+      makeObjectEvent({
+        id: 'obj-1',
+        updatedAt: new Date(NOW_BASE),
+        object: makeMockPinnedObject(metadata, 'obj-1'),
+      }),
+    ]
+
+    getSdkMock.mockReturnValue({
+      objectEvents: jest.fn().mockResolvedValueOnce(events),
+    } as any)
+
+    const result = await syncDownEvents()
+    expect(result).toBeUndefined()
+  })
+
+  test('returns undefined (use default interval) when no events found', async () => {
+    getSdkMock.mockReturnValue({
+      objectEvents: jest.fn().mockResolvedValueOnce([]),
+    } as any)
+
+    const result = await syncDownEvents()
+    expect(result).toBeUndefined()
   })
 })

--- a/src/managers/syncDownEvents.ts
+++ b/src/managers/syncDownEvents.ts
@@ -5,38 +5,41 @@ import type {
 } from 'react-native-sia'
 import { z } from 'zod'
 import { SYNC_EVENTS_INTERVAL } from '../config'
+import { withTransactionLock } from '../db'
 import { isoToEpochCodec } from '../encoding/date'
 import {
   decodeFileMetadata,
   hasCompleteFileMetadata,
   hasCompleteThumbnailMetadata,
 } from '../encoding/fileMetadata'
+import type { LocalObject } from '../encoding/localObject'
 import { pinnedObjectToLocalObject } from '../lib/localObjects'
 import { logger } from '../lib/logger'
 import { createServiceInterval } from '../lib/serviceInterval'
 import { uniqueId } from '../lib/uniqueId'
 import { getAsyncStorageJSON, setAsyncStorageJSON } from '../stores/asyncStore'
 import {
-  createFileRecordWithLocalObject,
+  createFileRecord,
   deleteFileRecord,
   type FileMetadata,
   type FileRecord,
   readFileRecordByContentHash,
   readFileRecordByObjectId,
-  updateFileRecordWithLocalObject,
+  updateFileRecord,
 } from '../stores/files'
 import { removeFsFile } from '../stores/fs'
 import {
   invalidateCacheLibraryAllStats,
   invalidateCacheLibraryLists,
 } from '../stores/librarySwr'
+import { upsertLocalObject } from '../stores/localObjects'
 import { getIsConnected, getSdk } from '../stores/sdk'
 import { getAutoSyncDownEvents, getIndexerURL } from '../stores/settings'
 import { removeTempDownloadFile } from '../stores/tempFs'
 import { readThumbnailRecordByThumbForHashAndSize } from '../stores/thumbnails'
 import { removeUpload } from '../stores/uploads'
 
-const batchSize = 100
+const batchSize = 500
 
 type Counts = {
   existing: number
@@ -44,13 +47,37 @@ type Counts = {
   added: number
 }
 
+type PreparedCreate = {
+  kind: 'create'
+  fileRecord: Omit<FileRecord, 'objects'>
+  localObject: LocalObject
+}
+
+type PreparedUpdate = {
+  kind: 'update'
+  fileRecord: Omit<FileRecord, 'objects'>
+  localObject: LocalObject
+  fileId: string
+}
+
+type PreparedDelete = {
+  kind: 'delete'
+  fileId: string
+  fileRecord: Omit<FileRecord, 'objects'>
+}
+
+type PreparedEvent = PreparedCreate | PreparedUpdate | PreparedDelete
+
 /**
  * Syncs down events from the indexer to the local database. The service works by
  * starting with a cursor saved in secure store. It iterates until there are no
  * more events to sync and saves the cursor to secure store after each batch.
  * The service runs again every SYNC_EVENTS_INTERVAL milliseconds.
+ *
+ * Returns 0 when multiple events were fetched (run again immediately),
+ * or void to use the default interval.
  */
-export async function syncDownEvents(): Promise<void> {
+export async function syncDownEvents(): Promise<number | void> {
   logger.debug('syncDownEvents', 'tick')
   const isConnected = getIsConnected()
   if (!isConnected) {
@@ -69,6 +96,8 @@ export async function syncDownEvents(): Promise<void> {
     deleted: 0,
   }
 
+  let totalEventsFetched = 0
+
   while (true) {
     try {
       const cursor = await getSyncDownCursor()
@@ -78,6 +107,7 @@ export async function syncDownEvents(): Promise<void> {
       })
 
       const events = await sdk.objectEvents(cursor, batchSize)
+      totalEventsFetched += events.length
 
       // If the batch size is 1, we are probably synced and repeatedly polling the last event.
       if (events.length === 1) {
@@ -86,7 +116,10 @@ export async function syncDownEvents(): Promise<void> {
         logger.info('syncDownEvents', 'batch', { size: events.length })
       }
 
+      const prevTotal = counts.added + counts.deleted + counts.existing
       await processBatch(events, counts)
+      const batchChanged =
+        counts.added + counts.deleted + counts.existing > prevTotal
 
       // Update the cursor to the last event in the batch.
       const lastEvent = events[events.length - 1]
@@ -96,6 +129,12 @@ export async function syncDownEvents(): Promise<void> {
           id: lastEvent.id,
           after: new Date(nextTimestamp),
         })
+      }
+
+      // Invalidate caches after each batch so the UI updates progressively.
+      if (batchChanged) {
+        await invalidateCacheLibraryAllStats()
+        invalidateCacheLibraryLists()
       }
 
       // If the batch is not full, we're done for now.
@@ -108,53 +147,110 @@ export async function syncDownEvents(): Promise<void> {
     }
   }
 
-  if (counts.added > 0 || counts.deleted > 0 || counts.existing > 0) {
-    await invalidateCacheLibraryAllStats()
-    invalidateCacheLibraryLists()
-  }
-
   logger.info('syncDownEvents', 'synced', {
     existing: counts.existing,
     added: counts.added,
     deleted: counts.deleted,
   })
-}
 
-async function processBatch(events: ObjectEvent[], counts: Counts) {
-  for (const { object, deleted, id } of events) {
-    if (deleted) {
-      await handleDeleteEvent(id, counts)
-      continue
-    }
-
-    // If the object is not deleted this will always be defined.
-    if (!object) continue
-
-    await handleUpdateEvent(id, object, counts)
+  if (totalEventsFetched > 1) {
+    return 0 // Zero interval — poll again immediately.
   }
 }
 
-async function handleDeleteEvent(id: string, counts: Counts): Promise<void> {
+type BatchDedup = {
+  byContentHash: Map<string, Omit<FileRecord, 'objects'>>
+  byThumbKey: Map<string, Omit<FileRecord, 'objects'>>
+}
+
+async function processBatch(events: ObjectEvent[], counts: Counts) {
+  // Phase 1: Prepare (no locks held)
+  const prepared: PreparedEvent[] = []
+  const dedup: BatchDedup = {
+    byContentHash: new Map(),
+    byThumbKey: new Map(),
+  }
+
+  for (const { object, deleted, id } of events) {
+    if (deleted) {
+      const result = await prepareDelete(id)
+      if (result) prepared.push(result)
+      continue
+    }
+    if (!object) continue
+    const result = await prepareUpsert(id, object, dedup)
+    if (result) prepared.push(result)
+  }
+
+  if (prepared.length === 0) return
+
+  // Phase 2: Commit (single transaction, per-event error handling)
+  await withTransactionLock(async () => {
+    for (const event of prepared) {
+      try {
+        switch (event.kind) {
+          case 'create':
+            await createFileRecord(event.fileRecord, false)
+            await upsertLocalObject(event.localObject, false)
+            counts.added++
+            break
+          case 'update':
+            await updateFileRecord(event.fileRecord, false, {
+              includeUpdatedAt: true,
+            })
+            await upsertLocalObject(event.localObject, false)
+            counts.existing++
+            break
+          case 'delete':
+            await deleteFileRecord(event.fileId, false)
+            counts.deleted++
+            break
+        }
+      } catch (e) {
+        logger.error('syncDownEvents', 'event_commit_error', {
+          kind: event.kind,
+          error: e as Error,
+        })
+      }
+    }
+  })
+
+  // Phase 3: Cleanup (errors are non-fatal)
+  for (const event of prepared) {
+    if (event.kind === 'delete') {
+      try {
+        await Promise.all([
+          removeFsFile(event.fileRecord),
+          removeTempDownloadFile(event.fileRecord),
+        ])
+      } catch (e) {
+        logger.error('syncDownEvents', 'cleanup_error', {
+          error: e as Error,
+        })
+      }
+    } else if (event.kind === 'update') {
+      removeUpload(event.fileId)
+    }
+  }
+}
+
+async function prepareDelete(id: string): Promise<PreparedDelete | null> {
   try {
     const existingFileRecord = await readFileRecordByObjectId(id)
-    if (existingFileRecord) {
-      logger.info('syncDownEvents', 'file_delete', {
-        fileId: existingFileRecord.id,
-      })
-      await Promise.all([
-        // Remove the file from the file system.
-        removeFsFile(existingFileRecord),
-        // Remove any temporary download file.
-        removeTempDownloadFile(existingFileRecord),
-        // Remove the file from the database (deferred invalidation).
-        deleteFileRecord(existingFileRecord.id, false),
-      ])
-      counts.deleted++
-    } else {
+    if (!existingFileRecord) {
       logger.debug('syncDownEvents', 'skipped', {
         reason: 'no_file_record',
         objectId: id,
       })
+      return null
+    }
+    logger.info('syncDownEvents', 'file_delete', {
+      fileId: existingFileRecord.id,
+    })
+    return {
+      kind: 'delete',
+      fileId: existingFileRecord.id,
+      fileRecord: existingFileRecord,
     }
   } catch (e) {
     logger.error('syncDownEvents', 'delete_error', { id, error: e as Error })
@@ -162,11 +258,11 @@ async function handleDeleteEvent(id: string, counts: Counts): Promise<void> {
   }
 }
 
-async function handleUpdateEvent(
+async function prepareUpsert(
   id: string,
   object: PinnedObjectInterface,
-  counts: Counts,
-): Promise<void> {
+  dedup: BatchDedup,
+): Promise<PreparedCreate | PreparedUpdate | null> {
   try {
     const indexerURL = await getIndexerURL()
     const metadata = decodeFileMetadata(object.metadata())
@@ -175,93 +271,109 @@ async function handleUpdateEvent(
         metadata.thumbForHash!,
         metadata.thumbSize!,
       )
-      await handleFileRecord(
+      return prepareFileRecord(
         'thumbnail',
         existingThumbnail,
         indexerURL,
         object,
         metadata,
-        counts,
+        dedup,
       )
-      return
     }
     if (hasCompleteFileMetadata(metadata)) {
       const existingFile = await readFileRecordByContentHash(metadata.hash)
-      await handleFileRecord(
+      return prepareFileRecord(
         'file',
         existingFile,
         indexerURL,
         object,
         metadata,
-        counts,
+        dedup,
       )
-      return
     }
-    logger.debug('syncDownEvents', 'skipped', { reason: 'incomplete_metadata' })
+    logger.debug('syncDownEvents', 'skipped', {
+      reason: 'incomplete_metadata',
+    })
+    return null
   } catch (e) {
     logger.error('syncDownEvents', 'update_error', { id, error: e as Error })
     throw e
   }
 }
 
-async function handleFileRecord(
+async function prepareFileRecord(
   type: 'file' | 'thumbnail',
   existingFile: FileRecord | null,
   indexerURL: string,
   object: PinnedObjectInterface,
   metadata: FileMetadata,
-  counts: Counts,
-) {
-  if (existingFile) {
+  dedup: BatchDedup,
+): Promise<PreparedCreate | PreparedUpdate> {
+  let inBatch: Omit<FileRecord, 'objects'> | undefined
+  if (!existingFile) {
+    inBatch = dedup.byContentHash.get(metadata.hash)
+    if (!inBatch && metadata.thumbForHash && metadata.thumbSize) {
+      inBatch = dedup.byThumbKey.get(
+        `${metadata.thumbForHash}:${metadata.thumbSize}`,
+      )
+    }
+  }
+  const existing = existingFile || inBatch
+
+  if (existing) {
     if (type === 'file') {
-      logger.debug('syncDownEvents', 'file_update', { hash: existingFile.hash })
+      logger.debug('syncDownEvents', 'file_update', { hash: existing.hash })
     } else {
       logger.debug('syncDownEvents', 'thumbnail_update', {
-        thumbForHash: existingFile.thumbForHash,
+        thumbForHash: existing.thumbForHash,
       })
     }
     const localObject = await pinnedObjectToLocalObject(
-      existingFile.id,
+      existing.id,
       indexerURL,
       object,
     )
-    await updateFileRecordWithLocalObject(
-      {
-        ...existingFile,
-        ...(metadata.updatedAt >= existingFile.updatedAt ? metadata : {}),
+    return {
+      kind: 'update',
+      fileRecord: {
+        ...existing,
+        ...(metadata.updatedAt >= existing.updatedAt ? metadata : {}),
       },
       localObject,
-      { includeUpdatedAt: true },
-      false,
-    )
-    // Cancel any inflight upload for this file since we now have a pinned object.
-    removeUpload(existingFile.id)
-    counts.existing++
+      fileId: existing.id,
+    }
+  }
+
+  if (type === 'file') {
+    logger.info('syncDownEvents', 'file_create', { hash: metadata.hash })
   } else {
-    if (type === 'file') {
-      logger.info('syncDownEvents', 'file_create', { hash: metadata.hash })
-    } else {
-      logger.info('syncDownEvents', 'thumbnail_create', {
-        thumbForHash: metadata.thumbForHash,
-      })
-    }
-    const fileId = uniqueId()
-    const localObject = await pinnedObjectToLocalObject(
-      fileId,
-      indexerURL,
-      object,
+    logger.info('syncDownEvents', 'thumbnail_create', {
+      thumbForHash: metadata.thumbForHash,
+    })
+  }
+  const fileId = uniqueId()
+  const localObject = await pinnedObjectToLocalObject(
+    fileId,
+    indexerURL,
+    object,
+  )
+  const fileRecord: Omit<FileRecord, 'objects'> = {
+    id: fileId,
+    ...metadata,
+    localId: null,
+    addedAt: Date.now(),
+  }
+  dedup.byContentHash.set(metadata.hash, fileRecord)
+  if (metadata.thumbForHash && metadata.thumbSize) {
+    dedup.byThumbKey.set(
+      `${metadata.thumbForHash}:${metadata.thumbSize}`,
+      fileRecord,
     )
-    await createFileRecordWithLocalObject(
-      {
-        id: fileId,
-        ...metadata,
-        localId: null,
-        addedAt: Date.now(),
-      },
-      localObject,
-      false,
-    )
-    counts.added++
+  }
+  return {
+    kind: 'create',
+    fileRecord,
+    localObject,
   }
 }
 

--- a/src/managers/syncDownEvents.ts
+++ b/src/managers/syncDownEvents.ts
@@ -23,6 +23,7 @@ import {
   deleteFileRecord,
   type FileMetadata,
   type FileRecord,
+  type FileRecordRow,
   readFileRecordByContentHash,
   readFileRecordByObjectId,
   updateFileRecord,
@@ -35,6 +36,7 @@ import {
 import { upsertLocalObject } from '../stores/localObjects'
 import { getIsConnected, getSdk } from '../stores/sdk'
 import { getAutoSyncDownEvents, getIndexerURL } from '../stores/settings'
+import { setSyncDownState } from '../stores/syncDown'
 import { removeTempDownloadFile } from '../stores/tempFs'
 import { readThumbnailRecordByThumbForHashAndSize } from '../stores/thumbnails'
 import { removeUpload } from '../stores/uploads'
@@ -49,13 +51,13 @@ type Counts = {
 
 type PreparedCreate = {
   kind: 'create'
-  fileRecord: Omit<FileRecord, 'objects'>
+  fileRecord: FileRecordRow
   localObject: LocalObject
 }
 
 type PreparedUpdate = {
   kind: 'update'
-  fileRecord: Omit<FileRecord, 'objects'>
+  fileRecord: FileRecordRow
   localObject: LocalObject
   fileId: string
 }
@@ -63,7 +65,7 @@ type PreparedUpdate = {
 type PreparedDelete = {
   kind: 'delete'
   fileId: string
-  fileRecord: Omit<FileRecord, 'objects'>
+  fileRecord: FileRecordRow
 }
 
 type PreparedEvent = PreparedCreate | PreparedUpdate | PreparedDelete
@@ -109,6 +111,10 @@ export async function syncDownEvents(): Promise<number | void> {
       const events = await sdk.objectEvents(cursor, batchSize)
       totalEventsFetched += events.length
 
+      if (totalEventsFetched > 1) {
+        setSyncDownState({ isSyncing: true })
+      }
+
       // If the batch size is 1, we are probably synced and repeatedly polling the last event.
       if (events.length === 1) {
         logger.debug('syncDownEvents', 'batch', { size: events.length })
@@ -153,14 +159,16 @@ export async function syncDownEvents(): Promise<number | void> {
     deleted: counts.deleted,
   })
 
+  setSyncDownState({ isSyncing: false })
+
   if (totalEventsFetched > 1) {
     return 0 // Zero interval — poll again immediately.
   }
 }
 
 type BatchDedup = {
-  byContentHash: Map<string, Omit<FileRecord, 'objects'>>
-  byThumbKey: Map<string, Omit<FileRecord, 'objects'>>
+  byContentHash: Map<string, FileRecordRow>
+  byThumbKey: Map<string, FileRecordRow>
 }
 
 async function processBatch(events: ObjectEvent[], counts: Counts) {
@@ -309,7 +317,7 @@ async function prepareFileRecord(
   metadata: FileMetadata,
   dedup: BatchDedup,
 ): Promise<PreparedCreate | PreparedUpdate> {
-  let inBatch: Omit<FileRecord, 'objects'> | undefined
+  let inBatch: FileRecordRow | undefined
   if (!existingFile) {
     inBatch = dedup.byContentHash.get(metadata.hash)
     if (!inBatch && metadata.thumbForHash && metadata.thumbSize) {
@@ -357,7 +365,7 @@ async function prepareFileRecord(
     indexerURL,
     object,
   )
-  const fileRecord: Omit<FileRecord, 'objects'> = {
+  const fileRecord: FileRecordRow = {
     id: fileId,
     ...metadata,
     localId: null,

--- a/src/screens/LibraryScreen.tsx
+++ b/src/screens/LibraryScreen.tsx
@@ -40,12 +40,14 @@ import {
 } from '../stores/library'
 import { useLibraryViewMode } from '../stores/settings'
 import { openSheet } from '../stores/sheets'
+import { useIsSyncingDown } from '../stores/syncDown'
 import { colors, overlay, palette, whiteA } from '../styles/colors'
 
 type Props = NativeStackScreenProps<MainStackParamList, 'LibraryHome'>
 
 export function LibraryScreen({ route, navigation }: Props) {
   const viewMode = useLibraryViewMode()
+  const isSyncing = useIsSyncingDown()
   const { selectedCategories, searchQuery } = useLibrary()
   const files = useFileList()
   const fileCount = useLibraryCount()
@@ -231,6 +233,13 @@ export function LibraryScreen({ route, navigation }: Props) {
             {files.error ? <LibraryLocalResetButton /> : null}
           </View>
         )
+      ) : isSyncing &&
+        searchQuery.trim().length === 0 &&
+        selectedCategories.size === 0 ? (
+        <View style={styles.emptyWrap}>
+          <ActivityIndicator color={palette.blue[400]} />
+          <Text style={styles.emptyTitle}>Syncing your files</Text>
+        </View>
       ) : (
         <View style={styles.emptyWrap}>
           <Image

--- a/src/stores/syncDown.ts
+++ b/src/stores/syncDown.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand'
+import { createGetterAndSelector } from '../lib/selectors'
+
+type SyncDownState = {
+  isSyncing: boolean
+}
+
+export const useSyncDownStore = create<SyncDownState>(() => ({
+  isSyncing: false,
+}))
+
+export const { setState: setSyncDownState } = useSyncDownStore
+
+export const [getIsSyncingDown, useIsSyncingDown] = createGetterAndSelector(
+  useSyncDownStore,
+  (s) => s.isSyncing,
+)


### PR DESCRIPTION
- This PR makes the sync down process significantly faster. Before it was very serial and slow mostly so things were easier to debug, this moves to large batches that are commited in a single transaction, and also removes waiting between batches. 
- Split processBatch into prepare/commit/cleanup phases so all DB writes in a batch share a single mutex acquire and SQLite transaction. FS cleanup for deletes is now non-fatal (errors logged, cursor still advances). Return 0 from syncDownEvents when multiple events are found to trigger immediate re-polling instead of waiting the default 10s.
- When sync-down-events is actively pulling files, show an ActivityIndicator with "Syncing your files" instead of the "Add files to get started" empty state. Adds a lightweight Zustand store to track sync-down progress.