### PR TITLE
feat: rework library to three-tab layout (Files, Tags, Media)

### DIFF
--- a/.changeset/library-ux-redesign.md
+++ b/.changeset/library-ux-redesign.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Reworked the library into three tabs: Files, Tags, and Media.

--- a/src/components/LibraryTabBar.tsx
+++ b/src/components/LibraryTabBar.tsx
@@ -1,20 +1,143 @@
-import { FilePlusIcon } from 'lucide-react-native'
-import { StyleSheet } from 'react-native'
+import {
+  FilePlusIcon,
+  FolderIcon,
+  FolderPlusIcon,
+  ImageIcon,
+  PlusIcon,
+  SearchIcon,
+  TagIcon,
+} from 'lucide-react-native'
+import { useEffect, useRef, useState } from 'react'
+import {
+  Animated,
+  type LayoutChangeEvent,
+  Pressable,
+  StyleSheet,
+  View,
+} from 'react-native'
+import type { ActiveLibraryTab } from '../stores/settings'
 import { openSheet } from '../stores/sheets'
-import { palette } from '../styles/colors'
+import { overlay, palette, whiteA } from '../styles/colors'
 import { BottomControlBar, FloatingPill } from './BottomControlBar'
 import { IconButton } from './IconButton'
 
-export function LibraryTabBar() {
+type Props = {
+  activeTab: ActiveLibraryTab
+  onChangeTab: (tab: ActiveLibraryTab) => void
+  onSearch: () => void
+  onCreateDirectory: () => void
+  onCreateTag: () => void
+}
+
+const INSET = 4
+const TABS: ActiveLibraryTab[] = ['files', 'tags', 'media']
+
+export function LibraryTabBar({
+  activeTab,
+  onChangeTab,
+  onSearch,
+  onCreateDirectory,
+  onCreateTag,
+}: Props) {
+  const [totalWidth, setTotalWidth] = useState(0)
+  const slideX = useRef(new Animated.Value(0)).current
+
+  const segmentWidth = totalWidth > 0 ? (totalWidth - INSET * 2) / 3 : 0
+
+  useEffect(() => {
+    if (segmentWidth > 0) {
+      const index = TABS.indexOf(activeTab)
+      Animated.spring(slideX, {
+        toValue: index * segmentWidth,
+        useNativeDriver: true,
+        tension: 300,
+        friction: 30,
+      }).start()
+    }
+  }, [activeTab, segmentWidth, slideX])
+
+  const handleLayout = (e: LayoutChangeEvent) => {
+    setTotalWidth(e.nativeEvent.layout.width)
+  }
+
+  const filesColor = activeTab === 'files' ? palette.gray[50] : whiteA.a50
+  const tagsColor = activeTab === 'tags' ? palette.gray[50] : whiteA.a50
+  const mediaColor = activeTab === 'media' ? palette.gray[50] : whiteA.a50
+
   return (
     <BottomControlBar variant="floating" style={styles.bar}>
-      <FloatingPill style={styles.actions}>
-        <IconButton
-          onPress={() => openSheet('addFile')}
-          accessibilityLabel="Add files"
+      <View style={styles.segmentedControl} onLayout={handleLayout}>
+        {segmentWidth > 0 ? (
+          <Animated.View
+            style={[
+              styles.indicator,
+              {
+                width: segmentWidth,
+                transform: [{ translateX: slideX }],
+              },
+            ]}
+          />
+        ) : null}
+        <Pressable
+          accessibilityRole="tab"
+          accessibilityState={{ selected: activeTab === 'files' }}
+          onPress={() => onChangeTab('files')}
+          style={styles.segment}
         >
-          <FilePlusIcon color={palette.gray[50]} size={20} />
-        </IconButton>
+          <FolderIcon size={20} color={filesColor} />
+        </Pressable>
+        <Pressable
+          accessibilityRole="tab"
+          accessibilityState={{ selected: activeTab === 'tags' }}
+          onPress={() => onChangeTab('tags')}
+          style={styles.segment}
+        >
+          <TagIcon size={20} color={tagsColor} />
+        </Pressable>
+        <Pressable
+          accessibilityRole="tab"
+          accessibilityState={{ selected: activeTab === 'media' }}
+          onPress={() => onChangeTab('media')}
+          style={styles.segment}
+        >
+          <ImageIcon size={20} color={mediaColor} />
+        </Pressable>
+      </View>
+      <FloatingPill style={styles.actions}>
+        {activeTab === 'files' ? (
+          <>
+            <IconButton
+              onPress={onCreateDirectory}
+              accessibilityLabel="Create directory"
+            >
+              <FolderPlusIcon color={palette.gray[50]} size={20} />
+            </IconButton>
+            <IconButton onPress={onSearch} accessibilityLabel="Search">
+              <SearchIcon color={palette.gray[50]} size={22} />
+            </IconButton>
+          </>
+        ) : activeTab === 'tags' ? (
+          <>
+            <IconButton onPress={onCreateTag} accessibilityLabel="Create tag">
+              <PlusIcon color={palette.gray[50]} size={20} />
+            </IconButton>
+            <IconButton onPress={onSearch} accessibilityLabel="Search">
+              <SearchIcon color={palette.gray[50]} size={22} />
+            </IconButton>
+          </>
+        ) : (
+          <>
+            <IconButton
+              onPress={() => openSheet('addFile')}
+              accessibilityLabel="Add files"
+            >
+              <FilePlusIcon color={palette.gray[50]} size={20} />
+            </IconButton>
+            <IconButton onPress={onSearch} accessibilityLabel="Search">
+              <SearchIcon color={palette.gray[50]} size={22} />
+            </IconButton>
+          </>
+        )}
       </FloatingPill>
     </BottomControlBar>
   )
@@ -24,8 +147,37 @@ const styles = StyleSheet.create({
   bar: {
     width: '90%',
     maxWidth: 600,
-    justifyContent: 'flex-end',
+    justifyContent: 'space-between',
     alignItems: 'center',
+  },
+  segmentedControl: {
+    height: 56,
+    borderRadius: 26,
+    backgroundColor: overlay.panelStrong,
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: INSET,
+    shadowColor: palette.gray[950],
+    shadowOffset: { width: 0, height: 10 },
+    shadowOpacity: 0.35,
+    shadowRadius: 28,
+    borderColor: whiteA.a08,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  indicator: {
+    position: 'absolute',
+    top: INSET,
+    bottom: INSET,
+    left: INSET,
+    borderRadius: 22,
+    backgroundColor: whiteA.a10,
+  },
+  segment: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 64,
+    height: '100%',
+    zIndex: 1,
   },
   actions: {
     gap: 2,

--- a/src/screens/LibraryScreen.tsx
+++ b/src/screens/LibraryScreen.tsx
@@ -9,6 +9,9 @@ import {
   View,
 } from 'react-native'
 import { AddFileActionSheet } from '../components/AddFileActionSheet'
+import { CreateDirectorySheet } from '../components/CreateDirectorySheet'
+import { CreateTagSheet } from '../components/CreateTagSheet'
+import { DirectoriesGrid } from '../components/DirectoriesGrid'
 import { DragToDismiss } from '../components/DragToDismiss'
 import { FileActionsSheet } from '../components/FileActionsSheet'
 import { FileCarousel } from '../components/FileCarousel'
@@ -22,7 +25,9 @@ import { LibraryTabBar } from '../components/LibraryTabBar'
 import { ManageTagsSheet } from '../components/ManageTagsSheet'
 import { MoveToDirectorySheet } from '../components/MoveToDirectorySheet'
 import { SelectionBar } from '../components/SelectionBar'
+import { TagsGrid } from '../components/TagsGrid'
 import type { MainStackParamList } from '../stacks/types'
+import { useAllDirectories } from '../stores/directories'
 import {
   enterSelectionMode,
   exitSelectionMode,
@@ -37,9 +42,16 @@ import {
   type FileListParams,
   useFileList,
   useLibraryCount,
+  useMediaCount,
 } from '../stores/library'
+import {
+  type ActiveLibraryTab,
+  setActiveLibraryTab,
+  useActiveLibraryTab,
+} from '../stores/settings'
 import { openSheet } from '../stores/sheets'
 import { useIsSyncingDown } from '../stores/syncDown'
+import { useAllTags } from '../stores/tags'
 import { useViewSettings } from '../stores/viewSettings'
 import { colors, overlay, palette, whiteA } from '../styles/colors'
 
@@ -59,6 +71,12 @@ export function LibraryScreen({ route, navigation }: Props) {
   )
   const files = useFileList(filters)
   const fileCount = useLibraryCount()
+  const mediaCount = useMediaCount()
+  const activeTabSetting = useActiveLibraryTab()
+  const activeTab: ActiveLibraryTab = activeTabSetting.data ?? 'files'
+  const handleChangeTab = useCallback((tab: ActiveLibraryTab) => {
+    void setActiveLibraryTab(tab)
+  }, [])
   const [selectedFile, setSelectedFile] = useState<FileRecord | null>(() => {
     const openFileId = route.params?.openFileId
     if (!openFileId) return null
@@ -103,20 +121,44 @@ export function LibraryScreen({ route, navigation }: Props) {
     openSheet('fileActions')
   }, [])
 
-  const handleShowTagSheet = useCallback(() => {
-    openSheet('manageFileTags')
-  }, [])
-
-  const handleMoveToDirectory = useCallback(() => {
-    openSheet('moveToDirectory')
-  }, [])
-
   const handleOpenSelectionActions = useCallback(() => {
     openSheet('fileActions')
   }, [])
 
   const handleBulkActionComplete = useCallback(() => {
     exitSelectionMode()
+  }, [])
+
+  const handleSelectDirectory = useCallback(
+    (directoryId: string, directoryName: string) => {
+      navigation.navigate('DirectoryScreen', { directoryId, directoryName })
+    },
+    [navigation],
+  )
+
+  const handleCreateDirectory = useCallback(() => {
+    openSheet('createDirectory')
+  }, [])
+
+  const handleDirectoryCreated = useCallback(
+    (directoryId: string, directoryName: string) => {
+      navigation.navigate('DirectoryScreen', { directoryId, directoryName })
+    },
+    [navigation],
+  )
+
+  const allDirectories = useAllDirectories()
+  const allTags = useAllTags()
+
+  const handleSelectTag = useCallback(
+    (tagId: string, tagName: string) => {
+      navigation.navigate('TagLibrary', { tagId, tagName })
+    },
+    [navigation],
+  )
+
+  const handleCreateTag = useCallback(() => {
+    openSheet('createTag')
   }, [])
 
   useEffect(() => {
@@ -161,6 +203,8 @@ export function LibraryScreen({ route, navigation }: Props) {
   const categorySet = new Set(vs.selectedCategories)
 
   const title = (() => {
+    if (activeTab === 'files') return 'Files'
+    if (activeTab === 'tags') return 'Tags'
     const n = categorySet.size
     if (n === 1) {
       const only = Array.from(categorySet)[0] as Category
@@ -174,19 +218,27 @@ export function LibraryScreen({ route, navigation }: Props) {
         case 'Files':
           return 'Files'
         default:
-          return 'Library'
+          return 'Media'
       }
     }
-    return 'Library'
+    return 'Media'
   })()
 
   const subtitle = (() => {
+    if (activeTab === 'files') {
+      const dirCount = allDirectories.data?.length ?? 0
+      return `${dirCount.toLocaleString()} ${dirCount === 1 ? 'folder' : 'folders'}`
+    }
+    if (activeTab === 'tags') {
+      const tagCount = allTags.data?.filter((t) => !t.system).length ?? 0
+      return `${tagCount.toLocaleString()} ${tagCount === 1 ? 'tag' : 'tags'}`
+    }
     if (categorySet.size > 0) {
       const filtered = files.data?.length ?? 0
       return `${filtered.toLocaleString()} results`
     }
-    const total = fileCount.data ?? 0
-    return `${total.toLocaleString()} ${total === 1 ? 'item' : 'items'}`
+    const media = mediaCount.data ?? 0
+    return `${media.toLocaleString()} ${media === 1 ? 'image & video' : 'images & videos'}`
   })()
 
   return (
@@ -200,15 +252,22 @@ export function LibraryScreen({ route, navigation }: Props) {
       <LibraryHeader
         title={title}
         subtitle={subtitle}
+        showViewSettings={activeTab === 'media'}
         scope="library"
-        isSelectionMode={isSelectionMode}
+        isSelectionMode={activeTab === 'media' ? isSelectionMode : undefined}
         selectedCount={selectedCount}
-        onEnterSelection={enterSelectionMode}
+        onEnterSelection={
+          activeTab === 'media' ? enterSelectionMode : undefined
+        }
         onExitSelection={exitSelectionMode}
         onOpenSelectionActions={handleOpenSelectionActions}
         onNavigateMenu={() => navigation.navigate('MenuTab' as never)}
       />
-      {files.isLoading ? (
+      {activeTab === 'files' ? (
+        <DirectoriesGrid onSelectDirectory={handleSelectDirectory} />
+      ) : activeTab === 'tags' ? (
+        <TagsGrid onSelectTag={handleSelectTag} />
+      ) : files.isLoading ? (
         <View style={styles.emptyWrap}>
           <ActivityIndicator color={palette.blue[400]} />
         </View>
@@ -261,11 +320,19 @@ export function LibraryScreen({ route, navigation }: Props) {
         </View>
       )}
       <AddFileActionSheet />
+      <CreateDirectorySheet onCreated={handleDirectoryCreated} />
+      <CreateTagSheet />
       <LibraryStatusSheet />
       {isSelectionMode ? (
         <SelectionBar onOpenSelectionActions={handleOpenSelectionActions} />
       ) : (
-        <LibraryTabBar />
+        <LibraryTabBar
+          activeTab={activeTab}
+          onChangeTab={handleChangeTab}
+          onSearch={() => navigation.navigate('Search')}
+          onCreateDirectory={handleCreateDirectory}
+          onCreateTag={handleCreateTag}
+        />
       )}
       {selectedFile ? (
         <Animated.View
@@ -302,8 +369,8 @@ export function LibraryScreen({ route, navigation }: Props) {
                 setIsCarouselDetail(false)
               }}
               onShowActionSheet={handleShowCarouselActions}
-              onShowTagSheet={handleShowTagSheet}
-              onMoveToDirectory={handleMoveToDirectory}
+              onShowTagSheet={() => openSheet('manageFileTags')}
+              onMoveToDirectory={() => openSheet('moveToDirectory')}
               onZoomChange={setIsCarouselZoomed}
               onViewStyleChange={(s) => setIsCarouselDetail(s === 'detail')}
               isDismissing={isDraggingToDismiss}

--- a/src/screens/SearchScreen.tsx
+++ b/src/screens/SearchScreen.tsx
@@ -96,7 +96,13 @@ export function SearchScreen({ navigation }: Props) {
       Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide'
 
     const handleShow = (e: KeyboardEvent) => {
-      setKeyboardOffset(e.endCoordinates?.height ?? 0)
+      const height = e.endCoordinates?.height ?? 0
+      // On Android with edge-to-edge, the reported keyboard height may
+      // not include the IME toolbar (clipboard, voice, etc.) above the
+      // keyboard. Add the bottom inset to compensate.
+      setKeyboardOffset(
+        Platform.OS === 'android' ? height + insets.bottom : height,
+      )
     }
     const handleHide = () => {
       setKeyboardOffset(0)
@@ -109,7 +115,7 @@ export function SearchScreen({ navigation }: Props) {
       showSub.remove()
       hideSub.remove()
     }
-  }, [])
+  }, [insets.bottom])
 
   useEffect(() => {
     if (selectedFile) {

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -109,3 +109,17 @@ export async function setPhotoImportDirectory(value: string) {
   await setAsyncStorageString('photoImportDirectory', value)
   await photoImportDirectoryCache.set(value)
 }
+
+// Active library tab
+
+export type ActiveLibraryTab = 'files' | 'tags' | 'media'
+
+export const [getActiveLibraryTab, useActiveLibraryTab, activeLibraryTabCache] =
+  createGetterAndSWRHook<ActiveLibraryTab>(() =>
+    getAsyncStorageString<ActiveLibraryTab>('activeLibraryTab', 'files'),
+  )
+
+export async function setActiveLibraryTab(value: ActiveLibraryTab) {
+  await setAsyncStorageString<ActiveLibraryTab>('activeLibraryTab', value)
+  await activeLibraryTabCache.set(value)
+}


### PR DESCRIPTION
Replaces the single-view library with a three-tab layout that separates file browsing, tag management, and media into distinct views, each with tab-specific actions.

- Animated segmented tab bar with spring-driven indicator
- Files tab: directories grid + file list, with quick actions for creating directories and searching
- Tags tab: tags grid with create-tag shortcut
- Media tab: gallery-only view of photos and videos, with add-file shortcut
- Tab selection persists across app restarts
- Tab-specific action buttons in the floating control bar (create directory, create tag, add files, search)

![Screenshot 2026-02-20 at 13.30.56.png](https://app.graphite.com/user-attachments/assets/8260c0e3-0ac5-4361-8c73-fd52df18dd2a.png)

