### PR TITLE
feat: show spinner during upload or sync activity

### DIFF
--- a/.changeset/spinner-sync-activity.md
+++ b/.changeset/spinner-sync-activity.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Replaced the upload icon with a spinner that shows during upload or sync activity.

--- a/src/hooks/useAppStatus.tsx
+++ b/src/hooks/useAppStatus.tsx
@@ -1,13 +1,12 @@
-import {
-  CircleCheckIcon,
-  TriangleAlertIcon,
-  UploadCloudIcon,
-} from 'lucide-react-native'
+import { CircleCheckIcon, TriangleAlertIcon } from 'lucide-react-native'
 import type React from 'react'
+import { SpinnerIcon } from '../components/SpinnerIcon'
 import { compactUploadPercent } from '../lib/uploadPercent'
 import { useIsInitializing } from '../stores/app'
 import { useIsConnected } from '../stores/sdk'
 import { useHasOnboarded } from '../stores/settings'
+import { useIsSyncingDown } from '../stores/syncDown'
+import { useIsSyncingUpMetadata } from '../stores/syncUpMetadata'
 import { useUploadProgress } from '../stores/uploads'
 import { palette } from '../styles/colors'
 import { useIsOnline } from './useIsOnline'
@@ -24,6 +23,8 @@ export function useAppStatus(): AppStatus {
   const isConnected = useIsConnected()
   const hasOnboarded = useHasOnboarded()
   const uploadsProgress = useUploadProgress()
+  const isSyncingDown = useIsSyncingDown()
+  const isSyncingUpMetadata = useIsSyncingUpMetadata()
   const isOnline = useIsOnline()
 
   if (!hasOnboarded || isInitializing) {
@@ -46,12 +47,15 @@ export function useAppStatus(): AppStatus {
     }
   }
 
-  if (uploadsProgress.show) {
-    const hint = compactUploadPercent(uploadsProgress.percentDecimal)
+  const isActive = uploadsProgress.show || isSyncingDown || isSyncingUpMetadata
+  if (isActive) {
+    const hint = uploadsProgress.show
+      ? (compactUploadPercent(uploadsProgress.percentDecimal) ?? undefined)
+      : undefined
     return {
       visible: true,
-      icon: <UploadCloudIcon size={14} color={palette.gray[50]} />,
-      hint: hint ?? undefined,
+      icon: <SpinnerIcon size={14} color={palette.gray[50]} />,
+      hint,
       level: 'info',
     }
   }

--- a/src/stores/fileCarousel.test.ts
+++ b/src/stores/fileCarousel.test.ts
@@ -539,12 +539,12 @@ describe('useFileCarousel hook', () => {
 
       // Simulate a sync storm: add files one at a time, firing sync after each
       for (let i = 4; i <= 10; i++) {
-        await createRecord({
-          id: `file-${i}`,
-          name: `${String.fromCharCode(96 + i)}.jpg`,
-          createdAt: base + i * 10,
-        })
         await act(async () => {
+          await createRecord({
+            id: `file-${i}`,
+            name: `${String.fromCharCode(96 + i)}.jpg`,
+            createdAt: base + i * 10,
+          })
           triggerSyncChange()
           await new Promise((r) => setTimeout(r, 30))
         })
@@ -611,9 +611,17 @@ describe('useFileCarousel hook', () => {
 
       // Add two files that would shift file-2's position in DB, then fire
       // two sync events. With frozen positions, nothing should change.
-      await createRecord({ id: 'file-4', name: 'd.jpg', createdAt: base + 30 })
-      await createRecord({ id: 'file-5', name: 'e.jpg', createdAt: base + 40 })
       await act(async () => {
+        await createRecord({
+          id: 'file-4',
+          name: 'd.jpg',
+          createdAt: base + 30,
+        })
+        await createRecord({
+          id: 'file-5',
+          name: 'e.jpg',
+          createdAt: base + 40,
+        })
         triggerSyncChange()
         triggerSyncChange()
         await new Promise((r) => setTimeout(r, 200))


### PR DESCRIPTION
Replace the upload cloud icon with a spinner that appears during uploads, sync down, or sync up metadata activity.