### PR TITLE
feat: show unfiled items under a "No folder" entry in the files view

### DIFF
--- a/.changeset/feat-uncategorized-files-view.md
+++ b/.changeset/feat-uncategorized-files-view.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Files not assigned to any folder now appear under a "No folder" entry in the files view.

--- a/apps/mobile/src/components/DirectoriesGrid.tsx
+++ b/apps/mobile/src/components/DirectoriesGrid.tsx
@@ -1,4 +1,5 @@
-import { FolderIcon } from 'lucide-react-native'
+import { FolderIcon, InboxIcon } from 'lucide-react-native'
+import { useMemo } from 'react'
 import {
   ActivityIndicator,
   FlatList,
@@ -9,8 +10,10 @@ import {
 } from 'react-native'
 import {
   type DirectoryWithCount,
+  UNFILED_DIRECTORY_ID,
   useAllDirectories,
 } from '../stores/directories'
+import { useUnfiledFileCount } from '../stores/library'
 import { overlay, palette, whiteA } from '../styles/colors'
 
 type Props = {
@@ -19,7 +22,21 @@ type Props = {
 
 export function DirectoriesGrid({ onSelectDirectory }: Props) {
   const allDirs = useAllDirectories()
+  const unfiledCount = useUnfiledFileCount()
   const dirs = allDirs.data ?? []
+
+  const listData = useMemo(() => {
+    const items: DirectoryWithCount[] = [...dirs]
+    if ((unfiledCount.data ?? 0) > 0) {
+      items.push({
+        id: UNFILED_DIRECTORY_ID,
+        name: 'No folder',
+        createdAt: 0,
+        fileCount: unfiledCount.data ?? 0,
+      })
+    }
+    return items
+  }, [dirs, unfiledCount.data])
 
   if (!allDirs.data) {
     return (
@@ -29,7 +46,7 @@ export function DirectoriesGrid({ onSelectDirectory }: Props) {
     )
   }
 
-  if (dirs.length === 0) {
+  if (listData.length === 0) {
     return (
       <View style={styles.emptyWrap}>
         <FolderIcon color={whiteA.a50} size={48} />
@@ -43,7 +60,7 @@ export function DirectoriesGrid({ onSelectDirectory }: Props) {
 
   return (
     <FlatList
-      data={dirs}
+      data={listData}
       keyExtractor={(dir) => dir.id}
       contentContainerStyle={styles.grid}
       ItemSeparatorComponent={() => <View style={styles.separator} />}
@@ -51,6 +68,7 @@ export function DirectoriesGrid({ onSelectDirectory }: Props) {
         <DirectoryCard
           dir={item}
           onPress={() => onSelectDirectory(item.id, item.name)}
+          isUnfiled={item.id === UNFILED_DIRECTORY_ID}
         />
       )}
     />
@@ -60,9 +78,11 @@ export function DirectoriesGrid({ onSelectDirectory }: Props) {
 function DirectoryCard({
   dir,
   onPress,
+  isUnfiled = false,
 }: {
   dir: DirectoryWithCount
   onPress: () => void
+  isUnfiled?: boolean
 }) {
   return (
     <Pressable
@@ -70,7 +90,11 @@ function DirectoryCard({
       onPress={onPress}
       style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}
     >
-      <FolderIcon color={palette.blue[400]} size={24} />
+      {isUnfiled ? (
+        <InboxIcon color={palette.gray[400]} size={24} />
+      ) : (
+        <FolderIcon color={palette.blue[400]} size={24} />
+      )}
       <View style={styles.cardText}>
         <Text style={styles.dirName} numberOfLines={1}>
           {dir.name}

--- a/apps/mobile/src/screens/DirectoryScreen.tsx
+++ b/apps/mobile/src/screens/DirectoryScreen.tsx
@@ -42,6 +42,7 @@ import {
   deleteDirectory,
   moveFilesToDirectory,
   renameDirectory,
+  UNFILED_DIRECTORY_ID,
 } from '../stores/directories'
 import {
   enterSelectionMode,
@@ -65,6 +66,7 @@ type Props = NativeStackScreenProps<MainStackParamList, 'DirectoryScreen'>
 export function DirectoryScreen({ route, navigation }: Props) {
   const { directoryId, directoryName: initialDirectoryName } = route.params
   const [directoryName, setDirectoryName] = useState(initialDirectoryName)
+  const isUnfiled = directoryId === UNFILED_DIRECTORY_ID
   const scope = `dir.${directoryId}`
   const vs = useViewSettings(scope)
   const filters: FileListParams = useMemo(
@@ -165,12 +167,13 @@ export function DirectoryScreen({ route, navigation }: Props) {
 
   const handleFilesAdded = useCallback(
     (addedFiles: FileRecord[]) => {
+      if (isUnfiled) return
       void moveFilesToDirectory(
         addedFiles.map((f) => f.id),
         directoryId,
       )
     },
-    [directoryId],
+    [directoryId, isUnfiled],
   )
 
   const actionSheetFileIds = isSelectionMode
@@ -319,12 +322,14 @@ export function DirectoryScreen({ route, navigation }: Props) {
             >
               <SearchIcon color={palette.gray[50]} size={22} />
             </IconButton>
-            <IconButton
-              onPress={() => openSheet('directoryActions')}
-              accessibilityLabel="More options"
-            >
-              <MoreVerticalIcon color={palette.gray[50]} size={22} />
-            </IconButton>
+            {!isUnfiled ? (
+              <IconButton
+                onPress={() => openSheet('directoryActions')}
+                accessibilityLabel="More options"
+              >
+                <MoreVerticalIcon color={palette.gray[50]} size={22} />
+              </IconButton>
+            ) : null}
           </FloatingPill>
         </BottomControlBar>
       )}

--- a/apps/mobile/src/stores/directories.ts
+++ b/apps/mobile/src/stores/directories.ts
@@ -5,6 +5,8 @@ import { sqlDelete, sqlInsert, sqlUpdate } from '../db/sql'
 import { swrCacheBy } from '../lib/swr'
 import { invalidateCacheLibraryLists } from './librarySwr'
 
+export const UNFILED_DIRECTORY_ID = '__unfiled__'
+
 export const directoriesSwr = swrCacheBy()
 
 export type Directory = {

--- a/apps/mobile/src/stores/library.ts
+++ b/apps/mobile/src/stores/library.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import useSWR from 'swr'
 import useSWRInfinite from 'swr/infinite'
 import { db } from '../db'
+import { UNFILED_DIRECTORY_ID } from './directories'
 import { type FileRecord, type FileRecordRow, transformRow } from './files'
 import { libraryStats, useOnLibraryListChange } from './librarySwr'
 import { readLocalObjectsForFiles } from './localObjects'
@@ -180,10 +181,27 @@ export function useTagFileCount(tagId: string) {
 // Count of files in a specific directory, excluding thumbnails.
 export function useDirectoryFileCount(directoryId: string) {
   return useSWR(libraryStats.key(`dirCount:${directoryId}`), async () => {
+    if (directoryId === UNFILED_DIRECTORY_ID) {
+      const row = await db().getFirstAsync<{ count: number }>(
+        `SELECT COUNT(*) as count FROM files
+         WHERE directoryId IS NULL AND kind = 'file'`,
+      )
+      return row?.count ?? 0
+    }
     const row = await db().getFirstAsync<{ count: number }>(
       `SELECT COUNT(*) as count FROM files
        WHERE directoryId = ? AND kind = 'file'`,
       directoryId,
+    )
+    return row?.count ?? 0
+  })
+}
+
+export function useUnfiledFileCount() {
+  return useSWR(libraryStats.key('unfiledCount'), async () => {
+    const row = await db().getFirstAsync<{ count: number }>(
+      `SELECT COUNT(*) as count FROM files
+       WHERE directoryId IS NULL AND kind = 'file'`,
     )
     return row?.count ?? 0
   })
@@ -274,7 +292,9 @@ export function buildLibraryQueryParts(
     params.push(...tags, tags.length)
   }
   // Directory filtering.
-  if (directoryId) {
+  if (directoryId === UNFILED_DIRECTORY_ID) {
+    whereParts.push(`${tableAlias}.directoryId IS NULL`)
+  } else if (directoryId) {
     whereParts.push(`${tableAlias}.directoryId = ?`)
     params.push(directoryId)
   }


### PR DESCRIPTION
- Add UNFILED_DIRECTORY_ID sentinel and useUnfiledFileCount() hook
- Append virtual "No folder" entry to DirectoriesGrid when unfiled files exist, with InboxIcon
- buildLibraryQueryParts handles UNFILED_DIRECTORY_ID as directoryId IS NULL filter
- useDirectoryFileCount handles UNFILED_DIRECTORY_ID with NULL directory query
- Hide folder actions (rename/delete) menu for the unfiled virtual entry