### PR TITLE
feat: allow editing tag and folder names

### DIFF
--- a/.changeset/feat-edit-tag-folder-names.md
+++ b/.changeset/feat-edit-tag-folder-names.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Added the ability to rename tags and folders.

--- a/apps/mobile/src/components/RenameSheet.tsx
+++ b/apps/mobile/src/components/RenameSheet.tsx
@@ -1,0 +1,161 @@
+import { PencilIcon } from 'lucide-react-native'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  Keyboard,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native'
+import { closeSheet, useSheetOpen } from '../stores/sheets'
+import { overlay, palette, whiteA } from '../styles/colors'
+import { ModalSheet } from './ModalSheet'
+
+type Props = {
+  sheetName: string
+  title: string
+  placeholder: string
+  initialValue: string
+  onRename: (newName: string) => Promise<void>
+}
+
+export function RenameSheet({
+  sheetName,
+  title,
+  placeholder,
+  initialValue,
+  onRename,
+}: Props) {
+  const isOpen = useSheetOpen(sheetName)
+  const [name, setName] = useState(initialValue)
+  const [error, setError] = useState('')
+  const inputRef = useRef<TextInput | null>(null)
+
+  useEffect(() => {
+    if (isOpen) {
+      setName(initialValue)
+      setTimeout(() => inputRef.current?.focus(), 400)
+    } else {
+      setError('')
+    }
+  }, [isOpen, initialValue])
+
+  const handleClose = useCallback(() => {
+    setError('')
+    Keyboard.dismiss()
+    closeSheet()
+  }, [])
+
+  const handleRename = useCallback(async () => {
+    const trimmed = name.trim()
+    if (!trimmed || trimmed === initialValue) return
+    try {
+      await onRename(trimmed)
+      closeSheet()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to rename')
+    }
+  }, [name, initialValue, onRename])
+
+  const canSubmit = name.trim().length > 0 && name.trim() !== initialValue
+
+  return (
+    <ModalSheet
+      visible={isOpen}
+      onRequestClose={handleClose}
+      title={title}
+      presentationStyle="formSheet"
+      headerRight={
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Cancel"
+          onPress={handleClose}
+          hitSlop={8}
+        >
+          <Text style={styles.cancelText}>Cancel</Text>
+        </Pressable>
+      }
+    >
+      <View style={styles.body}>
+        <View style={styles.inputContainer}>
+          <TextInput
+            ref={inputRef}
+            style={styles.input}
+            placeholder={placeholder}
+            placeholderTextColor={palette.gray[500]}
+            value={name}
+            onChangeText={(text) => {
+              setName(text)
+              setError('')
+            }}
+            autoCapitalize="none"
+            autoCorrect={false}
+            returnKeyType="done"
+            onSubmitEditing={handleRename}
+            selectTextOnFocus
+          />
+        </View>
+        {error ? <Text style={styles.error}>{error}</Text> : null}
+        <Pressable
+          accessibilityRole="button"
+          onPress={handleRename}
+          disabled={!canSubmit}
+          style={[
+            styles.renameButton,
+            !canSubmit && styles.renameButtonDisabled,
+          ]}
+        >
+          <PencilIcon size={18} color={palette.gray[50]} />
+          <Text style={styles.renameButtonText}>Rename</Text>
+        </Pressable>
+      </View>
+    </ModalSheet>
+  )
+}
+
+const styles = StyleSheet.create({
+  cancelText: {
+    color: palette.blue[400],
+    fontSize: 17,
+    fontWeight: '600',
+  },
+  body: {
+    paddingHorizontal: 16,
+  },
+  inputContainer: {
+    backgroundColor: overlay.panelMedium,
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: whiteA.a10,
+    marginBottom: 12,
+  },
+  input: {
+    color: palette.gray[50],
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 16,
+  },
+  error: {
+    color: palette.red[500],
+    fontSize: 13,
+    marginBottom: 8,
+  },
+  renameButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    backgroundColor: palette.blue[500],
+    borderRadius: 10,
+    paddingVertical: 14,
+  },
+  renameButtonDisabled: {
+    opacity: 0.4,
+  },
+  renameButtonText: {
+    color: palette.gray[50],
+    fontSize: 16,
+    fontWeight: '600',
+  },
+})

--- a/apps/mobile/src/screens/DirectoryScreen.tsx
+++ b/apps/mobile/src/screens/DirectoryScreen.tsx
@@ -4,6 +4,7 @@ import {
   FolderPlusIcon,
   ListFilterIcon,
   MoreVerticalIcon,
+  PencilIcon,
   SearchIcon,
   Trash2Icon,
   XIcon,
@@ -32,11 +33,16 @@ import { Gradient } from '../components/Gradient'
 import { IconButton } from '../components/IconButton'
 import { ManageTagsSheet } from '../components/ManageTagsSheet'
 import { MoveToDirectorySheet } from '../components/MoveToDirectorySheet'
+import { RenameSheet } from '../components/RenameSheet'
 import { ScreenHeader } from '../components/ScreenHeader'
 import { SelectionBar } from '../components/SelectionBar'
 import { ViewSettingsMenu } from '../components/ViewSettingsMenu'
 import type { MainStackParamList } from '../stacks/types'
-import { deleteDirectory, moveFilesToDirectory } from '../stores/directories'
+import {
+  deleteDirectory,
+  moveFilesToDirectory,
+  renameDirectory,
+} from '../stores/directories'
 import {
   enterSelectionMode,
   exitSelectionMode,
@@ -57,7 +63,8 @@ import { colors, overlay, palette, whiteA } from '../styles/colors'
 type Props = NativeStackScreenProps<MainStackParamList, 'DirectoryScreen'>
 
 export function DirectoryScreen({ route, navigation }: Props) {
-  const { directoryId, directoryName } = route.params
+  const { directoryId, directoryName: initialDirectoryName } = route.params
+  const [directoryName, setDirectoryName] = useState(initialDirectoryName)
   const scope = `dir.${directoryId}`
   const vs = useViewSettings(scope)
   const filters: FileListParams = useMemo(
@@ -178,6 +185,14 @@ export function DirectoryScreen({ route, navigation }: Props) {
   const fileCount = dirCount.data ?? 0
   const subtitle = `${fileCount.toLocaleString()} ${fileCount === 1 ? 'file' : 'files'}`
   const dirActionsOpen = useSheetOpen('directoryActions')
+
+  const handleRenameDirectory = useCallback(
+    async (newName: string) => {
+      await renameDirectory(directoryId, newName)
+      setDirectoryName(newName)
+    },
+    [directoryId],
+  )
 
   const handleDeleteDirectory = useCallback(() => {
     closeSheet()
@@ -354,7 +369,19 @@ export function DirectoryScreen({ route, navigation }: Props) {
         </Animated.View>
       ) : null}
 
-      <ActionSheet visible={dirActionsOpen} onRequestClose={() => closeSheet()}>
+      <ActionSheet
+        visible={dirActionsOpen}
+        onRequestClose={() => closeSheet('directoryActions')}
+      >
+        <ActionSheetButton
+          icon={<PencilIcon size={18} />}
+          onPress={() => {
+            closeSheet()
+            setTimeout(() => openSheet('renameDirectory'), 300)
+          }}
+        >
+          Rename folder
+        </ActionSheetButton>
         <ActionSheetButton
           variant="danger"
           icon={<Trash2Icon size={18} />}
@@ -363,6 +390,13 @@ export function DirectoryScreen({ route, navigation }: Props) {
           Delete folder
         </ActionSheetButton>
       </ActionSheet>
+      <RenameSheet
+        sheetName="renameDirectory"
+        title="Rename Folder"
+        placeholder="Folder name"
+        initialValue={directoryName}
+        onRename={handleRenameDirectory}
+      />
       {actionSheetFileIds.length > 0 ? (
         <>
           <FileActionsSheet

--- a/apps/mobile/src/screens/TagLibraryScreen.tsx
+++ b/apps/mobile/src/screens/TagLibraryScreen.tsx
@@ -4,6 +4,7 @@ import {
   FilePlusIcon,
   ListFilterIcon,
   MoreVerticalIcon,
+  PencilIcon,
   Trash2Icon,
   XIcon,
 } from 'lucide-react-native'
@@ -31,6 +32,7 @@ import { Gradient } from '../components/Gradient'
 import { IconButton } from '../components/IconButton'
 import { ManageTagsSheet } from '../components/ManageTagsSheet'
 import { MoveToDirectorySheet } from '../components/MoveToDirectorySheet'
+import { RenameSheet } from '../components/RenameSheet'
 import { ScreenHeader } from '../components/ScreenHeader'
 import { SelectionBar } from '../components/SelectionBar'
 import { ViewSettingsMenu } from '../components/ViewSettingsMenu'
@@ -49,14 +51,15 @@ import {
   useTagFileCount,
 } from '../stores/library'
 import { closeSheet, openSheet, useSheetOpen } from '../stores/sheets'
-import { addTagToFiles, deleteTag } from '../stores/tags'
+import { addTagToFiles, deleteTag, renameTag } from '../stores/tags'
 import { useViewSettings } from '../stores/viewSettings'
 import { colors, overlay, palette, whiteA } from '../styles/colors'
 
 type Props = NativeStackScreenProps<MainStackParamList, 'TagLibrary'>
 
 export function TagLibraryScreen({ route, navigation }: Props) {
-  const { tagId, tagName } = route.params
+  const { tagId, tagName: initialTagName } = route.params
+  const [tagName, setTagName] = useState(initialTagName)
   const scope = `tag.${tagId}`
   const vs = useViewSettings(scope)
   const filters: FileListParams = useMemo(
@@ -178,6 +181,14 @@ export function TagLibraryScreen({ route, navigation }: Props) {
   const subtitle = `${fileCount.toLocaleString()} ${fileCount === 1 ? 'file' : 'files'}`
   const isSystemTag = tagId.startsWith('sys_')
   const tagActionsOpen = useSheetOpen('tagActions')
+
+  const handleRenameTag = useCallback(
+    async (newName: string) => {
+      await renameTag(tagId, newName)
+      setTagName(newName)
+    },
+    [tagId],
+  )
 
   const handleDeleteTag = useCallback(() => {
     closeSheet()
@@ -348,7 +359,21 @@ export function TagLibraryScreen({ route, navigation }: Props) {
         </Animated.View>
       ) : null}
 
-      <ActionSheet visible={tagActionsOpen} onRequestClose={() => closeSheet()}>
+      <ActionSheet
+        visible={tagActionsOpen}
+        onRequestClose={() => closeSheet('tagActions')}
+      >
+        {!isSystemTag ? (
+          <ActionSheetButton
+            icon={<PencilIcon size={18} />}
+            onPress={() => {
+              closeSheet()
+              setTimeout(() => openSheet('renameTag'), 300)
+            }}
+          >
+            Rename tag
+          </ActionSheetButton>
+        ) : null}
         <ActionSheetButton
           variant="danger"
           icon={<Trash2Icon size={18} />}
@@ -358,6 +383,13 @@ export function TagLibraryScreen({ route, navigation }: Props) {
           Delete tag
         </ActionSheetButton>
       </ActionSheet>
+      <RenameSheet
+        sheetName="renameTag"
+        title="Rename Tag"
+        placeholder="Tag name"
+        initialValue={tagName}
+        onRename={handleRenameTag}
+      />
       {actionSheetFileIds.length > 0 ? (
         <>
           <FileActionsSheet

--- a/apps/mobile/src/stores/directories.test.ts
+++ b/apps/mobile/src/stores/directories.test.ts
@@ -182,6 +182,29 @@ describe('directories store', () => {
         'Folder name cannot be empty',
       )
     })
+
+    test('throws on duplicate name', async () => {
+      const dir = await createDirectory('Photos')
+      await createDirectory('Videos')
+      await expect(renameDirectory(dir.id, 'Videos')).rejects.toThrow(
+        'Folder "Videos" already exists',
+      )
+    })
+
+    test('bumps updatedAt on files in directory', async () => {
+      const dir = await createDirectory('Photos')
+      await createTestFile('file-1')
+      await createTestFile('file-2')
+      await moveFileToDirectory('file-1', dir.id)
+      await moveFileToDirectory('file-2', dir.id)
+
+      await renameDirectory(dir.id, 'Images')
+
+      const f1 = await readFileRecord('file-1')
+      const f2 = await readFileRecord('file-2')
+      expect(f1!.updatedAt).toBeGreaterThan(1000)
+      expect(f2!.updatedAt).toBeGreaterThan(1000)
+    })
   })
 
   describe('moveFileToDirectory', () => {

--- a/apps/mobile/src/stores/directories.ts
+++ b/apps/mobile/src/stores/directories.ts
@@ -107,6 +107,13 @@ export async function renameDirectory(id: string, name: string): Promise<void> {
     throw new Error(`Folder "${trimmed}" already exists`)
   }
   await sqlUpdate('directories', { name: trimmed }, { id })
+  // Bump updatedAt on affected files so syncUp pushes the new folder name.
+  const now = Date.now()
+  await db().runAsync(
+    'UPDATE files SET updatedAt = ? WHERE directoryId = ?',
+    now,
+    id,
+  )
   directoriesSwr.invalidate('all')
   invalidateCacheLibraryLists()
 }

--- a/apps/mobile/src/stores/sheets.ts
+++ b/apps/mobile/src/stores/sheets.ts
@@ -16,8 +16,11 @@ export function openSheet(name: string): void {
   })
 }
 
-export async function closeSheet(): Promise<void> {
-  setState(() => {
+export async function closeSheet(name?: string): Promise<void> {
+  setState((state) => {
+    // Only close if this sheet is actually open, so callers don't
+    // accidentally dismiss a different sheet that opened in the meantime.
+    if (name && state.openName !== name) return state
     return { openName: '' }
   })
   await new Promise((resolve) => setTimeout(resolve, 220))

--- a/apps/mobile/src/stores/tags.test.ts
+++ b/apps/mobile/src/stores/tags.test.ts
@@ -11,6 +11,7 @@ import {
   readTagNamesForFile,
   readTagsForFile,
   removeTagFromFile,
+  renameTag,
   searchTags,
   syncTagsFromMetadata,
   toggleFavorite,
@@ -514,6 +515,57 @@ describe('tags store', () => {
 
       await toggleFavorite('file-1')
       expect(await readIsFavorite('file-1')).toBe(false)
+    })
+  })
+
+  describe('renameTag', () => {
+    test('renames tag', async () => {
+      const tag = await createTag('vacation')
+      await renameTag(tag.id, 'travel')
+
+      const tags = userOnly(await readAllTagsWithCounts())
+      expect(tags).toHaveLength(1)
+      expect(tags[0].name).toBe('travel')
+    })
+
+    test('throws on empty name', async () => {
+      const tag = await createTag('vacation')
+      await expect(renameTag(tag.id, '')).rejects.toThrow(
+        'Tag name cannot be empty',
+      )
+    })
+
+    test('throws on duplicate name', async () => {
+      const tag = await createTag('vacation')
+      await createTag('travel')
+      await expect(renameTag(tag.id, 'travel')).rejects.toThrow(
+        'Tag "travel" already exists',
+      )
+    })
+
+    test('prevents renaming system tags', async () => {
+      await expect(renameTag('sys:favorites', 'Starred')).rejects.toThrow(
+        'System tags cannot be renamed',
+      )
+    })
+
+    test('bumps updatedAt on tagged files', async () => {
+      await createTestFile('file-1')
+      await createTestFile('file-2')
+      await addTagToFile('file-1', 'vacation')
+      await addTagToFile('file-2', 'vacation')
+
+      const tag = userOnly(await readAllTagsWithCounts())[0]
+      await renameTag(tag.id, 'travel')
+
+      const f1 = await readFileRecord('file-1')
+      const f2 = await readFileRecord('file-2')
+      expect(f1!.updatedAt).toBeGreaterThan(1000)
+      expect(f2!.updatedAt).toBeGreaterThan(1000)
+    })
+
+    test('no-ops for nonexistent tag', async () => {
+      await expect(renameTag('nonexistent', 'test')).resolves.not.toThrow()
     })
   })
 

--- a/apps/mobile/src/stores/tags.ts
+++ b/apps/mobile/src/stores/tags.ts
@@ -315,6 +315,50 @@ export async function readIsFavorite(fileId: string): Promise<boolean> {
 }
 
 /**
+ * Renames a tag and bumps updatedAt on all affected files so syncUp
+ * pushes the new name in their metadata.
+ */
+export async function renameTag(tagId: string, newName: string): Promise<void> {
+  const trimmed = newName.trim()
+  if (!trimmed) {
+    throw new Error('Tag name cannot be empty')
+  }
+
+  const tag = await db().getFirstAsync<Tag>(
+    'SELECT id, name, createdAt, usedAt, system FROM tags WHERE id = ?',
+    tagId,
+  )
+  if (!tag) return
+  if (tag.system) {
+    throw new Error('System tags cannot be renamed')
+  }
+
+  const existing = await db().getFirstAsync<{ id: string }>(
+    'SELECT id FROM tags WHERE name = ? COLLATE NOCASE AND id != ?',
+    trimmed,
+    tagId,
+  )
+  if (existing) {
+    throw new Error(`Tag "${trimmed}" already exists`)
+  }
+
+  await withTransactionLock(async () => {
+    await sqlUpdate('tags', { name: trimmed }, { id: tagId })
+    // Bump updatedAt on affected files so syncUp pushes the new tag name.
+    const now = Date.now()
+    await db().runAsync(
+      `UPDATE files SET updatedAt = ? WHERE id IN (
+        SELECT fileId FROM file_tags WHERE tagId = ?
+      )`,
+      now,
+      tagId,
+    )
+  })
+  tagsSwr.invalidateAll()
+  invalidateCacheLibraryLists()
+}
+
+/**
  * Deletes a tag. System tags cannot be deleted.
  */
 export async function deleteTag(tagId: string): Promise<void> {

--- a/apps/mobile/test/sync-up-metadata.test.ts
+++ b/apps/mobile/test/sync-up-metadata.test.ts
@@ -5,10 +5,18 @@
 import './utils/setup'
 
 import { decodeFileMetadata } from '@siastorage/core/encoding/fileMetadata'
-import { createDirectory, moveFileToDirectory } from '../src/stores/directories'
+import {
+  createDirectory,
+  moveFileToDirectory,
+  renameDirectory,
+} from '../src/stores/directories'
 import { readFileRecord, updateFileRecord } from '../src/stores/files'
 import { readLocalObjectsForFile } from '../src/stores/localObjects'
-import { addTagToFile } from '../src/stores/tags'
+import {
+  addTagToFile,
+  readAllTagsWithCounts,
+  renameTag,
+} from '../src/stores/tags'
 import { getUploadState } from '../src/stores/uploads'
 import {
   type AppCoreHarness,
@@ -225,6 +233,97 @@ describe('Sync Up Metadata', () => {
         return remoteMeta.directory === 'Vacation'
       },
       { timeout: 10_000, message: 'Remote metadata to include directory' },
+    )
+  }, 30_000)
+
+  it('pushes renamed tag to remote', async () => {
+    const [file] = await addTestFilesToHarness(
+      harness,
+      generateTestFilesFromAssets(TEST_ASSETS_DIR, ['test-image-1.png']),
+    )
+
+    await waitForCondition(() => getUploadState(file.id) !== undefined, {
+      timeout: 10_000,
+      message: 'File to be detected by scanner',
+    })
+    await harness.waitForNoActiveUploads()
+
+    const localObjects = await readLocalObjectsForFile(file.id)
+    expect(localObjects.length).toBeGreaterThan(0)
+    const objectId = localObjects[0].id
+
+    // Add a tag and wait for it to sync
+    await addTagToFile(file.id, 'vacation')
+    await updateFileRecord({ id: file.id, updatedAt: Date.now() }, true, {
+      includeUpdatedAt: true,
+    })
+
+    await waitForCondition(
+      async () => {
+        const remote = await harness.sdk.object(objectId)
+        const remoteMeta = decodeFileMetadata(remote.metadata())
+        return remoteMeta.tags?.includes('vacation') === true
+      },
+      { timeout: 10_000, message: 'Remote metadata to include tag' },
+    )
+
+    // Rename the tag — this bumps updatedAt on tagged files
+    const tags = await readAllTagsWithCounts()
+    const vacationTag = tags.find((t) => t.name === 'vacation')!
+    await renameTag(vacationTag.id, 'travel')
+
+    await waitForCondition(
+      async () => {
+        const remote = await harness.sdk.object(objectId)
+        const remoteMeta = decodeFileMetadata(remote.metadata())
+        return (
+          remoteMeta.tags?.includes('travel') === true &&
+          !remoteMeta.tags?.includes('vacation')
+        )
+      },
+      { timeout: 10_000, message: 'Remote metadata to have renamed tag' },
+    )
+  }, 30_000)
+
+  it('pushes renamed directory to remote', async () => {
+    const [file] = await addTestFilesToHarness(
+      harness,
+      generateTestFilesFromAssets(TEST_ASSETS_DIR, ['test-image-1.png']),
+    )
+
+    await waitForCondition(() => getUploadState(file.id) !== undefined, {
+      timeout: 10_000,
+      message: 'File to be detected by scanner',
+    })
+    await harness.waitForNoActiveUploads()
+
+    const localObjects = await readLocalObjectsForFile(file.id)
+    expect(localObjects.length).toBeGreaterThan(0)
+    const objectId = localObjects[0].id
+
+    // Move file to a directory and wait for sync
+    const dir = await createDirectory('Vacation')
+    await moveFileToDirectory(file.id, dir.id)
+
+    await waitForCondition(
+      async () => {
+        const remote = await harness.sdk.object(objectId)
+        const remoteMeta = decodeFileMetadata(remote.metadata())
+        return remoteMeta.directory === 'Vacation'
+      },
+      { timeout: 10_000, message: 'Remote metadata to include directory' },
+    )
+
+    // Rename the directory — this bumps updatedAt on files in it
+    await renameDirectory(dir.id, 'Travel')
+
+    await waitForCondition(
+      async () => {
+        const remote = await harness.sdk.object(objectId)
+        const remoteMeta = decodeFileMetadata(remote.metadata())
+        return remoteMeta.directory === 'Travel'
+      },
+      { timeout: 10_000, message: 'Remote metadata to have renamed directory' },
     )
   }, 30_000)
 })


### PR DESCRIPTION
- Add reusable RenameSheet component (modal with text input, validation, error display)
- Add renameTag() and renameDirectory() store functions with duplicate/empty name validation
- Bump updatedAt on affected files after rename so syncUp pushes the new name
- Hide rename option for system tags
- Guard closeSheet() with optional name param to prevent race condition between dismissing action sheet and opening rename sheet