### PR TITLE
fix: only auto-move files to import directory during photo sync

### DIFF
--- a/.changeset/fix-import-auto-move.md
+++ b/.changeset/fix-import-auto-move.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Manually imported files are no longer automatically moved to the photo import directory.

--- a/apps/mobile/src/lib/processAssets.test.ts
+++ b/apps/mobile/src/lib/processAssets.test.ts
@@ -1,11 +1,13 @@
 import { setExpoFileSystemMockMethods } from '../../mocks/expo-file-system'
-import { initializeDB, resetDb } from '../db'
+import { db, initializeDB, resetDb } from '../db'
+import { readAllDirectoriesWithCounts } from '../stores/directories'
 import {
   createFileRecord,
   readAllFileRecords,
   readFileRecord,
 } from '../stores/files'
 import { copyFileToFs, readFsFileMetadata } from '../stores/fs'
+import { setPhotoImportDirectory } from '../stores/settings'
 import { calculateContentHash } from './contentHash'
 import { getMediaLibraryUri } from './mediaLibrary'
 import { processAssets } from './processAssets'
@@ -301,6 +303,51 @@ describe('processAssets', () => {
     expect(meta).toMatchObject({
       fileId: files[0].id,
     })
+  })
+  it('does not auto-move files by default', async () => {
+    await setPhotoImportDirectory('Camera Roll')
+    const assets = [
+      {
+        id: undefined,
+        name: 'photo.jpg',
+        sourceUri: 'file:///photo.jpg',
+        type: 'image/jpeg',
+        timestamp: '2021-01-01',
+      },
+    ]
+    const { files } = await processAssets(assets)
+    expect(files).toHaveLength(1)
+    const row = await db().getFirstAsync<{ directoryId: string | null }>(
+      'SELECT directoryId FROM files WHERE id = ?',
+      files[0].id,
+    )
+    expect(row?.directoryId).toBeNull()
+    const dirs = await readAllDirectoriesWithCounts()
+    expect(dirs).toHaveLength(0)
+  })
+  it('addToImportDirectory moves media files to photo import directory', async () => {
+    await setPhotoImportDirectory('Camera Roll')
+    const assets = [
+      {
+        id: undefined,
+        name: 'photo.jpg',
+        sourceUri: 'file:///photo.jpg',
+        type: 'image/jpeg',
+        timestamp: '2021-01-01',
+      },
+    ]
+    const { files } = await processAssets(assets, 'file', {
+      addToImportDirectory: true,
+    })
+    expect(files).toHaveLength(1)
+    const row = await db().getFirstAsync<{ directoryId: string | null }>(
+      'SELECT directoryId FROM files WHERE id = ?',
+      files[0].id,
+    )
+    expect(row?.directoryId).toBeTruthy()
+    const dirs = await readAllDirectoriesWithCounts()
+    expect(dirs).toHaveLength(1)
+    expect(dirs[0].name).toBe('Camera Roll')
   })
   it('adds file size to new files', async () => {
     setExpoFileSystemMockMethods({

--- a/apps/mobile/src/lib/processAssets.ts
+++ b/apps/mobile/src/lib/processAssets.ts
@@ -79,7 +79,10 @@ type CandidateFileRecord = {
 export async function processAssets(
   assets: Asset[] | undefined,
   defaultFileName: string = 'file',
-  { allowDuplicates = false }: { allowDuplicates?: boolean } = {},
+  {
+    allowDuplicates = false,
+    addToImportDirectory = false,
+  }: { allowDuplicates?: boolean; addToImportDirectory?: boolean } = {},
 ) {
   const candidateFiles: CandidateFileRecord[] = await Promise.all(
     (assets ?? []).map(async (a) => ({
@@ -226,8 +229,9 @@ export async function processAssets(
   await createManyFileRecords(newFiles)
 
   // Move media files to the configured photo import directory.
+  // Skipped when importing from a directory or tag context.
   const photoImportDir = await getPhotoImportDirectory()
-  if (photoImportDir) {
+  if (photoImportDir && addToImportDirectory) {
     const mediaFileIds = newFiles
       .filter((f) => f.type.startsWith('image/') || f.type.startsWith('video/'))
       .map((f) => f.id)

--- a/apps/mobile/src/managers/syncNewPhotos.test.ts
+++ b/apps/mobile/src/managers/syncNewPhotos.test.ts
@@ -119,11 +119,15 @@ describe('syncNewPhotos', () => {
       ]),
     )
     await workNew()
-    expect(processAssetsMock).toHaveBeenCalledWith([
-      expect.objectContaining({ id: 'a1', name: 'new1.jpg' }),
-      expect.objectContaining({ id: 'a2', name: 'new2.jpg' }),
-      expect.objectContaining({ id: 'a3', name: 'exact.jpg' }),
-    ])
+    expect(processAssetsMock).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({ id: 'a1', name: 'new1.jpg' }),
+        expect.objectContaining({ id: 'a2', name: 'new2.jpg' }),
+        expect.objectContaining({ id: 'a3', name: 'exact.jpg' }),
+      ],
+      'file',
+      { addToImportDirectory: true },
+    )
   })
 
   it('skips processing when all photos are before enabledAt', async () => {
@@ -165,11 +169,15 @@ describe('syncNewPhotos', () => {
       ]),
     )
     await workNew()
-    expect(processAssetsMock).toHaveBeenCalledWith([
-      expect.objectContaining({
-        timestamp: new Date(5_000).toISOString(),
-      }),
-    ])
+    expect(processAssetsMock).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          timestamp: new Date(5_000).toISOString(),
+        }),
+      ],
+      'file',
+      { addToImportDirectory: true },
+    )
   })
 
   it('setAutoSyncNewPhotos saves enablement timestamp', async () => {

--- a/apps/mobile/src/managers/syncNewPhotos.ts
+++ b/apps/mobile/src/managers/syncNewPhotos.ts
@@ -80,6 +80,8 @@ export async function workNew(signal?: AbortSignal): Promise<void> {
           asset.creationTime || asset.modificationTime,
         ).toISOString(),
       })),
+      'file',
+      { addToImportDirectory: true },
     )
     if (files.length > 0) {
       await invalidateCacheLibraryAllStats()

--- a/apps/mobile/src/managers/syncPhotosArchive.test.ts
+++ b/apps/mobile/src/managers/syncPhotosArchive.test.ts
@@ -209,11 +209,15 @@ describe('syncPhotosArchive', () => {
       ),
     )
     await workBackward()
-    expect(processAssetsMock).toHaveBeenCalledWith([
-      expect.objectContaining({
-        timestamp: new Date(50_000).toISOString(),
-      }),
-    ])
+    expect(processAssetsMock).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          timestamp: new Date(50_000).toISOString(),
+        }),
+      ],
+      'file',
+      { addToImportDirectory: true },
+    )
   })
 
   it('processes all assets on the page without filtering', async () => {
@@ -229,11 +233,15 @@ describe('syncPhotosArchive', () => {
       ),
     )
     await workBackward()
-    expect(processAssetsMock).toHaveBeenCalledWith([
-      expect.objectContaining({ id: 'a1' }),
-      expect.objectContaining({ id: 'a2' }),
-      expect.objectContaining({ id: 'a3' }),
-    ])
+    expect(processAssetsMock).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({ id: 'a1' }),
+        expect.objectContaining({ id: 'a2' }),
+        expect.objectContaining({ id: 'a3' }),
+      ],
+      'file',
+      { addToImportDirectory: true },
+    )
   })
 
   it('aborts before processAssets when signal is aborted during getAssetsAsync', async () => {
@@ -339,10 +347,14 @@ describe('syncPhotosArchive', () => {
       )
       await workBackward()
 
-      expect(processAssetsMock).toHaveBeenCalledWith([
-        expect.objectContaining({ id: 'a1' }),
-        expect.objectContaining({ id: 'a2' }),
-      ])
+      expect(processAssetsMock).toHaveBeenCalledWith(
+        [
+          expect.objectContaining({ id: 'a1' }),
+          expect.objectContaining({ id: 'a2' }),
+        ],
+        'file',
+        { addToImportDirectory: true },
+      )
     })
   })
 })

--- a/apps/mobile/src/managers/syncPhotosArchive.ts
+++ b/apps/mobile/src/managers/syncPhotosArchive.ts
@@ -127,6 +127,8 @@ export async function workBackward(signal?: AbortSignal) {
           asset.creationTime || asset.modificationTime,
         ).toISOString(),
       })),
+      'file',
+      { addToImportDirectory: true },
     )
     if (files.length > 0) {
       logger.info('syncPhotosArchive', 'batch_processed', {


### PR DESCRIPTION
Add addToImportDirectory option to processAssets so only sync callers auto-move files to the configured photo import directory. Manual imports from pickers no longer get moved unexpectedly.