### PR TITLE
feat: add tag system with favorites, tag management UI, and tag library screen

### DIFF
--- a/.changeset/add-tags.md
+++ b/.changeset/add-tags.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Added tags for organizing files with favorites support.

--- a/src/components/BulkManageTagsSheet.tsx
+++ b/src/components/BulkManageTagsSheet.tsx
@@ -1,0 +1,193 @@
+import { CheckIcon, PlusIcon } from 'lucide-react-native'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  FlatList,
+  Keyboard,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native'
+import { useSelectedFileIds } from '../stores/fileSelection'
+import { closeSheet, useSheetOpen } from '../stores/sheets'
+import { addTagToFile, useAllTags } from '../stores/tags'
+import { palette, whiteA } from '../styles/colors'
+import { ModalSheet } from './ModalSheet'
+
+export function BulkManageTagsSheet() {
+  const isOpen = useSheetOpen('bulkManageTags')
+  const selectedFileIds = useSelectedFileIds()
+  const allTags = useAllTags()
+  const [query, setQuery] = useState('')
+  const inputRef = useRef<TextInput | null>(null)
+  const [addedTagIds, setAddedTagIds] = useState<Set<string>>(new Set())
+
+  const allTagList = (allTags.data ?? []).filter((t) => !t.system)
+
+  const filtered = query.trim()
+    ? allTagList.filter((t) =>
+        t.name.toLowerCase().includes(query.trim().toLowerCase()),
+      )
+    : allTagList
+
+  const exactMatch =
+    query.trim().length > 0 &&
+    allTagList.some((t) => t.name.toLowerCase() === query.trim().toLowerCase())
+
+  useEffect(() => {
+    if (isOpen) {
+      setTimeout(() => inputRef.current?.focus(), 400)
+    } else {
+      setQuery('')
+      setAddedTagIds(new Set())
+    }
+  }, [isOpen])
+
+  const handleAddTag = useCallback(
+    async (tagName: string) => {
+      if (!tagName.trim()) return
+      const fileIds = Array.from(selectedFileIds)
+      for (const fileId of fileIds) {
+        await addTagToFile(fileId, tagName.trim())
+      }
+      const tag = allTagList.find(
+        (t) => t.name.toLowerCase() === tagName.trim().toLowerCase(),
+      )
+      if (tag) {
+        setAddedTagIds((prev) => new Set([...prev, tag.id]))
+      }
+      setQuery('')
+    },
+    [selectedFileIds, allTagList],
+  )
+
+  const handleClose = useCallback(() => {
+    setQuery('')
+    Keyboard.dismiss()
+    closeSheet()
+  }, [])
+
+  const fileCount = selectedFileIds.size
+
+  return (
+    <ModalSheet
+      visible={isOpen}
+      onRequestClose={handleClose}
+      title={`Add ${fileCount} ${fileCount === 1 ? 'file' : 'files'} to tag`}
+    >
+      <View style={styles.inputRow}>
+        <TextInput
+          ref={inputRef}
+          style={styles.input}
+          placeholder="Search or create tag..."
+          placeholderTextColor={palette.gray[500]}
+          value={query}
+          onChangeText={setQuery}
+          autoCapitalize="none"
+          autoCorrect={false}
+          returnKeyType="done"
+          onSubmitEditing={() => {
+            if (query.trim()) handleAddTag(query.trim())
+          }}
+        />
+      </View>
+      <FlatList
+        data={filtered}
+        keyExtractor={(item) => item.id}
+        keyboardShouldPersistTaps="handled"
+        keyboardDismissMode="on-drag"
+        contentContainerStyle={styles.listContent}
+        ListHeaderComponent={
+          query.trim().length > 0 && !exactMatch ? (
+            <Pressable
+              style={styles.tagRow}
+              onPress={() => handleAddTag(query.trim())}
+            >
+              <View style={styles.tagRowLeft}>
+                <PlusIcon size={16} color={palette.blue[400]} />
+                <Text style={styles.createText}>Create "{query.trim()}"</Text>
+              </View>
+            </Pressable>
+          ) : null
+        }
+        renderItem={({ item }) => {
+          const justAdded = addedTagIds.has(item.id)
+          return (
+            <Pressable
+              style={styles.tagRow}
+              onPress={() => handleAddTag(item.name)}
+            >
+              <View style={styles.tagRowLeft}>
+                <Text style={styles.tagName}>{item.name}</Text>
+              </View>
+              {justAdded ? (
+                <CheckIcon size={18} color={palette.blue[400]} />
+              ) : null}
+            </Pressable>
+          )
+        }}
+        ListEmptyComponent={
+          query.trim().length === 0 ? (
+            <Text style={styles.emptyText}>
+              No tags yet. Type to create one.
+            </Text>
+          ) : null
+        }
+      />
+    </ModalSheet>
+  )
+}
+
+const styles = StyleSheet.create({
+  inputRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: whiteA.a10,
+  },
+  input: {
+    flex: 1,
+    minWidth: 120,
+    color: palette.gray[50],
+    fontSize: 16,
+    paddingVertical: 4,
+  },
+  listContent: {
+    paddingBottom: 40,
+  },
+  tagRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: whiteA.a08,
+  },
+  tagRowLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    flex: 1,
+  },
+  tagName: {
+    color: palette.gray[50],
+    fontSize: 16,
+  },
+  createText: {
+    color: palette.blue[400],
+    fontSize: 16,
+    fontWeight: '500',
+  },
+  emptyText: {
+    color: whiteA.a50,
+    fontSize: 15,
+    textAlign: 'center',
+    paddingTop: 40,
+  },
+})

--- a/src/components/CreateTagSheet.tsx
+++ b/src/components/CreateTagSheet.tsx
@@ -1,0 +1,148 @@
+import { TagIcon } from 'lucide-react-native'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  Keyboard,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native'
+import { closeSheet, useSheetOpen } from '../stores/sheets'
+import { createTag } from '../stores/tags'
+import { overlay, palette, whiteA } from '../styles/colors'
+import { ModalSheet } from './ModalSheet'
+
+export function CreateTagSheet() {
+  const isOpen = useSheetOpen('createTag')
+  const [name, setName] = useState('')
+  const [error, setError] = useState('')
+  const inputRef = useRef<TextInput | null>(null)
+
+  useEffect(() => {
+    if (isOpen) {
+      setTimeout(() => inputRef.current?.focus(), 400)
+    } else {
+      setName('')
+      setError('')
+    }
+  }, [isOpen])
+
+  const handleClose = useCallback(() => {
+    setName('')
+    setError('')
+    Keyboard.dismiss()
+    closeSheet()
+  }, [])
+
+  const handleCreate = useCallback(async () => {
+    const trimmed = name.trim()
+    if (!trimmed) return
+    try {
+      await createTag(trimmed)
+      setName('')
+      setError('')
+      closeSheet()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to create tag')
+    }
+  }, [name])
+
+  return (
+    <ModalSheet
+      visible={isOpen}
+      onRequestClose={handleClose}
+      title="Create Tag"
+      presentationStyle="formSheet"
+      headerRight={
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Cancel"
+          onPress={handleClose}
+          hitSlop={8}
+        >
+          <Text style={styles.cancelText}>Cancel</Text>
+        </Pressable>
+      }
+    >
+      <View style={styles.body}>
+        <View style={styles.inputContainer}>
+          <TextInput
+            ref={inputRef}
+            style={styles.input}
+            placeholder="Tag name"
+            placeholderTextColor={palette.gray[500]}
+            value={name}
+            onChangeText={(text) => {
+              setName(text)
+              setError('')
+            }}
+            autoCapitalize="none"
+            autoCorrect={false}
+            returnKeyType="done"
+            onSubmitEditing={handleCreate}
+          />
+        </View>
+        {error ? <Text style={styles.error}>{error}</Text> : null}
+        <Pressable
+          accessibilityRole="button"
+          onPress={handleCreate}
+          disabled={!name.trim()}
+          style={[
+            styles.createButton,
+            !name.trim() && styles.createButtonDisabled,
+          ]}
+        >
+          <TagIcon size={18} color={palette.gray[50]} />
+          <Text style={styles.createButtonText}>Create</Text>
+        </Pressable>
+      </View>
+    </ModalSheet>
+  )
+}
+
+const styles = StyleSheet.create({
+  cancelText: {
+    color: palette.blue[400],
+    fontSize: 17,
+    fontWeight: '600',
+  },
+  body: {
+    paddingHorizontal: 16,
+  },
+  inputContainer: {
+    backgroundColor: overlay.panelMedium,
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: whiteA.a10,
+    marginBottom: 12,
+  },
+  input: {
+    color: palette.gray[50],
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 16,
+  },
+  error: {
+    color: palette.red[500],
+    fontSize: 13,
+    marginBottom: 8,
+  },
+  createButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    backgroundColor: palette.blue[500],
+    borderRadius: 10,
+    paddingVertical: 14,
+  },
+  createButtonDisabled: {
+    opacity: 0.4,
+  },
+  createButtonText: {
+    color: palette.gray[50],
+    fontSize: 16,
+    fontWeight: '600',
+  },
+})

--- a/src/components/FileActionsSheet.tsx
+++ b/src/components/FileActionsSheet.tsx
@@ -4,8 +4,10 @@ import {
   CloudOffIcon,
   CloudUploadIcon,
   EraserIcon,
+  HeartIcon,
   LinkIcon,
   ShareIcon,
+  TagIcon,
   Trash2Icon,
 } from 'lucide-react-native'
 import { useCallback } from 'react'
@@ -29,7 +31,8 @@ import {
   useFileDetails,
 } from '../stores/files'
 import { getFsFileUri, removeFsFile } from '../stores/fs'
-import { closeSheet, useSheetOpen } from '../stores/sheets'
+import { closeSheet, openSheet, useSheetOpen } from '../stores/sheets'
+import { toggleFavorite, useIsFavorite } from '../stores/tags'
 import { palette } from '../styles/colors'
 import { ActionSheet } from './ActionSheet'
 import { ActionSheetButton } from './ActionSheetButton'
@@ -90,6 +93,12 @@ function SingleFileActionsSheet({
   const { handleShareFile, handleShareURL, canShare } = useShareAction({
     fileId,
   })
+  const favorite = useIsFavorite(isOpen ? fileId : null)
+
+  const handleToggleFavorite = useCallback(() => {
+    closeSheet()
+    void toggleFavorite(fileId)
+  }, [fileId])
 
   const handlePressAndClose = useCallback(
     (action: () => void | Promise<void>) => () => {
@@ -215,6 +224,29 @@ function SingleFileActionsSheet({
           Remove from network
         </ActionSheetButton>
       )}
+      <ActionSheetButton
+        variant="primary"
+        icon={
+          <HeartIcon
+            size={18}
+            fill={favorite.data ? palette.red[500] : 'none'}
+            color={favorite.data ? palette.red[500] : undefined}
+          />
+        }
+        onPress={handleToggleFavorite}
+      >
+        {favorite.data ? 'Remove from Favorites' : 'Add to Favorites'}
+      </ActionSheetButton>
+      <ActionSheetButton
+        variant="primary"
+        icon={<TagIcon size={18} />}
+        onPress={() => {
+          closeSheet()
+          setTimeout(() => openSheet('manageFileTags'), 300)
+        }}
+      >
+        Manage tags
+      </ActionSheetButton>
       <ActionSheetButton
         variant="danger"
         icon={<Trash2Icon size={18} />}

--- a/src/components/FileCarousel/FileCarouselControlBar.tsx
+++ b/src/components/FileCarousel/FileCarouselControlBar.tsx
@@ -1,11 +1,13 @@
 import {
   FullscreenIcon,
-  LinkIcon,
+  HeartIcon,
   MoreVerticalIcon,
   ShareIcon,
+  TagIcon,
   TextAlignStart,
 } from 'lucide-react-native'
 import { useWindowDimensions, View } from 'react-native'
+import { palette } from '../../styles/colors'
 import { BottomControlBar, iconColors } from '../BottomControlBar'
 import { IconButton } from '../IconButton'
 
@@ -13,22 +15,21 @@ type Props = {
   viewStyle: 'consume' | 'detail'
   setViewStyle: (viewStyle: 'consume' | 'detail') => void
   onShareFile: () => void
-  onShareURL: () => void
+  onAddTag: () => void
   onPressMore: () => void
+  onToggleFavorite: () => void
+  isFavorite: boolean
   canShare: boolean
 }
 
-/**
- * A control bar for the carousel overlay designed to work within a modal context.
- * All actions are passed as props from the parent to ensure toasts and sheets
- * render correctly above the modal.
- */
 export function FileCarouselControlBar({
   viewStyle,
   setViewStyle,
   onShareFile,
-  onShareURL,
+  onAddTag,
   onPressMore,
+  onToggleFavorite,
+  isFavorite,
   canShare,
 }: Props) {
   const { width, height } = useWindowDimensions()
@@ -48,11 +49,20 @@ export function FileCarouselControlBar({
         }}
       >
         <View style={{ flexDirection: 'row', gap: 12 }}>
+          <IconButton
+            onPress={onToggleFavorite}
+            accessibilityLabel={isFavorite ? 'Unfavorite' : 'Favorite'}
+          >
+            <HeartIcon
+              color={isFavorite ? palette.red[500] : iconColors.white}
+              fill={isFavorite ? palette.red[500] : 'none'}
+            />
+          </IconButton>
           <IconButton onPress={onShareFile} disabled={!canShare}>
             <ShareIcon color={iconColors.white} />
           </IconButton>
-          <IconButton onPress={onShareURL} disabled={!canShare}>
-            <LinkIcon color={iconColors.white} />
+          <IconButton onPress={onAddTag} accessibilityLabel="Add tag">
+            <TagIcon color={iconColors.white} />
           </IconButton>
         </View>
         <View style={{ flexDirection: 'row', gap: 12 }}>

--- a/src/components/FileCarousel/index.tsx
+++ b/src/components/FileCarousel/index.tsx
@@ -1,4 +1,3 @@
-import Clipboard from '@react-native-clipboard/clipboard'
 import * as ScreenOrientation from 'expo-screen-orientation'
 import { EyeIcon, EyeOffIcon } from 'lucide-react-native'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -15,18 +14,13 @@ import Carousel, {
 } from 'react-native-reanimated-carousel'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import Share from 'react-native-share'
-import {
-  getOneSealedObject,
-  getPinnedObject,
-  useFileStatus,
-} from '../../lib/file'
+import { useFileStatus } from '../../lib/file'
 import { logger } from '../../lib/logger'
-import { generateSiaShareUrl } from '../../lib/shareUrl'
 import { useToast } from '../../lib/toastContext'
 import { useFileCarousel } from '../../stores/fileCarousel'
 import type { FileRecord } from '../../stores/files'
 import type { Category, SortBy, SortDir } from '../../stores/library'
-import { useSdk } from '../../stores/sdk'
+import { toggleFavorite, useIsFavorite } from '../../stores/tags'
 import { palette } from '../../styles/colors'
 import BlocksLoader from '../BlocksLoader'
 import { useDragToDismissGesture } from '../DragToDismiss'
@@ -43,6 +37,7 @@ type Props = {
   categories?: Category[]
   onClose: () => void
   onShowActionSheet?: () => void
+  onShowTagSheet?: () => void
   onZoomChange?: (isZoomed: boolean) => void
   onViewStyleChange?: (viewStyle: 'consume' | 'detail') => void
   isDismissing?: boolean
@@ -56,6 +51,7 @@ export function FileCarousel({
   categories,
   onClose,
   onShowActionSheet,
+  onShowTagSheet,
   onZoomChange,
   onViewStyleChange,
   isDismissing,
@@ -105,7 +101,6 @@ export function FileCarousel({
   const [viewerSize, setViewerSize] = useState({ width: 0, height: 0 })
 
   const insets = useSafeAreaInsets()
-  const sdk = useSdk()
   const carouselRef = useRef<ICarouselInstance>(null)
   const dragToDismissGesture = useDragToDismissGesture()
 
@@ -183,32 +178,24 @@ export function FileCarousel({
     }
   }, [currentFile, status.data?.fileUri])
 
-  const handleShareURL = useCallback(async () => {
-    if (!currentFile || !sdk) return
-    try {
-      const result = getOneSealedObject(currentFile)
-      if (!result) return
-      const pinnedObject = await getPinnedObject(
-        result.indexerURL,
-        result.sealedObject,
-      )
-      const expiresAt = new Date()
-      expiresAt.setDate(expiresAt.getDate() + 1)
-      const shareUrl = await generateSiaShareUrl(sdk, pinnedObject, expiresAt)
-      if (!shareUrl) return
-      Clipboard.setString(shareUrl)
-      toast.show('Share URL copied')
-    } catch (e) {
-      logger.error('FileCarousel', 'share_url_failed', { error: e as Error })
-      toast.show('Failed to copy URL')
-    }
-  }, [currentFile, sdk, toast])
-
   const handleMore = useCallback(() => {
     if (onShowActionSheet) {
       onShowActionSheet()
     }
   }, [onShowActionSheet])
+
+  const handleAddTag = useCallback(() => {
+    if (onShowTagSheet) {
+      onShowTagSheet()
+    }
+  }, [onShowTagSheet])
+
+  const favorite = useIsFavorite(currentFile?.id ?? null)
+  const handleToggleFavorite = useCallback(() => {
+    if (currentFile) {
+      void toggleFavorite(currentFile.id)
+    }
+  }, [currentFile])
 
   const toggleControlsVisibility = useCallback(() => {
     setShowChrome((curr) => !curr)
@@ -373,8 +360,10 @@ export function FileCarousel({
             viewStyle={viewStyle}
             setViewStyle={setViewStyle}
             onShareFile={handleShareFile}
-            onShareURL={handleShareURL}
+            onAddTag={handleAddTag}
             onPressMore={handleMore}
+            onToggleFavorite={handleToggleFavorite}
+            isFavorite={favorite.data ?? false}
             canShare={status.data?.isUploaded ?? false}
           />
         </View>

--- a/src/components/FileDetails/FileMeta.tsx
+++ b/src/components/FileDetails/FileMeta.tsx
@@ -1,5 +1,13 @@
+import { PlusIcon } from 'lucide-react-native'
 import { Fragment, useMemo } from 'react'
-import { StyleSheet, Text, useWindowDimensions, View } from 'react-native'
+import {
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  useWindowDimensions,
+  View,
+} from 'react-native'
 import useSWR from 'swr'
 import { decodeFileMetadata } from '../../encoding/fileMetadata'
 import { useInputValue } from '../../hooks/useInputValue'
@@ -9,6 +17,8 @@ import { humanSize } from '../../lib/humanSize'
 import { type FileRecord, updateFileRecord } from '../../stores/files'
 import { getFsFileUri } from '../../stores/fs'
 import { useShowAdvanced } from '../../stores/settings'
+import { openSheet } from '../../stores/sheets'
+import { useTagsForFile } from '../../stores/tags'
 import {
   readThumbnailsByFileId,
   thumbnailsByFileIdCache,
@@ -18,6 +28,8 @@ import { RowGroup } from '../Group'
 import { InfoCard } from '../InfoCard'
 import { InputRow } from '../InputRow'
 import { LabeledValueRow } from '../LabeledValueRow'
+import { TagManageSheet } from '../TagManageSheet'
+import { TagPill } from '../TagPill'
 import { FileMap } from './FileMap'
 
 export function FileMeta({
@@ -52,6 +64,9 @@ export function FileMeta({
     },
   )
   const { height: windowHeight } = useWindowDimensions()
+  const { data: allFileTags } = useTagsForFile(file.id)
+  const userTags = allFileTags?.filter((t) => !t.system)
+  const tagManageSheetName = `tagManage-${file.id}`
   return (
     <View style={styles.container}>
       <RowGroup title="Details">
@@ -121,6 +136,33 @@ export function FileMeta({
           />
         </InfoCard>
       </RowGroup>
+      <RowGroup title="Tags">
+        <InfoCard>
+          <View style={styles.tagsSection}>
+            {userTags && userTags.length > 0 ? (
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                contentContainerStyle={styles.tagsContainer}
+              >
+                {userTags.map((tag) => (
+                  <TagPill key={tag.id} tag={tag} />
+                ))}
+              </ScrollView>
+            ) : (
+              <Text style={styles.noTagsText}>No tags</Text>
+            )}
+            <Pressable
+              style={styles.addTagButton}
+              onPress={() => openSheet(tagManageSheetName)}
+            >
+              <PlusIcon size={14} color={palette.blue[400]} />
+              <Text style={styles.addTagText}>Add Tag</Text>
+            </Pressable>
+          </View>
+        </InfoCard>
+      </RowGroup>
+      <TagManageSheet sheetName={tagManageSheetName} fileId={file.id} />
       <RowGroup title="File shard storage locations">
         <InfoCard>
           <View style={{ height: Math.round(windowHeight * 0.5) }}>
@@ -236,5 +278,28 @@ const styles = StyleSheet.create({
     borderColor: colors.borderSubtle,
     borderWidth: StyleSheet.hairlineWidth,
     overflow: 'hidden',
+  },
+  tagsSection: {
+    padding: 12,
+    gap: 12,
+  },
+  tagsContainer: {
+    gap: 8,
+    flexDirection: 'row',
+  },
+  noTagsText: {
+    color: palette.gray[400],
+    fontSize: 14,
+  },
+  addTagButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingVertical: 6,
+  },
+  addTagText: {
+    color: palette.blue[400],
+    fontSize: 14,
+    fontWeight: '500',
   },
 })

--- a/src/components/FileListItem.tsx
+++ b/src/components/FileListItem.tsx
@@ -1,10 +1,16 @@
-import { CircleCheckIcon, CircleIcon, DotIcon } from 'lucide-react-native'
+import {
+  CircleCheckIcon,
+  CircleIcon,
+  DotIcon,
+  HeartIcon,
+} from 'lucide-react-native'
 import { memo } from 'react'
 import { Pressable, StyleSheet, Text, View } from 'react-native'
 import { useFileStatus } from '../lib/file'
 import { humanSize } from '../lib/humanSize'
 import { useIsFileSelected, useIsSelectionMode } from '../stores/fileSelection'
 import type { FileRecord } from '../stores/files'
+import { useIsFavorite } from '../stores/tags'
 import { palette, whiteA } from '../styles/colors'
 import { FileThumbnail } from './FileThumbnail'
 import { UploadStatusIcon } from './UploadStatusIcon'
@@ -19,6 +25,7 @@ function FileListItemComponent({ file, onPressItem, onLongPressItem }: Props) {
   const isSelectionMode = useIsSelectionMode()
   const isSelected = useIsFileSelected(file.id)
   const status = useFileStatus(file)
+  const isFavorite = useIsFavorite(file.id)
 
   return (
     <Pressable
@@ -50,6 +57,16 @@ function FileListItemComponent({ file, onPressItem, onLongPressItem }: Props) {
             <Text style={styles.fileText}>{humanSize(file.size)}</Text>
             <DotIcon size={16} color="grey" />
             <Text style={styles.fileText}>{file.type}</Text>
+            {isFavorite.data ? (
+              <>
+                <DotIcon size={16} color="grey" />
+                <HeartIcon
+                  size={10}
+                  color={palette.red[500]}
+                  fill={palette.red[500]}
+                />
+              </>
+            ) : null}
           </View>
         </View>
       </View>

--- a/src/components/ManageTagsSheet.tsx
+++ b/src/components/ManageTagsSheet.tsx
@@ -1,0 +1,226 @@
+import { CheckIcon, PlusIcon } from 'lucide-react-native'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  FlatList,
+  Keyboard,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native'
+import { closeSheet, useSheetOpen } from '../stores/sheets'
+import {
+  addTagToFile,
+  removeTagFromFile,
+  useAllTags,
+  useTagsForFile,
+} from '../stores/tags'
+import { palette, whiteA } from '../styles/colors'
+import { ModalSheet } from './ModalSheet'
+import { TagPill } from './TagPill'
+
+type Props = {
+  fileId: string
+  sheetName: string
+}
+
+export function ManageTagsSheet({ fileId, sheetName }: Props) {
+  const isOpen = useSheetOpen(sheetName)
+  const fileTags = useTagsForFile(fileId)
+  const allTags = useAllTags()
+  const [query, setQuery] = useState('')
+  const inputRef = useRef<TextInput | null>(null)
+
+  const existingTagIds = new Set((fileTags.data ?? []).map((t) => t.id))
+  const userFileTags = (fileTags.data ?? []).filter((t) => !t.system)
+  const allTagList = (allTags.data ?? []).filter((t) => !t.system)
+
+  const filtered = query.trim()
+    ? allTagList.filter((t) =>
+        t.name.toLowerCase().includes(query.trim().toLowerCase()),
+      )
+    : allTagList
+
+  const exactMatch =
+    query.trim().length > 0 &&
+    allTagList.some((t) => t.name.toLowerCase() === query.trim().toLowerCase())
+
+  useEffect(() => {
+    if (isOpen) {
+      setTimeout(() => inputRef.current?.focus(), 400)
+    } else {
+      setQuery('')
+    }
+  }, [isOpen])
+
+  const handleAddTag = useCallback(
+    async (tagName: string) => {
+      if (!tagName.trim()) return
+      await addTagToFile(fileId, tagName.trim())
+      setQuery('')
+    },
+    [fileId],
+  )
+
+  const handleRemoveTag = useCallback(
+    async (tagId: string) => {
+      await removeTagFromFile(fileId, tagId)
+    },
+    [fileId],
+  )
+
+  const handleClose = useCallback(() => {
+    setQuery('')
+    Keyboard.dismiss()
+    closeSheet()
+  }, [])
+
+  const handleToggleTag = useCallback(
+    (tag: { id: string; name: string }) => {
+      if (existingTagIds.has(tag.id)) {
+        handleRemoveTag(tag.id)
+      } else {
+        handleAddTag(tag.name)
+      }
+    },
+    [existingTagIds, handleAddTag, handleRemoveTag],
+  )
+
+  return (
+    <ModalSheet visible={isOpen} onRequestClose={handleClose} title="Tags">
+      <View style={styles.inputRow}>
+        {userFileTags.map((tag) => (
+          <TagPill
+            key={tag.id}
+            tag={tag}
+            selected
+            onRemove={() => handleRemoveTag(tag.id)}
+          />
+        ))}
+        <TextInput
+          ref={inputRef}
+          style={styles.input}
+          placeholder={
+            userFileTags.length > 0 ? 'Add more...' : 'Search or create tag...'
+          }
+          placeholderTextColor={palette.gray[500]}
+          value={query}
+          onChangeText={setQuery}
+          autoCapitalize="none"
+          autoCorrect={false}
+          returnKeyType="done"
+          onSubmitEditing={() => {
+            if (query.trim()) handleAddTag(query.trim())
+          }}
+        />
+      </View>
+      <FlatList
+        data={filtered}
+        keyExtractor={(item) => item.id}
+        keyboardShouldPersistTaps="handled"
+        keyboardDismissMode="on-drag"
+        contentContainerStyle={styles.listContent}
+        ListHeaderComponent={
+          query.trim().length > 0 && !exactMatch ? (
+            <Pressable
+              style={styles.tagRow}
+              onPress={() => handleAddTag(query.trim())}
+            >
+              <View style={styles.tagRowLeft}>
+                <PlusIcon size={16} color={palette.blue[400]} />
+                <Text style={styles.createText}>Create "{query.trim()}"</Text>
+              </View>
+            </Pressable>
+          ) : null
+        }
+        renderItem={({ item }) => {
+          const isOnFile = existingTagIds.has(item.id)
+          return (
+            <Pressable
+              style={styles.tagRow}
+              onPress={() => handleToggleTag(item)}
+            >
+              <View style={styles.tagRowLeft}>
+                <Text style={styles.tagName}>{item.name}</Text>
+                {'fileCount' in item ? (
+                  <Text style={styles.tagCount}>
+                    {(item as { fileCount: number }).fileCount}
+                  </Text>
+                ) : null}
+              </View>
+              {isOnFile ? (
+                <CheckIcon size={18} color={palette.blue[400]} />
+              ) : null}
+            </Pressable>
+          )
+        }}
+        ListEmptyComponent={
+          query.trim().length > 0 && exactMatch ? null : query.trim().length ===
+            0 ? (
+            <Text style={styles.emptyText}>
+              No tags yet. Type to create one.
+            </Text>
+          ) : null
+        }
+      />
+    </ModalSheet>
+  )
+}
+
+const styles = StyleSheet.create({
+  inputRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: whiteA.a10,
+  },
+  input: {
+    flex: 1,
+    minWidth: 120,
+    color: palette.gray[50],
+    fontSize: 16,
+    paddingVertical: 4,
+  },
+  listContent: {
+    paddingBottom: 40,
+  },
+  tagRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: whiteA.a08,
+  },
+  tagRowLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    flex: 1,
+  },
+  tagName: {
+    color: palette.gray[50],
+    fontSize: 16,
+  },
+  tagCount: {
+    color: whiteA.a50,
+    fontSize: 14,
+  },
+  createText: {
+    color: palette.blue[400],
+    fontSize: 16,
+    fontWeight: '500',
+  },
+  emptyText: {
+    color: whiteA.a50,
+    fontSize: 15,
+    textAlign: 'center',
+    paddingTop: 40,
+  },
+})

--- a/src/components/SelectionBar.tsx
+++ b/src/components/SelectionBar.tsx
@@ -1,8 +1,10 @@
-import { Trash2Icon } from 'lucide-react-native'
+import { TagIcon, Trash2Icon } from 'lucide-react-native'
 import { StyleSheet, Text, View } from 'react-native'
 import { useSelectedCount } from '../stores/fileSelection'
+import { openSheet } from '../stores/sheets'
 import { palette } from '../styles/colors'
 import { BottomControlBar, iconColors } from './BottomControlBar'
+import { BulkManageTagsSheet } from './BulkManageTagsSheet'
 import { IconButton } from './IconButton'
 
 type Props = {
@@ -13,24 +15,36 @@ export function SelectionBar({ onOpenSelectionActions }: Props) {
   const selectedCount = useSelectedCount()
 
   return (
-    <BottomControlBar style={styles.bar}>
-      <View style={styles.container}>
-        <View style={styles.spacer} />
-        <Text style={styles.count}>
-          {selectedCount > 0 ? `${selectedCount} selected` : 'Select items'}
-        </Text>
-        <IconButton
-          onPress={onOpenSelectionActions}
-          disabled={selectedCount === 0}
-          accessibilityLabel="Delete"
-        >
-          <Trash2Icon
-            color={selectedCount > 0 ? palette.red[500] : iconColors.inactive}
-            size={20}
-          />
-        </IconButton>
-      </View>
-    </BottomControlBar>
+    <>
+      <BottomControlBar style={styles.bar}>
+        <View style={styles.container}>
+          <IconButton
+            onPress={() => openSheet('bulkManageTags')}
+            disabled={selectedCount === 0}
+            accessibilityLabel="Add tag"
+          >
+            <TagIcon
+              color={selectedCount > 0 ? iconColors.white : iconColors.inactive}
+              size={20}
+            />
+          </IconButton>
+          <Text style={styles.count}>
+            {selectedCount > 0 ? `${selectedCount} selected` : 'Select items'}
+          </Text>
+          <IconButton
+            onPress={onOpenSelectionActions}
+            disabled={selectedCount === 0}
+            accessibilityLabel="Delete"
+          >
+            <Trash2Icon
+              color={selectedCount > 0 ? palette.red[500] : iconColors.inactive}
+              size={20}
+            />
+          </IconButton>
+        </View>
+      </BottomControlBar>
+      <BulkManageTagsSheet />
+    </>
   )
 }
 
@@ -49,8 +63,5 @@ const styles = StyleSheet.create({
     color: palette.gray[50],
     fontSize: 14,
     fontWeight: '600',
-  },
-  spacer: {
-    width: 20,
   },
 })

--- a/src/components/TagInput.tsx
+++ b/src/components/TagInput.tsx
@@ -1,0 +1,146 @@
+import { PlusIcon } from 'lucide-react-native'
+import type React from 'react'
+import { useCallback, useState } from 'react'
+import {
+  Keyboard,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native'
+import { addTagToFile, type Tag, useTagSearch } from '../stores/tags'
+import { colors, overlay, palette, whiteA } from '../styles/colors'
+
+type TagInputProps = {
+  fileId: string
+  existingTagIds: Set<string>
+  onTagAdded?: () => void
+}
+
+export function TagInput({
+  fileId,
+  existingTagIds,
+  onTagAdded,
+}: TagInputProps): React.ReactElement {
+  const [query, setQuery] = useState('')
+  const searchResults = useTagSearch(query.trim())
+
+  const filteredResults = (searchResults.data ?? []).filter(
+    (tag) => !existingTagIds.has(tag.id),
+  )
+
+  const showSuggestions = query.trim().length > 0
+
+  const exactMatch = filteredResults.some(
+    (tag) => tag.name.toLowerCase() === query.trim().toLowerCase(),
+  )
+
+  const handleAddTag = useCallback(
+    async (tagName: string) => {
+      if (!tagName.trim()) return
+      await addTagToFile(fileId, tagName.trim())
+      setQuery('')
+      Keyboard.dismiss()
+      onTagAdded?.()
+    },
+    [fileId, onTagAdded],
+  )
+
+  const handleSelectTag = useCallback(
+    (tag: Tag) => {
+      handleAddTag(tag.name)
+    },
+    [handleAddTag],
+  )
+
+  const handleCreateNew = useCallback(() => {
+    handleAddTag(query.trim())
+  }, [query, handleAddTag])
+
+  return (
+    <View>
+      <View style={styles.inputContainer}>
+        <TextInput
+          style={styles.input}
+          placeholder="Add tag..."
+          placeholderTextColor={palette.gray[400]}
+          value={query}
+          onChangeText={setQuery}
+          autoCapitalize="none"
+          autoCorrect={false}
+          returnKeyType="done"
+          onSubmitEditing={() => {
+            if (query.trim()) {
+              handleAddTag(query.trim())
+            }
+          }}
+        />
+      </View>
+      {showSuggestions && (
+        <View style={styles.suggestions}>
+          {filteredResults.map((tag) => (
+            <Pressable
+              key={tag.id}
+              style={styles.suggestionItem}
+              onPress={() => handleSelectTag(tag)}
+            >
+              <Text style={styles.suggestionText}>{tag.name}</Text>
+            </Pressable>
+          ))}
+          {query.trim() && !exactMatch ? (
+            <Pressable style={styles.createNewItem} onPress={handleCreateNew}>
+              <PlusIcon size={14} color={palette.blue[400]} />
+              <Text style={styles.createNewText}>Create "{query.trim()}"</Text>
+            </Pressable>
+          ) : null}
+        </View>
+      )}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  inputContainer: {
+    backgroundColor: overlay.panelMedium,
+    borderRadius: 8,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: whiteA.a10,
+  },
+  input: {
+    color: colors.textPrimary,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 14,
+  },
+  suggestions: {
+    marginTop: 4,
+    backgroundColor: palette.gray[900],
+    borderRadius: 8,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: whiteA.a10,
+    overflow: 'hidden',
+  },
+  suggestionItem: {
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: whiteA.a10,
+  },
+  suggestionText: {
+    color: colors.textPrimary,
+    fontSize: 14,
+  },
+  createNewItem: {
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  createNewText: {
+    color: palette.blue[400],
+    fontSize: 14,
+    fontWeight: '500',
+  },
+})

--- a/src/components/TagManageSheet.tsx
+++ b/src/components/TagManageSheet.tsx
@@ -1,0 +1,94 @@
+import { ScrollView, StyleSheet, Text, View } from 'react-native'
+import { closeSheet, useSheetOpen } from '../stores/sheets'
+import { removeTagFromFile, useTagsForFile } from '../stores/tags'
+import { palette } from '../styles/colors'
+import { ActionSheet } from './ActionSheet'
+import { TagInput } from './TagInput'
+import { TagPill } from './TagPill'
+
+type TagManageSheetProps = {
+  sheetName?: string
+  fileId: string
+}
+
+export function TagManageSheet({
+  sheetName = 'tagManage',
+  fileId,
+}: TagManageSheetProps) {
+  const isOpen = useSheetOpen(sheetName)
+  const { data: tags, mutate } = useTagsForFile(isOpen ? fileId : null)
+
+  const existingTagIds = new Set((tags ?? []).map((t) => t.id))
+
+  const handleRemoveTag = async (tagId: string) => {
+    await removeTagFromFile(fileId, tagId)
+    mutate()
+  }
+
+  const handleTagAdded = () => {
+    mutate()
+  }
+
+  return (
+    <ActionSheet visible={isOpen} onRequestClose={() => closeSheet()}>
+      <View style={styles.container}>
+        <Text style={styles.title}>Manage Tags</Text>
+        {tags && tags.length > 0 && (
+          <View style={styles.tagsSection}>
+            <Text style={styles.sectionLabel}>Current tags</Text>
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={styles.tagsContainer}
+            >
+              {tags.map((tag) => (
+                <TagPill
+                  key={tag.id}
+                  tag={tag}
+                  onRemove={() => handleRemoveTag(tag.id)}
+                />
+              ))}
+            </ScrollView>
+          </View>
+        )}
+        <View style={styles.inputSection}>
+          <Text style={styles.sectionLabel}>Add tag</Text>
+          <TagInput
+            fileId={fileId}
+            existingTagIds={existingTagIds}
+            onTagAdded={handleTagAdded}
+          />
+        </View>
+      </View>
+    </ActionSheet>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 16,
+  },
+  title: {
+    color: palette.gray[50],
+    fontSize: 18,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  tagsSection: {
+    gap: 8,
+  },
+  sectionLabel: {
+    color: palette.gray[400],
+    fontSize: 12,
+    fontWeight: '500',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  tagsContainer: {
+    gap: 8,
+    flexDirection: 'row',
+  },
+  inputSection: {
+    gap: 8,
+  },
+})

--- a/src/components/TagPill.tsx
+++ b/src/components/TagPill.tsx
@@ -1,0 +1,76 @@
+import { XIcon } from 'lucide-react-native'
+import type React from 'react'
+import { Pressable, StyleSheet, Text, View, type ViewStyle } from 'react-native'
+import type { Tag } from '../stores/tags'
+import { overlay, palette, whiteA } from '../styles/colors'
+
+type TagPillProps = {
+  tag: Tag
+  selected?: boolean
+  onPress?: () => void
+  onRemove?: () => void
+  style?: ViewStyle
+}
+
+export function TagPill({
+  tag,
+  selected = false,
+  onPress,
+  onRemove,
+  style,
+}: TagPillProps): React.ReactElement {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      onPress={onPress}
+      disabled={!onPress}
+      style={[
+        styles.pill,
+        {
+          backgroundColor: selected ? palette.blue[500] : overlay.panelMedium,
+          borderColor: selected ? palette.blue[500] : whiteA.a10,
+        },
+        style,
+      ]}
+    >
+      <View style={styles.content}>
+        <Text style={styles.text} numberOfLines={1}>
+          {tag.name}
+        </Text>
+        {onRemove && (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={`Remove tag ${tag.name}`}
+            onPress={onRemove}
+            hitSlop={8}
+            style={styles.removeButton}
+          >
+            <XIcon size={12} color={whiteA.a70} />
+          </Pressable>
+        )}
+      </View>
+    </Pressable>
+  )
+}
+
+const styles = StyleSheet.create({
+  pill: {
+    paddingVertical: 4,
+    paddingHorizontal: 8,
+    borderRadius: 999,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  content: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  text: {
+    color: palette.gray[50],
+    fontSize: 11,
+    fontWeight: '500',
+  },
+  removeButton: {
+    marginLeft: 2,
+  },
+})

--- a/src/components/TagsGrid.tsx
+++ b/src/components/TagsGrid.tsx
@@ -1,0 +1,147 @@
+import { TagIcon } from 'lucide-react-native'
+import { useMemo } from 'react'
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native'
+import { type TagWithCount, useAllTags } from '../stores/tags'
+import { overlay, palette, whiteA } from '../styles/colors'
+
+type TagOrSpacer = TagWithCount | { id: '__spacer' }
+
+type Props = {
+  onSelectTag: (tagId: string, tagName: string) => void
+}
+
+export function TagsGrid({ onSelectTag }: Props) {
+  const allTags = useAllTags()
+  const tags = allTags.data ?? []
+
+  const paddedTags: TagOrSpacer[] = useMemo(
+    () => (tags.length % 2 === 1 ? [...tags, { id: '__spacer' }] : tags),
+    [tags],
+  )
+
+  if (!allTags.data) {
+    return (
+      <View style={styles.emptyWrap}>
+        <ActivityIndicator color={palette.blue[400]} />
+      </View>
+    )
+  }
+
+  if (tags.length === 0) {
+    return (
+      <View style={styles.emptyWrap}>
+        <TagIcon color={whiteA.a50} size={48} />
+        <Text style={styles.emptyTitle}>No tags yet</Text>
+        <Text style={styles.emptyText}>
+          Create tags to organize your files.
+        </Text>
+      </View>
+    )
+  }
+
+  return (
+    <FlatList
+      data={paddedTags}
+      keyExtractor={(tag) => tag.id}
+      numColumns={2}
+      contentContainerStyle={styles.grid}
+      columnWrapperStyle={styles.row}
+      renderItem={({ item }) =>
+        item.id === '__spacer' ? (
+          <View style={styles.spacer} />
+        ) : (
+          <TagCard
+            tag={item as TagWithCount}
+            onPress={() => onSelectTag(item.id, (item as TagWithCount).name)}
+          />
+        )
+      }
+    />
+  )
+}
+
+function TagCard({ tag, onPress }: { tag: TagWithCount; onPress: () => void }) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      onPress={onPress}
+      style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}
+    >
+      <TagIcon color={palette.blue[400]} size={24} />
+      <View style={styles.cardText}>
+        <Text style={styles.tagName} numberOfLines={1}>
+          {tag.name}
+        </Text>
+        <Text style={styles.tagCount}>
+          {tag.fileCount.toLocaleString()}{' '}
+          {tag.fileCount === 1 ? 'file' : 'files'}
+        </Text>
+      </View>
+    </Pressable>
+  )
+}
+
+const styles = StyleSheet.create({
+  grid: {
+    padding: 16,
+    paddingTop: 140,
+    paddingBottom: 120,
+  },
+  row: {
+    gap: 12,
+    marginBottom: 12,
+  },
+  spacer: {
+    flex: 1,
+  },
+  card: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: overlay.panelMedium,
+    borderRadius: 16,
+    padding: 16,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: whiteA.a10,
+    gap: 12,
+  },
+  cardPressed: {
+    backgroundColor: overlay.panelStrong,
+  },
+  cardText: {
+    flex: 1,
+  },
+  tagName: {
+    color: palette.gray[50],
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  tagCount: {
+    color: whiteA.a50,
+    fontSize: 13,
+  },
+  emptyWrap: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+  },
+  emptyTitle: {
+    color: palette.gray[100],
+    fontWeight: '800',
+    fontSize: 18,
+    paddingTop: 12,
+    paddingBottom: 6,
+  },
+  emptyText: {
+    color: whiteA.a70,
+    textAlign: 'center',
+  },
+})

--- a/src/db/migrations/0006_add_tags_and_directories.ts
+++ b/src/db/migrations/0006_add_tags_and_directories.ts
@@ -1,0 +1,59 @@
+import type * as SQLite from 'expo-sqlite'
+import { logger } from '../../lib/logger'
+import type { Migration } from './types'
+
+async function up(db: SQLite.SQLiteDatabase): Promise<void> {
+  try {
+    // Create the tags table for autocomplete/discovery.
+    await db.execAsync(
+      `CREATE TABLE IF NOT EXISTS tags (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL UNIQUE COLLATE NOCASE,
+        createdAt INTEGER NOT NULL,
+        usedAt INTEGER NOT NULL,
+        system INTEGER NOT NULL DEFAULT 0
+      );`,
+    )
+
+    // Index for ordering by recently used.
+    await db.execAsync(
+      `CREATE INDEX IF NOT EXISTS idx_tags_usedAt ON tags(usedAt);`,
+    )
+
+    // Create the file_tags junction table (local source of truth).
+    await db.execAsync(
+      `CREATE TABLE IF NOT EXISTS file_tags (
+        fileId TEXT NOT NULL,
+        tagId TEXT NOT NULL,
+        PRIMARY KEY (fileId, tagId),
+        FOREIGN KEY (fileId) REFERENCES files(id) ON DELETE CASCADE,
+        FOREIGN KEY (tagId) REFERENCES tags(id) ON DELETE CASCADE
+      );`,
+    )
+
+    // Index for looking up files by tag.
+    await db.execAsync(
+      `CREATE INDEX IF NOT EXISTS idx_file_tags_tagId ON file_tags(tagId);`,
+    )
+
+    // Insert the Favorites system tag.
+    const now = Date.now()
+    await db.runAsync(
+      `INSERT OR IGNORE INTO tags (id, name, createdAt, usedAt, system) VALUES (?, ?, ?, ?, 1)`,
+      'sys:favorites',
+      'Favorites',
+      now,
+      now,
+    )
+  } catch (e) {
+    logger.error('db', 'migration_0006_error', { error: e as Error })
+    throw e
+  }
+}
+
+export const migration_0006_add_tags_and_directories: Migration = {
+  id: '0006_add_tags_and_directories',
+  description:
+    'Add tags, file_tags, directories tables and Favorites system tag.',
+  up,
+}

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -23,6 +23,7 @@ import { migration_0002_keychain_accessibility } from './0002_keychain_accessibi
 import { migration_0003_logs_data_column } from './0003_logs_data_column'
 import { migration_0004_hash_and_thumbs } from './0004_hash_and_thumbs'
 import { migration_0005_reset_sync_up_cursor } from './0005_reset_sync_up_cursor'
+import { migration_0006_add_tags_and_directories } from './0006_add_tags_and_directories'
 import type { Migration, MigrationProgressHandler } from './types'
 
 const migrations: Migration[] = [
@@ -31,6 +32,7 @@ const migrations: Migration[] = [
   migration_0003_logs_data_column,
   migration_0004_hash_and_thumbs,
   migration_0005_reset_sync_up_cursor,
+  migration_0006_add_tags_and_directories,
 ]
 
 export async function runMigrations(

--- a/src/managers/syncDownEvents.ts
+++ b/src/managers/syncDownEvents.ts
@@ -41,6 +41,7 @@ import {
 import { getIsConnected, getSdk } from '../stores/sdk'
 import { getAutoSyncDownEvents, getIndexerURL } from '../stores/settings'
 import { setSyncDownState } from '../stores/syncDown'
+import { syncTagsFromMetadata } from '../stores/tags'
 import { removeTempDownloadFile } from '../stores/tempFs'
 import { removeUpload } from '../stores/uploads'
 
@@ -57,6 +58,8 @@ type PreparedCreate = {
   kind: 'create'
   fileRecord: FileRecordRow
   localObject: LocalObject
+  tags?: string[]
+  isFile: boolean
 }
 
 // An "update" means a file record already exists; merge metadata fields.
@@ -65,6 +68,9 @@ type PreparedUpdate = {
   fileRecord: FileRecordRow
   localObject: LocalObject
   fileId: string
+  tags?: string[]
+  isFile: boolean
+  isRemoteNewer: boolean
 }
 
 // A "delete" means the object was removed from the indexer.
@@ -87,6 +93,8 @@ type PreparedAdopt = {
   fileRecord: FileRecordRow
   localObject: LocalObject
   indexerURL: string
+  tags?: string[]
+  isFile: boolean
 }
 
 type PreparedEvent =
@@ -297,7 +305,7 @@ async function processBatch(
   })
 
   // Phase 3: Cleanup — delete local files for deleted records, clear
-  // upload state for updated records. Errors here are non-fatal.
+  // upload state for updated records, sync tags. Errors here are non-fatal.
   for (const event of prepared) {
     if (event.kind === 'delete' && deletedFileIds.has(event.fileId)) {
       try {
@@ -312,6 +320,23 @@ async function processBatch(
       }
     } else if (event.kind === 'update') {
       removeUpload(event.fileId)
+    }
+    // Sync tags from remote metadata for file records.
+    if (event.kind !== 'delete' && event.isFile) {
+      const shouldSync =
+        event.kind === 'create' ||
+        event.kind === 'adopt' ||
+        (event.kind === 'update' && event.isRemoteNewer)
+      if (shouldSync) {
+        try {
+          await syncTagsFromMetadata(event.fileRecord.id, event.tags)
+        } catch (e) {
+          logger.error('syncDownEvents', 'tag_sync_error', {
+            fileId: event.fileRecord.id,
+            error: e as Error,
+          })
+        }
+      }
     }
   }
 }
@@ -485,6 +510,9 @@ async function prepareFileRecord(
       },
       localObject,
       fileId: existing.id,
+      tags: metadata.tags,
+      isFile: type === 'file',
+      isRemoteNewer: metadata.updatedAt >= existing.updatedAt,
     }
   }
 
@@ -511,6 +539,8 @@ async function prepareFileRecord(
     kind: 'create',
     fileRecord,
     localObject,
+    tags: metadata.tags,
+    isFile: type === 'file',
   }
 }
 
@@ -552,6 +582,8 @@ async function prepareAdopt(
     fileRecord,
     localObject,
     indexerURL,
+    tags: metadata.tags,
+    isFile: metadata.kind === 'file',
   }
 }
 

--- a/src/managers/syncUpMetadata.ts
+++ b/src/managers/syncUpMetadata.ts
@@ -14,6 +14,7 @@ import { createServiceInterval } from '../lib/serviceInterval'
 import { SlotPool } from '../lib/slotPool'
 import { getAsyncStorageJSON, setAsyncStorageJSON } from '../stores/asyncStore'
 import {
+  type FileMetadata,
   fileMetadataKeys,
   readAllFileRecords,
   readAllFileRecordsCount,
@@ -24,6 +25,7 @@ import {
   getIsSyncingUpMetadata,
   setSyncUpMetadataState,
 } from '../stores/syncUpMetadata'
+import { readTagNamesForFile } from '../stores/tags'
 
 type DiffEntry = { local: unknown; remote: unknown }
 
@@ -219,10 +221,16 @@ export async function runSyncUpMetadata(
         })
 
         if (isLocalNewer) {
-          const fileToEncode =
+          let fileToEncode: FileMetadata =
             remoteMeta.id && remoteMeta.id !== f.id
               ? { ...f, id: remoteMeta.id }
               : f
+          if (f.kind === 'file') {
+            const tags = await readTagNamesForFile(f.id)
+            if (tags) {
+              fileToEncode = { ...fileToEncode, tags }
+            }
+          }
           logger.info('syncUpMetadata', 'pushing_v1', {
             fileId: fileToEncode.id,
             objectId: obj.id,

--- a/src/screens/LibraryScreen.tsx
+++ b/src/screens/LibraryScreen.tsx
@@ -19,6 +19,7 @@ import { LibraryHeader } from '../components/LibraryHeader'
 import { LibraryLocalResetButton } from '../components/LibraryLocalResetButton'
 import { LibraryStatusSheet } from '../components/LibraryStatusSheet'
 import { LibraryTabBar } from '../components/LibraryTabBar'
+import { ManageTagsSheet } from '../components/ManageTagsSheet'
 import { SelectionBar } from '../components/SelectionBar'
 import type { MainStackParamList } from '../stacks/types'
 import {
@@ -99,6 +100,10 @@ export function LibraryScreen({ route, navigation }: Props) {
 
   const handleShowCarouselActions = useCallback(() => {
     openSheet('fileActions')
+  }, [])
+
+  const handleShowTagSheet = useCallback(() => {
+    openSheet('manageFileTags')
   }, [])
 
   const handleOpenSelectionActions = useCallback(() => {
@@ -292,6 +297,7 @@ export function LibraryScreen({ route, navigation }: Props) {
                 setIsCarouselDetail(false)
               }}
               onShowActionSheet={handleShowCarouselActions}
+              onShowTagSheet={handleShowTagSheet}
               onZoomChange={setIsCarouselZoomed}
               onViewStyleChange={(s) => setIsCarouselDetail(s === 'detail')}
               isDismissing={isDraggingToDismiss}
@@ -300,11 +306,19 @@ export function LibraryScreen({ route, navigation }: Props) {
         </Animated.View>
       ) : null}
       {actionSheetFileIds.length > 0 ? (
-        <FileActionsSheet
-          fileIds={actionSheetFileIds}
-          sheetName="fileActions"
-          onComplete={isSelectionMode ? handleBulkActionComplete : undefined}
-        />
+        <>
+          <FileActionsSheet
+            fileIds={actionSheetFileIds}
+            sheetName="fileActions"
+            onComplete={isSelectionMode ? handleBulkActionComplete : undefined}
+          />
+          {actionSheetFileIds.length === 1 ? (
+            <ManageTagsSheet
+              fileId={actionSheetFileIds[0]}
+              sheetName="manageFileTags"
+            />
+          ) : null}
+        </>
       ) : null}
     </View>
   )

--- a/src/screens/TagLibraryScreen.tsx
+++ b/src/screens/TagLibraryScreen.tsx
@@ -1,0 +1,443 @@
+import type { NativeStackScreenProps } from '@react-navigation/native-stack'
+import {
+  ArrowLeftIcon,
+  FilePlusIcon,
+  ListFilterIcon,
+  MoreVerticalIcon,
+  Trash2Icon,
+  XIcon,
+} from 'lucide-react-native'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  ActivityIndicator,
+  Alert,
+  Animated,
+  Image,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native'
+import { ActionSheet } from '../components/ActionSheet'
+import { ActionSheetButton } from '../components/ActionSheetButton'
+import { AddFileActionSheet } from '../components/AddFileActionSheet'
+import { BottomControlBar, FloatingPill } from '../components/BottomControlBar'
+import { DragToDismiss } from '../components/DragToDismiss'
+import { FileActionsSheet } from '../components/FileActionsSheet'
+import { FileCarousel } from '../components/FileCarousel'
+import { FileGallery } from '../components/FileGallery'
+import { FileList } from '../components/FileList'
+import { Gradient } from '../components/Gradient'
+import { IconButton } from '../components/IconButton'
+import { ManageTagsSheet } from '../components/ManageTagsSheet'
+import { ScreenHeader } from '../components/ScreenHeader'
+import { SelectionBar } from '../components/SelectionBar'
+import { ViewSettingsMenu } from '../components/ViewSettingsMenu'
+import type { MainStackParamList } from '../stacks/types'
+import {
+  enterSelectionMode,
+  exitSelectionMode,
+  toggleFileSelection,
+  useIsSelectionMode,
+  useSelectedFileIds,
+} from '../stores/fileSelection'
+import type { FileRecord } from '../stores/files'
+import {
+  type FileListParams,
+  useFileList,
+  useTagFileCount,
+} from '../stores/library'
+import { closeSheet, openSheet, useSheetOpen } from '../stores/sheets'
+import { addTagToFile, deleteTag } from '../stores/tags'
+import { useViewSettings } from '../stores/viewSettings'
+import { colors, overlay, palette, whiteA } from '../styles/colors'
+
+type Props = NativeStackScreenProps<MainStackParamList, 'TagLibrary'>
+
+export function TagLibraryScreen({ route, navigation }: Props) {
+  const { tagId, tagName } = route.params
+  const scope = `tag.${tagId}`
+  const vs = useViewSettings(scope)
+  const filters: FileListParams = useMemo(
+    () => ({
+      scope: `tag:${tagId}`,
+      sortBy: vs.sortBy,
+      sortDir: vs.sortDir,
+      categories: vs.selectedCategories,
+      tags: [tagId],
+    }),
+    [tagId, vs.sortBy, vs.sortDir, vs.selectedCategories],
+  )
+  const files = useFileList(filters)
+  const isSelectionMode = useIsSelectionMode()
+  const selectedFileIds = useSelectedFileIds()
+  const isSelectionModeRef = useRef(isSelectionMode)
+
+  const [selectedFile, setSelectedFile] = useState<FileRecord | null>(null)
+  const [isCarouselZoomed, setIsCarouselZoomed] = useState(false)
+  const [isCarouselDetail, setIsCarouselDetail] = useState(false)
+  const [isDraggingToDismiss, setIsDraggingToDismiss] = useState(false)
+  const [actionFileId, setActionFileId] = useState<string | null>(null)
+  const fadeAnim = useRef(new Animated.Value(0)).current
+  const scaleAnim = useRef(new Animated.Value(0.95)).current
+
+  useEffect(() => {
+    isSelectionModeRef.current = isSelectionMode
+  }, [isSelectionMode])
+
+  useEffect(() => {
+    return () => {
+      exitSelectionMode()
+    }
+  }, [])
+
+  useEffect(() => {
+    if (selectedFile) {
+      Animated.parallel([
+        Animated.timing(fadeAnim, {
+          toValue: 1,
+          duration: 250,
+          useNativeDriver: true,
+        }),
+        Animated.spring(scaleAnim, {
+          toValue: 1,
+          useNativeDriver: true,
+          tension: 65,
+          friction: 8,
+        }),
+      ]).start()
+    } else {
+      Animated.parallel([
+        Animated.timing(fadeAnim, {
+          toValue: 0,
+          duration: 200,
+          useNativeDriver: true,
+        }),
+        Animated.timing(scaleAnim, {
+          toValue: 0.95,
+          duration: 200,
+          useNativeDriver: true,
+        }),
+      ]).start()
+    }
+  }, [selectedFile, fadeAnim, scaleAnim])
+
+  const handlePressItem = useCallback((file: FileRecord) => {
+    if (isSelectionModeRef.current) {
+      toggleFileSelection(file.id)
+    } else {
+      setActionFileId(null)
+      setSelectedFile(file)
+    }
+  }, [])
+
+  const handleLongPressItem = useCallback((file: FileRecord) => {
+    if (isSelectionModeRef.current) {
+      toggleFileSelection(file.id)
+      return
+    }
+    setActionFileId(file.id)
+    openSheet('tagLibraryFileActions')
+  }, [])
+
+  const handleCloseCarousel = useCallback(() => {
+    setSelectedFile(null)
+    setIsCarouselZoomed(false)
+    setIsCarouselDetail(false)
+  }, [])
+
+  const handleOpenSelectionActions = useCallback(() => {
+    openSheet('tagLibraryFileActions')
+  }, [])
+
+  const handleBulkActionComplete = useCallback(() => {
+    exitSelectionMode()
+  }, [])
+
+  const handleFilesAdded = useCallback(
+    (files: FileRecord[]) => {
+      for (const file of files) {
+        void addTagToFile(file.id, tagName)
+      }
+    },
+    [tagName],
+  )
+
+  const actionSheetFileIds = isSelectionMode
+    ? Array.from(selectedFileIds)
+    : selectedFile
+      ? [selectedFile.id]
+      : actionFileId
+        ? [actionFileId]
+        : []
+
+  const tagCount = useTagFileCount(tagId)
+  const fileCount = tagCount.data ?? 0
+  const subtitle = `${fileCount.toLocaleString()} ${fileCount === 1 ? 'file' : 'files'}`
+  const isSystemTag = tagId.startsWith('sys_')
+  const tagActionsOpen = useSheetOpen('tagActions')
+
+  const handleDeleteTag = useCallback(() => {
+    closeSheet()
+    setTimeout(() => {
+      Alert.alert(
+        `Delete "${tagName}"?`,
+        'This will remove the tag and unlink all files from it. Files will not be deleted.',
+        [
+          { text: 'Cancel', style: 'cancel' },
+          {
+            text: 'Delete',
+            style: 'destructive',
+            onPress: async () => {
+              await deleteTag(tagId)
+              navigation.goBack()
+            },
+          },
+        ],
+      )
+    }, 300)
+  }, [tagId, tagName, navigation])
+
+  return (
+    <View style={styles.container}>
+      <Gradient
+        fadeTo="bottom"
+        overlayTopColor={overlay.gradientDark}
+        overlayBottomColor={overlay.gradientLight}
+        style={styles.topBlur}
+      />
+      <ScreenHeader>
+        <View style={styles.headerLeft}>
+          <IconButton
+            onPress={() => navigation.goBack()}
+            accessibilityLabel="Back"
+          >
+            <ArrowLeftIcon color={palette.gray[50]} size={22} />
+          </IconButton>
+          <View>
+            <Text style={styles.titleLarge} numberOfLines={1}>
+              {tagName}
+            </Text>
+            <Text style={styles.subtitle}>{subtitle}</Text>
+          </View>
+        </View>
+        <View style={styles.buttonRow}>
+          <ViewSettingsMenu scope={scope}>
+            <IconButton accessibilityLabel="View settings">
+              <ListFilterIcon color={palette.gray[50]} size={20} />
+            </IconButton>
+          </ViewSettingsMenu>
+          {isSelectionMode ? (
+            <Pressable
+              accessibilityRole="button"
+              onPress={() => exitSelectionMode()}
+              style={styles.headerPill}
+            >
+              <XIcon color={palette.gray[50]} size={18} />
+            </Pressable>
+          ) : (
+            <Pressable
+              accessibilityRole="button"
+              onPress={() => enterSelectionMode()}
+              style={styles.headerPill}
+            >
+              <Text style={styles.selectText}>Select</Text>
+            </Pressable>
+          )}
+        </View>
+      </ScreenHeader>
+
+      {files.isLoading || !files.data ? (
+        <View style={styles.emptyWrap}>
+          <ActivityIndicator color={palette.blue[400]} />
+        </View>
+      ) : files.data.length > 0 ? (
+        vs.viewMode === 'gallery' ? (
+          <FileGallery
+            filters={filters}
+            onPressItem={handlePressItem}
+            onLongPressItem={handleLongPressItem}
+          />
+        ) : (
+          <FileList
+            filters={filters}
+            onPressItem={handlePressItem}
+            onLongPressItem={handleLongPressItem}
+          />
+        )
+      ) : (
+        <View style={styles.emptyWrap}>
+          <Image
+            style={styles.emptyImage}
+            source={require('../../assets/image-stack.png')}
+          />
+          <Text style={styles.emptyTitle}>No files with this tag</Text>
+          <Text style={styles.emptyText}>
+            Add files to this tag from the file actions menu.
+          </Text>
+        </View>
+      )}
+
+      <AddFileActionSheet
+        sheetName="tagLibraryAddFile"
+        onFilesAdded={handleFilesAdded}
+      />
+      {isSelectionMode ? (
+        <SelectionBar onOpenSelectionActions={handleOpenSelectionActions} />
+      ) : (
+        <BottomControlBar variant="floating" style={styles.controlBar}>
+          <FloatingPill style={styles.actions}>
+            <IconButton
+              onPress={() => openSheet('tagLibraryAddFile')}
+              accessibilityLabel="Add files"
+            >
+              <FilePlusIcon color={palette.gray[50]} size={20} />
+            </IconButton>
+            <IconButton
+              onPress={() => openSheet('tagActions')}
+              accessibilityLabel="More options"
+            >
+              <MoreVerticalIcon color={palette.gray[50]} size={22} />
+            </IconButton>
+          </FloatingPill>
+        </BottomControlBar>
+      )}
+
+      {selectedFile ? (
+        <Animated.View
+          style={[
+            StyleSheet.absoluteFillObject,
+            styles.carouselOverlay,
+            {
+              opacity: fadeAnim,
+              transform: [{ scale: scaleAnim }],
+            },
+          ]}
+          pointerEvents="box-none"
+        >
+          <DragToDismiss
+            onDismiss={() => {
+              handleCloseCarousel()
+              setIsDraggingToDismiss(false)
+            }}
+            onDragStart={() => setIsDraggingToDismiss(true)}
+            onDragCancel={() => setIsDraggingToDismiss(false)}
+            enabled={!isCarouselZoomed && !isCarouselDetail}
+          >
+            <FileCarousel
+              initialId={selectedFile.id}
+              initialFile={selectedFile}
+              sortBy={vs.sortBy}
+              sortDir={vs.sortDir}
+              categories={vs.selectedCategories}
+              onClose={handleCloseCarousel}
+              onShowActionSheet={() => openSheet('tagLibraryFileActions')}
+              onShowTagSheet={() => openSheet('tagLibraryManageTags')}
+              onZoomChange={setIsCarouselZoomed}
+              onViewStyleChange={(s) => setIsCarouselDetail(s === 'detail')}
+              isDismissing={isDraggingToDismiss}
+            />
+          </DragToDismiss>
+        </Animated.View>
+      ) : null}
+
+      <ActionSheet visible={tagActionsOpen} onRequestClose={() => closeSheet()}>
+        <ActionSheetButton
+          variant="danger"
+          icon={<Trash2Icon size={18} />}
+          onPress={handleDeleteTag}
+          disabled={isSystemTag}
+        >
+          Delete tag
+        </ActionSheetButton>
+      </ActionSheet>
+      {actionSheetFileIds.length > 0 ? (
+        <>
+          <FileActionsSheet
+            fileIds={actionSheetFileIds}
+            sheetName="tagLibraryFileActions"
+            onComplete={isSelectionMode ? handleBulkActionComplete : undefined}
+          />
+          {actionSheetFileIds.length === 1 ? (
+            <ManageTagsSheet
+              fileId={actionSheetFileIds[0]}
+              sheetName="tagLibraryManageTags"
+            />
+          ) : null}
+        </>
+      ) : null}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: colors.bgCanvas },
+  topBlur: {
+    zIndex: 10,
+    pointerEvents: 'none',
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    top: 0,
+    height: 180,
+  },
+  headerLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    flex: 1,
+  },
+  titleLarge: {
+    color: palette.gray[50],
+    fontSize: 24,
+    fontWeight: '800',
+  },
+  subtitle: {
+    color: whiteA.a50,
+    fontSize: 13,
+    fontWeight: '600',
+    marginTop: 2,
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  headerPill: {
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 18,
+    backgroundColor: overlay.pill,
+  },
+  selectText: {
+    color: palette.gray[50],
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  emptyWrap: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+  },
+  emptyImage: { width: 140, height: 140 },
+  emptyTitle: {
+    color: palette.gray[100],
+    fontWeight: '800',
+    fontSize: 18,
+    paddingTop: 12,
+    paddingBottom: 6,
+  },
+  emptyText: { color: whiteA.a70, textAlign: 'center' },
+  controlBar: {
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    paddingRight: 16,
+  },
+  actions: {
+    gap: 8,
+  },
+  carouselOverlay: {
+    zIndex: 100,
+  },
+})

--- a/src/stacks/MainStack.tsx
+++ b/src/stacks/MainStack.tsx
@@ -1,5 +1,6 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import { LibraryScreen } from '../screens/LibraryScreen'
+import { TagLibraryScreen } from '../screens/TagLibraryScreen'
 import type { MainStackParamList } from './types'
 
 const Stack = createNativeStackNavigator<MainStackParamList>()
@@ -11,6 +12,11 @@ export function MainStack() {
         name="LibraryHome"
         options={{ title: 'Library', headerShown: false }}
         component={LibraryScreen}
+      />
+      <Stack.Screen
+        name="TagLibrary"
+        options={{ headerShown: false }}
+        component={TagLibraryScreen}
       />
     </Stack.Navigator>
   )

--- a/src/stacks/types.ts
+++ b/src/stacks/types.ts
@@ -2,6 +2,7 @@ import type { NavigatorScreenParams } from '@react-navigation/native'
 
 export type MainStackParamList = {
   LibraryHome: { openFileId?: string } | undefined
+  TagLibrary: { tagId: string; tagName: string }
 }
 
 export type SwitchIndexerStackParamList = {

--- a/src/stores/library.test.ts
+++ b/src/stores/library.test.ts
@@ -1,0 +1,177 @@
+import { db, initializeDB, resetDb } from '../db'
+import { createFileRecord } from './files'
+import { buildLibraryQueryParts } from './library'
+import { addTagToFile } from './tags'
+
+jest.mock('./localObjects', () => ({
+  readLocalObjectsForFiles: jest.fn().mockResolvedValue({}),
+}))
+
+describe('library tag filtering', () => {
+  beforeEach(async () => {
+    await initializeDB()
+  })
+
+  afterEach(async () => {
+    await resetDb()
+    jest.clearAllMocks()
+  })
+
+  async function createTestFile(id: string, type: string = 'image/jpeg') {
+    await createFileRecord({
+      id,
+      name: `${id}.jpg`,
+      type,
+      kind: 'file',
+      size: 100,
+      hash: `hash-${id}`,
+      createdAt: 1000,
+      updatedAt: 1000,
+      localId: null,
+      addedAt: 1000,
+    })
+  }
+
+  async function createFileWithTags(id: string, tagNames: string[]) {
+    await createTestFile(id)
+    for (const name of tagNames) {
+      await addTagToFile(id, name)
+    }
+  }
+
+  describe('buildLibraryQueryParts with tags', () => {
+    test('filters files having ALL selected tags (AND logic)', async () => {
+      await createFileWithTags('file-1', ['a', 'b'])
+      await createFileWithTags('file-2', ['a', 'c'])
+      await createFileWithTags('file-3', ['a', 'b', 'c'])
+
+      const tagA = await db().getFirstAsync<{ id: string }>(
+        "SELECT id FROM tags WHERE name = 'a'",
+      )
+      const tagB = await db().getFirstAsync<{ id: string }>(
+        "SELECT id FROM tags WHERE name = 'b'",
+      )
+
+      const { where, params } = buildLibraryQueryParts({
+        tags: [tagA!.id, tagB!.id],
+        tableAlias: 'files',
+      })
+
+      const rows = await db().getAllAsync<{ id: string }>(
+        `SELECT id FROM files ${where}`,
+        ...params,
+      )
+
+      expect(rows.map((r) => r.id).sort()).toEqual(['file-1', 'file-3'])
+    })
+
+    test('returns no files when none have all tags', async () => {
+      await createFileWithTags('file-1', ['a'])
+      await createFileWithTags('file-2', ['b'])
+
+      const tagA = await db().getFirstAsync<{ id: string }>(
+        "SELECT id FROM tags WHERE name = 'a'",
+      )
+      const tagB = await db().getFirstAsync<{ id: string }>(
+        "SELECT id FROM tags WHERE name = 'b'",
+      )
+
+      const { where, params } = buildLibraryQueryParts({
+        tags: [tagA!.id, tagB!.id],
+        tableAlias: 'files',
+      })
+
+      const rows = await db().getAllAsync<{ id: string }>(
+        `SELECT id FROM files ${where}`,
+        ...params,
+      )
+
+      expect(rows).toHaveLength(0)
+    })
+
+    test('works with single tag filter', async () => {
+      await createFileWithTags('file-1', ['a'])
+      await createFileWithTags('file-2', ['b'])
+      await createFileWithTags('file-3', ['a', 'b'])
+
+      const tagA = await db().getFirstAsync<{ id: string }>(
+        "SELECT id FROM tags WHERE name = 'a'",
+      )
+
+      const { where, params } = buildLibraryQueryParts({
+        tags: [tagA!.id],
+        tableAlias: 'files',
+      })
+
+      const rows = await db().getAllAsync<{ id: string }>(
+        `SELECT id FROM files ${where}`,
+        ...params,
+      )
+
+      expect(rows.map((r) => r.id).sort()).toEqual(['file-1', 'file-3'])
+    })
+
+    test('combines with category filters', async () => {
+      await createTestFile('video-1', 'video/mp4')
+      await createTestFile('image-1', 'image/jpeg')
+      await addTagToFile('video-1', 'tag1')
+      await addTagToFile('image-1', 'tag1')
+
+      const tag = await db().getFirstAsync<{ id: string }>(
+        "SELECT id FROM tags WHERE name = 'tag1'",
+      )
+
+      const { where, params } = buildLibraryQueryParts({
+        tags: [tag!.id],
+        categories: ['Video'],
+        tableAlias: 'files',
+      })
+
+      const rows = await db().getAllAsync<{ id: string }>(
+        `SELECT id FROM files ${where}`,
+        ...params,
+      )
+
+      expect(rows.map((r) => r.id)).toEqual(['video-1'])
+    })
+
+    test('combines with search query', async () => {
+      await createFileWithTags('abc', ['tag1'])
+      await createFileWithTags('xyz', ['tag1'])
+
+      const tag = await db().getFirstAsync<{ id: string }>(
+        "SELECT id FROM tags WHERE name = 'tag1'",
+      )
+
+      const { where, params } = buildLibraryQueryParts({
+        tags: [tag!.id],
+        query: 'abc',
+        tableAlias: 'files',
+      })
+
+      const rows = await db().getAllAsync<{ id: string }>(
+        `SELECT id FROM files ${where}`,
+        ...params,
+      )
+
+      expect(rows.map((r) => r.id)).toEqual(['abc'])
+    })
+
+    test('returns all files when no tags selected', async () => {
+      await createTestFile('file-1')
+      await createTestFile('file-2')
+
+      const { where, params } = buildLibraryQueryParts({
+        tags: [],
+        tableAlias: 'files',
+      })
+
+      const rows = await db().getAllAsync<{ id: string }>(
+        `SELECT id FROM files ${where}`,
+        ...params,
+      )
+
+      expect(rows).toHaveLength(2)
+    })
+  })
+})

--- a/src/stores/library.ts
+++ b/src/stores/library.ts
@@ -18,6 +18,7 @@ type FileOrderParams = {
   sortDir?: SortDir
   categories?: Category[]
   query?: string
+  tags?: string[]
   limit?: number
   offset?: number
 }
@@ -30,6 +31,7 @@ async function readOrderedFileRecords(
     sortDir,
     categories = [],
     query,
+    tags = [],
     limit,
     offset,
   } = opts ?? {}
@@ -40,6 +42,7 @@ async function readOrderedFileRecords(
     sortDir: dir,
     categories,
     query,
+    tags,
     tableAlias: 'files',
   })
 
@@ -69,6 +72,7 @@ export type FileListParams = {
   sortDir?: SortDir
   categories?: Category[]
   query?: string
+  tags?: string[]
 }
 
 export function useFileList(params: FileListParams) {
@@ -78,6 +82,7 @@ export function useFileList(params: FileListParams) {
     sortDir: sortDirParam,
     categories = [],
     query,
+    tags = [],
   } = params
   const sortingDir = sortDirParam ?? (sortBy === 'NAME' ? 'ASC' : 'DESC')
 
@@ -85,7 +90,9 @@ export function useFileList(params: FileListParams) {
     ? categories.slice().sort().join(',')
     : ''
 
-  const base = `library/${scope}:list:${sortBy}:${sortingDir}:${categoriesKey}:${query ?? ''}`
+  const tagsKey = tags.length ? tags.slice().sort().join(',') : ''
+
+  const base = `library/${scope}:list:${sortBy}:${sortingDir}:${categoriesKey}:${tagsKey}:${query ?? ''}`
 
   const fetcher = async (key: string) => {
     const pageIndex = Number(key.split('|page=').pop() ?? '0')
@@ -94,6 +101,7 @@ export function useFileList(params: FileListParams) {
       sortDir: sortingDir,
       categories: categories.length ? categories : undefined,
       query: query?.trim().length ? query : undefined,
+      tags: tags.length ? tags : undefined,
       limit: PAGE_SIZE,
       offset: pageIndex * PAGE_SIZE,
     })
@@ -150,6 +158,19 @@ export function useMediaCount() {
   })
 }
 
+// Count of files with a specific tag, excluding thumbnails.
+export function useTagFileCount(tagId: string) {
+  return useSWR(libraryStats.key(`tagCount:${tagId}`), async () => {
+    const row = await db().getFirstAsync<{ count: number }>(
+      `SELECT COUNT(*) as count FROM files f
+       INNER JOIN file_tags ft ON ft.fileId = f.id
+       WHERE ft.tagId = ? AND f.kind = 'file'`,
+      tagId,
+    )
+    return row?.count ?? 0
+  })
+}
+
 // File View Store
 export type SortBy = 'NAME' | 'DATE' | 'ADDED' | 'SIZE'
 export type SortDir = 'ASC' | 'DESC'
@@ -162,6 +183,7 @@ export function buildLibraryQueryParts(
     sortDir?: SortDir
     categories?: Category[]
     query?: string
+    tags?: string[]
     tableAlias?: string
   } = {},
 ): {
@@ -174,6 +196,7 @@ export function buildLibraryQueryParts(
     sortDir,
     categories = [],
     query,
+    tags = [],
     tableAlias = 'files',
   } = opts
   const dir: SortDir = sortDir ?? (sortBy === 'NAME' ? 'ASC' : 'DESC')
@@ -216,6 +239,19 @@ export function buildLibraryQueryParts(
     whereParts.push(`${tableAlias}.name LIKE ? COLLATE NOCASE ESCAPE '\\'`)
     const escaped = (query ?? '').replace(/[%_\\]/g, (m) => `\\${m}`)
     params.push(`%${escaped}%`)
+  }
+  // Tag filtering: file must have ALL selected tags (AND logic).
+  if (tags.length > 0) {
+    const placeholders = tags.map(() => '?').join(',')
+    whereParts.push(`
+      ${tableAlias}.id IN (
+        SELECT ft.fileId FROM file_tags ft
+        WHERE ft.tagId IN (${placeholders})
+        GROUP BY ft.fileId
+        HAVING COUNT(DISTINCT ft.tagId) = ?
+      )
+    `)
+    params.push(...tags, tags.length)
   }
   const where = whereParts.length ? `WHERE ${whereParts.join(' AND ')}` : ''
 

--- a/src/stores/tags.test.ts
+++ b/src/stores/tags.test.ts
@@ -1,0 +1,474 @@
+import { initializeDB, resetDb } from '../db'
+import { createFileRecord, readFileRecord } from './files'
+import {
+  addTagToFile,
+  createTag,
+  deleteTag,
+  getOrCreateTag,
+  readAllTagsWithCounts,
+  readIsFavorite,
+  readTagNamesForFile,
+  readTagsForFile,
+  removeTagFromFile,
+  searchTags,
+  syncTagsFromMetadata,
+  toggleFavorite,
+} from './tags'
+
+jest.mock('./librarySwr', () => ({
+  libraryStats: {
+    key: jest.fn((...parts: string[]) => [`mock/${parts.join('/')}`]),
+    invalidateAll: jest.fn(),
+  },
+  invalidateCacheLibraryAllStats: jest.fn(),
+  invalidateCacheLibraryLists: jest.fn(),
+}))
+
+describe('tags store', () => {
+  beforeEach(async () => {
+    await initializeDB()
+  })
+
+  afterEach(async () => {
+    await resetDb()
+    jest.clearAllMocks()
+  })
+
+  function userOnly<T extends { system: number }>(tags: T[]): T[] {
+    return tags.filter((t) => !t.system)
+  }
+
+  async function createTestFile(id: string) {
+    await createFileRecord({
+      id,
+      name: `${id}.jpg`,
+      type: 'image/jpeg',
+      kind: 'file',
+      size: 100,
+      hash: `hash-${id}`,
+      createdAt: 1000,
+      updatedAt: 1000,
+      localId: null,
+      addedAt: 1000,
+    })
+  }
+
+  describe('createTag', () => {
+    test('creates tag with correct fields', async () => {
+      const tag = await createTag('vacation')
+      expect(tag.name).toBe('vacation')
+      expect(tag.id).toBeDefined()
+      expect(tag.createdAt).toBeDefined()
+      expect(tag.usedAt).toBeDefined()
+    })
+
+    test('trims whitespace from name', async () => {
+      const tag = await createTag('  travel  ')
+      expect(tag.name).toBe('travel')
+    })
+
+    test('throws on empty name', async () => {
+      await expect(createTag('')).rejects.toThrow('Tag name cannot be empty')
+      await expect(createTag('   ')).rejects.toThrow('Tag name cannot be empty')
+    })
+
+    test('throws on duplicate name (case-insensitive)', async () => {
+      await createTag('Work')
+      await expect(createTag('work')).rejects.toThrow()
+      await expect(createTag('WORK')).rejects.toThrow()
+    })
+  })
+
+  describe('getOrCreateTag', () => {
+    test('returns existing tag (case-insensitive match)', async () => {
+      const original = await createTag('Travel')
+      const found = await getOrCreateTag('travel')
+      expect(found.id).toBe(original.id)
+      expect(found.name).toBe('Travel')
+    })
+
+    test('creates new tag if not found', async () => {
+      const tag = await getOrCreateTag('NewTag')
+      expect(tag.name).toBe('NewTag')
+      expect(tag.id).toBeDefined()
+    })
+
+    test('updates usedAt on existing tag', async () => {
+      const original = await createTag('Beach')
+      const originalUsedAt = original.usedAt
+
+      await new Promise((r) => setTimeout(r, 10))
+
+      const found = await getOrCreateTag('beach')
+      expect(found.usedAt).toBeGreaterThan(originalUsedAt)
+    })
+
+    test('throws on empty name', async () => {
+      await expect(getOrCreateTag('')).rejects.toThrow(
+        'Tag name cannot be empty',
+      )
+    })
+  })
+
+  describe('searchTags', () => {
+    test('returns matching tags ordered by usedAt', async () => {
+      await createTag('vacation')
+      await new Promise((r) => setTimeout(r, 10))
+      await createTag('video')
+      await new Promise((r) => setTimeout(r, 10))
+      await createTag('vintage')
+
+      const results = userOnly(await searchTags('v'))
+      expect(results).toHaveLength(3)
+      expect(results[0].name).toBe('vintage')
+      expect(results[1].name).toBe('video')
+      expect(results[2].name).toBe('vacation')
+    })
+
+    test('matches case-insensitively', async () => {
+      await createTag('Work')
+      const results = await searchTags('WORK')
+      expect(results).toHaveLength(1)
+      expect(results[0].name).toBe('Work')
+    })
+
+    test('escapes special characters in query', async () => {
+      await createTag('100%')
+      await createTag('100_percent')
+
+      const results = await searchTags('100%')
+      expect(results).toHaveLength(1)
+      expect(results[0].name).toBe('100%')
+    })
+
+    test('respects limit parameter', async () => {
+      await createTag('tag1')
+      await createTag('tag2')
+      await createTag('tag3')
+
+      const results = await searchTags('tag', 2)
+      expect(results).toHaveLength(2)
+    })
+
+    test('returns empty array for no matches', async () => {
+      await createTag('vacation')
+      const results = await searchTags('xyz')
+      expect(results).toEqual([])
+    })
+
+    test('returns all tags ordered by usedAt when query is empty', async () => {
+      await createTag('aaa')
+      await new Promise((r) => setTimeout(r, 10))
+      await createTag('bbb')
+
+      const results = userOnly(await searchTags(''))
+      expect(results).toHaveLength(2)
+      expect(results[0].name).toBe('bbb')
+    })
+  })
+
+  describe('readTagsForFile', () => {
+    test('returns tags for file ordered by name', async () => {
+      await createTestFile('file-1')
+      await addTagToFile('file-1', 'zebra')
+      await addTagToFile('file-1', 'alpha')
+      await addTagToFile('file-1', 'beta')
+
+      const tags = userOnly(await readTagsForFile('file-1'))
+      expect(tags).toHaveLength(3)
+      expect(tags[0].name).toBe('alpha')
+      expect(tags[1].name).toBe('beta')
+      expect(tags[2].name).toBe('zebra')
+    })
+
+    test('returns empty array for file with no user tags', async () => {
+      await createTestFile('file-1')
+      const tags = userOnly(await readTagsForFile('file-1'))
+      expect(tags).toHaveLength(0)
+    })
+  })
+
+  describe('readTagNamesForFile', () => {
+    test('returns tag names for file', async () => {
+      await createTestFile('file-1')
+      await addTagToFile('file-1', 'tag1')
+      await addTagToFile('file-1', 'tag2')
+
+      const names = await readTagNamesForFile('file-1')
+      expect(names).toContain('tag1')
+      expect(names).toContain('tag2')
+    })
+
+    test('returns undefined for file with no tags', async () => {
+      await createTestFile('file-1')
+      const names = await readTagNamesForFile('file-1')
+      expect(names).toBeUndefined()
+    })
+  })
+
+  describe('readAllTagsWithCounts', () => {
+    test('returns all tags with correct file counts', async () => {
+      await createTestFile('file-1')
+      await createTestFile('file-2')
+
+      await addTagToFile('file-1', 'shared')
+      await addTagToFile('file-2', 'shared')
+      await addTagToFile('file-1', 'unique')
+
+      const tags = userOnly(await readAllTagsWithCounts())
+      expect(tags).toHaveLength(2)
+
+      const shared = tags.find((t) => t.name === 'shared')
+      expect(shared?.fileCount).toBe(2)
+
+      const unique = tags.find((t) => t.name === 'unique')
+      expect(unique?.fileCount).toBe(1)
+    })
+
+    test('returns 0 count for unused tags', async () => {
+      await createTag('orphan')
+      const tags = userOnly(await readAllTagsWithCounts())
+      expect(tags).toHaveLength(1)
+      expect(tags[0].fileCount).toBe(0)
+    })
+  })
+
+  describe('addTagToFile', () => {
+    test('creates junction entry', async () => {
+      await createTestFile('file-1')
+      await addTagToFile('file-1', 'tag1')
+
+      const tags = userOnly(await readTagsForFile('file-1'))
+      expect(tags).toHaveLength(1)
+      expect(tags[0].name).toBe('tag1')
+    })
+
+    test('creates new tag if name not found', async () => {
+      await createTestFile('file-1')
+      await addTagToFile('file-1', 'newTag')
+
+      const tags = userOnly(await readTagsForFile('file-1'))
+      expect(tags).toHaveLength(1)
+      expect(tags[0].name).toBe('newTag')
+    })
+
+    test('ignores duplicate add (same file+tag)', async () => {
+      await createTestFile('file-1')
+      await addTagToFile('file-1', 'tag1')
+      await addTagToFile('file-1', 'tag1')
+
+      const tags = userOnly(await readTagsForFile('file-1'))
+      expect(tags).toHaveLength(1)
+    })
+
+    test('uses existing tag (case-insensitive)', async () => {
+      await createTestFile('file-1')
+      await createTestFile('file-2')
+
+      await addTagToFile('file-1', 'Work')
+      await addTagToFile('file-2', 'work')
+
+      const allTags = userOnly(await readAllTagsWithCounts())
+      expect(allTags).toHaveLength(1)
+      expect(allTags[0].fileCount).toBe(2)
+    })
+
+    test('bumps file updatedAt', async () => {
+      await createTestFile('file-1')
+      const before = await readFileRecord('file-1')
+      expect(before!.updatedAt).toBe(1000)
+
+      await addTagToFile('file-1', 'tag1')
+
+      const after = await readFileRecord('file-1')
+      expect(after!.updatedAt).toBeGreaterThan(1000)
+    })
+  })
+
+  describe('removeTagFromFile', () => {
+    test('removes junction entry', async () => {
+      await createTestFile('file-1')
+      await addTagToFile('file-1', 'tag1')
+      await addTagToFile('file-1', 'tag2')
+
+      const tagToRemove = (await readTagsForFile('file-1')).find(
+        (t) => t.name === 'tag1',
+      )!
+      await removeTagFromFile('file-1', tagToRemove.id)
+
+      const tags = userOnly(await readTagsForFile('file-1'))
+      expect(tags).toHaveLength(1)
+      expect(tags[0].name).toBe('tag2')
+    })
+
+    test('does not delete the tag itself', async () => {
+      await createTestFile('file-1')
+      await addTagToFile('file-1', 'tag1')
+
+      const tag = userOnly(await readTagsForFile('file-1'))[0]
+      await removeTagFromFile('file-1', tag.id)
+
+      const allTags = await readAllTagsWithCounts()
+      expect(allTags.find((t) => t.id === tag.id)).toBeDefined()
+    })
+
+    test('handles removing non-existent relationship', async () => {
+      await createTestFile('file-1')
+      await createTag('tag1')
+      const tag = (await readAllTagsWithCounts())[0]
+
+      await expect(removeTagFromFile('file-1', tag.id)).resolves.not.toThrow()
+    })
+
+    test('bumps file updatedAt', async () => {
+      await createTestFile('file-1')
+      await addTagToFile('file-1', 'tag1')
+
+      const before = await readFileRecord('file-1')
+      const beforeUpdatedAt = before!.updatedAt
+
+      const tag = (await readTagsForFile('file-1'))[0]
+      await removeTagFromFile('file-1', tag.id)
+
+      const after = await readFileRecord('file-1')
+      expect(after!.updatedAt).toBeGreaterThanOrEqual(beforeUpdatedAt)
+    })
+  })
+
+  describe('syncTagsFromMetadata', () => {
+    test('populates junction table from tag names', async () => {
+      await createTestFile('file-1')
+      await syncTagsFromMetadata('file-1', ['vacation', 'beach'])
+
+      const tags = userOnly(await readTagsForFile('file-1'))
+      expect(tags.map((t) => t.name).sort()).toEqual(['beach', 'vacation'])
+    })
+
+    test('creates new tags for unknown names', async () => {
+      await createTestFile('file-1')
+      await syncTagsFromMetadata('file-1', ['newTag1', 'newTag2'])
+
+      const allTags = userOnly(await readAllTagsWithCounts())
+      expect(allTags).toHaveLength(2)
+    })
+
+    test('clears existing user tags before sync', async () => {
+      await createTestFile('file-1')
+      await addTagToFile('file-1', 'oldTag')
+
+      await syncTagsFromMetadata('file-1', ['newTag'])
+
+      const tags = userOnly(await readTagsForFile('file-1'))
+      expect(tags).toHaveLength(1)
+      expect(tags[0].name).toBe('newTag')
+    })
+
+    test('handles empty tags array', async () => {
+      await createTestFile('file-1')
+      await addTagToFile('file-1', 'tag1')
+
+      await syncTagsFromMetadata('file-1', [])
+
+      const tags = userOnly(await readTagsForFile('file-1'))
+      expect(tags).toHaveLength(0)
+    })
+
+    test('preserves system tags when clearing user tags', async () => {
+      await createTestFile('file-1')
+      await toggleFavorite('file-1')
+      await addTagToFile('file-1', 'tag1')
+
+      await syncTagsFromMetadata('file-1', [])
+
+      const allTags = await readTagsForFile('file-1')
+      const systemTags = allTags.filter((t) => t.system)
+      expect(systemTags.length).toBe(1)
+      expect(systemTags[0].name).toBe('Favorites')
+    })
+
+    test('preserves local tags when metadata tags are undefined', async () => {
+      await createTestFile('file-1')
+      await addTagToFile('file-1', 'tag1')
+
+      await syncTagsFromMetadata('file-1', undefined)
+
+      const tags = userOnly(await readTagsForFile('file-1'))
+      expect(tags).toHaveLength(1)
+      expect(tags[0].name).toBe('tag1')
+    })
+
+    test('clears user tags when metadata tags are empty array', async () => {
+      await createTestFile('file-1')
+      await addTagToFile('file-1', 'tag1')
+
+      await syncTagsFromMetadata('file-1', [])
+
+      const tags = userOnly(await readTagsForFile('file-1'))
+      expect(tags).toHaveLength(0)
+    })
+
+    test('remote tags win when metadata has explicit tags', async () => {
+      await createTestFile('file-1')
+      await addTagToFile('file-1', 'localTag')
+
+      await syncTagsFromMetadata('file-1', ['remoteTag1', 'remoteTag2'])
+
+      const tags = userOnly(await readTagsForFile('file-1'))
+      expect(tags.map((t) => t.name).sort()).toEqual([
+        'remoteTag1',
+        'remoteTag2',
+      ])
+    })
+
+    test('local tags survive when metadata has no tag data', async () => {
+      await createTestFile('file-1')
+      await addTagToFile('file-1', 'localTag')
+
+      await syncTagsFromMetadata('file-1', undefined)
+
+      const tags = userOnly(await readTagsForFile('file-1'))
+      expect(tags).toHaveLength(1)
+      expect(tags[0].name).toBe('localTag')
+    })
+
+    test('explicit empty array removes all user tags', async () => {
+      await createTestFile('file-1')
+      await addTagToFile('file-1', 'tag1')
+      await addTagToFile('file-1', 'tag2')
+
+      await syncTagsFromMetadata('file-1', [])
+
+      const tags = userOnly(await readTagsForFile('file-1'))
+      expect(tags).toHaveLength(0)
+    })
+  })
+
+  describe('favorites', () => {
+    test('toggleFavorite adds and removes', async () => {
+      await createTestFile('file-1')
+
+      expect(await readIsFavorite('file-1')).toBe(false)
+
+      await toggleFavorite('file-1')
+      expect(await readIsFavorite('file-1')).toBe(true)
+
+      await toggleFavorite('file-1')
+      expect(await readIsFavorite('file-1')).toBe(false)
+    })
+  })
+
+  describe('deleteTag', () => {
+    test('deletes user tag', async () => {
+      const tag = await createTag('myTag')
+      await deleteTag(tag.id)
+      const tags = userOnly(await readAllTagsWithCounts())
+      expect(tags).toHaveLength(0)
+    })
+
+    test('prevents deleting system tags', async () => {
+      await expect(deleteTag('sys:favorites')).rejects.toThrow(
+        'System tags cannot be deleted',
+      )
+    })
+  })
+})

--- a/src/stores/tags.ts
+++ b/src/stores/tags.ts
@@ -1,0 +1,325 @@
+import useSWR from 'swr'
+import { db, withTransactionLock } from '../db'
+import { sqlDelete, sqlInsert, sqlUpdate } from '../db/sql'
+import { swrCacheBy } from '../lib/swr'
+import { uniqueId } from '../lib/uniqueId'
+import { invalidateCacheLibraryLists } from './librarySwr'
+
+export const tagsSwr = swrCacheBy()
+
+/**
+ * System tags are auto-created and cannot be deleted.
+ * Users can add/remove files from system tags.
+ * System tags are synced to metadata like user tags.
+ * Auto-created on first use via ensureSystemTags().
+ */
+export const SYSTEM_TAGS = {
+  favorites: { id: 'sys:favorites', name: 'Favorites' },
+} as const
+
+export type Tag = {
+  id: string
+  name: string
+  createdAt: number
+  usedAt: number
+  system: number
+}
+
+export type TagWithCount = Tag & {
+  fileCount: number
+}
+
+/**
+ * Ensures all system tags exist in the database.
+ * Called lazily before operations that reference system tags.
+ * Idempotent — uses INSERT OR IGNORE.
+ */
+let systemTagsEnsured = false
+export async function ensureSystemTags(): Promise<void> {
+  if (systemTagsEnsured) return
+  const now = Date.now()
+  for (const tag of Object.values(SYSTEM_TAGS)) {
+    await db().runAsync(
+      `INSERT OR IGNORE INTO tags (id, name, createdAt, usedAt, system) VALUES (?, ?, ?, ?, 1)`,
+      tag.id,
+      tag.name,
+      now,
+      now,
+    )
+  }
+  systemTagsEnsured = true
+}
+
+/**
+ * Creates a new user tag.
+ * @throws if name is empty or tag with same name exists (case-insensitive)
+ */
+export async function createTag(name: string): Promise<Tag> {
+  const trimmed = name.trim()
+  if (!trimmed) {
+    throw new Error('Tag name cannot be empty')
+  }
+
+  const existing = await db().getFirstAsync<{ id: string }>(
+    'SELECT id FROM tags WHERE name = ? COLLATE NOCASE',
+    trimmed,
+  )
+  if (existing) {
+    throw new Error(`Tag "${trimmed}" already exists`)
+  }
+
+  const now = Date.now()
+  const tag: Tag = {
+    id: uniqueId(),
+    name: trimmed,
+    createdAt: now,
+    usedAt: now,
+    system: 0,
+  }
+
+  await sqlInsert('tags', tag)
+  tagsSwr.invalidateAll()
+  return tag
+}
+
+/**
+ * Gets an existing tag by name (case-insensitive) or creates a new one.
+ * Updates usedAt timestamp when getting existing tag.
+ */
+export async function getOrCreateTag(name: string): Promise<Tag> {
+  const trimmed = name.trim()
+  if (!trimmed) {
+    throw new Error('Tag name cannot be empty')
+  }
+
+  const existing = await db().getFirstAsync<Tag>(
+    'SELECT id, name, createdAt, usedAt, system FROM tags WHERE name = ? COLLATE NOCASE',
+    trimmed,
+  )
+
+  if (existing) {
+    const now = Date.now()
+    await db().runAsync(
+      'UPDATE tags SET usedAt = ? WHERE id = ?',
+      now,
+      existing.id,
+    )
+    tagsSwr.invalidateAll()
+    return { ...existing, usedAt: now }
+  }
+
+  return createTag(trimmed)
+}
+
+/**
+ * Searches tags by name prefix for autocomplete.
+ * Returns tags ordered by most recently used.
+ */
+export async function searchTags(
+  query: string,
+  limit: number = 10,
+): Promise<Tag[]> {
+  const trimmed = query.trim()
+  if (!trimmed) {
+    return db().getAllAsync<Tag>(
+      'SELECT id, name, createdAt, usedAt, system FROM tags ORDER BY usedAt DESC LIMIT ?',
+      limit,
+    )
+  }
+
+  const escaped = trimmed.replace(/[%_\\]/g, (m) => `\\${m}`)
+  return db().getAllAsync<Tag>(
+    `SELECT id, name, createdAt, usedAt, system FROM tags
+     WHERE name LIKE ? COLLATE NOCASE ESCAPE '\\'
+     ORDER BY usedAt DESC
+     LIMIT ?`,
+    `${escaped}%`,
+    limit,
+  )
+}
+
+/**
+ * Reads all tags for a file, ordered by name.
+ */
+export async function readTagsForFile(fileId: string): Promise<Tag[]> {
+  return db().getAllAsync<Tag>(
+    `SELECT t.id, t.name, t.createdAt, t.usedAt, t.system
+     FROM tags t
+     INNER JOIN file_tags ft ON ft.tagId = t.id
+     WHERE ft.fileId = ?
+     ORDER BY t.name COLLATE NOCASE`,
+    fileId,
+  )
+}
+
+/**
+ * Reads tag names for a file, for use in metadata sync.
+ * Returns undefined if no tags (to avoid serializing empty arrays).
+ */
+export async function readTagNamesForFile(
+  fileId: string,
+): Promise<string[] | undefined> {
+  const tags = await readTagsForFile(fileId)
+  return tags.length > 0 ? tags.map((t) => t.name) : undefined
+}
+
+/**
+ * Reads all tags with their file counts.
+ */
+export async function readAllTagsWithCounts(): Promise<TagWithCount[]> {
+  return db().getAllAsync<TagWithCount>(
+    `SELECT t.id, t.name, t.createdAt, t.usedAt, t.system, COUNT(f.id) as fileCount
+     FROM tags t
+     LEFT JOIN file_tags ft ON ft.tagId = t.id
+     LEFT JOIN files f ON f.id = ft.fileId AND f.kind = 'file'
+     GROUP BY t.id
+     ORDER BY t.system DESC, t.name COLLATE NOCASE`,
+  )
+}
+
+/**
+ * Adds a tag to a file. Creates the tag if it doesn't exist.
+ * Ignores if the relationship already exists.
+ */
+export async function addTagToFile(
+  fileId: string,
+  tagName: string,
+): Promise<void> {
+  await withTransactionLock(async () => {
+    const tag = await getOrCreateTag(tagName)
+    await sqlInsert(
+      'file_tags',
+      { fileId, tagId: tag.id },
+      { conflictClause: 'OR IGNORE' },
+    )
+    await sqlUpdate('files', { updatedAt: Date.now() }, { id: fileId })
+  })
+  tagsSwr.invalidateAll()
+  invalidateCacheLibraryLists()
+}
+
+/**
+ * Removes a tag from a file.
+ */
+export async function removeTagFromFile(
+  fileId: string,
+  tagId: string,
+): Promise<void> {
+  await sqlDelete('file_tags', { fileId, tagId })
+  await sqlUpdate('files', { updatedAt: Date.now() }, { id: fileId })
+  tagsSwr.invalidateAll()
+  invalidateCacheLibraryLists()
+}
+
+/**
+ * Syncs file tags from metadata tag names.
+ * Clears existing user tags and re-creates relationships from metadata.
+ * System tags in the incoming list are matched by name to existing system tags.
+ * Used during down sync to populate junction table from metadata.
+ */
+export async function syncTagsFromMetadata(
+  fileId: string,
+  tagNames: string[] | undefined,
+): Promise<void> {
+  if (tagNames === undefined) {
+    return
+  }
+  await ensureSystemTags()
+  await withTransactionLock(async () => {
+    // Only clear non-system tag associations; keep system tags intact
+    await db().runAsync(
+      `DELETE FROM file_tags WHERE fileId = ? AND tagId NOT IN (
+        SELECT id FROM tags WHERE system = 1
+      )`,
+      fileId,
+    )
+
+    for (const name of tagNames) {
+      const tag = await getOrCreateTag(name)
+      await sqlInsert(
+        'file_tags',
+        { fileId, tagId: tag.id },
+        { conflictClause: 'OR IGNORE' },
+      )
+    }
+  })
+  tagsSwr.invalidateAll()
+  invalidateCacheLibraryLists()
+}
+
+/**
+ * Toggles the Favorites system tag on a file.
+ */
+export async function toggleFavorite(fileId: string): Promise<void> {
+  const tagId = SYSTEM_TAGS.favorites.id
+  const existing = await db().getFirstAsync<{ tagId: string }>(
+    'SELECT tagId FROM file_tags WHERE fileId = ? AND tagId = ?',
+    fileId,
+    tagId,
+  )
+
+  if (existing) {
+    await sqlDelete('file_tags', { fileId, tagId })
+  } else {
+    await sqlInsert(
+      'file_tags',
+      { fileId, tagId },
+      { conflictClause: 'OR IGNORE' },
+    )
+  }
+  await sqlUpdate('files', { updatedAt: Date.now() }, { id: fileId })
+  tagsSwr.invalidateAll()
+  invalidateCacheLibraryLists()
+}
+
+/**
+ * Checks if a file is favorited.
+ */
+export async function readIsFavorite(fileId: string): Promise<boolean> {
+  const row = await db().getFirstAsync<{ tagId: string }>(
+    'SELECT tagId FROM file_tags WHERE fileId = ? AND tagId = ?',
+    fileId,
+    SYSTEM_TAGS.favorites.id,
+  )
+  return !!row
+}
+
+/**
+ * Deletes a tag. System tags cannot be deleted.
+ */
+export async function deleteTag(tagId: string): Promise<void> {
+  const tag = await db().getFirstAsync<Tag>(
+    'SELECT id, name, createdAt, usedAt, system FROM tags WHERE id = ?',
+    tagId,
+  )
+  if (!tag) return
+  if (tag.system) {
+    throw new Error('System tags cannot be deleted')
+  }
+  await sqlDelete('file_tags', { tagId })
+  await sqlDelete('tags', { id: tagId })
+  tagsSwr.invalidateAll()
+  invalidateCacheLibraryLists()
+}
+
+// SWR Hooks
+
+export function useAllTags() {
+  return useSWR(tagsSwr.key('all'), readAllTagsWithCounts)
+}
+
+export function useTagsForFile(fileId: string | null) {
+  return useSWR(fileId ? tagsSwr.key(`file/${fileId}`) : null, () =>
+    fileId ? readTagsForFile(fileId) : [],
+  )
+}
+
+export function useTagSearch(query: string) {
+  return useSWR(tagsSwr.key(`search/${query}`), () => searchTags(query))
+}
+
+export function useIsFavorite(fileId: string | null) {
+  return useSWR(fileId ? tagsSwr.key(`favorite/${fileId}`) : null, () =>
+    fileId ? readIsFavorite(fileId) : false,
+  )
+}

--- a/test/sync-down.test.ts
+++ b/test/sync-down.test.ts
@@ -5,6 +5,7 @@
 import './utils/setup'
 
 import { readAllFileRecords } from '../src/stores/files'
+import { addTagToFile, readTagsForFile } from '../src/stores/tags'
 import { type AppCoreHarness, createHarness } from './utils/harness'
 import { generateMockFileMetadata } from './utils/mockSdk'
 import { waitForCondition } from './utils/waitFor'
@@ -115,6 +116,105 @@ describe('Sync Down Integration', () => {
         return files.length === 0
       },
       { timeout: 10_000, message: 'File to be deleted' },
+    )
+  })
+
+  it('syncs objects with tags from server', async () => {
+    harness.sdk.injectObject({
+      metadata: generateMockFileMetadata(1, {
+        name: 'tagged.jpg',
+        tags: ['vacation', 'beach'],
+      }),
+    })
+
+    let fileId: string | undefined
+    await waitForCondition(
+      async () => {
+        const files = await readAllFileRecords({ order: 'ASC' })
+        if (files.length === 1 && files[0].name === 'tagged.jpg') {
+          fileId = files[0].id
+          return true
+        }
+        return false
+      },
+      { timeout: 10_000, message: 'Tagged file to sync' },
+    )
+
+    const tags = (await readTagsForFile(fileId!)).filter((t) => !t.system)
+    expect(tags.map((t) => t.name).sort()).toEqual(['beach', 'vacation'])
+  })
+
+  it('preserves local tags when remote metadata has no tag data', async () => {
+    const metadata = generateMockFileMetadata(1, { name: 'photo.jpg' })
+    harness.sdk.injectObject({ metadata })
+
+    let fileId: string | undefined
+    await waitForCondition(
+      async () => {
+        const files = await readAllFileRecords({ order: 'ASC' })
+        if (files.length === 1) {
+          fileId = files[0].id
+          return true
+        }
+        return false
+      },
+      { timeout: 10_000, message: 'File to sync' },
+    )
+
+    await addTagToFile(fileId!, 'myTag')
+    const tagsAfterAdd = (await readTagsForFile(fileId!)).filter(
+      (t) => !t.system,
+    )
+    expect(tagsAfterAdd).toHaveLength(1)
+    expect(tagsAfterAdd[0].name).toBe('myTag')
+
+    await new Promise((r) => setTimeout(r, 5000))
+
+    const tagsAfterSync = (await readTagsForFile(fileId!)).filter(
+      (t) => !t.system,
+    )
+    expect(tagsAfterSync).toHaveLength(1)
+    expect(tagsAfterSync[0].name).toBe('myTag')
+  })
+
+  it('syncs tag updates from server', async () => {
+    const stored = harness.sdk.injectObject({
+      metadata: generateMockFileMetadata(1, {
+        name: 'file.jpg',
+        tags: ['original'],
+      }),
+    })
+
+    let fileId: string | undefined
+    await waitForCondition(
+      async () => {
+        const files = await readAllFileRecords({ order: 'ASC' })
+        if (files.length === 1) {
+          fileId = files[0].id
+          const tags = (await readTagsForFile(files[0].id)).filter(
+            (t) => !t.system,
+          )
+          return tags.length === 1 && tags[0].name === 'original'
+        }
+        return false
+      },
+      { timeout: 10_000, message: 'Initial tags to sync' },
+    )
+
+    harness.sdk.injectMetadataChange(stored.id, { tags: ['updated', 'new'] })
+
+    await waitForCondition(
+      async () => {
+        const tags = (await readTagsForFile(fileId!)).filter((t) => !t.system)
+        return (
+          tags.length === 2 &&
+          tags
+            .map((t) => t.name)
+            .sort()
+            .join(',') === 'new,updated'
+        )
+      },
+      { timeout: 10_000, message: 'Updated tags to sync' },
     )
   })
 })

--- a/test/sync-up-metadata.test.ts
+++ b/test/sync-up-metadata.test.ts
@@ -7,6 +7,7 @@ import './utils/setup'
 import { decodeFileMetadata } from '../src/encoding/fileMetadata'
 import { readFileRecord, updateFileRecord } from '../src/stores/files'
 import { readLocalObjectsForFile } from '../src/stores/localObjects'
+import { addTagToFile } from '../src/stores/tags'
 import { getUploadState } from '../src/stores/uploads'
 import {
   type AppCoreHarness,
@@ -158,5 +159,41 @@ describe('Sync Up Metadata', () => {
     const remoteMeta1 = decodeFileMetadata(remote1AfterSync.metadata())
     expect(remoteMeta1.name).toBe(remoteNewerName)
     expect(remoteMeta1.updatedAt).toBe(T_remote)
+  }, 30_000)
+
+  it('pushes local tags to remote', async () => {
+    const [file] = await addTestFilesToHarness(
+      harness,
+      generateTestFilesFromAssets(TEST_ASSETS_DIR, ['test-image-1.png']),
+    )
+
+    await waitForCondition(() => getUploadState(file.id) !== undefined, {
+      timeout: 10_000,
+      message: 'File to be detected by scanner',
+    })
+    await harness.waitForNoActiveUploads()
+
+    const localObjects = await readLocalObjectsForFile(file.id)
+    expect(localObjects.length).toBeGreaterThan(0)
+    const objectId = localObjects[0].id
+
+    await addTagToFile(file.id, 'vacation')
+    await addTagToFile(file.id, 'beach')
+    await updateFileRecord({ id: file.id, updatedAt: Date.now() }, true, {
+      includeUpdatedAt: true,
+    })
+
+    await waitForCondition(
+      async () => {
+        const remote = await harness.sdk.object(objectId)
+        const remoteMeta = decodeFileMetadata(remote.metadata())
+        return (
+          remoteMeta.tags !== undefined &&
+          remoteMeta.tags.length === 2 &&
+          remoteMeta.tags.slice().sort().join(',') === 'beach,vacation'
+        )
+      },
+      { timeout: 10_000, message: 'Remote metadata to include tags' },
+    )
   }, 30_000)
 })


### PR DESCRIPTION
Introduces a tagging system that lets users organize files with custom tags and a built-in Favorites tag. Tags sync across devices via file metadata.

- Add tags and file_tags tables with DB migration
- Tag CRUD: create, search, add/remove from files, delete
- System tags (Favorites) with toggle support from the file carousel and detail view
- ManageTagsSheet with autocomplete for adding/removing tags on individual files
- BulkManageTagsSheet for tagging multiple selected files at once
- TagsGrid showing all tags with file counts
- TagLibraryScreen for browsing files within a tag, with full carousel, selection, and view settings support
- Sync integration: tags round-trip through metadata as string array

![Screenshot 2026-02-20 at 13.30.47.png](https://app.graphite.com/user-attachments/assets/f4b50f4d-7149-4889-a905-c417c82bdb83.png)

![Screenshot 2026-02-20 at 13.31.37.png](https://app.graphite.com/user-attachments/assets/88418780-c987-4ae8-ac20-2ef0f72d82aa.png)

