### PR TITLE
fix: properly reset app state and return to onboarding

### DIFF
--- a/.changeset/fix-app-reset.md
+++ b/.changeset/fix-app-reset.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fixed app reset to fully stop background services and return to onboarding.

--- a/src/lib/serviceInterval.test.ts
+++ b/src/lib/serviceInterval.test.ts
@@ -1,0 +1,157 @@
+jest.mock('./logger', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), error: jest.fn() },
+}))
+
+import {
+  createServiceInterval,
+  shutdownAllServiceIntervals,
+} from './serviceInterval'
+
+beforeEach(async () => {
+  jest.useFakeTimers()
+  await shutdownAllServiceIntervals()
+})
+
+afterEach(() => {
+  jest.useRealTimers()
+})
+
+test('shutdown waits for in-flight worker with abort signal loop', async () => {
+  const iterations: number[] = []
+  let resolveWork: (() => void) | null = null
+
+  const { init } = createServiceInterval({
+    name: 'loopService',
+    worker: async (signal) => {
+      let i = 0
+      while (!signal.aborted) {
+        i++
+        iterations.push(i)
+        await new Promise<void>((r) => {
+          resolveWork = r
+        })
+      }
+    },
+    getState: async () => true,
+    interval: 1000,
+  })
+
+  init()
+
+  // Let the first tick fire.
+  await jest.advanceTimersByTimeAsync(1000)
+
+  // Worker is now in its loop, iteration 1 is waiting on resolveWork.
+  expect(iterations).toEqual([1])
+
+  // Complete iteration 1, worker loops and starts iteration 2.
+  resolveWork!()
+  await jest.advanceTimersByTimeAsync(0)
+  expect(iterations).toEqual([1, 2])
+
+  // Start shutdown while worker is mid-loop (iteration 2 waiting on resolveWork).
+  const shutdownPromise = shutdownAllServiceIntervals()
+
+  // Shutdown has aborted the signal but the worker is still awaiting resolveWork.
+  let shutdownDone = false
+  shutdownPromise.then(() => {
+    shutdownDone = true
+  })
+  await jest.advanceTimersByTimeAsync(0)
+  expect(shutdownDone).toBe(false)
+
+  // Resolve the pending work — worker sees signal.aborted and exits.
+  resolveWork!()
+  await jest.advanceTimersByTimeAsync(0)
+
+  // Shutdown should now be complete.
+  await shutdownPromise
+  expect(shutdownDone).toBe(true)
+
+  // Worker exited after seeing abort, no iteration 3.
+  expect(iterations).toEqual([1, 2])
+})
+
+test('shutdown waits for multiple services concurrently', async () => {
+  let fastDone = false
+  let slowResolve: (() => void) | null = null
+
+  const fast = createServiceInterval({
+    name: 'fast',
+    worker: async () => {
+      fastDone = true
+    },
+    getState: async () => true,
+    interval: 100,
+  })
+
+  const slow = createServiceInterval({
+    name: 'slow',
+    worker: async () => {
+      await new Promise<void>((r) => {
+        slowResolve = r
+      })
+    },
+    getState: async () => true,
+    interval: 100,
+  })
+
+  fast.init()
+  slow.init()
+
+  // Let both fire.
+  await jest.advanceTimersByTimeAsync(100)
+  expect(fastDone).toBe(true)
+
+  // Fast is done, slow is blocked.
+  const shutdownPromise = shutdownAllServiceIntervals()
+
+  let shutdownDone = false
+  shutdownPromise.then(() => {
+    shutdownDone = true
+  })
+  await jest.advanceTimersByTimeAsync(0)
+  expect(shutdownDone).toBe(false)
+
+  // Unblock slow worker.
+  slowResolve!()
+  await jest.advanceTimersByTimeAsync(0)
+
+  await shutdownPromise
+  expect(shutdownDone).toBe(true)
+})
+
+test('triggerNow is a noop while worker is running', async () => {
+  let callCount = 0
+  let resolveWork: (() => void) | null = null
+
+  const { init, triggerNow } = createServiceInterval({
+    name: 'triggerTest',
+    worker: async () => {
+      callCount++
+      await new Promise<void>((r) => {
+        resolveWork = r
+      })
+    },
+    getState: async () => true,
+    interval: 5000,
+  })
+
+  init()
+  await jest.advanceTimersByTimeAsync(5000)
+  expect(callCount).toBe(1)
+
+  // Worker is in-flight. triggerNow should noop.
+  triggerNow()
+  await jest.advanceTimersByTimeAsync(0)
+  expect(callCount).toBe(1)
+
+  // Complete the worker.
+  resolveWork!()
+  await jest.advanceTimersByTimeAsync(0)
+
+  // Now triggerNow should work.
+  triggerNow()
+  await jest.advanceTimersByTimeAsync(0)
+  expect(callCount).toBe(2)
+})

--- a/src/lib/serviceInterval.ts
+++ b/src/lib/serviceInterval.ts
@@ -1,12 +1,14 @@
 import { logger } from './logger'
 
-// Scheduler state for a service: the latest token and its timeout handle.
+// Scheduler state for a service: the latest token, its timeout handle, and abort controller.
 type SchedulerState = {
   token: number
   timeoutId: NodeJS.Timeout | null
+  abortController: AbortController
 }
 
 const schedulerStateMap = new Map<string, SchedulerState>()
+const runningPromises = new Set<Promise<void>>()
 
 // Pause/resume state for testing
 let paused = false
@@ -48,23 +50,37 @@ export function createServiceInterval({
   interval,
 }: {
   name: string
-  worker: () => void | undefined | number | Promise<void | undefined | number>
+  worker: (
+    signal: AbortSignal,
+  ) => void | undefined | number | Promise<void | undefined | number>
   getState: () => Promise<boolean>
   interval: number
-}): () => void {
+}): { init: () => void; triggerNow: () => void } {
+  let running = false
+  let runTick: (() => void) | null = null
+
   const init = () => {
     const existing = schedulerStateMap.get(name)
     if (existing?.timeoutId) {
       clearTimeout(existing.timeoutId)
     }
+    existing?.abortController.abort()
 
     logger.debug(name, 'initializing')
 
     // Increment the token to invalidate any previously scheduled or in-flight ticks.
     const token = (existing?.token ?? 0) + 1
-    schedulerStateMap.set(name, { token, timeoutId: null })
+    const abortController = new AbortController()
+    running = false
+    schedulerStateMap.set(name, { token, timeoutId: null, abortController })
 
-    async function runTick() {
+    runTick = () => {
+      const p = runTickAsync()
+      runningPromises.add(p)
+      p.finally(() => runningPromises.delete(p))
+    }
+
+    async function runTickAsync() {
       // Guard against stale ticks created before the latest init.
       const current = schedulerStateMap.get(name)
       if (!current || current.token !== token) return
@@ -81,13 +97,17 @@ export function createServiceInterval({
         return
       }
 
+      running = true
       let nextInterval = interval
       try {
-        const customInterval = await Promise.resolve(worker())
+        const customInterval = await Promise.resolve(
+          worker(abortController.signal),
+        )
         if (typeof customInterval === 'number') {
           nextInterval = customInterval
         }
       } finally {
+        running = false
         scheduleNextRun(nextInterval)
       }
     }
@@ -103,21 +123,34 @@ export function createServiceInterval({
         return
       }
 
-      const timeoutId = setTimeout(runTick, interval)
-      schedulerStateMap.set(name, { token, timeoutId })
+      const timeoutId = setTimeout(runTick!, interval)
+      schedulerStateMap.set(name, { token, timeoutId, abortController })
     }
 
     scheduleNextRun(interval)
   }
 
-  return init
+  const triggerNow = () => {
+    const current = schedulerStateMap.get(name)
+    if (!current || !runTick || running) return
+    if (current.timeoutId) {
+      clearTimeout(current.timeoutId)
+      schedulerStateMap.set(name, { ...current, timeoutId: null })
+    }
+    runTick()
+  }
+
+  return { init, triggerNow }
 }
 
-export function shutdownAllServiceIntervals() {
+export async function shutdownAllServiceIntervals() {
   schedulerStateMap.forEach((state) => {
     if (state.timeoutId) {
       clearTimeout(state.timeoutId)
     }
+    state.abortController.abort()
   })
   schedulerStateMap.clear()
+  await Promise.allSettled(runningPromises)
+  runningPromises.clear()
 }

--- a/src/managers/app.ts
+++ b/src/managers/app.ts
@@ -1,29 +1,32 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
 import { mutate } from 'swr'
 import { initializeDB, resetDb } from '../db'
 import { shutdownAllServiceIntervals } from '../lib/serviceInterval'
 import { type InitStep, setAppState } from '../stores/app'
 import { clearAppKeys } from '../stores/appKey'
-import { cancelAllDownloads } from '../stores/downloads'
-import { deleteAllFileRecords } from '../stores/files'
+import { useAuthWebViewStore } from '../stores/authWebView'
+import { cancelAllDownloads, useDownloadsStore } from '../stores/downloads'
+import { useFileSelectionStore } from '../stores/fileSelection'
 import { ensureFsStorageDirectory } from '../stores/fs'
+import { useLibrary } from '../stores/library'
+import { invalidateCacheLibraryLists } from '../stores/librarySwr'
 import { initLogger } from '../stores/logs'
 import { clearMnemonicHash } from '../stores/mnemonic'
-import { reconnectIndexer, resetSdk } from '../stores/sdk'
-import { getHasOnboarded, setHasOnboarded } from '../stores/settings'
+import { reconnectIndexer, useSdkStore } from '../stores/sdk'
+import { getHasOnboarded } from '../stores/settings'
+import { useSheetsStore } from '../stores/sheets'
+import { useSyncDownStore } from '../stores/syncDown'
 import { ensureTempFsStorageDirectory } from '../stores/tempFs'
-import { clearAllUploads } from '../stores/uploads'
+import { clearAllUploads, useUploadsStore } from '../stores/uploads'
 import { initBackgroundTasks } from './backgroundTasks'
 import { runFsEvictionScanner } from './fsEvictionScanner'
 import { runFsOrphanScanner } from './fsOrphanScanner'
 import { initLogRotation } from './logRotation'
 import { initPerfMonitor } from './perfMonitor'
 import { initSyncDownEvents, resetSyncDownCursor } from './syncDownEvents'
-import { initSyncNewPhotos, resetPhotosNewCursor } from './syncNewPhotos'
-import {
-  initSyncPhotosArchive,
-  resetPhotosArchiveCursor,
-} from './syncPhotosArchive'
-import { initSyncUpMetadata } from './syncUpMetadata'
+import { initSyncNewPhotos } from './syncNewPhotos'
+import { initSyncPhotosArchive } from './syncPhotosArchive'
+import { initSyncUpMetadata, resetSyncUpCursor } from './syncUpMetadata'
 import { initThumbnailScanner } from './thumbnailScanner'
 import { getUploadManager } from './uploader'
 
@@ -83,19 +86,27 @@ export async function initApp(): Promise<void> {
         await runFsEvictionScanner()
       },
     })
+
+    steps.push({
+      id: 'services',
+      label: 'Starting background services',
+      message: 'Launching background services...',
+      runner: async () => {
+        initSyncDownEvents()
+        initSyncNewPhotos()
+        initSyncPhotosArchive()
+        initBackgroundTasks()
+        initSyncUpMetadata()
+        initThumbnailScanner()
+      },
+    })
   }
 
   steps.push({
-    id: 'services',
-    label: 'Starting background services',
-    message: 'Launching background services...',
+    id: 'monitoring',
+    label: 'Starting monitoring',
+    message: 'Launching monitoring...',
     runner: async () => {
-      initSyncDownEvents()
-      initSyncNewPhotos()
-      initSyncPhotosArchive()
-      initBackgroundTasks()
-      initSyncUpMetadata()
-      initThumbnailScanner()
       initPerfMonitor()
       await initLogRotation()
     },
@@ -117,15 +128,18 @@ export async function shutdownApp() {
 }
 
 export async function resetData() {
-  await deleteAllFileRecords()
   await resetDb()
   await resetSyncDownCursor()
+  await resetSyncUpCursor()
   await cancelAllTransfers()
 }
 
 export async function resetApp() {
+  // 1. Show splash screen immediately.
   startInitState()
-  shutdownAllServiceIntervals()
+
+  // 2. Stop all service intervals and wait for in-flight workers to finish.
+  await shutdownAllServiceIntervals()
 
   await runSteps([
     {
@@ -133,19 +147,55 @@ export async function resetApp() {
       label: 'Resetting application',
       message: 'Clearing data...',
       runner: async () => {
-        await resetData()
+        // 3. Cancel uploads and downloads (side-effect cleanup).
+        await cancelAllTransfers()
+
+        // 4. Drop and recreate all database tables.
+        await resetDb()
+
+        // 5. Wipe all persisted state.
+        await AsyncStorage.clear()
         await clearAppKeys()
         await clearMnemonicHash()
-        await setHasOnboarded(false)
-        await resetSdk()
-        await resetPhotosNewCursor()
-        await resetPhotosArchiveCursor()
+
+        // 6. Reset all in-memory state (zustand stores).
+        resetAllStores()
+
+        // 7. Clear SWR cache (must come after store resets to avoid races).
         await mutate(() => true, undefined, { revalidate: false })
       },
     },
   ])
 
+  // 8. Re-initialize the app from clean state.
   await initApp()
+}
+
+function resetAllStores() {
+  useSdkStore.setState({
+    sdk: null,
+    isConnected: false,
+    connectionError: null,
+    isAuthing: false,
+    isReconnecting: false,
+    pendingApproval: null,
+  })
+  useSyncDownStore.setState({ isSyncing: false })
+  useUploadsStore.setState({ uploads: {} })
+  useDownloadsStore.setState({ downloads: {} })
+  useFileSelectionStore.setState({
+    selectedFileIds: new Set(),
+    isSelectionMode: false,
+  })
+  useSheetsStore.setState({ openName: '' })
+  useAuthWebViewStore.setState({ visible: false, url: '', resolver: null })
+  useLibrary.setState({
+    sortBy: 'DATE',
+    sortDir: 'DESC',
+    selectedCategories: new Set(),
+    searchQuery: '',
+  })
+  invalidateCacheLibraryLists()
 }
 
 function startInitState(): void {

--- a/src/managers/logRotation.ts
+++ b/src/managers/logRotation.ts
@@ -46,7 +46,7 @@ export async function initLogRotation(): Promise<void> {
   initLogRotationInterval()
 }
 
-const initLogRotationInterval = createServiceInterval({
+const { init: initLogRotationInterval } = createServiceInterval({
   name: 'logRotation',
   worker: async () => {
     await runLogRotation()

--- a/src/managers/perfMonitor.ts
+++ b/src/managers/perfMonitor.ts
@@ -3,7 +3,7 @@ import { PERF_MONITOR_INTERVAL } from '../config'
 import { logger } from '../lib/logger'
 import { createServiceInterval } from '../lib/serviceInterval'
 
-export const initPerfMonitor = createServiceInterval({
+export const { init: initPerfMonitor } = createServiceInterval({
   name: 'perfMonitor',
   worker: () => {
     const cpu = getCpuUsage()

--- a/src/managers/syncDownEvents.test.ts
+++ b/src/managers/syncDownEvents.test.ts
@@ -142,14 +142,14 @@ describe('syncDownEvents', () => {
 
   test('early exit when not connected', async () => {
     getIsConnectedMock.mockReturnValue(false)
-    await syncDownEvents()
+    await syncDownEvents(new AbortController().signal)
     expect(getSdkMock).not.toHaveBeenCalled()
   })
 
   test('early exit when no sdk', async () => {
     getIsConnectedMock.mockReturnValue(true)
     getSdkMock.mockReturnValue(null)
-    await syncDownEvents()
+    await syncDownEvents(new AbortController().signal)
     const cur = await getSyncDownCursor()
     expect(cur).toBeUndefined()
   })
@@ -194,7 +194,7 @@ describe('syncDownEvents', () => {
       objectEvents: jest.fn().mockResolvedValueOnce(events),
     } as any)
 
-    await syncDownEvents()
+    await syncDownEvents(new AbortController().signal)
 
     expect(getSdkMock).toHaveBeenCalledTimes(1)
 
@@ -241,7 +241,7 @@ describe('syncDownEvents', () => {
       objectEvents: jest.fn().mockResolvedValueOnce(events),
     } as any)
 
-    await syncDownEvents()
+    await syncDownEvents(new AbortController().signal)
 
     // Should only call once since batch is not full.
     expect(getSdkMock).toHaveBeenCalledTimes(1)
@@ -290,7 +290,7 @@ describe('syncDownEvents', () => {
       objectEvents: jest.fn().mockResolvedValueOnce(events),
     } as any)
 
-    await syncDownEvents()
+    await syncDownEvents(new AbortController().signal)
 
     expect(removeFsFileMock).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'file-1' }),
@@ -352,7 +352,7 @@ describe('syncDownEvents', () => {
       objectEvents: jest.fn().mockResolvedValueOnce(events),
     } as any)
 
-    await syncDownEvents()
+    await syncDownEvents(new AbortController().signal)
 
     expect(removeUploadMock).toHaveBeenCalledWith('file-1')
     const updatedFile = await readFileRecordByObjectId('obj-1')
@@ -383,7 +383,7 @@ describe('syncDownEvents', () => {
       objectEvents: jest.fn().mockResolvedValueOnce(events),
     } as any)
 
-    await syncDownEvents()
+    await syncDownEvents(new AbortController().signal)
 
     const newFile = await readFileRecordByObjectId('obj-1')
     expect(newFile).not.toBeNull()
@@ -439,7 +439,7 @@ describe('syncDownEvents', () => {
       objectEvents: jest.fn().mockResolvedValueOnce(events),
     } as any)
 
-    await syncDownEvents()
+    await syncDownEvents(new AbortController().signal)
 
     // Verify all metadata fields were merged from remote since it's newer.
     const updatedFile = await readFileRecordByObjectId('obj-1')
@@ -518,7 +518,7 @@ describe('syncDownEvents', () => {
       objectEvents: jest.fn().mockResolvedValueOnce(events),
     } as any)
 
-    await syncDownEvents()
+    await syncDownEvents(new AbortController().signal)
 
     // Verify local metadata was preserved since it's newer.
     const file2 = await readFileRecordByObjectId('obj-1')
@@ -559,7 +559,7 @@ describe('syncDownEvents', () => {
       objectEvents: jest.fn().mockResolvedValueOnce(events),
     } as any)
 
-    await syncDownEvents()
+    await syncDownEvents(new AbortController().signal)
 
     const file = await readFileRecordByObjectId('obj-1')
     expect(file).toBeNull()
@@ -611,7 +611,7 @@ describe('syncDownEvents', () => {
     // Simulate error during file system removal (cleanup phase).
     jest.mocked(removeFsFile).mockRejectedValueOnce(new Error('FS error'))
 
-    await syncDownEvents()
+    await syncDownEvents(new AbortController().signal)
 
     // Cursor should have advanced because DB commit succeeded (FS cleanup is non-fatal).
     const cursor = await getSyncDownCursor()
@@ -676,7 +676,7 @@ describe('syncDownEvents', () => {
       .mocked(getAppKeyForIndexer)
       .mockRejectedValueOnce(new Error('AppKey error'))
 
-    await syncDownEvents()
+    await syncDownEvents(new AbortController().signal)
 
     // Cursor should not have advanced because error broke the loop.
     const cursor = await getSyncDownCursor()
@@ -711,7 +711,7 @@ describe('syncDownEvents', () => {
       objectEvents: jest.fn().mockResolvedValueOnce(events),
     } as any)
 
-    await syncDownEvents()
+    await syncDownEvents(new AbortController().signal)
 
     // Verify the thumbnail was created.
     const thumb = await readFileRecordByObjectId('obj-thumb')
@@ -758,7 +758,7 @@ describe('syncDownEvents', () => {
       objectEvents: jest.fn().mockResolvedValueOnce(events),
     } as any)
 
-    await syncDownEvents()
+    await syncDownEvents(new AbortController().signal)
 
     // First event creates the thumbnail.
     const t1 = await readFileRecordByObjectId('obj-thumb-1')
@@ -826,7 +826,7 @@ describe('syncDownEvents', () => {
     } as any)
 
     // First run.
-    await syncDownEvents()
+    await syncDownEvents(new AbortController().signal)
     const cursor1 = await getSyncDownCursor()
     expect(cursor1).toEqual({
       id: 'obj-1',
@@ -834,7 +834,7 @@ describe('syncDownEvents', () => {
     })
 
     // Second run.
-    await syncDownEvents()
+    await syncDownEvents(new AbortController().signal)
     const cursor2 = await getSyncDownCursor()
     expect(cursor2).toEqual({
       id: 'obj-2',
@@ -897,7 +897,7 @@ describe('syncDownEvents', () => {
       objectEvents: jest.fn().mockResolvedValueOnce(events),
     } as any)
 
-    const result = await syncDownEvents()
+    const result = await syncDownEvents(new AbortController().signal)
     expect(result).toBe(0)
   })
 
@@ -925,7 +925,7 @@ describe('syncDownEvents', () => {
       objectEvents: jest.fn().mockResolvedValueOnce(events),
     } as any)
 
-    const result = await syncDownEvents()
+    const result = await syncDownEvents(new AbortController().signal)
     expect(result).toBeUndefined()
   })
 
@@ -934,7 +934,7 @@ describe('syncDownEvents', () => {
       objectEvents: jest.fn().mockResolvedValueOnce([]),
     } as any)
 
-    const result = await syncDownEvents()
+    const result = await syncDownEvents(new AbortController().signal)
     expect(result).toBeUndefined()
   })
 })

--- a/src/managers/syncDownEvents.ts
+++ b/src/managers/syncDownEvents.ts
@@ -79,7 +79,9 @@ type PreparedEvent = PreparedCreate | PreparedUpdate | PreparedDelete
  * Returns 0 when multiple events were fetched (run again immediately),
  * or void to use the default interval.
  */
-export async function syncDownEvents(): Promise<number | void> {
+export async function syncDownEvents(
+  signal: AbortSignal,
+): Promise<number | void> {
   logger.debug('syncDownEvents', 'tick')
   const isConnected = getIsConnected()
   if (!isConnected) {
@@ -101,6 +103,7 @@ export async function syncDownEvents(): Promise<number | void> {
   let totalEventsFetched = 0
 
   while (true) {
+    if (signal.aborted) break
     try {
       const cursor = await getSyncDownCursor()
       logger.debug('syncDownEvents', 'syncing', {
@@ -123,7 +126,7 @@ export async function syncDownEvents(): Promise<number | void> {
       }
 
       const prevTotal = counts.added + counts.deleted + counts.existing
-      await processBatch(events, counts)
+      await processBatch(events, counts, signal)
       const batchChanged =
         counts.added + counts.deleted + counts.existing > prevTotal
 
@@ -171,7 +174,11 @@ type BatchDedup = {
   byThumbKey: Map<string, FileRecordRow>
 }
 
-async function processBatch(events: ObjectEvent[], counts: Counts) {
+async function processBatch(
+  events: ObjectEvent[],
+  counts: Counts,
+  signal: AbortSignal,
+) {
   // Phase 1: Prepare (no locks held)
   const prepared: PreparedEvent[] = []
   const dedup: BatchDedup = {
@@ -180,6 +187,7 @@ async function processBatch(events: ObjectEvent[], counts: Counts) {
   }
 
   for (const { object, deleted, id } of events) {
+    if (signal.aborted) return
     if (deleted) {
       const result = await prepareDelete(id)
       if (result) prepared.push(result)
@@ -190,7 +198,7 @@ async function processBatch(events: ObjectEvent[], counts: Counts) {
     if (result) prepared.push(result)
   }
 
-  if (prepared.length === 0) return
+  if (prepared.length === 0 || signal.aborted) return
 
   // Phase 2: Commit (single transaction, per-event error handling)
   await withTransactionLock(async () => {
@@ -385,12 +393,13 @@ async function prepareFileRecord(
   }
 }
 
-export const initSyncDownEvents = createServiceInterval({
-  name: 'syncDownEvents',
-  worker: syncDownEvents,
-  getState: getAutoSyncDownEvents,
-  interval: SYNC_EVENTS_INTERVAL,
-})
+export const { init: initSyncDownEvents, triggerNow: triggerSyncDownEvents } =
+  createServiceInterval({
+    name: 'syncDownEvents',
+    worker: syncDownEvents,
+    getState: getAutoSyncDownEvents,
+    interval: SYNC_EVENTS_INTERVAL,
+  })
 
 // Persistent cursor saved for next batch.
 

--- a/src/managers/syncNewPhotos.ts
+++ b/src/managers/syncNewPhotos.ts
@@ -65,7 +65,7 @@ async function workForward(): Promise<void> {
   }
 }
 
-export const initSyncNewPhotos = createServiceInterval({
+export const { init: initSyncNewPhotos } = createServiceInterval({
   name: 'syncNewPhotos',
   worker: workForward,
   getState: () => getAutoSyncNewPhotos(),

--- a/src/managers/syncPhotosArchive.ts
+++ b/src/managers/syncPhotosArchive.ts
@@ -82,7 +82,7 @@ export async function workBackward() {
   }
 }
 
-export const initSyncPhotosArchive = createServiceInterval({
+export const { init: initSyncPhotosArchive } = createServiceInterval({
   name: 'syncPhotosArchive',
   worker: workBackward,
   getState: async () => getAutoSyncPhotosArchive(),

--- a/src/managers/syncUpMetadata.ts
+++ b/src/managers/syncUpMetadata.ts
@@ -93,6 +93,10 @@ export async function setSyncUpCursor(
   await setAsyncStorageJSON('syncUpCursor', value, syncUpCursorCodec)
 }
 
+export async function resetSyncUpCursor(): Promise<void> {
+  await setSyncUpCursor(undefined)
+}
+
 /**
  * Iterate files pinned to the current indexer, fetch latest remote metadata,
  * diff against local file metadata, and if local is newer, push to remote.
@@ -182,7 +186,7 @@ export async function runSyncUpMetadata(batchSize: number): Promise<void> {
   }
 }
 
-export const initSyncUpMetadata = createServiceInterval({
+export const { init: initSyncUpMetadata } = createServiceInterval({
   name: 'syncUpMetadata',
   worker: async () => {
     return runSyncUpMetadata(SYNC_UP_METADATA_BATCH_SIZE)

--- a/src/managers/thumbnailScanner.ts
+++ b/src/managers/thumbnailScanner.ts
@@ -268,7 +268,7 @@ export async function runThumbnailScanner(): Promise<ThumbnailScannerResult> {
   return summary
 }
 
-export const initThumbnailScanner = createServiceInterval({
+export const { init: initThumbnailScanner } = createServiceInterval({
   name: 'thumbnailScanner',
   worker: async () => {
     await runThumbnailScanner()

--- a/src/screens/OnboardingFinishedScreen.tsx
+++ b/src/screens/OnboardingFinishedScreen.tsx
@@ -12,6 +12,7 @@ import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 import BlocksGrid from '../components/BlocksGrid'
 import BlocksShape from '../components/BlocksShape'
 import { Button } from '../components/Button'
+import { initApp } from '../managers/app'
 import { setHasOnboarded } from '../stores/settings'
 import { palette } from '../styles/colors'
 
@@ -141,6 +142,7 @@ export default function OnboardingFinishedScreen() {
           variant="primary"
           onPress={async () => {
             await setHasOnboarded(true)
+            await initApp()
           }}
         >
           Upload files

--- a/src/stores/sdk.test.ts
+++ b/src/stores/sdk.test.ts
@@ -78,6 +78,7 @@ describe('sdk store', () => {
       object: jest.fn(),
       saveObject: jest.fn(),
       appKey: jest.fn(() => mockAppKey),
+      objectEvents: jest.fn().mockResolvedValue([]),
     } as unknown as SdkInterface
 
     // Default: mnemonic validation returns null (no hash to validate against)

--- a/src/stores/sdk.ts
+++ b/src/stores/sdk.ts
@@ -108,6 +108,8 @@ export async function connectSdk(): Promise<SdkInterface | null> {
 
     if (sdk) {
       await setSdkWithUploader(sdk)
+      // Warm up the HTTP connection pool so the first real request doesn't timeout.
+      sdk.objectEvents(undefined, 1).catch(() => {})
       return sdk
     }
 


### PR DESCRIPTION
Reset app does not always work and often requires restarting the app. This is because services are not cleanly shutdown and therefore can continue to update state, plus a few other caches are not being reset. This PR adds the ability to abort services fully, and makes sure we cover all caches and state.

- Add AbortSignal support to service intervals so in-flight workers (particularly syncDownEvents' while loop) can be stopped during shutdown. 
- Overhaul resetApp to use AsyncStorage.clear() instead of fragile per-key clearing, reset syncDown isSyncing state, and only start sync services after onboarding.
- Trigger syncDownEvents immediately after onboarding completes.