### PR TITLE
feat: batch DB calls and add loading spinners for bulk operations

### DIFF
--- a/src/components/BulkManageTagsSheet.tsx
+++ b/src/components/BulkManageTagsSheet.tsx
@@ -11,9 +11,10 @@ import {
 } from 'react-native'
 import { useSelectedFileIds } from '../stores/fileSelection'
 import { closeSheet, useSheetOpen } from '../stores/sheets'
-import { addTagToFile, useAllTags } from '../stores/tags'
+import { addTagToFiles, useAllTags } from '../stores/tags'
 import { palette, whiteA } from '../styles/colors'
 import { ModalSheet } from './ModalSheet'
+import { SpinnerIcon } from './SpinnerIcon'
 
 export function BulkManageTagsSheet() {
   const isOpen = useSheetOpen('bulkManageTags')
@@ -22,6 +23,7 @@ export function BulkManageTagsSheet() {
   const [query, setQuery] = useState('')
   const inputRef = useRef<TextInput | null>(null)
   const [addedTagIds, setAddedTagIds] = useState<Set<string>>(new Set())
+  const [loadingTagNames, setLoadingTagNames] = useState<Set<string>>(new Set())
 
   const allTagList = (allTags.data ?? []).filter((t) => !t.system)
 
@@ -41,23 +43,30 @@ export function BulkManageTagsSheet() {
     } else {
       setQuery('')
       setAddedTagIds(new Set())
+      setLoadingTagNames(new Set())
     }
   }, [isOpen])
 
   const handleAddTag = useCallback(
     async (tagName: string) => {
-      if (!tagName.trim()) return
-      const fileIds = Array.from(selectedFileIds)
-      for (const fileId of fileIds) {
-        await addTagToFile(fileId, tagName.trim())
+      const trimmed = tagName.trim()
+      if (!trimmed) return
+      const key = trimmed.toLowerCase()
+      setLoadingTagNames((prev) => new Set([...prev, key]))
+      try {
+        await addTagToFiles(Array.from(selectedFileIds), trimmed)
+        const tag = allTagList.find((t) => t.name.toLowerCase() === key)
+        if (tag) {
+          setAddedTagIds((prev) => new Set([...prev, tag.id]))
+        }
+        setQuery('')
+      } finally {
+        setLoadingTagNames((prev) => {
+          const next = new Set(prev)
+          next.delete(key)
+          return next
+        })
       }
-      const tag = allTagList.find(
-        (t) => t.name.toLowerCase() === tagName.trim().toLowerCase(),
-      )
-      if (tag) {
-        setAddedTagIds((prev) => new Set([...prev, tag.id]))
-      }
-      setQuery('')
     },
     [selectedFileIds, allTagList],
   )
@@ -99,29 +108,47 @@ export function BulkManageTagsSheet() {
         keyboardDismissMode="on-drag"
         contentContainerStyle={styles.listContent}
         ListHeaderComponent={
-          query.trim().length > 0 && !exactMatch ? (
-            <Pressable
-              style={styles.tagRow}
-              onPress={() => handleAddTag(query.trim())}
-            >
-              <View style={styles.tagRowLeft}>
-                <PlusIcon size={16} color={palette.blue[400]} />
-                <Text style={styles.createText}>Create "{query.trim()}"</Text>
-              </View>
-            </Pressable>
-          ) : null
+          query.trim().length > 0 && !exactMatch
+            ? (() => {
+                const isCreating = loadingTagNames.has(
+                  query.trim().toLowerCase(),
+                )
+                return (
+                  <Pressable
+                    style={styles.tagRow}
+                    onPress={() => handleAddTag(query.trim())}
+                    disabled={isCreating}
+                  >
+                    <View style={styles.tagRowLeft}>
+                      {isCreating ? (
+                        <SpinnerIcon size={16} color={palette.blue[400]} />
+                      ) : (
+                        <PlusIcon size={16} color={palette.blue[400]} />
+                      )}
+                      <Text style={styles.createText}>
+                        Create "{query.trim()}"
+                      </Text>
+                    </View>
+                  </Pressable>
+                )
+              })()
+            : null
         }
         renderItem={({ item }) => {
+          const isLoading = loadingTagNames.has(item.name.toLowerCase())
           const justAdded = addedTagIds.has(item.id)
           return (
             <Pressable
               style={styles.tagRow}
               onPress={() => handleAddTag(item.name)}
+              disabled={isLoading}
             >
               <View style={styles.tagRowLeft}>
                 <Text style={styles.tagName}>{item.name}</Text>
               </View>
-              {justAdded ? (
+              {isLoading ? (
+                <SpinnerIcon size={18} color={palette.blue[400]} />
+              ) : justAdded ? (
                 <CheckIcon size={18} color={palette.blue[400]} />
               ) : null}
             </Pressable>

--- a/src/components/ManageTagsSheet.tsx
+++ b/src/components/ManageTagsSheet.tsx
@@ -18,6 +18,7 @@ import {
 } from '../stores/tags'
 import { palette, whiteA } from '../styles/colors'
 import { ModalSheet } from './ModalSheet'
+import { SpinnerIcon } from './SpinnerIcon'
 import { TagPill } from './TagPill'
 
 type Props = {
@@ -31,6 +32,8 @@ export function ManageTagsSheet({ fileId, sheetName }: Props) {
   const allTags = useAllTags()
   const [query, setQuery] = useState('')
   const inputRef = useRef<TextInput | null>(null)
+  const [loadingTagIds, setLoadingTagIds] = useState<Set<string>>(new Set())
+  const [loadingTagNames, setLoadingTagNames] = useState<Set<string>>(new Set())
 
   const existingTagIds = new Set((fileTags.data ?? []).map((t) => t.id))
   const userFileTags = (fileTags.data ?? []).filter((t) => !t.system)
@@ -51,21 +54,43 @@ export function ManageTagsSheet({ fileId, sheetName }: Props) {
       setTimeout(() => inputRef.current?.focus(), 400)
     } else {
       setQuery('')
+      setLoadingTagIds(new Set())
+      setLoadingTagNames(new Set())
     }
   }, [isOpen])
 
   const handleAddTag = useCallback(
     async (tagName: string) => {
-      if (!tagName.trim()) return
-      await addTagToFile(fileId, tagName.trim())
-      setQuery('')
+      const trimmed = tagName.trim()
+      if (!trimmed) return
+      const key = trimmed.toLowerCase()
+      setLoadingTagNames((prev) => new Set([...prev, key]))
+      try {
+        await addTagToFile(fileId, trimmed)
+        setQuery('')
+      } finally {
+        setLoadingTagNames((prev) => {
+          const next = new Set(prev)
+          next.delete(key)
+          return next
+        })
+      }
     },
     [fileId],
   )
 
   const handleRemoveTag = useCallback(
     async (tagId: string) => {
-      await removeTagFromFile(fileId, tagId)
+      setLoadingTagIds((prev) => new Set([...prev, tagId]))
+      try {
+        await removeTagFromFile(fileId, tagId)
+      } finally {
+        setLoadingTagIds((prev) => {
+          const next = new Set(prev)
+          next.delete(tagId)
+          return next
+        })
+      }
     },
     [fileId],
   )
@@ -122,24 +147,42 @@ export function ManageTagsSheet({ fileId, sheetName }: Props) {
         keyboardDismissMode="on-drag"
         contentContainerStyle={styles.listContent}
         ListHeaderComponent={
-          query.trim().length > 0 && !exactMatch ? (
-            <Pressable
-              style={styles.tagRow}
-              onPress={() => handleAddTag(query.trim())}
-            >
-              <View style={styles.tagRowLeft}>
-                <PlusIcon size={16} color={palette.blue[400]} />
-                <Text style={styles.createText}>Create "{query.trim()}"</Text>
-              </View>
-            </Pressable>
-          ) : null
+          query.trim().length > 0 && !exactMatch
+            ? (() => {
+                const isCreating = loadingTagNames.has(
+                  query.trim().toLowerCase(),
+                )
+                return (
+                  <Pressable
+                    style={styles.tagRow}
+                    onPress={() => handleAddTag(query.trim())}
+                    disabled={isCreating}
+                  >
+                    <View style={styles.tagRowLeft}>
+                      {isCreating ? (
+                        <SpinnerIcon size={16} color={palette.blue[400]} />
+                      ) : (
+                        <PlusIcon size={16} color={palette.blue[400]} />
+                      )}
+                      <Text style={styles.createText}>
+                        Create "{query.trim()}"
+                      </Text>
+                    </View>
+                  </Pressable>
+                )
+              })()
+            : null
         }
         renderItem={({ item }) => {
           const isOnFile = existingTagIds.has(item.id)
+          const isLoading =
+            loadingTagIds.has(item.id) ||
+            loadingTagNames.has(item.name.toLowerCase())
           return (
             <Pressable
               style={styles.tagRow}
               onPress={() => handleToggleTag(item)}
+              disabled={isLoading}
             >
               <View style={styles.tagRowLeft}>
                 <Text style={styles.tagName}>{item.name}</Text>
@@ -149,7 +192,9 @@ export function ManageTagsSheet({ fileId, sheetName }: Props) {
                   </Text>
                 ) : null}
               </View>
-              {isOnFile ? (
+              {isLoading ? (
+                <SpinnerIcon size={18} color={palette.blue[400]} />
+              ) : isOnFile ? (
                 <CheckIcon size={18} color={palette.blue[400]} />
               ) : null}
             </Pressable>

--- a/src/components/MoveToDirectorySheet.tsx
+++ b/src/components/MoveToDirectorySheet.tsx
@@ -20,6 +20,7 @@ import {
 import { closeSheet, useSheetOpen } from '../stores/sheets'
 import { palette, whiteA } from '../styles/colors'
 import { ModalSheet } from './ModalSheet'
+import { SpinnerIcon } from './SpinnerIcon'
 
 type Props = {
   fileIds: string[]
@@ -36,6 +37,7 @@ export function MoveToDirectorySheet({
   const inputRef = useRef<TextInput | null>(null)
   const [currentDirName, setCurrentDirName] = useState<string | null>(null)
   const [filesInDirCount, setFilesInDirCount] = useState(0)
+  const [loadingDirId, setLoadingDirId] = useState<string | null>(null)
 
   const isSingleFile = fileIds.length === 1
   const dirs = allDirs.data ?? []
@@ -63,43 +65,59 @@ export function MoveToDirectorySheet({
       setQuery('')
       setCurrentDirName(null)
       setFilesInDirCount(0)
+      setLoadingDirId(null)
     }
   }, [isOpen, fileIds, isSingleFile])
 
   const handleMoveToDirectory = useCallback(
     async (directoryId: string) => {
-      if (fileIds.length === 1) {
-        await moveFileToDirectory(fileIds[0], directoryId)
-      } else if (fileIds.length > 1) {
-        await moveFilesToDirectory(fileIds, directoryId)
+      setLoadingDirId(directoryId)
+      try {
+        if (fileIds.length === 1) {
+          await moveFileToDirectory(fileIds[0], directoryId)
+        } else if (fileIds.length > 1) {
+          await moveFilesToDirectory(fileIds, directoryId)
+        }
+        closeSheet()
+      } finally {
+        setLoadingDirId(null)
       }
-      closeSheet()
     },
     [fileIds],
   )
 
   const handleRemoveFromDirectory = useCallback(async () => {
-    if (fileIds.length === 1) {
-      await moveFileToDirectory(fileIds[0], null)
-    } else if (fileIds.length > 1) {
-      await moveFilesToDirectory(fileIds, null)
+    setLoadingDirId('none')
+    try {
+      if (fileIds.length === 1) {
+        await moveFileToDirectory(fileIds[0], null)
+      } else if (fileIds.length > 1) {
+        await moveFilesToDirectory(fileIds, null)
+      }
+      closeSheet()
+    } finally {
+      setLoadingDirId(null)
     }
-    closeSheet()
   }, [fileIds])
 
   const handleCreateAndMove = useCallback(
     async (name: string) => {
       if (!name.trim()) return
+      setLoadingDirId('create')
       try {
-        const dir = await createDirectory(name.trim())
-        await handleMoveToDirectory(dir.id)
-      } catch {
-        const existing = dirs.find(
-          (d) => d.name.toLowerCase() === name.trim().toLowerCase(),
-        )
-        if (existing) {
-          await handleMoveToDirectory(existing.id)
+        try {
+          const dir = await createDirectory(name.trim())
+          await handleMoveToDirectory(dir.id)
+        } catch {
+          const existing = dirs.find(
+            (d) => d.name.toLowerCase() === name.trim().toLowerCase(),
+          )
+          if (existing) {
+            await handleMoveToDirectory(existing.id)
+          }
         }
+      } finally {
+        setLoadingDirId(null)
       }
     },
     [dirs, handleMoveToDirectory],
@@ -175,9 +193,14 @@ export function MoveToDirectorySheet({
             <Pressable
               style={styles.dirRow}
               onPress={handleRemoveFromDirectory}
+              disabled={loadingDirId !== null}
             >
               <View style={styles.dirRowLeft}>
-                <XIcon size={18} color={palette.gray[400]} />
+                {loadingDirId === 'none' ? (
+                  <SpinnerIcon size={18} color={palette.gray[400]} />
+                ) : (
+                  <XIcon size={18} color={palette.gray[400]} />
+                )}
                 <Text style={styles.removeText}>No directory</Text>
               </View>
             </Pressable>
@@ -185,9 +208,14 @@ export function MoveToDirectorySheet({
               <Pressable
                 style={styles.dirRow}
                 onPress={() => handleCreateAndMove(query.trim())}
+                disabled={loadingDirId !== null}
               >
                 <View style={styles.dirRowLeft}>
-                  <PlusIcon size={16} color={palette.blue[400]} />
+                  {loadingDirId === 'create' ? (
+                    <SpinnerIcon size={16} color={palette.blue[400]} />
+                  ) : (
+                    <PlusIcon size={16} color={palette.blue[400]} />
+                  )}
                   <Text style={styles.createText}>Create "{query.trim()}"</Text>
                 </View>
               </Pressable>
@@ -198,9 +226,14 @@ export function MoveToDirectorySheet({
           <Pressable
             style={styles.dirRow}
             onPress={() => handleMoveToDirectory(item.id)}
+            disabled={loadingDirId !== null}
           >
             <View style={styles.dirRowLeft}>
-              <FolderIcon size={18} color={palette.blue[400]} />
+              {loadingDirId === item.id ? (
+                <SpinnerIcon size={18} color={palette.blue[400]} />
+              ) : (
+                <FolderIcon size={18} color={palette.blue[400]} />
+              )}
               <Text style={styles.dirName}>{item.name}</Text>
               <Text style={styles.dirCount}>{item.fileCount}</Text>
             </View>

--- a/src/screens/TagLibraryScreen.tsx
+++ b/src/screens/TagLibraryScreen.tsx
@@ -49,7 +49,7 @@ import {
   useTagFileCount,
 } from '../stores/library'
 import { closeSheet, openSheet, useSheetOpen } from '../stores/sheets'
-import { addTagToFile, deleteTag } from '../stores/tags'
+import { addTagToFiles, deleteTag } from '../stores/tags'
 import { useViewSettings } from '../stores/viewSettings'
 import { colors, overlay, palette, whiteA } from '../styles/colors'
 
@@ -157,9 +157,10 @@ export function TagLibraryScreen({ route, navigation }: Props) {
 
   const handleFilesAdded = useCallback(
     (files: FileRecord[]) => {
-      for (const file of files) {
-        void addTagToFile(file.id, tagName)
-      }
+      void addTagToFiles(
+        files.map((f) => f.id),
+        tagName,
+      )
     },
     [tagName],
   )

--- a/src/stores/tags.test.ts
+++ b/src/stores/tags.test.ts
@@ -2,6 +2,7 @@ import { initializeDB, resetDb } from '../db'
 import { createFileRecord, readFileRecord } from './files'
 import {
   addTagToFile,
+  addTagToFiles,
   createTag,
   deleteTag,
   getOrCreateTag,
@@ -282,6 +283,65 @@ describe('tags store', () => {
 
       const after = await readFileRecord('file-1')
       expect(after!.updatedAt).toBeGreaterThan(1000)
+    })
+  })
+
+  describe('addTagToFiles', () => {
+    test('creates junction entries for all files', async () => {
+      await createTestFile('file-1')
+      await createTestFile('file-2')
+      await createTestFile('file-3')
+      await addTagToFiles(['file-1', 'file-2', 'file-3'], 'tag1')
+
+      for (const id of ['file-1', 'file-2', 'file-3']) {
+        const tags = userOnly(await readTagsForFile(id))
+        expect(tags).toHaveLength(1)
+        expect(tags[0].name).toBe('tag1')
+      }
+    })
+
+    test('creates new tag if name not found', async () => {
+      await createTestFile('file-1')
+      await addTagToFiles(['file-1'], 'brandNew')
+
+      const tags = userOnly(await readTagsForFile('file-1'))
+      expect(tags).toHaveLength(1)
+      expect(tags[0].name).toBe('brandNew')
+    })
+
+    test('ignores duplicate add (same file+tag)', async () => {
+      await createTestFile('file-1')
+      await addTagToFiles(['file-1', 'file-1'], 'tag1')
+
+      const tags = userOnly(await readTagsForFile('file-1'))
+      expect(tags).toHaveLength(1)
+    })
+
+    test('uses existing tag (case-insensitive)', async () => {
+      await createTestFile('file-1')
+      await createTestFile('file-2')
+      await addTagToFile('file-1', 'Work')
+      await addTagToFiles(['file-2'], 'work')
+
+      const allTags = userOnly(await readAllTagsWithCounts())
+      expect(allTags).toHaveLength(1)
+      expect(allTags[0].fileCount).toBe(2)
+    })
+
+    test('bumps updatedAt for all files', async () => {
+      await createTestFile('file-1')
+      await createTestFile('file-2')
+
+      await addTagToFiles(['file-1', 'file-2'], 'tag1')
+
+      const f1 = await readFileRecord('file-1')
+      const f2 = await readFileRecord('file-2')
+      expect(f1!.updatedAt).toBeGreaterThan(1000)
+      expect(f2!.updatedAt).toBeGreaterThan(1000)
+    })
+
+    test('handles empty array', async () => {
+      await expect(addTagToFiles([], 'tag1')).resolves.not.toThrow()
     })
   })
 

--- a/src/stores/tags.ts
+++ b/src/stores/tags.ts
@@ -199,6 +199,36 @@ export async function addTagToFile(
 }
 
 /**
+ * Adds a tag to multiple files in a single transaction.
+ * Creates the tag if it doesn't exist. Ignores duplicate relationships.
+ */
+export async function addTagToFiles(
+  fileIds: string[],
+  tagName: string,
+): Promise<void> {
+  if (fileIds.length === 0) return
+  await withTransactionLock(async () => {
+    const tag = await getOrCreateTag(tagName)
+    for (const fileId of fileIds) {
+      await sqlInsert(
+        'file_tags',
+        { fileId, tagId: tag.id },
+        { conflictClause: 'OR IGNORE' },
+      )
+    }
+    const now = Date.now()
+    const placeholders = fileIds.map(() => '?').join(',')
+    await db().runAsync(
+      `UPDATE files SET updatedAt = ? WHERE id IN (${placeholders})`,
+      now,
+      ...fileIds,
+    )
+  })
+  tagsSwr.invalidateAll()
+  invalidateCacheLibraryLists()
+}
+
+/**
  * Removes a tag from a file.
  */
 export async function removeTagFromFile(


### PR DESCRIPTION
Add addTagToFiles() that performs all work in a single transaction instead of N sequential mutex acquisitions. Add loading spinners to BulkManageTagsSheet, ManageTagsSheet, and MoveToDirectorySheet for immediate visual feedback during operations.