### PR TITLE
feat: add directory picker sheet for photo import setting

### DIFF
--- a/src/components/SelectDirectorySheet.tsx
+++ b/src/components/SelectDirectorySheet.tsx
@@ -1,0 +1,247 @@
+import { CheckIcon, FolderIcon, PlusIcon, XIcon } from 'lucide-react-native'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  FlatList,
+  Keyboard,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native'
+import { createDirectory, useAllDirectories } from '../stores/directories'
+import { closeSheet, useSheetOpen } from '../stores/sheets'
+import { palette, whiteA } from '../styles/colors'
+import { ModalSheet } from './ModalSheet'
+
+type Props = {
+  sheetName?: string
+  currentValue: string
+  onSelect: (name: string) => void
+  onClear: () => void
+}
+
+export function SelectDirectorySheet({
+  sheetName = 'selectDirectory',
+  currentValue,
+  onSelect,
+  onClear,
+}: Props) {
+  const isOpen = useSheetOpen(sheetName)
+  const allDirs = useAllDirectories()
+  const [query, setQuery] = useState('')
+  const inputRef = useRef<TextInput | null>(null)
+
+  const dirs = allDirs.data ?? []
+  const filtered = query.trim()
+    ? dirs.filter((d) =>
+        d.name.toLowerCase().includes(query.trim().toLowerCase()),
+      )
+    : dirs
+
+  const exactMatch =
+    query.trim().length > 0 &&
+    dirs.some((d) => d.name.toLowerCase() === query.trim().toLowerCase())
+
+  useEffect(() => {
+    if (isOpen) {
+      setTimeout(() => inputRef.current?.focus(), 400)
+    } else {
+      setQuery('')
+    }
+  }, [isOpen])
+
+  const handleSelect = useCallback(
+    (name: string) => {
+      onSelect(name)
+      Keyboard.dismiss()
+      closeSheet()
+    },
+    [onSelect],
+  )
+
+  const handleClear = useCallback(() => {
+    onClear()
+    Keyboard.dismiss()
+    closeSheet()
+  }, [onClear])
+
+  const handleCreateAndSelect = useCallback(
+    async (name: string) => {
+      const trimmed = name.trim()
+      if (!trimmed) return
+      try {
+        const dir = await createDirectory(trimmed)
+        handleSelect(dir.name)
+      } catch {
+        const existing = dirs.find(
+          (d) => d.name.toLowerCase() === trimmed.toLowerCase(),
+        )
+        if (existing) {
+          handleSelect(existing.name)
+        }
+      }
+    },
+    [dirs, handleSelect],
+  )
+
+  const handleClose = useCallback(() => {
+    setQuery('')
+    Keyboard.dismiss()
+    closeSheet()
+  }, [])
+
+  return (
+    <ModalSheet
+      visible={isOpen}
+      onRequestClose={handleClose}
+      title="Import directory"
+      headerRight={
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Cancel"
+          onPress={handleClose}
+          hitSlop={8}
+        >
+          <Text style={styles.cancelText}>Cancel</Text>
+        </Pressable>
+      }
+    >
+      <View style={styles.inputRow}>
+        <TextInput
+          ref={inputRef}
+          style={styles.input}
+          placeholder="Search or create directory..."
+          placeholderTextColor={palette.gray[500]}
+          value={query}
+          onChangeText={setQuery}
+          autoCapitalize="none"
+          autoCorrect={false}
+          returnKeyType="done"
+          onSubmitEditing={() => {
+            if (query.trim()) handleCreateAndSelect(query.trim())
+          }}
+        />
+      </View>
+      <FlatList
+        data={filtered}
+        keyExtractor={(item) => item.id}
+        keyboardShouldPersistTaps="handled"
+        keyboardDismissMode="on-drag"
+        contentContainerStyle={styles.listContent}
+        ListHeaderComponent={
+          <>
+            <Pressable style={styles.dirRow} onPress={handleClear}>
+              <View style={styles.dirRowLeft}>
+                <XIcon size={18} color={palette.gray[400]} />
+                <Text style={styles.removeText}>No directory</Text>
+              </View>
+              {currentValue === '' && (
+                <CheckIcon size={18} color={palette.blue[400]} />
+              )}
+            </Pressable>
+            {query.trim().length > 0 && !exactMatch ? (
+              <Pressable
+                style={styles.dirRow}
+                onPress={() => handleCreateAndSelect(query.trim())}
+              >
+                <View style={styles.dirRowLeft}>
+                  <PlusIcon size={16} color={palette.blue[400]} />
+                  <Text style={styles.createText}>Create "{query.trim()}"</Text>
+                </View>
+              </Pressable>
+            ) : null}
+          </>
+        }
+        renderItem={({ item }) => (
+          <Pressable
+            style={styles.dirRow}
+            onPress={() => handleSelect(item.name)}
+          >
+            <View style={styles.dirRowLeft}>
+              <FolderIcon size={18} color={palette.blue[400]} />
+              <Text style={styles.dirName}>{item.name}</Text>
+              <Text style={styles.dirCount}>{item.fileCount}</Text>
+            </View>
+            {item.name.toLowerCase() === currentValue.toLowerCase() && (
+              <CheckIcon size={18} color={palette.blue[400]} />
+            )}
+          </Pressable>
+        )}
+        ListEmptyComponent={
+          query.trim().length === 0 ? (
+            <Text style={styles.emptyText}>
+              No directories yet. Type to create one.
+            </Text>
+          ) : null
+        }
+      />
+    </ModalSheet>
+  )
+}
+
+const styles = StyleSheet.create({
+  cancelText: {
+    color: palette.blue[400],
+    fontSize: 17,
+    fontWeight: '600',
+  },
+  inputRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: whiteA.a10,
+  },
+  input: {
+    flex: 1,
+    minWidth: 120,
+    color: palette.gray[50],
+    fontSize: 16,
+    paddingVertical: 4,
+  },
+  listContent: {
+    paddingBottom: 40,
+  },
+  dirRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: whiteA.a08,
+  },
+  dirRowLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    flex: 1,
+  },
+  dirName: {
+    color: palette.gray[50],
+    fontSize: 16,
+  },
+  dirCount: {
+    color: whiteA.a50,
+    fontSize: 14,
+  },
+  removeText: {
+    color: palette.gray[400],
+    fontSize: 16,
+  },
+  createText: {
+    color: palette.blue[400],
+    fontSize: 16,
+    fontWeight: '500',
+  },
+  emptyText: {
+    color: whiteA.a50,
+    fontSize: 15,
+    textAlign: 'center',
+    paddingTop: 40,
+  },
+})

--- a/src/components/SettingsSyncPhotos.tsx
+++ b/src/components/SettingsSyncPhotos.tsx
@@ -1,12 +1,5 @@
 import { useCallback } from 'react'
-import {
-  Alert,
-  Linking,
-  Pressable,
-  StyleSheet,
-  Switch,
-  Text,
-} from 'react-native'
+import { Linking, Pressable, StyleSheet, Switch, Text } from 'react-native'
 import { SYNC_ARCHIVE_RESUME_THRESHOLD } from '../config'
 import { humanSize } from '../lib/humanSize'
 import { useMediaLibraryPermissions } from '../lib/mediaLibraryPermissions'
@@ -25,11 +18,13 @@ import {
   setPhotoImportDirectory,
   usePhotoImportDirectory,
 } from '../stores/settings'
+import { openSheet } from '../stores/sheets'
 import { colors } from '../styles/colors'
 import { Button } from './Button'
 import { RowGroup } from './Group'
 import { InfoCard } from './InfoCard'
 import { LabeledValueRow } from './LabeledValueRow'
+import { SelectDirectorySheet } from './SelectDirectorySheet'
 
 export function SettingsSyncPhotos() {
   const autoSyncNew = useAutoSyncNewPhotos()
@@ -46,23 +41,17 @@ export function SettingsSyncPhotos() {
   const syncPhotosArchiveControlsDisabled =
     isPhotosAccessDisabled || !autoSyncPhotosArchive.data
 
-  const handleSetPhotoImportDir = useCallback(() => {
-    Alert.prompt(
-      'Photo import directory',
-      'Imported photos and videos will be placed in this directory. Leave empty to disable.',
-      [
-        { text: 'Cancel', style: 'cancel' },
-        {
-          text: 'Save',
-          onPress: (value: string | undefined) => {
-            void setPhotoImportDirectory(value?.trim() ?? '')
-          },
-        },
-      ],
-      'plain-text',
-      photoImportDir.data ?? '',
-    )
-  }, [photoImportDir.data])
+  const handleOpenDirectoryPicker = useCallback(() => {
+    openSheet('selectPhotoImportDirectory')
+  }, [])
+
+  const handleSelectDirectory = useCallback((name: string) => {
+    void setPhotoImportDirectory(name)
+  }, [])
+
+  const handleClearDirectory = useCallback(() => {
+    void setPhotoImportDirectory('')
+  }, [])
 
   return (
     <RowGroup
@@ -80,7 +69,7 @@ export function SettingsSyncPhotos() {
       }
     >
       <InfoCard>
-        <Pressable onPress={handleSetPhotoImportDir}>
+        <Pressable onPress={handleOpenDirectoryPicker}>
           <LabeledValueRow
             label="Import directory"
             labelWidth={250}
@@ -89,6 +78,12 @@ export function SettingsSyncPhotos() {
           />
         </Pressable>
       </InfoCard>
+      <SelectDirectorySheet
+        sheetName="selectPhotoImportDirectory"
+        currentValue={photoImportDir.data ?? ''}
+        onSelect={handleSelectDirectory}
+        onClear={handleClearDirectory}
+      />
       <InfoCard style={{ marginTop: 10 }}>
         <LabeledValueRow
           label="Import new photos"

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -102,7 +102,7 @@ export const [
   usePhotoImportDirectory,
   photoImportDirectoryCache,
 ] = createGetterAndSWRHook<string>(() =>
-  getAsyncStorageString<string>('photoImportDirectory', ''),
+  getAsyncStorageString<string>('photoImportDirectory', 'Media'),
 )
 
 export async function setPhotoImportDirectory(value: string) {


### PR DESCRIPTION
- Replace Alert.prompt with a searchable directory picker sheet for the photo import directory setting.
- Default the import directory to "Media" instead of empty.
- The picker reuses the same UI pattern as MoveToDirectorySheet with existing directory list, inline create, and a "No directory" option to disable.