### PR TITLE
fix: disable auto-capitalization on search input

### DIFF
--- a/.changeset/fix-disable-auto-capitalize.md
+++ b/.changeset/fix-disable-auto-capitalize.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Search input no longer auto-capitalizes text.

--- a/apps/mobile/src/screens/SearchScreen.tsx
+++ b/apps/mobile/src/screens/SearchScreen.tsx
@@ -326,6 +326,7 @@ export function SearchScreen({ navigation }: Props) {
               placeholder="Search files..."
               placeholderTextColor={whiteA.a50}
               style={styles.input}
+              autoCapitalize="none"
               returnKeyType="search"
               onSubmitEditing={() => Keyboard.dismiss()}
               onKeyPress={(e) => {


### PR DESCRIPTION
- Search input no longer auto-capitalizes text.