### PR TITLE
fix: use standard back arrow on settings sub-pages

### DIFF
--- a/.changeset/fix-settings-nav.md
+++ b/.changeset/fix-settings-nav.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Settings sub-pages use the standard back arrow instead of a custom header.

--- a/apps/mobile/src/screens/SettingsLogsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsLogsScreen.tsx
@@ -6,14 +6,12 @@ import { LogView } from '../components/LogView'
 import { SettingsFullLayout } from '../components/SettingsLayout'
 import { SettingsLogsControlBar } from '../components/SettingsLogsControlBar'
 import { logsCache, useHasNewLogs } from '../hooks/useLogs'
-import { useMenuHeader } from '../hooks/useMenuHeader'
 import type { MenuStackParamList } from '../stacks/types'
 import { palette } from '../styles/colors'
 
 type Props = NativeStackScreenProps<MenuStackParamList, 'Logs'>
 
 export function SettingsLogsScreen({ route, navigation }: Props) {
-  useMenuHeader()
   const [lastFetchedCount, setLastFetchedCount] = useState(0)
   const [isFollowing, setIsFollowing] = useState(true)
   const hasNewLogs = useHasNewLogs(lastFetchedCount)


### PR DESCRIPTION
- Remove custom header override from SettingsLogsScreen
- Sub-pages now use default React Navigation back button