### PR TITLE
fix: prevent status spinner from activating on sync heartbeat polls

### DIFF
--- a/.changeset/fix-sync-spinner-heartbeat.md
+++ b/.changeset/fix-sync-spinner-heartbeat.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fixed the status spinner activating on every sync heartbeat even when there's nothing to sync.

--- a/packages/core/src/services/syncDownEvents.ts
+++ b/packages/core/src/services/syncDownEvents.ts
@@ -191,11 +191,13 @@ export async function syncDownEventsBatch(
         })
       }
 
-      // Update progress and notify after each batch.
+      // Update progress after each batch. Only report isSyncing when there are
+      // real events to process (>1), not on the periodic heartbeat check which
+      // returns a single cursor-marker event.
       deps.hooks.onProgress({
         ...counts,
         cursorAt: nextTimestamp,
-        isSyncing: true,
+        isSyncing: totalEventsFetched > 1,
       })
       if (batchChanged) {
         await deps.hooks.onBatchChanged()


### PR DESCRIPTION
Fixed the status spinner activating on every sync heartbeat even when there's nothing to sync.