### PR TITLE
feat: add sync status indicators, delete lost files, and export database

### DIFF
--- a/.changeset/delete-lost-files.md
+++ b/.changeset/delete-lost-files.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Added a control to delete lost file records that are no longer on the network or device.

--- a/.changeset/export-database.md
+++ b/.changeset/export-database.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Added a control to export the app database for debugging.

--- a/.changeset/reset-sync-up-cursor.md
+++ b/.changeset/reset-sync-up-cursor.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Added a control to reset the sync up cursor, allowing metadata to be re-pushed for all files.

--- a/.changeset/share-logs.md
+++ b/.changeset/share-logs.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Changed log sharing to use the native share sheet instead of copying to clipboard.

--- a/.changeset/sync-status-display.md
+++ b/.changeset/sync-status-display.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Added sync metadata status display showing remote down and local up progress.

--- a/src/components/LibraryStatusSheet.tsx
+++ b/src/components/LibraryStatusSheet.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 import {
+  Alert,
   Platform,
   Pressable,
   ScrollView,
@@ -13,11 +14,21 @@ import { humanSize } from '../lib/humanSize'
 import { humanUploadPercent } from '../lib/uploadPercent'
 import type { UploadCategoryStats } from '../stores/fileStats'
 import { getUploadStats } from '../stores/fileStats'
-import { useFileStatsLocal, useFileStatsLost } from '../stores/files'
+import {
+  deleteLostFiles,
+  useFileStatsLocal,
+  useFileStatsLost,
+} from '../stores/files'
 import { useIsConnected } from '../stores/sdk'
 import { setStatusDisplayMode, useStatusDisplayMode } from '../stores/settings'
 import { closeSheet, useSheetOpen } from '../stores/sheets'
+import { useIsSyncingDown, useSyncDownProgress } from '../stores/syncDown'
+import {
+  useIsSyncingUpMetadata,
+  useSyncUpMetadataProgress,
+} from '../stores/syncUpMetadata'
 import { palette, whiteA } from '../styles/colors'
+import { Button } from './Button'
 import { RowGroup, RowSubGroup } from './Group'
 import { InfoCard } from './InfoCard'
 import { LabeledValueRow } from './LabeledValueRow'
@@ -59,6 +70,10 @@ function formatCategoryValue(
 export function LibraryStatusSheet() {
   const isConnected = useIsConnected()
   const isOnline = useIsOnline()
+  const isSyncingDown = useIsSyncingDown()
+  const syncDownProgress = useSyncDownProgress()
+  const isSyncingUpMetadata = useIsSyncingUpMetadata()
+  const syncUpMetadataProgress = useSyncUpMetadataProgress()
   const isOpen = useSheetOpen('libraryStatus')
   const { data: displayMode = 'count' } = useStatusDisplayMode()
   const stats = useSWR(
@@ -141,6 +156,54 @@ export function LibraryStatusSheet() {
                   />
                 </View>
               }
+              showDividerTop
+              canCopy={false}
+            />
+          </InfoCard>
+        </RowGroup>
+
+        <RowGroup title="Sync metadata" style={styles.groupSpacing}>
+          <InfoCard>
+            <LabeledValueRow
+              label="Remote down"
+              labelWidth={120}
+              value={
+                <View style={styles.valueRight}>
+                  <View style={{ flex: 1 }} />
+                  <Text style={styles.valueText}>
+                    {isSyncingDown
+                      ? syncDownProgress.cursorAt
+                        ? new Date(syncDownProgress.cursorAt).toLocaleString()
+                        : 'Starting...'
+                      : 'Synced'}
+                  </Text>
+                  <View
+                    style={isSyncingDown ? styles.dotSyncing : styles.dotOnline}
+                  />
+                </View>
+              }
+              align="right"
+              canCopy={false}
+            />
+            <LabeledValueRow
+              label="Local up"
+              labelWidth={120}
+              value={
+                <View style={styles.valueRight}>
+                  <View style={{ flex: 1 }} />
+                  <Text style={styles.valueText}>
+                    {isSyncingUpMetadata
+                      ? `${syncUpMetadataProgress.processed.toLocaleString()} / ${syncUpMetadataProgress.total.toLocaleString()}`
+                      : 'Synced'}
+                  </Text>
+                  <View
+                    style={
+                      isSyncingUpMetadata ? styles.dotSyncing : styles.dotOnline
+                    }
+                  />
+                </View>
+              }
+              align="right"
               showDividerTop
               canCopy={false}
             />
@@ -379,6 +442,45 @@ export function LibraryStatusSheet() {
                 showDividerTop
               />
             </InfoCard>
+            {(lost.data?.count ?? 0) > 0 && (
+              <View style={styles.deleteLostContainer}>
+                <Button
+                  variant="secondary"
+                  style={styles.deleteLostButton}
+                  onPress={() => {
+                    Alert.alert(
+                      'Delete Lost Files',
+                      `This will delete ${lost.data?.count ?? 0} file records that are not on the network or this device. This cannot be undone.`,
+                      [
+                        { text: 'Cancel', style: 'cancel' },
+                        {
+                          text: 'Delete',
+                          style: 'destructive',
+                          onPress: async () => {
+                            try {
+                              await deleteLostFiles()
+                              Alert.alert(
+                                'Lost files deleted',
+                                'Lost file records were successfully deleted.',
+                              )
+                            } catch (error) {
+                              Alert.alert(
+                                'Error deleting lost files',
+                                error instanceof Error
+                                  ? error.message
+                                  : 'An unexpected error occurred while deleting lost files.',
+                              )
+                            }
+                          },
+                        },
+                      ],
+                    )
+                  }}
+                >
+                  Delete lost files
+                </Button>
+              </View>
+            )}
           </RowSubGroup>
         </RowGroup>
       </ScrollView>
@@ -447,5 +549,19 @@ const styles = StyleSheet.create({
     height: 8,
     borderRadius: 4,
     backgroundColor: palette.red[500],
+  },
+  dotSyncing: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: palette.yellow[400],
+  },
+  deleteLostContainer: {
+    marginTop: 8,
+    alignItems: 'flex-end',
+  },
+  deleteLostButton: {
+    paddingVertical: 8,
+    paddingHorizontal: 16,
   },
 })

--- a/src/components/SettingsAdvancedInfo.tsx
+++ b/src/components/SettingsAdvancedInfo.tsx
@@ -1,5 +1,7 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack'
-import { Pressable, StyleSheet, Switch, Text, View } from 'react-native'
+import { Alert, Pressable, StyleSheet, Switch, Text, View } from 'react-native'
+import Share from 'react-native-share'
+import { database } from '../db'
 import type { MenuStackParamList } from '../stacks/types'
 import { setShowAdvanced, useShowAdvanced } from '../stores/settings'
 import { colors, palette } from '../styles/colors'
@@ -25,6 +27,32 @@ export function SettingsAdvancedInfo({ navigation }: Props) {
             />
           }
         />
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Export database"
+          onPress={async () => {
+            try {
+              await Share.open({
+                url: `file://${database.databasePath}`,
+                type: 'application/x-sqlite3',
+                filename: 'app.db',
+              })
+            } catch (e: unknown) {
+              if (
+                e instanceof Error &&
+                e.message?.includes('User did not share')
+              )
+                return
+              Alert.alert('Error', String(e))
+            }
+          }}
+          style={styles.debugButton}
+        >
+          <View style={styles.rowItem}>
+            <Text style={styles.rowLabel}>Export Database</Text>
+            <Text style={styles.rowChevron}>›</Text>
+          </View>
+        </Pressable>
         <Pressable
           accessibilityRole="button"
           accessibilityLabel="Debug"

--- a/src/components/SettingsAdvancedSync.tsx
+++ b/src/components/SettingsAdvancedSync.tsx
@@ -1,5 +1,6 @@
 import { Alert, Switch } from 'react-native'
 import { resetSyncDownCursor } from '../managers/syncDownEvents'
+import { resetSyncUpCursor } from '../managers/syncUpMetadata'
 import {
   toggleAutoScanUploads,
   toggleAutoSyncDownEvents,
@@ -39,7 +40,7 @@ export function SettingsAdvancedSync() {
           }
         />
         <LabeledValueRow
-          label="Reset sync cursor"
+          label="Reset sync down cursor"
           labelWidth={250}
           value={
             <Button
@@ -47,14 +48,40 @@ export function SettingsAdvancedSync() {
               style={{ paddingVertical: 8, paddingHorizontal: 16 }}
               onPress={() => {
                 Alert.alert(
-                  'Reset Sync Cursor',
-                  'This will reset the sync cursor and cause the app to resync all events from the beginning. Continue?',
+                  'Reset Sync Down Cursor',
+                  'This will reset the sync down cursor and cause the app to resync all events from the beginning. Continue?',
                   [
                     { text: 'Cancel', style: 'cancel' },
                     {
                       text: 'Reset',
                       style: 'destructive',
                       onPress: () => resetSyncDownCursor(),
+                    },
+                  ],
+                )
+              }}
+            >
+              Reset
+            </Button>
+          }
+        />
+        <LabeledValueRow
+          label="Reset sync up cursor"
+          labelWidth={250}
+          value={
+            <Button
+              variant="secondary"
+              style={{ paddingVertical: 8, paddingHorizontal: 16 }}
+              onPress={() => {
+                Alert.alert(
+                  'Reset Sync Up Cursor',
+                  'This will reset the sync up cursor and cause the app to re-push metadata for all files. Continue?',
+                  [
+                    { text: 'Cancel', style: 'cancel' },
+                    {
+                      text: 'Reset',
+                      style: 'destructive',
+                      onPress: () => resetSyncUpCursor(),
                     },
                   ],
                 )

--- a/src/components/SettingsLogsControlBar.tsx
+++ b/src/components/SettingsLogsControlBar.tsx
@@ -1,10 +1,10 @@
-import Clipboard from '@react-native-clipboard/clipboard'
 import type { NativeStackScreenProps } from '@react-navigation/native-stack'
+import { File, Paths } from 'expo-file-system'
 import {
   ChevronDownIcon,
-  CopyIcon,
   DownloadIcon,
   FilterIcon,
+  ShareIcon,
   Trash2Icon,
 } from 'lucide-react-native'
 import { useCallback, useMemo, useState } from 'react'
@@ -16,6 +16,7 @@ import {
   Text,
   View,
 } from 'react-native'
+import Share from 'react-native-share'
 import { logsCache } from '../hooks/useLogs'
 import { exportLogs } from '../lib/exportLogs'
 import { type LogLevel, logger } from '../lib/logger'
@@ -129,12 +130,12 @@ export function SettingsLogsControlBar({ navigation }: Props) {
     )
   }, [toast])
 
-  const handleCopyLogs = useCallback(async () => {
+  const handleShareLogs = useCallback(async () => {
     try {
       const state = useLogsStore.getState()
       const logs = await readLogs(state.logLevel, state.logScopes)
       if (logs.length === 0) {
-        toast.show('No logs to copy')
+        toast.show('No logs to share')
         return
       }
       const content = logs
@@ -148,21 +149,42 @@ export function SettingsLogsControlBar({ navigation }: Props) {
           }),
         )
         .join('\n')
-      Clipboard.setString(content)
-      toast.show('Logs copied')
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
+      const fileName = `logs-${timestamp}.jsonl`
+      const tempFile = new File(Paths.cache, fileName)
+      tempFile.create({ intermediates: true })
+      const writer = tempFile.writableStream().getWriter()
+      try {
+        await writer.write(new TextEncoder().encode(content))
+      } finally {
+        await writer.close()
+      }
+      try {
+        await Share.open({
+          url: `file://${tempFile.uri}`,
+          type: 'application/x-ndjson',
+          filename: fileName,
+        })
+      } catch (e: unknown) {
+        if (e instanceof Error && e.message?.includes('User did not share'))
+          return
+        throw e
+      } finally {
+        tempFile.delete()
+      }
     } catch (error) {
-      logger.error('logs', 'copy_failed', { error: error as Error })
-      toast.show('Failed to copy logs')
+      logger.error('logs', 'share_failed', { error: error as Error })
+      toast.show('Failed to share logs')
     }
   }, [toast])
 
   const actions: OverflowAction[] = useMemo(
     () => [
       {
-        key: 'copy',
-        icon: <CopyIcon color={iconColors.white} />,
-        label: 'Copy to Clipboard',
-        onPress: handleCopyLogs,
+        key: 'share',
+        icon: <ShareIcon color={iconColors.white} />,
+        label: 'Share Logs',
+        onPress: handleShareLogs,
       },
       {
         key: 'export',
@@ -183,7 +205,7 @@ export function SettingsLogsControlBar({ navigation }: Props) {
         variant: 'danger' as const,
       },
     ],
-    [handleClearLogs, handleCopyLogs, handleExportLogs, isExporting],
+    [handleClearLogs, handleShareLogs, handleExportLogs, isExporting],
   )
 
   return (

--- a/src/stores/files.ts
+++ b/src/stores/files.ts
@@ -480,6 +480,22 @@ export async function deleteManyFileRecordsAndThumbnails(
   invalidateCacheLibraryLists()
 }
 
+/** Delete all lost files (not pinned on current indexer and not on device). */
+export async function deleteLostFiles(): Promise<number> {
+  const currentIndexerURL = await getIndexerURL()
+  const lost = await readAllFileRecords({
+    order: 'ASC',
+    pinned: {
+      indexerURL: currentIndexerURL,
+      isPinned: false,
+    },
+    fileExistsLocally: false,
+  })
+  if (lost.length === 0) return 0
+  await deleteManyFileRecordsAndThumbnails(lost.map((f) => f.id))
+  return lost.length
+}
+
 export async function deleteAllFileRecords(): Promise<void> {
   await sqlDelete('files')
 }


### PR DESCRIPTION
- Added some debugging controls from testing previous PR. Also adds ability to export the database file and updates to similar share sheet for the logs. Also adds sync up/down progress and status to the app status sheet.  
  

- Add Sync metadata section to status sheet showing Remote down progress (cursor timestamp) and Local up progress (processed/total count) with colored status dots.
- Add delete lost files button that appears in the Device section when lost files exist, with confirmation alert.
- Add Export Database button to advanced settings for sharing the SQLite database file.
- Split the sync cursor reset button into separate controls for down and up cursors.