### PR TITLE
feat: add directory system with move-to-directory, directory screen, and photo import directory

### DIFF
--- a/.changeset/add-directories.md
+++ b/.changeset/add-directories.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Added directories for organizing files into folders.

--- a/src/components/CreateDirectorySheet.tsx
+++ b/src/components/CreateDirectorySheet.tsx
@@ -1,0 +1,153 @@
+import { FolderPlusIcon } from 'lucide-react-native'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  Keyboard,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native'
+import { createDirectory } from '../stores/directories'
+import { closeSheet, useSheetOpen } from '../stores/sheets'
+import { overlay, palette, whiteA } from '../styles/colors'
+import { ModalSheet } from './ModalSheet'
+
+type Props = {
+  onCreated?: (directoryId: string, directoryName: string) => void
+}
+
+export function CreateDirectorySheet({ onCreated }: Props) {
+  const isOpen = useSheetOpen('createDirectory')
+  const [name, setName] = useState('')
+  const [error, setError] = useState('')
+  const inputRef = useRef<TextInput | null>(null)
+
+  useEffect(() => {
+    if (isOpen) {
+      setTimeout(() => inputRef.current?.focus(), 400)
+    } else {
+      setName('')
+      setError('')
+    }
+  }, [isOpen])
+
+  const handleClose = useCallback(() => {
+    setName('')
+    setError('')
+    Keyboard.dismiss()
+    closeSheet()
+  }, [])
+
+  const handleCreate = useCallback(async () => {
+    const trimmed = name.trim()
+    if (!trimmed) return
+    try {
+      const dir = await createDirectory(trimmed)
+      setName('')
+      setError('')
+      closeSheet()
+      onCreated?.(dir.id, dir.name)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to create directory')
+    }
+  }, [name, onCreated])
+
+  return (
+    <ModalSheet
+      visible={isOpen}
+      onRequestClose={handleClose}
+      title="New Directory"
+      presentationStyle="formSheet"
+      headerRight={
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Cancel"
+          onPress={handleClose}
+          hitSlop={8}
+        >
+          <Text style={styles.cancelText}>Cancel</Text>
+        </Pressable>
+      }
+    >
+      <View style={styles.body}>
+        <View style={styles.inputContainer}>
+          <TextInput
+            ref={inputRef}
+            style={styles.input}
+            placeholder="Directory name"
+            placeholderTextColor={palette.gray[500]}
+            value={name}
+            onChangeText={(text) => {
+              setName(text)
+              setError('')
+            }}
+            autoCapitalize="none"
+            autoCorrect={false}
+            returnKeyType="done"
+            onSubmitEditing={handleCreate}
+          />
+        </View>
+        {error ? <Text style={styles.error}>{error}</Text> : null}
+        <Pressable
+          accessibilityRole="button"
+          onPress={handleCreate}
+          disabled={!name.trim()}
+          style={[
+            styles.createButton,
+            !name.trim() && styles.createButtonDisabled,
+          ]}
+        >
+          <FolderPlusIcon size={18} color={palette.gray[50]} />
+          <Text style={styles.createButtonText}>Create</Text>
+        </Pressable>
+      </View>
+    </ModalSheet>
+  )
+}
+
+const styles = StyleSheet.create({
+  cancelText: {
+    color: palette.blue[400],
+    fontSize: 17,
+    fontWeight: '600',
+  },
+  body: {
+    paddingHorizontal: 16,
+  },
+  inputContainer: {
+    backgroundColor: overlay.panelMedium,
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: whiteA.a10,
+    marginBottom: 12,
+  },
+  input: {
+    color: palette.gray[50],
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 16,
+  },
+  error: {
+    color: palette.red[500],
+    fontSize: 13,
+    marginBottom: 8,
+  },
+  createButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    backgroundColor: palette.blue[500],
+    borderRadius: 10,
+    paddingVertical: 14,
+  },
+  createButtonDisabled: {
+    opacity: 0.4,
+  },
+  createButtonText: {
+    color: palette.gray[50],
+    fontSize: 16,
+    fontWeight: '600',
+  },
+})

--- a/src/components/DirectoriesGrid.tsx
+++ b/src/components/DirectoriesGrid.tsx
@@ -1,0 +1,138 @@
+import { FolderIcon } from 'lucide-react-native'
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native'
+import {
+  type DirectoryWithCount,
+  useAllDirectories,
+} from '../stores/directories'
+import { overlay, palette, whiteA } from '../styles/colors'
+
+type Props = {
+  onSelectDirectory: (directoryId: string, directoryName: string) => void
+}
+
+export function DirectoriesGrid({ onSelectDirectory }: Props) {
+  const allDirs = useAllDirectories()
+  const dirs = allDirs.data ?? []
+
+  if (!allDirs.data) {
+    return (
+      <View style={styles.emptyWrap}>
+        <ActivityIndicator color={palette.blue[400]} />
+      </View>
+    )
+  }
+
+  if (dirs.length === 0) {
+    return (
+      <View style={styles.emptyWrap}>
+        <FolderIcon color={whiteA.a50} size={48} />
+        <Text style={styles.emptyTitle}>No directories yet</Text>
+        <Text style={styles.emptyText}>
+          Create directories to organize your files.
+        </Text>
+      </View>
+    )
+  }
+
+  return (
+    <FlatList
+      data={dirs}
+      keyExtractor={(dir) => dir.id}
+      contentContainerStyle={styles.grid}
+      ItemSeparatorComponent={() => <View style={styles.separator} />}
+      renderItem={({ item }) => (
+        <DirectoryCard
+          dir={item}
+          onPress={() => onSelectDirectory(item.id, item.name)}
+        />
+      )}
+    />
+  )
+}
+
+function DirectoryCard({
+  dir,
+  onPress,
+}: {
+  dir: DirectoryWithCount
+  onPress: () => void
+}) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      onPress={onPress}
+      style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}
+    >
+      <FolderIcon color={palette.blue[400]} size={24} />
+      <View style={styles.cardText}>
+        <Text style={styles.dirName} numberOfLines={1}>
+          {dir.name}
+        </Text>
+        <Text style={styles.dirCount}>
+          {dir.fileCount.toLocaleString()}{' '}
+          {dir.fileCount === 1 ? 'file' : 'files'}
+        </Text>
+      </View>
+    </Pressable>
+  )
+}
+
+const styles = StyleSheet.create({
+  grid: {
+    padding: 16,
+    paddingTop: 140,
+    paddingBottom: 120,
+  },
+  separator: {
+    height: 12,
+  },
+  card: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: overlay.panelMedium,
+    borderRadius: 16,
+    padding: 16,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: whiteA.a10,
+    gap: 12,
+  },
+  cardPressed: {
+    backgroundColor: overlay.panelStrong,
+  },
+  cardText: {
+    flex: 1,
+  },
+  dirName: {
+    color: palette.gray[50],
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  dirCount: {
+    color: whiteA.a50,
+    fontSize: 13,
+  },
+  emptyWrap: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+  },
+  emptyTitle: {
+    color: palette.gray[100],
+    fontWeight: '800',
+    fontSize: 18,
+    paddingTop: 12,
+    paddingBottom: 6,
+  },
+  emptyText: {
+    color: whiteA.a70,
+    textAlign: 'center',
+  },
+})

--- a/src/components/FileActionsSheet.tsx
+++ b/src/components/FileActionsSheet.tsx
@@ -4,6 +4,7 @@ import {
   CloudOffIcon,
   CloudUploadIcon,
   EraserIcon,
+  FolderIcon,
   HeartIcon,
   LinkIcon,
   ShareIcon,
@@ -248,6 +249,16 @@ function SingleFileActionsSheet({
         Manage tags
       </ActionSheetButton>
       <ActionSheetButton
+        variant="primary"
+        icon={<FolderIcon size={18} />}
+        onPress={() => {
+          closeSheet()
+          setTimeout(() => openSheet('moveToDirectory'), 300)
+        }}
+      >
+        Move to directory
+      </ActionSheetButton>
+      <ActionSheetButton
         variant="danger"
         icon={<Trash2Icon size={18} />}
         onPress={handlePressAndClose(handleDelete)}
@@ -464,6 +475,16 @@ function BulkFileActionsSheet({
         disabled={!counts || counts.onNetwork === 0}
       >
         Remove from network{counts ? ` (${counts.onNetwork})` : ''}
+      </ActionSheetButton>
+      <ActionSheetButton
+        variant="primary"
+        icon={<FolderIcon size={18} />}
+        onPress={() => {
+          closeSheet()
+          setTimeout(() => openSheet('moveToDirectory'), 300)
+        }}
+      >
+        Move to directory
       </ActionSheetButton>
       <ActionSheetButton
         variant="danger"

--- a/src/components/FileCarousel/FileCarouselControlBar.tsx
+++ b/src/components/FileCarousel/FileCarouselControlBar.tsx
@@ -1,4 +1,5 @@
 import {
+  FolderIcon,
   FullscreenIcon,
   HeartIcon,
   MoreVerticalIcon,
@@ -16,6 +17,7 @@ type Props = {
   setViewStyle: (viewStyle: 'consume' | 'detail') => void
   onShareFile: () => void
   onAddTag: () => void
+  onMoveToDirectory: () => void
   onPressMore: () => void
   onToggleFavorite: () => void
   isFavorite: boolean
@@ -27,6 +29,7 @@ export function FileCarouselControlBar({
   setViewStyle,
   onShareFile,
   onAddTag,
+  onMoveToDirectory,
   onPressMore,
   onToggleFavorite,
   isFavorite,
@@ -63,6 +66,12 @@ export function FileCarouselControlBar({
           </IconButton>
           <IconButton onPress={onAddTag} accessibilityLabel="Add tag">
             <TagIcon color={iconColors.white} />
+          </IconButton>
+          <IconButton
+            onPress={onMoveToDirectory}
+            accessibilityLabel="Move to directory"
+          >
+            <FolderIcon color={iconColors.white} />
           </IconButton>
         </View>
         <View style={{ flexDirection: 'row', gap: 12 }}>

--- a/src/components/FileCarousel/index.tsx
+++ b/src/components/FileCarousel/index.tsx
@@ -38,6 +38,7 @@ type Props = {
   onClose: () => void
   onShowActionSheet?: () => void
   onShowTagSheet?: () => void
+  onMoveToDirectory?: () => void
   onZoomChange?: (isZoomed: boolean) => void
   onViewStyleChange?: (viewStyle: 'consume' | 'detail') => void
   isDismissing?: boolean
@@ -52,6 +53,7 @@ export function FileCarousel({
   onClose,
   onShowActionSheet,
   onShowTagSheet,
+  onMoveToDirectory,
   onZoomChange,
   onViewStyleChange,
   isDismissing,
@@ -189,6 +191,12 @@ export function FileCarousel({
       onShowTagSheet()
     }
   }, [onShowTagSheet])
+
+  const handleMoveToDirectory = useCallback(() => {
+    if (onMoveToDirectory) {
+      onMoveToDirectory()
+    }
+  }, [onMoveToDirectory])
 
   const favorite = useIsFavorite(currentFile?.id ?? null)
   const handleToggleFavorite = useCallback(() => {
@@ -361,6 +369,7 @@ export function FileCarousel({
             setViewStyle={setViewStyle}
             onShareFile={handleShareFile}
             onAddTag={handleAddTag}
+            onMoveToDirectory={handleMoveToDirectory}
             onPressMore={handleMore}
             onToggleFavorite={handleToggleFavorite}
             isFavorite={favorite.data ?? false}

--- a/src/components/MoveToDirectorySheet.tsx
+++ b/src/components/MoveToDirectorySheet.tsx
@@ -1,0 +1,299 @@
+import { FolderIcon, FoldersIcon, PlusIcon, XIcon } from 'lucide-react-native'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  FlatList,
+  Keyboard,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native'
+import {
+  countFilesWithDirectories,
+  createDirectory,
+  moveFilesToDirectory,
+  moveFileToDirectory,
+  readDirectoryNameForFile,
+  useAllDirectories,
+} from '../stores/directories'
+import { closeSheet, useSheetOpen } from '../stores/sheets'
+import { palette, whiteA } from '../styles/colors'
+import { ModalSheet } from './ModalSheet'
+
+type Props = {
+  fileIds: string[]
+  sheetName?: string
+}
+
+export function MoveToDirectorySheet({
+  fileIds,
+  sheetName = 'moveToDirectory',
+}: Props) {
+  const isOpen = useSheetOpen(sheetName)
+  const allDirs = useAllDirectories()
+  const [query, setQuery] = useState('')
+  const inputRef = useRef<TextInput | null>(null)
+  const [currentDirName, setCurrentDirName] = useState<string | null>(null)
+  const [filesInDirCount, setFilesInDirCount] = useState(0)
+
+  const isSingleFile = fileIds.length === 1
+  const dirs = allDirs.data ?? []
+  const filtered = query.trim()
+    ? dirs.filter((d) =>
+        d.name.toLowerCase().includes(query.trim().toLowerCase()),
+      )
+    : dirs
+
+  const exactMatch =
+    query.trim().length > 0 &&
+    dirs.some((d) => d.name.toLowerCase() === query.trim().toLowerCase())
+
+  useEffect(() => {
+    if (isOpen) {
+      setTimeout(() => inputRef.current?.focus(), 400)
+      if (isSingleFile) {
+        readDirectoryNameForFile(fileIds[0]).then((name) =>
+          setCurrentDirName(name ?? null),
+        )
+      } else {
+        countFilesWithDirectories(fileIds).then(setFilesInDirCount)
+      }
+    } else {
+      setQuery('')
+      setCurrentDirName(null)
+      setFilesInDirCount(0)
+    }
+  }, [isOpen, fileIds, isSingleFile])
+
+  const handleMoveToDirectory = useCallback(
+    async (directoryId: string) => {
+      if (fileIds.length === 1) {
+        await moveFileToDirectory(fileIds[0], directoryId)
+      } else if (fileIds.length > 1) {
+        await moveFilesToDirectory(fileIds, directoryId)
+      }
+      closeSheet()
+    },
+    [fileIds],
+  )
+
+  const handleRemoveFromDirectory = useCallback(async () => {
+    if (fileIds.length === 1) {
+      await moveFileToDirectory(fileIds[0], null)
+    } else if (fileIds.length > 1) {
+      await moveFilesToDirectory(fileIds, null)
+    }
+    closeSheet()
+  }, [fileIds])
+
+  const handleCreateAndMove = useCallback(
+    async (name: string) => {
+      if (!name.trim()) return
+      try {
+        const dir = await createDirectory(name.trim())
+        await handleMoveToDirectory(dir.id)
+      } catch {
+        const existing = dirs.find(
+          (d) => d.name.toLowerCase() === name.trim().toLowerCase(),
+        )
+        if (existing) {
+          await handleMoveToDirectory(existing.id)
+        }
+      }
+    },
+    [dirs, handleMoveToDirectory],
+  )
+
+  const handleClose = useCallback(() => {
+    setQuery('')
+    Keyboard.dismiss()
+    closeSheet()
+  }, [])
+
+  const fileCount = fileIds.length
+
+  return (
+    <ModalSheet
+      visible={isOpen}
+      onRequestClose={handleClose}
+      title={`Move ${fileCount} ${fileCount === 1 ? 'file' : 'files'} to directory`}
+      headerRight={
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Cancel"
+          onPress={handleClose}
+          hitSlop={8}
+        >
+          <Text style={styles.cancelText}>Cancel</Text>
+        </Pressable>
+      }
+    >
+      {isSingleFile ? (
+        <View style={styles.infoBanner}>
+          <FolderIcon size={16} color={whiteA.a50} />
+          <Text style={styles.infoText}>
+            {currentDirName
+              ? `Currently in ${currentDirName}`
+              : 'Not in a directory'}
+          </Text>
+        </View>
+      ) : filesInDirCount > 0 ? (
+        <View style={styles.infoBanner}>
+          <FoldersIcon size={16} color={whiteA.a50} />
+          <Text style={styles.infoText}>
+            {filesInDirCount === fileIds.length
+              ? 'All files are already in directories'
+              : `${filesInDirCount} ${filesInDirCount === 1 ? 'file is' : 'files are'} already in a directory`}
+          </Text>
+        </View>
+      ) : null}
+      <View style={styles.inputRow}>
+        <TextInput
+          ref={inputRef}
+          style={styles.input}
+          placeholder="Search or create directory..."
+          placeholderTextColor={palette.gray[500]}
+          value={query}
+          onChangeText={setQuery}
+          autoCapitalize="none"
+          autoCorrect={false}
+          returnKeyType="done"
+          onSubmitEditing={() => {
+            if (query.trim()) handleCreateAndMove(query.trim())
+          }}
+        />
+      </View>
+      <FlatList
+        data={filtered}
+        keyExtractor={(item) => item.id}
+        keyboardShouldPersistTaps="handled"
+        keyboardDismissMode="on-drag"
+        contentContainerStyle={styles.listContent}
+        ListHeaderComponent={
+          <>
+            <Pressable
+              style={styles.dirRow}
+              onPress={handleRemoveFromDirectory}
+            >
+              <View style={styles.dirRowLeft}>
+                <XIcon size={18} color={palette.gray[400]} />
+                <Text style={styles.removeText}>No directory</Text>
+              </View>
+            </Pressable>
+            {query.trim().length > 0 && !exactMatch ? (
+              <Pressable
+                style={styles.dirRow}
+                onPress={() => handleCreateAndMove(query.trim())}
+              >
+                <View style={styles.dirRowLeft}>
+                  <PlusIcon size={16} color={palette.blue[400]} />
+                  <Text style={styles.createText}>Create "{query.trim()}"</Text>
+                </View>
+              </Pressable>
+            ) : null}
+          </>
+        }
+        renderItem={({ item }) => (
+          <Pressable
+            style={styles.dirRow}
+            onPress={() => handleMoveToDirectory(item.id)}
+          >
+            <View style={styles.dirRowLeft}>
+              <FolderIcon size={18} color={palette.blue[400]} />
+              <Text style={styles.dirName}>{item.name}</Text>
+              <Text style={styles.dirCount}>{item.fileCount}</Text>
+            </View>
+          </Pressable>
+        )}
+        ListEmptyComponent={
+          query.trim().length === 0 ? (
+            <Text style={styles.emptyText}>
+              No directories yet. Type to create one.
+            </Text>
+          ) : null
+        }
+      />
+    </ModalSheet>
+  )
+}
+
+const styles = StyleSheet.create({
+  cancelText: {
+    color: palette.blue[400],
+    fontSize: 17,
+    fontWeight: '600',
+  },
+  infoBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: whiteA.a08,
+  },
+  infoText: {
+    color: whiteA.a50,
+    fontSize: 13,
+    flex: 1,
+  },
+  inputRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: whiteA.a10,
+  },
+  input: {
+    flex: 1,
+    minWidth: 120,
+    color: palette.gray[50],
+    fontSize: 16,
+    paddingVertical: 4,
+  },
+  listContent: {
+    paddingBottom: 40,
+  },
+  dirRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: whiteA.a08,
+  },
+  dirRowLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    flex: 1,
+  },
+  dirName: {
+    color: palette.gray[50],
+    fontSize: 16,
+  },
+  dirCount: {
+    color: whiteA.a50,
+    fontSize: 14,
+  },
+  removeText: {
+    color: palette.gray[400],
+    fontSize: 16,
+  },
+  createText: {
+    color: palette.blue[400],
+    fontSize: 16,
+    fontWeight: '500',
+  },
+  emptyText: {
+    color: whiteA.a50,
+    fontSize: 15,
+    textAlign: 'center',
+    paddingTop: 40,
+  },
+})

--- a/src/components/SelectionBar.tsx
+++ b/src/components/SelectionBar.tsx
@@ -1,4 +1,4 @@
-import { TagIcon, Trash2Icon } from 'lucide-react-native'
+import { FolderIcon, TagIcon, Trash2Icon } from 'lucide-react-native'
 import { StyleSheet, Text, View } from 'react-native'
 import { useSelectedCount } from '../stores/fileSelection'
 import { openSheet } from '../stores/sheets'
@@ -9,25 +9,45 @@ import { IconButton } from './IconButton'
 
 type Props = {
   onOpenSelectionActions: () => void
+  moveToDirectorySheet?: string
 }
 
-export function SelectionBar({ onOpenSelectionActions }: Props) {
+export function SelectionBar({
+  onOpenSelectionActions,
+  moveToDirectorySheet = 'moveToDirectory',
+}: Props) {
   const selectedCount = useSelectedCount()
 
   return (
     <>
       <BottomControlBar style={styles.bar}>
         <View style={styles.container}>
-          <IconButton
-            onPress={() => openSheet('bulkManageTags')}
-            disabled={selectedCount === 0}
-            accessibilityLabel="Add tag"
-          >
-            <TagIcon
-              color={selectedCount > 0 ? iconColors.white : iconColors.inactive}
-              size={20}
-            />
-          </IconButton>
+          <View style={styles.leftButtons}>
+            <IconButton
+              onPress={() => openSheet('bulkManageTags')}
+              disabled={selectedCount === 0}
+              accessibilityLabel="Add tag"
+            >
+              <TagIcon
+                color={
+                  selectedCount > 0 ? iconColors.white : iconColors.inactive
+                }
+                size={20}
+              />
+            </IconButton>
+            <IconButton
+              onPress={() => openSheet(moveToDirectorySheet)}
+              disabled={selectedCount === 0}
+              accessibilityLabel="Move to directory"
+            >
+              <FolderIcon
+                color={
+                  selectedCount > 0 ? iconColors.white : iconColors.inactive
+                }
+                size={20}
+              />
+            </IconButton>
+          </View>
           <Text style={styles.count}>
             {selectedCount > 0 ? `${selectedCount} selected` : 'Select items'}
           </Text>
@@ -58,6 +78,11 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
+  },
+  leftButtons: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
   },
   count: {
     color: palette.gray[50],

--- a/src/components/SettingsSyncPhotos.tsx
+++ b/src/components/SettingsSyncPhotos.tsx
@@ -1,4 +1,12 @@
-import { Linking, StyleSheet, Switch, Text } from 'react-native'
+import { useCallback } from 'react'
+import {
+  Alert,
+  Linking,
+  Pressable,
+  StyleSheet,
+  Switch,
+  Text,
+} from 'react-native'
 import { SYNC_ARCHIVE_RESUME_THRESHOLD } from '../config'
 import { humanSize } from '../lib/humanSize'
 import { useMediaLibraryPermissions } from '../lib/mediaLibraryPermissions'
@@ -13,6 +21,10 @@ import {
   usePhotosArchiveCursor,
 } from '../managers/syncPhotosArchive'
 import { useFileStatsLocal } from '../stores/files'
+import {
+  setPhotoImportDirectory,
+  usePhotoImportDirectory,
+} from '../stores/settings'
 import { colors } from '../styles/colors'
 import { Button } from './Button'
 import { RowGroup } from './Group'
@@ -27,11 +39,30 @@ export function SettingsSyncPhotos() {
   const cursorValue = photosArchiveCursor.data ?? 0
   const photosArchiveInProgress = cursorValue > 0
   const { isSomeAccess, accessLabel, color } = useMediaLibraryPermissions()
+  const photoImportDir = usePhotoImportDirectory()
 
   const isPhotosAccessDisabled = !isSomeAccess
   const archiveDateLabel = formatArchiveCursor(cursorValue)
   const syncPhotosArchiveControlsDisabled =
     isPhotosAccessDisabled || !autoSyncPhotosArchive.data
+
+  const handleSetPhotoImportDir = useCallback(() => {
+    Alert.prompt(
+      'Photo import directory',
+      'Imported photos and videos will be placed in this directory. Leave empty to disable.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Save',
+          onPress: (value: string | undefined) => {
+            void setPhotoImportDirectory(value?.trim() ?? '')
+          },
+        },
+      ],
+      'plain-text',
+      photoImportDir.data ?? '',
+    )
+  }, [photoImportDir.data])
 
   return (
     <RowGroup
@@ -49,6 +80,16 @@ export function SettingsSyncPhotos() {
       }
     >
       <InfoCard>
+        <Pressable onPress={handleSetPhotoImportDir}>
+          <LabeledValueRow
+            label="Import directory"
+            labelWidth={250}
+            value={photoImportDir.data || 'None'}
+            canCopy={false}
+          />
+        </Pressable>
+      </InfoCard>
+      <InfoCard style={{ marginTop: 10 }}>
         <LabeledValueRow
           label="Import new photos"
           labelWidth={250}

--- a/src/db/migrations/0006_add_tags_and_directories.ts
+++ b/src/db/migrations/0006_add_tags_and_directories.ts
@@ -36,6 +36,25 @@ async function up(db: SQLite.SQLiteDatabase): Promise<void> {
       `CREATE INDEX IF NOT EXISTS idx_file_tags_tagId ON file_tags(tagId);`,
     )
 
+    // Create the directories table.
+    await db.execAsync(
+      `CREATE TABLE IF NOT EXISTS directories (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL UNIQUE COLLATE NOCASE,
+        createdAt INTEGER NOT NULL
+      );`,
+    )
+
+    // Add directoryId column to files table.
+    await db.execAsync(
+      `ALTER TABLE files ADD COLUMN directoryId TEXT REFERENCES directories(id) ON DELETE SET NULL;`,
+    )
+
+    // Index for looking up files by directory.
+    await db.execAsync(
+      `CREATE INDEX IF NOT EXISTS idx_files_directoryId ON files(directoryId);`,
+    )
+
     // Insert the Favorites system tag.
     const now = Date.now()
     await db.runAsync(

--- a/src/lib/processAssets.ts
+++ b/src/lib/processAssets.ts
@@ -1,6 +1,10 @@
 import { File } from 'expo-file-system'
 import { generateThumbnails } from '../managers/thumbnailer'
 import {
+  getOrCreateDirectory,
+  moveFilesToDirectory,
+} from '../stores/directories'
+import {
   createManyFileRecords,
   type FileRecord,
   readFileRecordsByContentHashes,
@@ -8,6 +12,7 @@ import {
   updateManyFileRecords,
 } from '../stores/files'
 import { copyFileToFs } from '../stores/fs'
+import { getPhotoImportDirectory } from '../stores/settings'
 import { calculateContentHash } from './contentHash'
 import { getMimeType, type MimeType } from './fileTypes'
 import { logger } from './logger'
@@ -222,6 +227,18 @@ export async function processAssets(
 
   await updateManyFileRecords(existingFiles)
   await createManyFileRecords(newFiles)
+
+  // Move media files to the configured photo import directory.
+  const photoImportDir = await getPhotoImportDirectory()
+  if (photoImportDir) {
+    const mediaFileIds = newFiles
+      .filter((f) => f.type.startsWith('image/') || f.type.startsWith('video/'))
+      .map((f) => f.id)
+    if (mediaFileIds.length > 0) {
+      const dir = await getOrCreateDirectory(photoImportDir)
+      await moveFilesToDirectory(mediaFileIds, dir.id)
+    }
+  }
 
   // Generate thumbnails for new image and video files.
   logger.debug('processAssets', 'generating_thumbnails', {

--- a/src/managers/syncDownEvents.ts
+++ b/src/managers/syncDownEvents.ts
@@ -19,6 +19,7 @@ import { logger } from '../lib/logger'
 import { createServiceInterval } from '../lib/serviceInterval'
 import { uniqueId } from '../lib/uniqueId'
 import { getAsyncStorageJSON, setAsyncStorageJSON } from '../stores/asyncStore'
+import { syncDirectoryFromMetadata } from '../stores/directories'
 import {
   createFileRecord,
   deleteFileRecord,
@@ -59,6 +60,7 @@ type PreparedCreate = {
   fileRecord: FileRecordRow
   localObject: LocalObject
   tags?: string[]
+  directory?: string
   isFile: boolean
 }
 
@@ -69,6 +71,7 @@ type PreparedUpdate = {
   localObject: LocalObject
   fileId: string
   tags?: string[]
+  directory?: string
   isFile: boolean
   isRemoteNewer: boolean
 }
@@ -94,6 +97,7 @@ type PreparedAdopt = {
   localObject: LocalObject
   indexerURL: string
   tags?: string[]
+  directory?: string
   isFile: boolean
 }
 
@@ -321,7 +325,7 @@ async function processBatch(
     } else if (event.kind === 'update') {
       removeUpload(event.fileId)
     }
-    // Sync tags from remote metadata for file records.
+    // Sync tags and directories from remote metadata for file records.
     if (event.kind !== 'delete' && event.isFile) {
       const shouldSync =
         event.kind === 'create' ||
@@ -332,6 +336,14 @@ async function processBatch(
           await syncTagsFromMetadata(event.fileRecord.id, event.tags)
         } catch (e) {
           logger.error('syncDownEvents', 'tag_sync_error', {
+            fileId: event.fileRecord.id,
+            error: e as Error,
+          })
+        }
+        try {
+          await syncDirectoryFromMetadata(event.fileRecord.id, event.directory)
+        } catch (e) {
+          logger.error('syncDownEvents', 'directory_sync_error', {
             fileId: event.fileRecord.id,
             error: e as Error,
           })
@@ -511,6 +523,7 @@ async function prepareFileRecord(
       localObject,
       fileId: existing.id,
       tags: metadata.tags,
+      directory: metadata.directory,
       isFile: type === 'file',
       isRemoteNewer: metadata.updatedAt >= existing.updatedAt,
     }
@@ -540,6 +553,7 @@ async function prepareFileRecord(
     fileRecord,
     localObject,
     tags: metadata.tags,
+    directory: metadata.directory,
     isFile: type === 'file',
   }
 }
@@ -583,6 +597,7 @@ async function prepareAdopt(
     localObject,
     indexerURL,
     tags: metadata.tags,
+    directory: metadata.directory,
     isFile: metadata.kind === 'file',
   }
 }

--- a/src/managers/syncUpMetadata.ts
+++ b/src/managers/syncUpMetadata.ts
@@ -13,6 +13,7 @@ import { logger } from '../lib/logger'
 import { createServiceInterval } from '../lib/serviceInterval'
 import { SlotPool } from '../lib/slotPool'
 import { getAsyncStorageJSON, setAsyncStorageJSON } from '../stores/asyncStore'
+import { readDirectoryNameForFile } from '../stores/directories'
 import {
   type FileMetadata,
   fileMetadataKeys,
@@ -229,6 +230,10 @@ export async function runSyncUpMetadata(
             const tags = await readTagNamesForFile(f.id)
             if (tags) {
               fileToEncode = { ...fileToEncode, tags }
+            }
+            const directory = await readDirectoryNameForFile(f.id)
+            if (directory) {
+              fileToEncode = { ...fileToEncode, directory }
             }
           }
           logger.info('syncUpMetadata', 'pushing_v1', {

--- a/src/screens/DirectoryScreen.tsx
+++ b/src/screens/DirectoryScreen.tsx
@@ -1,7 +1,7 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack'
 import {
   ArrowLeftIcon,
-  FilePlusIcon,
+  FolderPlusIcon,
   ListFilterIcon,
   MoreVerticalIcon,
   Trash2Icon,
@@ -35,6 +35,7 @@ import { ScreenHeader } from '../components/ScreenHeader'
 import { SelectionBar } from '../components/SelectionBar'
 import { ViewSettingsMenu } from '../components/ViewSettingsMenu'
 import type { MainStackParamList } from '../stacks/types'
+import { deleteDirectory, moveFilesToDirectory } from '../stores/directories'
 import {
   enterSelectionMode,
   exitSelectionMode,
@@ -45,29 +46,28 @@ import {
 import type { FileRecord } from '../stores/files'
 import {
   type FileListParams,
+  useDirectoryFileCount,
   useFileList,
-  useTagFileCount,
 } from '../stores/library'
 import { closeSheet, openSheet, useSheetOpen } from '../stores/sheets'
-import { addTagToFile, deleteTag } from '../stores/tags'
 import { useViewSettings } from '../stores/viewSettings'
 import { colors, overlay, palette, whiteA } from '../styles/colors'
 
-type Props = NativeStackScreenProps<MainStackParamList, 'TagLibrary'>
+type Props = NativeStackScreenProps<MainStackParamList, 'DirectoryScreen'>
 
-export function TagLibraryScreen({ route, navigation }: Props) {
-  const { tagId, tagName } = route.params
-  const scope = `tag.${tagId}`
+export function DirectoryScreen({ route, navigation }: Props) {
+  const { directoryId, directoryName } = route.params
+  const scope = `dir.${directoryId}`
   const vs = useViewSettings(scope)
   const filters: FileListParams = useMemo(
     () => ({
-      scope: `tag:${tagId}`,
+      scope: `dir:${directoryId}`,
       sortBy: vs.sortBy,
       sortDir: vs.sortDir,
       categories: vs.selectedCategories,
-      tags: [tagId],
+      directoryId,
     }),
-    [tagId, vs.sortBy, vs.sortDir, vs.selectedCategories],
+    [directoryId, vs.sortBy, vs.sortDir, vs.selectedCategories],
   )
   const files = useFileList(filters)
   const isSelectionMode = useIsSelectionMode()
@@ -138,7 +138,7 @@ export function TagLibraryScreen({ route, navigation }: Props) {
       return
     }
     setActionFileId(file.id)
-    openSheet('tagLibraryFileActions')
+    openSheet('directoryFileActions')
   }, [])
 
   const handleCloseCarousel = useCallback(() => {
@@ -148,7 +148,7 @@ export function TagLibraryScreen({ route, navigation }: Props) {
   }, [])
 
   const handleOpenSelectionActions = useCallback(() => {
-    openSheet('tagLibraryFileActions')
+    openSheet('directoryFileActions')
   }, [])
 
   const handleBulkActionComplete = useCallback(() => {
@@ -156,12 +156,13 @@ export function TagLibraryScreen({ route, navigation }: Props) {
   }, [])
 
   const handleFilesAdded = useCallback(
-    (files: FileRecord[]) => {
-      for (const file of files) {
-        void addTagToFile(file.id, tagName)
-      }
+    (addedFiles: FileRecord[]) => {
+      void moveFilesToDirectory(
+        addedFiles.map((f) => f.id),
+        directoryId,
+      )
     },
-    [tagName],
+    [directoryId],
   )
 
   const actionSheetFileIds = isSelectionMode
@@ -172,32 +173,31 @@ export function TagLibraryScreen({ route, navigation }: Props) {
         ? [actionFileId]
         : []
 
-  const tagCount = useTagFileCount(tagId)
-  const fileCount = tagCount.data ?? 0
+  const dirCount = useDirectoryFileCount(directoryId)
+  const fileCount = dirCount.data ?? 0
   const subtitle = `${fileCount.toLocaleString()} ${fileCount === 1 ? 'file' : 'files'}`
-  const isSystemTag = tagId.startsWith('sys_')
-  const tagActionsOpen = useSheetOpen('tagActions')
+  const dirActionsOpen = useSheetOpen('directoryActions')
 
-  const handleDeleteTag = useCallback(() => {
+  const handleDeleteDirectory = useCallback(() => {
     closeSheet()
     setTimeout(() => {
       Alert.alert(
-        `Delete "${tagName}"?`,
-        'This will remove the tag and unlink all files from it. Files will not be deleted.',
+        `Delete "${directoryName}"?`,
+        'This will remove the directory. Files will be moved out but not deleted.',
         [
           { text: 'Cancel', style: 'cancel' },
           {
             text: 'Delete',
             style: 'destructive',
             onPress: async () => {
-              await deleteTag(tagId)
+              await deleteDirectory(directoryId)
               navigation.goBack()
             },
           },
         ],
       )
     }, 300)
-  }, [tagId, tagName, navigation])
+  }, [directoryId, directoryName, navigation])
 
   return (
     <View style={styles.container}>
@@ -217,7 +217,7 @@ export function TagLibraryScreen({ route, navigation }: Props) {
           </IconButton>
           <View>
             <Text style={styles.titleLarge} numberOfLines={1}>
-              {tagName}
+              {directoryName}
             </Text>
             <Text style={styles.subtitle}>{subtitle}</Text>
           </View>
@@ -225,7 +225,7 @@ export function TagLibraryScreen({ route, navigation }: Props) {
         <View style={styles.buttonRow}>
           <ViewSettingsMenu scope={scope}>
             <IconButton accessibilityLabel="View settings">
-              <ListFilterIcon color={palette.gray[50]} size={20} />
+              <ListFilterIcon color={palette.gray[50]} size={22} />
             </IconButton>
           </ViewSettingsMenu>
           {isSelectionMode ? (
@@ -272,33 +272,33 @@ export function TagLibraryScreen({ route, navigation }: Props) {
             style={styles.emptyImage}
             source={require('../../assets/image-stack.png')}
           />
-          <Text style={styles.emptyTitle}>No files with this tag</Text>
+          <Text style={styles.emptyTitle}>No files in this directory</Text>
           <Text style={styles.emptyText}>
-            Add files to this tag from the file actions menu.
+            Move files here from the file actions menu.
           </Text>
         </View>
       )}
 
       <AddFileActionSheet
-        sheetName="tagLibraryAddFile"
+        sheetName="directoryAddFile"
         onFilesAdded={handleFilesAdded}
       />
       {isSelectionMode ? (
         <SelectionBar
           onOpenSelectionActions={handleOpenSelectionActions}
-          moveToDirectorySheet="tagLibraryMoveToDir"
+          moveToDirectorySheet="directoryMoveToDir"
         />
       ) : (
         <BottomControlBar variant="floating" style={styles.controlBar}>
           <FloatingPill style={styles.actions}>
             <IconButton
-              onPress={() => openSheet('tagLibraryAddFile')}
+              onPress={() => openSheet('directoryAddFile')}
               accessibilityLabel="Add files"
             >
-              <FilePlusIcon color={palette.gray[50]} size={20} />
+              <FolderPlusIcon color={palette.gray[50]} size={20} />
             </IconButton>
             <IconButton
-              onPress={() => openSheet('tagActions')}
+              onPress={() => openSheet('directoryActions')}
               accessibilityLabel="More options"
             >
               <MoreVerticalIcon color={palette.gray[50]} size={22} />
@@ -335,9 +335,9 @@ export function TagLibraryScreen({ route, navigation }: Props) {
               sortDir={vs.sortDir}
               categories={vs.selectedCategories}
               onClose={handleCloseCarousel}
-              onShowActionSheet={() => openSheet('tagLibraryFileActions')}
-              onShowTagSheet={() => openSheet('tagLibraryManageTags')}
-              onMoveToDirectory={() => openSheet('tagLibraryMoveToDir')}
+              onShowActionSheet={() => openSheet('directoryFileActions')}
+              onShowTagSheet={() => openSheet('directoryManageTags')}
+              onMoveToDirectory={() => openSheet('directoryMoveToDir')}
               onZoomChange={setIsCarouselZoomed}
               onViewStyleChange={(s) => setIsCarouselDetail(s === 'detail')}
               isDismissing={isDraggingToDismiss}
@@ -346,34 +346,33 @@ export function TagLibraryScreen({ route, navigation }: Props) {
         </Animated.View>
       ) : null}
 
-      <ActionSheet visible={tagActionsOpen} onRequestClose={() => closeSheet()}>
+      <ActionSheet visible={dirActionsOpen} onRequestClose={() => closeSheet()}>
         <ActionSheetButton
           variant="danger"
           icon={<Trash2Icon size={18} />}
-          onPress={handleDeleteTag}
-          disabled={isSystemTag}
+          onPress={handleDeleteDirectory}
         >
-          Delete tag
+          Delete directory
         </ActionSheetButton>
       </ActionSheet>
       {actionSheetFileIds.length > 0 ? (
         <>
           <FileActionsSheet
             fileIds={actionSheetFileIds}
-            sheetName="tagLibraryFileActions"
+            sheetName="directoryFileActions"
             onComplete={isSelectionMode ? handleBulkActionComplete : undefined}
           />
           {actionSheetFileIds.length === 1 ? (
             <ManageTagsSheet
               fileId={actionSheetFileIds[0]}
-              sheetName="tagLibraryManageTags"
+              sheetName="directoryManageTags"
             />
           ) : null}
         </>
       ) : null}
       <MoveToDirectorySheet
         fileIds={actionSheetFileIds}
-        sheetName="tagLibraryMoveToDir"
+        sheetName="directoryMoveToDir"
       />
     </View>
   )

--- a/src/screens/LibraryScreen.tsx
+++ b/src/screens/LibraryScreen.tsx
@@ -20,6 +20,7 @@ import { LibraryLocalResetButton } from '../components/LibraryLocalResetButton'
 import { LibraryStatusSheet } from '../components/LibraryStatusSheet'
 import { LibraryTabBar } from '../components/LibraryTabBar'
 import { ManageTagsSheet } from '../components/ManageTagsSheet'
+import { MoveToDirectorySheet } from '../components/MoveToDirectorySheet'
 import { SelectionBar } from '../components/SelectionBar'
 import type { MainStackParamList } from '../stacks/types'
 import {
@@ -104,6 +105,10 @@ export function LibraryScreen({ route, navigation }: Props) {
 
   const handleShowTagSheet = useCallback(() => {
     openSheet('manageFileTags')
+  }, [])
+
+  const handleMoveToDirectory = useCallback(() => {
+    openSheet('moveToDirectory')
   }, [])
 
   const handleOpenSelectionActions = useCallback(() => {
@@ -298,6 +303,7 @@ export function LibraryScreen({ route, navigation }: Props) {
               }}
               onShowActionSheet={handleShowCarouselActions}
               onShowTagSheet={handleShowTagSheet}
+              onMoveToDirectory={handleMoveToDirectory}
               onZoomChange={setIsCarouselZoomed}
               onViewStyleChange={(s) => setIsCarouselDetail(s === 'detail')}
               isDismissing={isDraggingToDismiss}
@@ -320,6 +326,7 @@ export function LibraryScreen({ route, navigation }: Props) {
           ) : null}
         </>
       ) : null}
+      <MoveToDirectorySheet fileIds={actionSheetFileIds} />
     </View>
   )
 }

--- a/src/stacks/MainStack.tsx
+++ b/src/stacks/MainStack.tsx
@@ -1,4 +1,5 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
+import { DirectoryScreen } from '../screens/DirectoryScreen'
 import { LibraryScreen } from '../screens/LibraryScreen'
 import { TagLibraryScreen } from '../screens/TagLibraryScreen'
 import type { MainStackParamList } from './types'
@@ -17,6 +18,11 @@ export function MainStack() {
         name="TagLibrary"
         options={{ headerShown: false }}
         component={TagLibraryScreen}
+      />
+      <Stack.Screen
+        name="DirectoryScreen"
+        options={{ headerShown: false }}
+        component={DirectoryScreen}
       />
     </Stack.Navigator>
   )

--- a/src/stacks/types.ts
+++ b/src/stacks/types.ts
@@ -3,6 +3,7 @@ import type { NavigatorScreenParams } from '@react-navigation/native'
 export type MainStackParamList = {
   LibraryHome: { openFileId?: string } | undefined
   TagLibrary: { tagId: string; tagName: string }
+  DirectoryScreen: { directoryId: string; directoryName: string }
 }
 
 export type SwitchIndexerStackParamList = {

--- a/src/stores/directories.test.ts
+++ b/src/stores/directories.test.ts
@@ -1,0 +1,262 @@
+import { initializeDB, resetDb } from '../db'
+import {
+  createDirectory,
+  deleteDirectory,
+  getOrCreateDirectory,
+  moveFilesToDirectory,
+  moveFileToDirectory,
+  readAllDirectoriesWithCounts,
+  readDirectoryNameForFile,
+  renameDirectory,
+  sanitizeDirectoryName,
+  syncDirectoryFromMetadata,
+} from './directories'
+import { createFileRecord, readFileRecord } from './files'
+
+jest.mock('./librarySwr', () => ({
+  libraryStats: {
+    key: jest.fn((...parts: string[]) => [`mock/${parts.join('/')}`]),
+    invalidateAll: jest.fn(),
+  },
+  invalidateCacheLibraryAllStats: jest.fn(),
+  invalidateCacheLibraryLists: jest.fn(),
+}))
+
+describe('directories store', () => {
+  beforeEach(async () => {
+    await initializeDB()
+  })
+
+  afterEach(async () => {
+    await resetDb()
+    jest.clearAllMocks()
+  })
+
+  async function createTestFile(id: string) {
+    await createFileRecord({
+      id,
+      name: `${id}.jpg`,
+      type: 'image/jpeg',
+      kind: 'file',
+      size: 100,
+      hash: `hash-${id}`,
+      createdAt: 1000,
+      updatedAt: 1000,
+      localId: null,
+      addedAt: 1000,
+    })
+  }
+
+  describe('sanitizeDirectoryName', () => {
+    test('strips forward slashes', () => {
+      expect(sanitizeDirectoryName('a/b/c')).toBe('abc')
+    })
+
+    test('strips backslashes', () => {
+      expect(sanitizeDirectoryName('a\\b')).toBe('ab')
+    })
+
+    test('strips control characters', () => {
+      expect(sanitizeDirectoryName('foo\x00bar\x1f')).toBe('foobar')
+    })
+
+    test('rejects . and ..', () => {
+      expect(sanitizeDirectoryName('.')).toBe('')
+      expect(sanitizeDirectoryName('..')).toBe('')
+      expect(sanitizeDirectoryName('...')).toBe('')
+    })
+
+    test('trims whitespace', () => {
+      expect(sanitizeDirectoryName('  hello  ')).toBe('hello')
+    })
+
+    test('truncates to 255 characters', () => {
+      const long = 'x'.repeat(300)
+      expect(sanitizeDirectoryName(long)).toHaveLength(255)
+    })
+
+    test('preserves valid names', () => {
+      expect(sanitizeDirectoryName('Photos 2024')).toBe('Photos 2024')
+    })
+  })
+
+  describe('createDirectory', () => {
+    test('creates directory with correct fields', async () => {
+      const dir = await createDirectory('Photos')
+      expect(dir.name).toBe('Photos')
+      expect(dir.id).toBeDefined()
+      expect(dir.createdAt).toBeDefined()
+    })
+
+    test('trims whitespace from name', async () => {
+      const dir = await createDirectory('  Travel  ')
+      expect(dir.name).toBe('Travel')
+    })
+
+    test('throws on empty name', async () => {
+      await expect(createDirectory('')).rejects.toThrow(
+        'Directory name cannot be empty',
+      )
+    })
+
+    test('strips slashes from name', async () => {
+      const dir = await createDirectory('my/dir/name')
+      expect(dir.name).toBe('mydirname')
+    })
+
+    test('throws on name that sanitizes to empty', async () => {
+      await expect(createDirectory('/')).rejects.toThrow(
+        'Directory name cannot be empty',
+      )
+    })
+
+    test('throws on duplicate name (case-insensitive)', async () => {
+      await createDirectory('Photos')
+      await expect(createDirectory('photos')).rejects.toThrow()
+    })
+  })
+
+  describe('getOrCreateDirectory', () => {
+    test('returns existing directory (case-insensitive)', async () => {
+      const original = await createDirectory('Photos')
+      const found = await getOrCreateDirectory('photos')
+      expect(found.id).toBe(original.id)
+    })
+
+    test('creates new directory if not found', async () => {
+      const dir = await getOrCreateDirectory('NewDir')
+      expect(dir.name).toBe('NewDir')
+      expect(dir.id).toBeDefined()
+    })
+  })
+
+  describe('readAllDirectoriesWithCounts', () => {
+    test('returns directories with file counts', async () => {
+      const dir = await createDirectory('Photos')
+      await createTestFile('file-1')
+      await createTestFile('file-2')
+      await moveFileToDirectory('file-1', dir.id)
+      await moveFileToDirectory('file-2', dir.id)
+
+      const dirs = await readAllDirectoriesWithCounts()
+      expect(dirs).toHaveLength(1)
+      expect(dirs[0].fileCount).toBe(2)
+    })
+
+    test('returns 0 count for empty directories', async () => {
+      await createDirectory('Empty')
+      const dirs = await readAllDirectoriesWithCounts()
+      expect(dirs).toHaveLength(1)
+      expect(dirs[0].fileCount).toBe(0)
+    })
+  })
+
+  describe('deleteDirectory', () => {
+    test('deletes directory and unlinks files', async () => {
+      const dir = await createDirectory('Photos')
+      await createTestFile('file-1')
+      await moveFileToDirectory('file-1', dir.id)
+
+      await deleteDirectory(dir.id)
+
+      const dirs = await readAllDirectoriesWithCounts()
+      expect(dirs).toHaveLength(0)
+
+      const file = await readFileRecord('file-1')
+      expect(file).toBeTruthy()
+    })
+  })
+
+  describe('renameDirectory', () => {
+    test('renames directory', async () => {
+      const dir = await createDirectory('Photos')
+      await renameDirectory(dir.id, 'Images')
+
+      const dirs = await readAllDirectoriesWithCounts()
+      expect(dirs[0].name).toBe('Images')
+    })
+
+    test('throws on empty name', async () => {
+      const dir = await createDirectory('Photos')
+      await expect(renameDirectory(dir.id, '')).rejects.toThrow(
+        'Directory name cannot be empty',
+      )
+    })
+  })
+
+  describe('moveFileToDirectory', () => {
+    test('moves file to directory', async () => {
+      const dir = await createDirectory('Photos')
+      await createTestFile('file-1')
+      await moveFileToDirectory('file-1', dir.id)
+
+      const name = await readDirectoryNameForFile('file-1')
+      expect(name).toBe('Photos')
+    })
+
+    test('moves file out of directory with null', async () => {
+      const dir = await createDirectory('Photos')
+      await createTestFile('file-1')
+      await moveFileToDirectory('file-1', dir.id)
+      await moveFileToDirectory('file-1', null)
+
+      const name = await readDirectoryNameForFile('file-1')
+      expect(name).toBeUndefined()
+    })
+
+    test('bumps file updatedAt', async () => {
+      const dir = await createDirectory('Photos')
+      await createTestFile('file-1')
+      await moveFileToDirectory('file-1', dir.id)
+
+      const file = await readFileRecord('file-1')
+      expect(file!.updatedAt).toBeGreaterThan(1000)
+    })
+  })
+
+  describe('moveFilesToDirectory', () => {
+    test('moves multiple files to directory', async () => {
+      const dir = await createDirectory('Photos')
+      await createTestFile('file-1')
+      await createTestFile('file-2')
+      await moveFilesToDirectory(['file-1', 'file-2'], dir.id)
+
+      const dirs = await readAllDirectoriesWithCounts()
+      expect(dirs[0].fileCount).toBe(2)
+    })
+
+    test('handles empty array', async () => {
+      await expect(moveFilesToDirectory([], null)).resolves.not.toThrow()
+    })
+  })
+
+  describe('syncDirectoryFromMetadata', () => {
+    test('sets directory from metadata name', async () => {
+      await createTestFile('file-1')
+      await syncDirectoryFromMetadata('file-1', 'Photos')
+
+      const name = await readDirectoryNameForFile('file-1')
+      expect(name).toBe('Photos')
+    })
+
+    test('preserves local directory when undefined', async () => {
+      await createTestFile('file-1')
+      await syncDirectoryFromMetadata('file-1', 'Photos')
+      await syncDirectoryFromMetadata('file-1', undefined)
+
+      const name = await readDirectoryNameForFile('file-1')
+      expect(name).toBe('Photos')
+    })
+
+    test('reuses existing directory (case-insensitive)', async () => {
+      await createTestFile('file-1')
+      await createTestFile('file-2')
+      await syncDirectoryFromMetadata('file-1', 'Photos')
+      await syncDirectoryFromMetadata('file-2', 'photos')
+
+      const dirs = await readAllDirectoriesWithCounts()
+      expect(dirs).toHaveLength(1)
+      expect(dirs[0].fileCount).toBe(2)
+    })
+  })
+})

--- a/src/stores/directories.ts
+++ b/src/stores/directories.ts
@@ -1,0 +1,194 @@
+import useSWR from 'swr'
+import { db } from '../db'
+import { sqlDelete, sqlInsert, sqlUpdate } from '../db/sql'
+import { swrCacheBy } from '../lib/swr'
+import { uniqueId } from '../lib/uniqueId'
+import { invalidateCacheLibraryLists } from './librarySwr'
+
+export const directoriesSwr = swrCacheBy()
+
+export type Directory = {
+  id: string
+  name: string
+  createdAt: number
+}
+
+export type DirectoryWithCount = Directory & {
+  fileCount: number
+}
+
+export function sanitizeDirectoryName(name: string): string {
+  let result = ''
+  for (const ch of name) {
+    const code = ch.codePointAt(0)!
+    if (ch === '/' || ch === '\\') continue
+    if (code < 0x20 || code === 0x7f) continue
+    result += ch
+  }
+  result = result.trim()
+  if (/^\.+$/.test(result)) return ''
+  return result.slice(0, 255)
+}
+
+export async function createDirectory(name: string): Promise<Directory> {
+  const trimmed = sanitizeDirectoryName(name)
+  if (!trimmed) {
+    throw new Error('Directory name cannot be empty')
+  }
+
+  const existing = await db().getFirstAsync<{ id: string }>(
+    'SELECT id FROM directories WHERE name = ? COLLATE NOCASE',
+    trimmed,
+  )
+  if (existing) {
+    throw new Error(`Directory "${trimmed}" already exists`)
+  }
+
+  const now = Date.now()
+  const dir: Directory = {
+    id: uniqueId(),
+    name: trimmed,
+    createdAt: now,
+  }
+
+  await sqlInsert('directories', dir)
+  directoriesSwr.invalidate('all')
+  return dir
+}
+
+export async function getOrCreateDirectory(name: string): Promise<Directory> {
+  const trimmed = sanitizeDirectoryName(name)
+  if (!trimmed) {
+    throw new Error('Directory name cannot be empty')
+  }
+
+  const existing = await db().getFirstAsync<Directory>(
+    'SELECT id, name, createdAt FROM directories WHERE name = ? COLLATE NOCASE',
+    trimmed,
+  )
+
+  if (existing) {
+    return existing
+  }
+
+  return createDirectory(trimmed)
+}
+
+export async function readAllDirectoriesWithCounts(): Promise<
+  DirectoryWithCount[]
+> {
+  return db().getAllAsync<DirectoryWithCount>(
+    `SELECT d.id, d.name, d.createdAt, COUNT(f.id) as fileCount
+     FROM directories d
+     LEFT JOIN files f ON f.directoryId = d.id AND f.kind = 'file'
+     GROUP BY d.id
+     ORDER BY d.name COLLATE NOCASE`,
+  )
+}
+
+export async function deleteDirectory(id: string): Promise<void> {
+  await sqlUpdate('files', { directoryId: null }, { directoryId: id })
+  await sqlDelete('directories', { id })
+  directoriesSwr.invalidateAll()
+  invalidateCacheLibraryLists()
+}
+
+export async function renameDirectory(id: string, name: string): Promise<void> {
+  const trimmed = sanitizeDirectoryName(name)
+  if (!trimmed) {
+    throw new Error('Directory name cannot be empty')
+  }
+  const existing = await db().getFirstAsync<{ id: string }>(
+    'SELECT id FROM directories WHERE name = ? COLLATE NOCASE AND id != ?',
+    trimmed,
+    id,
+  )
+  if (existing) {
+    throw new Error(`Directory "${trimmed}" already exists`)
+  }
+  await sqlUpdate('directories', { name: trimmed }, { id })
+  directoriesSwr.invalidate('all')
+  invalidateCacheLibraryLists()
+}
+
+export async function moveFileToDirectory(
+  fileId: string,
+  directoryId: string | null,
+): Promise<void> {
+  await sqlUpdate(
+    'files',
+    { directoryId, updatedAt: Date.now() },
+    { id: fileId },
+  )
+  directoriesSwr.invalidate('all')
+  directoriesSwr.invalidate(`file/${fileId}`)
+  invalidateCacheLibraryLists()
+}
+
+export async function moveFilesToDirectory(
+  fileIds: string[],
+  directoryId: string | null,
+): Promise<void> {
+  if (fileIds.length === 0) return
+  const now = Date.now()
+  const placeholders = fileIds.map(() => '?').join(',')
+  await db().runAsync(
+    `UPDATE files SET directoryId = ?, updatedAt = ? WHERE id IN (${placeholders})`,
+    directoryId,
+    now,
+    ...fileIds,
+  )
+  directoriesSwr.invalidate('all')
+  for (const id of fileIds) {
+    directoriesSwr.invalidate(`file/${id}`)
+  }
+  invalidateCacheLibraryLists()
+}
+
+export async function readDirectoryNameForFile(
+  fileId: string,
+): Promise<string | undefined> {
+  const row = await db().getFirstAsync<{ name: string }>(
+    `SELECT d.name FROM directories d
+     INNER JOIN files f ON f.directoryId = d.id
+     WHERE f.id = ?`,
+    fileId,
+  )
+  return row?.name
+}
+
+export async function countFilesWithDirectories(
+  fileIds: string[],
+): Promise<number> {
+  if (fileIds.length === 0) return 0
+  const placeholders = fileIds.map(() => '?').join(',')
+  const row = await db().getFirstAsync<{ count: number }>(
+    `SELECT COUNT(*) as count FROM files WHERE id IN (${placeholders}) AND directoryId IS NOT NULL`,
+    ...fileIds,
+  )
+  return row?.count ?? 0
+}
+
+export async function syncDirectoryFromMetadata(
+  fileId: string,
+  directoryName: string | undefined,
+): Promise<void> {
+  if (directoryName === undefined) return
+  const dir = await getOrCreateDirectory(directoryName)
+  await sqlUpdate('files', { directoryId: dir.id }, { id: fileId })
+  directoriesSwr.invalidate('all')
+  directoriesSwr.invalidate(`file/${fileId}`)
+  invalidateCacheLibraryLists()
+}
+
+// SWR Hooks
+
+export function useAllDirectories() {
+  return useSWR(directoriesSwr.key('all'), readAllDirectoriesWithCounts)
+}
+
+export function useDirectoryForFile(fileId: string | null) {
+  return useSWR(fileId ? directoriesSwr.key(`file/${fileId}`) : null, () =>
+    fileId ? readDirectoryNameForFile(fileId) : undefined,
+  )
+}

--- a/src/stores/library.ts
+++ b/src/stores/library.ts
@@ -19,6 +19,7 @@ type FileOrderParams = {
   categories?: Category[]
   query?: string
   tags?: string[]
+  directoryId?: string
   limit?: number
   offset?: number
 }
@@ -32,6 +33,7 @@ async function readOrderedFileRecords(
     categories = [],
     query,
     tags = [],
+    directoryId,
     limit,
     offset,
   } = opts ?? {}
@@ -43,6 +45,7 @@ async function readOrderedFileRecords(
     categories,
     query,
     tags,
+    directoryId,
     tableAlias: 'files',
   })
 
@@ -73,6 +76,7 @@ export type FileListParams = {
   categories?: Category[]
   query?: string
   tags?: string[]
+  directoryId?: string
 }
 
 export function useFileList(params: FileListParams) {
@@ -83,6 +87,7 @@ export function useFileList(params: FileListParams) {
     categories = [],
     query,
     tags = [],
+    directoryId,
   } = params
   const sortingDir = sortDirParam ?? (sortBy === 'NAME' ? 'ASC' : 'DESC')
 
@@ -92,7 +97,7 @@ export function useFileList(params: FileListParams) {
 
   const tagsKey = tags.length ? tags.slice().sort().join(',') : ''
 
-  const base = `library/${scope}:list:${sortBy}:${sortingDir}:${categoriesKey}:${tagsKey}:${query ?? ''}`
+  const base = `library/${scope}:list:${sortBy}:${sortingDir}:${categoriesKey}:${tagsKey}:${directoryId ?? ''}:${query ?? ''}`
 
   const fetcher = async (key: string) => {
     const pageIndex = Number(key.split('|page=').pop() ?? '0')
@@ -102,6 +107,7 @@ export function useFileList(params: FileListParams) {
       categories: categories.length ? categories : undefined,
       query: query?.trim().length ? query : undefined,
       tags: tags.length ? tags : undefined,
+      directoryId,
       limit: PAGE_SIZE,
       offset: pageIndex * PAGE_SIZE,
     })
@@ -171,6 +177,18 @@ export function useTagFileCount(tagId: string) {
   })
 }
 
+// Count of files in a specific directory, excluding thumbnails.
+export function useDirectoryFileCount(directoryId: string) {
+  return useSWR(libraryStats.key(`dirCount:${directoryId}`), async () => {
+    const row = await db().getFirstAsync<{ count: number }>(
+      `SELECT COUNT(*) as count FROM files
+       WHERE directoryId = ? AND kind = 'file'`,
+      directoryId,
+    )
+    return row?.count ?? 0
+  })
+}
+
 // File View Store
 export type SortBy = 'NAME' | 'DATE' | 'ADDED' | 'SIZE'
 export type SortDir = 'ASC' | 'DESC'
@@ -184,6 +202,7 @@ export function buildLibraryQueryParts(
     categories?: Category[]
     query?: string
     tags?: string[]
+    directoryId?: string
     tableAlias?: string
   } = {},
 ): {
@@ -197,6 +216,7 @@ export function buildLibraryQueryParts(
     categories = [],
     query,
     tags = [],
+    directoryId,
     tableAlias = 'files',
   } = opts
   const dir: SortDir = sortDir ?? (sortBy === 'NAME' ? 'ASC' : 'DESC')
@@ -252,6 +272,11 @@ export function buildLibraryQueryParts(
       )
     `)
     params.push(...tags, tags.length)
+  }
+  // Directory filtering.
+  if (directoryId) {
+    whereParts.push(`${tableAlias}.directoryId = ?`)
+    params.push(directoryId)
   }
   const where = whereParts.length ? `WHERE ${whereParts.join(' AND ')}` : ''
 

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -94,3 +94,18 @@ export async function setStatusDisplayMode(value: StatusDisplayMode) {
   await setAsyncStorageString<StatusDisplayMode>('statusDisplayMode', value)
   await statusDisplayModeCache.set(value)
 }
+
+// Photo import directory
+
+export const [
+  getPhotoImportDirectory,
+  usePhotoImportDirectory,
+  photoImportDirectoryCache,
+] = createGetterAndSWRHook<string>(() =>
+  getAsyncStorageString<string>('photoImportDirectory', ''),
+)
+
+export async function setPhotoImportDirectory(value: string) {
+  await setAsyncStorageString('photoImportDirectory', value)
+  await photoImportDirectoryCache.set(value)
+}

--- a/test/multi-device-convergence.test.ts
+++ b/test/multi-device-convergence.test.ts
@@ -14,7 +14,13 @@
 import './utils/setup'
 
 import { decodeFileMetadata } from '../src/encoding/fileMetadata'
+import {
+  createDirectory,
+  moveFileToDirectory,
+  readDirectoryNameForFile,
+} from '../src/stores/directories'
 import { readAllFileRecords, readFileRecord } from '../src/stores/files'
+import { addTagToFile, readTagsForFile } from '../src/stores/tags'
 import { readThumbnailsByFileId } from '../src/stores/thumbnails'
 import {
   addTestFilesToHarness,
@@ -983,4 +989,85 @@ describe('Multi-Device Convergence', () => {
 
     await harnessB.shutdown()
   }, 90_000)
+
+  it('v0 node overwrites v1: tags and directory preserved, syncUp repairs', async () => {
+    const sharedStorage = createEmptyStorage()
+
+    // Device A: upload 1 file with tags and directory
+    const sdkA = new MockSdk(sharedStorage)
+    const harnessA = createHarness({ sdk: sdkA })
+    await harnessA.start()
+
+    const fileFactories = generateTestFiles(1, { type: 'data' })
+    const files = await addTestFilesToHarness(harnessA, fileFactories)
+    await harnessA.waitForNoActiveUploads()
+    await waitForAllObjectsV1(sharedStorage, 1)
+
+    // Add tags and directory
+    await addTagToFile(files[0].id, 'important')
+    const dir = await createDirectory('Work')
+    await moveFileToDirectory(files[0].id, dir.id)
+
+    // Wait for syncUp to push tags + directory to remote
+    const objectId = Array.from(sharedStorage.objects.keys())[0]
+    await waitForCondition(
+      () => {
+        const meta = decodeFileMetadata(
+          sharedStorage.objects.get(objectId)!.metadata,
+        )
+        return !!meta.tags?.includes('important') && meta.directory === 'Work'
+      },
+      { timeout: 15_000, message: 'Tags and directory in remote metadata' },
+    )
+
+    // Simulate v0 node overwriting (strips tags, directory, version, id, kind)
+    harnessA.pause()
+    sdkA.simulateV0Overwrite(objectId)
+
+    // Verify v0 metadata has no tags or directory
+    const v0Raw = JSON.parse(
+      new TextDecoder().decode(sharedStorage.objects.get(objectId)!.metadata),
+    )
+    expect(v0Raw.tags).toBeUndefined()
+    expect(v0Raw.directory).toBeUndefined()
+    expect(v0Raw.version).toBeUndefined()
+
+    harnessA.resume()
+
+    // syncUp should repair remote metadata to v1 with tags and directory
+    await waitForCondition(
+      () => {
+        try {
+          const raw = JSON.parse(
+            new TextDecoder().decode(
+              sharedStorage.objects.get(objectId)!.metadata,
+            ),
+          )
+          return (
+            raw.version === 1 &&
+            Array.isArray(raw.tags) &&
+            raw.tags.includes('important') &&
+            raw.directory === 'Work'
+          )
+        } catch {
+          return false
+        }
+      },
+      {
+        timeout: 15_000,
+        message: 'syncUp to repair remote with tags and directory',
+      },
+    )
+
+    // Verify local state is intact
+    const localTags = (await readTagsForFile(files[0].id)).filter(
+      (t) => !t.system,
+    )
+    expect(localTags.map((t) => t.name)).toContain('important')
+
+    const localDir = await readDirectoryNameForFile(files[0].id)
+    expect(localDir).toBe('Work')
+
+    await harnessA.shutdown()
+  }, 60_000)
 })

--- a/test/sync-down.test.ts
+++ b/test/sync-down.test.ts
@@ -4,6 +4,10 @@
 
 import './utils/setup'
 
+import {
+  readAllDirectoriesWithCounts,
+  readDirectoryNameForFile,
+} from '../src/stores/directories'
 import { readAllFileRecords } from '../src/stores/files'
 import { addTagToFile, readTagsForFile } from '../src/stores/tags'
 import { type AppCoreHarness, createHarness } from './utils/harness'
@@ -216,5 +220,73 @@ describe('Sync Down Integration', () => {
       },
       { timeout: 10_000, message: 'Updated tags to sync' },
     )
+  })
+
+  it('syncs objects with directory from server', async () => {
+    harness.sdk.injectObject({
+      metadata: generateMockFileMetadata(1, {
+        name: 'vacation-photo.jpg',
+        directory: 'Vacation',
+      }),
+    })
+
+    let fileId: string | undefined
+    await waitForCondition(
+      async () => {
+        const files = await readAllFileRecords({ order: 'ASC' })
+        if (files.length === 1 && files[0].name === 'vacation-photo.jpg') {
+          fileId = files[0].id
+          return true
+        }
+        return false
+      },
+      { timeout: 10_000, message: 'File with directory to sync' },
+    )
+
+    const dirName = await readDirectoryNameForFile(fileId!)
+    expect(dirName).toBe('Vacation')
+
+    const dirs = await readAllDirectoriesWithCounts()
+    expect(dirs).toHaveLength(1)
+    expect(dirs[0].name).toBe('Vacation')
+    expect(dirs[0].fileCount).toBe(1)
+  })
+
+  it('syncs directory updates from server', async () => {
+    const stored = harness.sdk.injectObject({
+      metadata: generateMockFileMetadata(1, {
+        name: 'photo.jpg',
+        directory: 'Trip',
+      }),
+    })
+
+    let fileId: string | undefined
+    await waitForCondition(
+      async () => {
+        const files = await readAllFileRecords({ order: 'ASC' })
+        if (files.length === 1) {
+          fileId = files[0].id
+          const dir = await readDirectoryNameForFile(files[0].id)
+          return dir === 'Trip'
+        }
+        return false
+      },
+      { timeout: 10_000, message: 'Initial directory to sync' },
+    )
+
+    harness.sdk.injectMetadataChange(stored.id, { directory: 'Vacation' })
+
+    await waitForCondition(
+      async () => {
+        const dir = await readDirectoryNameForFile(fileId!)
+        return dir === 'Vacation'
+      },
+      { timeout: 10_000, message: 'Updated directory to sync' },
+    )
+
+    const dirs = await readAllDirectoriesWithCounts()
+    const vacationDir = dirs.find((d) => d.name === 'Vacation')
+    expect(vacationDir).toBeDefined()
+    expect(vacationDir!.fileCount).toBe(1)
   })
 })

--- a/test/sync-up-metadata.test.ts
+++ b/test/sync-up-metadata.test.ts
@@ -5,6 +5,7 @@
 import './utils/setup'
 
 import { decodeFileMetadata } from '../src/encoding/fileMetadata'
+import { createDirectory, moveFileToDirectory } from '../src/stores/directories'
 import { readFileRecord, updateFileRecord } from '../src/stores/files'
 import { readLocalObjectsForFile } from '../src/stores/localObjects'
 import { addTagToFile } from '../src/stores/tags'
@@ -194,6 +195,36 @@ describe('Sync Up Metadata', () => {
         )
       },
       { timeout: 10_000, message: 'Remote metadata to include tags' },
+    )
+  }, 30_000)
+
+  it('pushes local directory to remote', async () => {
+    const [file] = await addTestFilesToHarness(
+      harness,
+      generateTestFilesFromAssets(TEST_ASSETS_DIR, ['test-image-1.png']),
+    )
+
+    await waitForCondition(() => getUploadState(file.id) !== undefined, {
+      timeout: 10_000,
+      message: 'File to be detected by scanner',
+    })
+    await harness.waitForNoActiveUploads()
+
+    const localObjects = await readLocalObjectsForFile(file.id)
+    expect(localObjects.length).toBeGreaterThan(0)
+    const objectId = localObjects[0].id
+
+    // Move file to a directory (this bumps updatedAt internally)
+    const dir = await createDirectory('Vacation')
+    await moveFileToDirectory(file.id, dir.id)
+
+    await waitForCondition(
+      async () => {
+        const remote = await harness.sdk.object(objectId)
+        const remoteMeta = decodeFileMetadata(remote.metadata())
+        return remoteMeta.directory === 'Vacation'
+      },
+      { timeout: 10_000, message: 'Remote metadata to include directory' },
     )
   }, 30_000)
 })


### PR DESCRIPTION
Adds user-created directories for organizing files into folders, with a configurable photo import directory.

- Add directories table and directoryId foreign key on files, with index — extends the existing tags migration
- directories store with create, rename, delete, move files, and file count queries
- DirectoryScreen for browsing files in a directory with full carousel and view settings
- MoveToDirectorySheet with inline directory creation and a warning when moving files that belong to other directories
- CreateDirectorySheet for standalone directory creation
- DirectoriesGrid showing all directories with file counts
- Photo import directory setting — new photos automatically land in a chosen directory
- Sync integration: directoryId persists through metadata

![Screenshot 2026-02-20 at 13.30.56.png](https://app.graphite.com/user-attachments/assets/76b0a15d-42cd-4d6d-9658-fc43cabbb545.png)

![Screenshot 2026-02-20 at 13.31.23.png](https://app.graphite.com/user-attachments/assets/4aada2bc-6972-44a1-9ba2-446c9b5f346f.png)

![Screenshot 2026-02-20 at 13.54.01.png](https://app.graphite.com/user-attachments/assets/35cc0282-e9de-4aab-884e-4e2b20427312.png)

![Screenshot 2026-02-20 at 13.53.50.png](https://app.graphite.com/user-attachments/assets/cd3dea4b-5db4-4486-a569-0a9182c76fa0.png)

