### PR TITLE
fix: thread abort signal through all service interval workers

### DIFF
--- a/src/managers/syncNewPhotos.test.ts
+++ b/src/managers/syncNewPhotos.test.ts
@@ -2,6 +2,7 @@ import * as MediaLibrary from 'expo-media-library'
 import { SYNC_NEW_PHOTOS_INTERVAL } from '../config'
 import { ensureMediaLibraryPermission } from '../lib/mediaLibraryPermissions'
 import { processAssets } from '../lib/processAssets'
+import { shutdownAllServiceIntervals } from '../lib/serviceInterval'
 import { initSyncNewPhotos, setAutoSyncNewPhotos } from './syncNewPhotos'
 
 jest.useFakeTimers()
@@ -113,5 +114,32 @@ describe('syncNewPhotos', () => {
     expect(processAssetsMock).toHaveBeenNthCalledWith(3, [
       expect.objectContaining({ id: 'a4', name: '4.jpg' }),
     ])
+  })
+
+  it('aborts before processAssets when shutdown is called mid-tick', async () => {
+    const getAssetsAsyncMock = jest.mocked(MediaLibrary.getAssetsAsync)
+    const processAssetsMock = jest.mocked(processAssets)
+
+    await setAutoSyncNewPhotos(true)
+
+    let resolveGetAssets: ((v: any) => void) | null = null
+    getAssetsAsyncMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveGetAssets = resolve
+      }),
+    )
+
+    initSyncNewPhotos()
+    await jest.advanceTimersByTimeAsync(SYNC_NEW_PHOTOS_INTERVAL)
+
+    // Worker is now blocked on getAssetsAsync.
+    const shutdownPromise = shutdownAllServiceIntervals()
+
+    // Resolve getAssetsAsync — worker will see signal.aborted and return.
+    resolveGetAssets!(page([asset('a1', '1.jpg', 1000)]))
+    await jest.advanceTimersByTimeAsync(0)
+    await shutdownPromise
+
+    expect(processAssetsMock).not.toHaveBeenCalled()
   })
 })

--- a/src/managers/syncNewPhotos.ts
+++ b/src/managers/syncNewPhotos.ts
@@ -22,9 +22,10 @@ import {
 
 const PAGE_SIZE = 200
 
-async function workForward(): Promise<void> {
+async function workForward(signal: AbortSignal): Promise<void> {
   logger.debug('syncNewPhotos', 'tick')
   if (!(await getMediaLibraryPermissions())) return
+  if (signal.aborted) return
   const cursor = await getPhotosNewCursor()
 
   try {
@@ -37,6 +38,7 @@ async function workForward(): Promise<void> {
       // Resolve full info. For images this gets the full EXIF data and can fix the orientation.
       resolveWithFullInfo: true,
     })
+    if (signal.aborted) return
     if (page.assets.length === 0) {
       logger.debug('syncNewPhotos', 'no_new_photos')
       return
@@ -46,6 +48,7 @@ async function workForward(): Promise<void> {
       page.assets[page.assets.length - 1].creationTime
     const nextTimestamp = lastAssetCreationTime ? lastAssetCreationTime + 1 : 0
     await setPhotosNewCursor(nextTimestamp)
+    if (signal.aborted) return
     const { files } = await processAssets(
       page.assets.map((asset) => ({
         id: asset.id,

--- a/src/managers/syncPhotosArchive.test.ts
+++ b/src/managers/syncPhotosArchive.test.ts
@@ -7,6 +7,7 @@ import {
   initSyncPhotosArchive,
   restartPhotosArchiveCursor,
   setAutoSyncPhotosArchive,
+  workBackward,
 } from './syncPhotosArchive'
 
 jest.useFakeTimers()
@@ -181,5 +182,21 @@ describe('syncPhotosArchive', () => {
     await runTick()
     expect(await getPhotosArchiveCursor()).toBe(0)
     expect(processAssetsMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('aborts before processAssets when signal is aborted during getAssetsAsync', async () => {
+    const getAssetsAsyncMock = jest.mocked(MediaLibrary.getAssetsAsync)
+    const processAssetsMock = jest.mocked(processAssets)
+
+    const ac = new AbortController()
+    getAssetsAsyncMock.mockImplementation(async () => {
+      ac.abort()
+      return page([asset('b1', 'one.jpg', 10_000)])
+    })
+
+    await restartPhotosArchiveCursor()
+    await workBackward(ac.signal)
+
+    expect(processAssetsMock).not.toHaveBeenCalled()
   })
 })

--- a/src/managers/syncPhotosArchive.ts
+++ b/src/managers/syncPhotosArchive.ts
@@ -26,9 +26,10 @@ import {
 
 const PAGE_SIZE = 50
 
-export async function workBackward() {
+export async function workBackward(signal: AbortSignal) {
   logger.debug('syncPhotosArchive', 'tick')
   if (!(await getMediaLibraryPermissions())) return
+  if (signal.aborted) return
   const { count, totalBytes } = await getFileStatsLocal({ localOnly: true })
   if (totalBytes >= SYNC_ARCHIVE_RESUME_THRESHOLD) {
     logger.info('syncPhotosArchive', 'skipped', {
@@ -50,6 +51,7 @@ export async function workBackward() {
       // Resolve full info. For images this gets the full EXIF data and can fix the orientation.
       resolveWithFullInfo: true,
     })
+    if (signal.aborted) return
     if (page.assets.length === 0) {
       logger.info('syncPhotosArchive', 'fully_synced')
       await setPhotosArchiveCursor(0)
@@ -60,6 +62,7 @@ export async function workBackward() {
       page.assets[page.assets.length - 1].creationTime ?? 0
     const nextTimestamp = lastAssetCreationTime ? lastAssetCreationTime - 1 : 0
     await setPhotosArchiveCursor(nextTimestamp)
+    if (signal.aborted) return
     const { files } = await processAssets(
       page.assets.map((asset) => ({
         id: asset.id,

--- a/src/managers/syncUpMetadata.test.ts
+++ b/src/managers/syncUpMetadata.test.ts
@@ -410,6 +410,95 @@ describe('syncUpMetadata', () => {
     expect(sdk.updateMetadata).not.toHaveBeenCalled()
   })
 
+  test('skips all work when signal is already aborted', async () => {
+    sdk.getIsConnected.mockReturnValue(true)
+
+    const file: Omit<FileRecord, 'objects'> = {
+      id: 'file-0',
+      name: 'a.jpg',
+      type: 'image/jpeg',
+      kind: 'file',
+      size: 100,
+      hash: 'hash-0',
+      createdAt: NOW_BASE,
+      updatedAt: NOW_BASE,
+      localId: null,
+      addedAt: NOW_BASE,
+      thumbForId: undefined,
+      thumbSize: undefined,
+    }
+    await createFileRecordWithLocalObject(
+      file,
+      makeLocalObject({
+        fileId: file.id,
+        objectId: 'obj-0',
+        indexerURL: INDEXER_URL,
+        createdAt: NOW_BASE,
+        updatedAt: NOW_BASE,
+      }),
+    )
+
+    const ac = new AbortController()
+    ac.abort()
+    await runSyncUpMetadata(5, ac.signal)
+
+    expect(sdk.getPinnedObject).not.toHaveBeenCalled()
+  })
+
+  test('stops fetching objects when signal is aborted mid-batch', async () => {
+    sdk.getIsConnected.mockReturnValue(true)
+
+    for (let i = 0; i < 5; i++) {
+      const file: Omit<FileRecord, 'objects'> = {
+        id: `file-${i}`,
+        name: `name-${i}`,
+        type: 'image/jpeg',
+        kind: 'file',
+        size: 100 + i,
+        hash: `hash-${i}`,
+        createdAt: NOW_BASE + i,
+        updatedAt: NOW_BASE + i,
+        localId: null,
+        addedAt: NOW_BASE + i,
+        thumbForId: undefined,
+        thumbSize: undefined,
+      }
+      await createFileRecordWithLocalObject(
+        file,
+        makeLocalObject({
+          fileId: file.id,
+          objectId: `obj-${i}`,
+          indexerURL: INDEXER_URL,
+          createdAt: NOW_BASE + i,
+          updatedAt: NOW_BASE + i,
+        }),
+      )
+    }
+
+    const ac = new AbortController()
+    let callCount = 0
+    sdk.getPinnedObject.mockImplementation(async () => {
+      callCount++
+      if (callCount >= 2) ac.abort()
+      return { metadata: () => new ArrayBuffer(0) }
+    })
+    meta.decodeFileMetadata.mockReturnValue({
+      name: 'name',
+      type: 'image/jpeg',
+      kind: 'file',
+      size: 100,
+      hash: 'hash',
+      createdAt: NOW_BASE,
+      updatedAt: NOW_BASE,
+      thumbForId: undefined,
+      thumbSize: undefined,
+    })
+
+    await runSyncUpMetadata(5, ac.signal)
+
+    expect(sdk.getPinnedObject).toHaveBeenCalledTimes(2)
+  })
+
   test('preserves remote canonical id when pushing other field changes', async () => {
     sdk.getIsConnected.mockReturnValue(true)
 

--- a/src/managers/syncUpMetadata.ts
+++ b/src/managers/syncUpMetadata.ts
@@ -109,12 +109,16 @@ export async function resetSyncUpCursor(): Promise<void> {
  * This function processes files with updatedAt after the cursor, to pick
  * up any unsynced changes.
  */
-export async function runSyncUpMetadata(batchSize: number): Promise<void> {
+export async function runSyncUpMetadata(
+  batchSize: number,
+  signal?: AbortSignal,
+): Promise<void> {
   if (!getIsConnected()) {
     logger.debug('syncUpMetadata', 'skipped', { reason: 'not_connected' })
     setSyncUpMetadataState({ isSyncing: false })
     return
   }
+  if (signal?.aborted) return
   const indexerURL = await getIndexerURL()
   const after = await getSyncUpCursor()
   logger.debug('syncUpMetadata', 'tick', {
@@ -156,6 +160,7 @@ export async function runSyncUpMetadata(batchSize: number): Promise<void> {
       if (!obj || !obj.id) return
       if (f.kind === 'thumb' && !f.thumbForId) return
       return pool.withSlot(async () => {
+        if (signal?.aborted) return
         const ctx = { fileId: f.id, objectId: obj.id, fileName: f.name }
 
         const remote = await tryWithLog(
@@ -271,8 +276,8 @@ export async function runSyncUpMetadata(batchSize: number): Promise<void> {
 
 export const { init: initSyncUpMetadata } = createServiceInterval({
   name: 'syncUpMetadata',
-  worker: async () => {
-    return runSyncUpMetadata(SYNC_UP_METADATA_BATCH_SIZE)
+  worker: async (signal) => {
+    return runSyncUpMetadata(SYNC_UP_METADATA_BATCH_SIZE, signal)
   },
   getState: async () => true,
   interval: SYNC_UP_METADATA_INTERVAL,

--- a/src/managers/thumbnailScanner.test.ts
+++ b/src/managers/thumbnailScanner.test.ts
@@ -389,6 +389,75 @@ describe('thumbnailScanner', () => {
     expect(ctx.resize).toHaveBeenCalledWith({ width: 64, height: undefined })
   })
 
+  it('stops immediately when signal is already aborted', async () => {
+    const now = Date.now()
+    await createFileRecord({
+      id: 'file1',
+      name: 'test.jpg',
+      type: 'image/jpeg',
+      kind: 'file',
+      size: 1000,
+      hash: 'hash1',
+      createdAt: now,
+      updatedAt: now,
+      addedAt: now,
+      localId: 'local-file1',
+    })
+    getFsFileUriMock.mockResolvedValue('file://test.jpg')
+
+    const ac = new AbortController()
+    ac.abort()
+    const result = await runThumbnailScanner(ac.signal)
+    expect(result.produced).toHaveLength(0)
+    expect(result.processedCandidates).toBe(0)
+    expect(imageManipulatorMock).not.toHaveBeenCalled()
+  })
+
+  it('stops mid-scan when signal is aborted', async () => {
+    const now = Date.now()
+    for (let i = 0; i < 5; i++) {
+      await createFileRecord({
+        id: `file${i}`,
+        name: `test${i}.jpg`,
+        type: 'image/jpeg',
+        kind: 'file',
+        size: 1000,
+        hash: `hash${i}`,
+        createdAt: now - i,
+        updatedAt: now - i,
+        addedAt: now - i,
+        localId: `local-${i}`,
+      })
+    }
+    getFsFileUriMock.mockResolvedValue('file://test.jpg')
+    let counter = 0
+    calculateContentHashMock.mockImplementation(
+      async () => `sha256:thumb-hash-${++counter}`,
+    )
+
+    const ac = new AbortController()
+    let manipCalls = 0
+    imageManipulatorMock.mockImplementation(() => {
+      manipCalls++
+      if (manipCalls >= 2) ac.abort()
+      const renderAsync = jest.fn().mockResolvedValue({
+        saveAsync: jest.fn().mockResolvedValue({
+          uri: 'file://temp/thumb.webp',
+          width: 64,
+          height: 36,
+        }),
+      })
+      return {
+        resize: jest.fn().mockReturnThis(),
+        renderAsync,
+      } as unknown as ImageManipulatorContext
+    })
+
+    const result = await runThumbnailScanner(ac.signal)
+    expect(result.produced.length).toBeGreaterThan(0)
+    expect(result.produced.length).toBeLessThan(ThumbSizes.length * 5)
+  })
+
   it('logs and continues when manipulation throws', async () => {
     const now = Date.now()
     await createFileRecord({

--- a/src/managers/thumbnailScanner.ts
+++ b/src/managers/thumbnailScanner.ts
@@ -135,7 +135,9 @@ async function queryCandidateOriginals(
   return results
 }
 
-export async function runThumbnailScanner(): Promise<ThumbnailScannerResult> {
+export async function runThumbnailScanner(
+  signal?: AbortSignal,
+): Promise<ThumbnailScannerResult> {
   const summary: ThumbnailScannerResult = {
     processedCandidates: 0,
     attempts: [],
@@ -152,12 +154,14 @@ export async function runThumbnailScanner(): Promise<ThumbnailScannerResult> {
     const processedThisRun = new Set<string>()
 
     while (producedCount < MAX_THUMBS_PER_TICK) {
+      if (signal?.aborted) break
       const batch = await queryCandidateOriginals(25, processedThisRun)
       if (batch.length === 0) {
         break
       }
 
       for (const c of batch) {
+        if (signal?.aborted) break
         if (producedCount >= MAX_THUMBS_PER_TICK) break
         processedThisRun.add(c.id)
 
@@ -256,8 +260,8 @@ export async function runThumbnailScanner(): Promise<ThumbnailScannerResult> {
 
 export const { init: initThumbnailScanner } = createServiceInterval({
   name: 'thumbnailScanner',
-  worker: async () => {
-    await runThumbnailScanner()
+  worker: async (signal) => {
+    await runThumbnailScanner(signal)
   },
   getState: async () => true,
   interval: THUMBNAIL_SCANNER_INTERVAL,


### PR DESCRIPTION
- Previous PR made resetting the app abort services. Some services were still running for a bit, the adds the abort signal to all services in their inner loops for a faster abort.
- syncDownEvents was the only worker that checked signal.aborted during shutdown. The other four workers (syncNewPhotos, syncPhotosArchive, syncUpMetadata, thumbnailScanner) ignored the signal entirely, causing resetApp to hang on "Getting things ready..." while waiting for in-flight workers to run to completion.
- Thread AbortSignal through all workers with checks at key async boundaries so shutdownAllServiceIntervals resolves promptly.