### PR TITLE
fix: handle stale credentials on reinstall during onboarding

### DIFF
--- a/.changeset/fix-recovery-key-generate.md
+++ b/.changeset/fix-recovery-key-generate.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fixed onboarding failing after app reinstall due to stale Keychain credentials from a previous install.

--- a/apps/mobile/src/screens/OnboardingRecoveryPhraseScreen.tsx
+++ b/apps/mobile/src/screens/OnboardingRecoveryPhraseScreen.tsx
@@ -3,7 +3,7 @@ import type { RouteProp } from '@react-navigation/native'
 import { useNavigation, useRoute } from '@react-navigation/native'
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack'
 import { logger } from '@siastorage/logger'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
   Platform,
   Pressable,
@@ -22,6 +22,8 @@ import { useRecoveryPhraseRegistration } from '../hooks/useRecoveryPhraseRegistr
 import { useRecoveryPhraseValidation } from '../hooks/useRecoveryPhraseValidation'
 import { useToast } from '../lib/toastContext'
 import type { OnboardingStackParamList } from '../stacks/types'
+import { clearAppKeys } from '../stores/appKey'
+import { clearMnemonicHash } from '../stores/mnemonic'
 import { palette } from '../styles/colors'
 
 export default function OnboardingRecoveryPhraseScreen() {
@@ -42,6 +44,11 @@ export default function OnboardingRecoveryPhraseScreen() {
     useRecoveryPhraseValidation(manualPhrase)
 
   const { register, isSubmitting } = useRecoveryPhraseRegistration()
+
+  useEffect(() => {
+    clearMnemonicHash()
+    clearAppKeys()
+  }, [])
 
   const handleContinue = async () => {
     try {

--- a/apps/mobile/src/stores/mnemonic.ts
+++ b/apps/mobile/src/stores/mnemonic.ts
@@ -4,9 +4,12 @@ import { getSecureStoreString, setSecureStoreString } from './secureStore'
 const MNEMONIC_HASH_SECURE_STORE_KEY = 'mnemonicHash'
 
 /**
- * The mnemonic hash is used to validate that a user enters the correct recovery
- * phrase when connecting to a new indexer. This ensures they derive the same
- * AppKey and can decrypt their existing data.
+ * The mnemonic hash validates that a user enters the correct recovery phrase
+ * when switching indexers, ensuring they derive the same AppKey.
+ *
+ * Stored in iOS Keychain (via expo-secure-store) which persists across app
+ * delete/reinstall. During onboarding the hash is cleared first so a stale
+ * hash from a previous install doesn't block registration.
  */
 
 /**


### PR DESCRIPTION
- Clear mnemonic hash before registering in onboarding so stale Keychain data from a previous install does not block registration
- Clear stale AppKey and fall through to browser auth when stored key fails to connect
- Add clearAppKeyForIndexer to remove a single indexer's key
- Update tests to verify stale key clearing and browser auth fallthrough