### PR TITLE
feat: scope file carousel to the opening screen's context

### DIFF
--- a/src/components/FileCarousel/index.tsx
+++ b/src/components/FileCarousel/index.tsx
@@ -35,6 +35,9 @@ type Props = {
   sortBy?: SortBy
   sortDir?: SortDir
   categories?: Category[]
+  directoryId?: string
+  tags?: string[]
+  query?: string
   onClose: () => void
   onShowActionSheet?: () => void
   onShowTagSheet?: () => void
@@ -50,6 +53,9 @@ export function FileCarousel({
   sortBy,
   sortDir,
   categories,
+  directoryId,
+  tags,
+  query,
   onClose,
   onShowActionSheet,
   onShowTagSheet,
@@ -95,6 +101,9 @@ export function FileCarousel({
     sortBy,
     sortDir,
     categories,
+    directoryId,
+    tags,
+    query,
     prefetchRadius: 3,
     maxCacheSize: 50,
     onDeleted: handleFileDeleted,

--- a/src/screens/DirectoryScreen.tsx
+++ b/src/screens/DirectoryScreen.tsx
@@ -341,6 +341,7 @@ export function DirectoryScreen({ route, navigation }: Props) {
               sortBy={vs.sortBy}
               sortDir={vs.sortDir}
               categories={vs.selectedCategories}
+              directoryId={directoryId}
               onClose={handleCloseCarousel}
               onShowActionSheet={() => openSheet('directoryFileActions')}
               onShowTagSheet={() => openSheet('directoryManageTags')}

--- a/src/screens/SearchScreen.tsx
+++ b/src/screens/SearchScreen.tsx
@@ -378,6 +378,8 @@ export function SearchScreen({ navigation }: Props) {
               sortBy={vs.sortBy}
               sortDir={vs.sortDir}
               categories={vs.selectedCategories}
+              query={debounced}
+              tags={Array.from(selectedTags)}
               onClose={handleCloseCarousel}
               onShowActionSheet={() => openSheet('searchFileActions')}
               onShowTagSheet={() => openSheet('searchManageTags')}

--- a/src/screens/TagLibraryScreen.tsx
+++ b/src/screens/TagLibraryScreen.tsx
@@ -334,6 +334,7 @@ export function TagLibraryScreen({ route, navigation }: Props) {
               sortBy={vs.sortBy}
               sortDir={vs.sortDir}
               categories={vs.selectedCategories}
+              tags={[tagId]}
               onClose={handleCloseCarousel}
               onShowActionSheet={() => openSheet('tagLibraryFileActions')}
               onShowTagSheet={() => openSheet('tagLibraryManageTags')}

--- a/src/stores/fileCarousel.ts
+++ b/src/stores/fileCarousel.ts
@@ -91,6 +91,9 @@ type VirtualListQueryParams = {
   sortBy: SortBy
   sortDir: SortDir
   categories: Category[]
+  directoryId?: string
+  tags?: string[]
+  query?: string
 }
 
 function buildOrderExpr(sortBy: SortBy, sortDir: SortDir, alias: string = 'f') {
@@ -107,6 +110,9 @@ export async function fetchTotalCount(
     sortBy: params.sortBy,
     sortDir: params.sortDir,
     categories: params.categories,
+    directoryId: params.directoryId,
+    tags: params.tags,
+    query: params.query,
     tableAlias: 'f',
   })
 
@@ -128,6 +134,9 @@ export async function fetchFilePosition(
     sortBy: params.sortBy,
     sortDir: params.sortDir,
     categories: params.categories,
+    directoryId: params.directoryId,
+    tags: params.tags,
+    query: params.query,
     tableAlias: 'f',
   })
 
@@ -182,6 +191,9 @@ export async function fetchSortedFileIds(
     sortBy: params.sortBy,
     sortDir: params.sortDir,
     categories: params.categories,
+    directoryId: params.directoryId,
+    tags: params.tags,
+    query: params.query,
     tableAlias: 'f',
   })
 
@@ -219,6 +231,9 @@ type UseFileCarouselParams = {
   sortBy?: SortBy
   sortDir?: SortDir
   categories?: Category[]
+  directoryId?: string
+  tags?: string[]
+  query?: string
   prefetchRadius?: number
   maxCacheSize?: number
   onDeleted?: () => void
@@ -267,6 +282,9 @@ export function useFileCarousel({
   sortBy: sortByParam = 'DATE',
   sortDir: sortDirParam,
   categories: categoriesParam = [],
+  directoryId,
+  tags,
+  query,
   prefetchRadius = 3,
   maxCacheSize = 50,
   onDeleted,
@@ -298,13 +316,21 @@ export function useFileCarousel({
     [categoriesParam],
   )
 
+  const tagsKey = useMemo(
+    () => (tags ? tags.slice().sort().join(',') : ''),
+    [tags],
+  )
+
   const queryParams = useMemo<VirtualListQueryParams>(
     () => ({
       sortBy,
       sortDir: sortingDir,
       categories: categoriesKey ? (categoriesKey.split(',') as Category[]) : [],
+      directoryId,
+      tags: tagsKey ? tagsKey.split(',') : undefined,
+      query,
     }),
-    [sortBy, sortingDir, categoriesKey],
+    [sortBy, sortingDir, categoriesKey, directoryId, tagsKey, query],
   )
 
   const populateCaches = useCallback(


### PR DESCRIPTION
Pass directoryId, tags, and query filters from each screen to the FileCarousel so swiping prev/next stays within the originating context instead of traversing the entire library.