### PR TITLE
fix: match carousel sort order to gallery for all sort modes

### DIFF
--- a/.changeset/fix-carousel-sort-order.md
+++ b/.changeset/fix-carousel-sort-order.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fixed carousel sort order for ADDED and SIZE sorts to match the gallery.

--- a/apps/mobile/src/stores/fileCarousel.test.ts
+++ b/apps/mobile/src/stores/fileCarousel.test.ts
@@ -29,18 +29,20 @@ describe('fileCarousel virtual list functions', () => {
     name: string | null
     createdAt: number
     type?: string
+    addedAt?: number
+    size?: number
   }) {
     await createFileRecord({
       id: params.id,
       name: params.name ?? `${params.id}.jpg`,
       type: params.type ?? 'image/jpeg',
       kind: 'file',
-      size: 100,
+      size: params.size ?? 100,
       hash: `hash-${params.id}`,
       createdAt: params.createdAt,
       updatedAt: params.createdAt,
       localId: null,
-      addedAt: params.createdAt,
+      addedAt: params.addedAt ?? params.createdAt,
     })
   }
 
@@ -58,6 +60,72 @@ describe('fileCarousel virtual list functions', () => {
     await createRecord({ id: 'id-5', name: 'c.jpg', createdAt: base + 20 })
     await createRecord({ id: 'id-2', name: 'd.jpg', createdAt: base + 30 })
     await createRecord({ id: 'id-4', name: 'e.jpg', createdAt: base + 40 })
+  }
+
+  async function seedAddedRecords() {
+    await createRecord({
+      id: 'file-a',
+      name: 'a.jpg',
+      createdAt: base,
+      addedAt: base + 40,
+    })
+    await createRecord({
+      id: 'file-b',
+      name: 'b.jpg',
+      createdAt: base + 10,
+      addedAt: base + 20,
+    })
+    await createRecord({
+      id: 'file-c',
+      name: 'c.jpg',
+      createdAt: base + 20,
+      addedAt: base + 30,
+    })
+    await createRecord({
+      id: 'file-d',
+      name: 'd.jpg',
+      createdAt: base + 30,
+      addedAt: base,
+    })
+    await createRecord({
+      id: 'file-e',
+      name: 'e.jpg',
+      createdAt: base + 40,
+      addedAt: base + 10,
+    })
+  }
+
+  async function seedSizeRecords() {
+    await createRecord({
+      id: 'file-a',
+      name: 'a.jpg',
+      createdAt: base,
+      size: 500,
+    })
+    await createRecord({
+      id: 'file-b',
+      name: 'b.jpg',
+      createdAt: base + 10,
+      size: 200,
+    })
+    await createRecord({
+      id: 'file-c',
+      name: 'c.jpg',
+      createdAt: base + 20,
+      size: 800,
+    })
+    await createRecord({
+      id: 'file-d',
+      name: 'd.jpg',
+      createdAt: base + 30,
+      size: 100,
+    })
+    await createRecord({
+      id: 'file-e',
+      name: 'e.jpg',
+      createdAt: base + 40,
+      size: 1000,
+    })
   }
 
   const defaultParams = {
@@ -198,6 +266,62 @@ describe('fileCarousel virtual list functions', () => {
       })
     })
 
+    describe('ADDED sorting (DESC)', () => {
+      const addedParams = {
+        ...defaultParams,
+        sortBy: 'ADDED' as const,
+        sortDir: 'DESC' as const,
+      }
+
+      test('returns correct position for middle file', async () => {
+        await seedAddedRecords()
+        // addedAt values: a=base+40, c=base+30, b=base+20, e=base+10, d=base
+        // DESC order: file-a(0), file-c(1), file-b(2), file-e(3), file-d(4)
+        const position = await fetchFilePosition('file-b', addedParams)
+        expect(position).toBe(2)
+      })
+
+      test('returns 0 for first file', async () => {
+        await seedAddedRecords()
+        const position = await fetchFilePosition('file-a', addedParams)
+        expect(position).toBe(0)
+      })
+
+      test('returns last position for last file', async () => {
+        await seedAddedRecords()
+        const position = await fetchFilePosition('file-d', addedParams)
+        expect(position).toBe(4)
+      })
+    })
+
+    describe('SIZE sorting (DESC)', () => {
+      const sizeParams = {
+        ...defaultParams,
+        sortBy: 'SIZE' as const,
+        sortDir: 'DESC' as const,
+      }
+
+      test('returns correct position for middle file', async () => {
+        await seedSizeRecords()
+        // size values: e=1000, c=800, a=500, b=200, d=100
+        // DESC order: file-e(0), file-c(1), file-a(2), file-b(3), file-d(4)
+        const position = await fetchFilePosition('file-a', sizeParams)
+        expect(position).toBe(2)
+      })
+
+      test('returns 0 for first file', async () => {
+        await seedSizeRecords()
+        const position = await fetchFilePosition('file-e', sizeParams)
+        expect(position).toBe(0)
+      })
+
+      test('returns last position for last file', async () => {
+        await seedSizeRecords()
+        const position = await fetchFilePosition('file-d', sizeParams)
+        expect(position).toBe(4)
+      })
+    })
+
     describe('tie-breaking by ID', () => {
       test('breaks DATE ties using ID', async () => {
         await createRecord({ id: 'file-c', name: 'c.jpg', createdAt: base })
@@ -318,6 +442,28 @@ describe('fileCarousel virtual list functions', () => {
     test('returns empty array for empty database', async () => {
       const ids = await fetchSortedFileIds(defaultParams, 10, 0)
       expect(ids).toEqual([])
+    })
+
+    test('returns IDs in ADDED sort order', async () => {
+      await seedAddedRecords()
+      // addedAt values: a=base+40, c=base+30, b=base+20, e=base+10, d=base
+      const ids = await fetchSortedFileIds(
+        { ...defaultParams, sortBy: 'ADDED', sortDir: 'DESC' },
+        5,
+        0,
+      )
+      expect(ids).toEqual(['file-a', 'file-c', 'file-b', 'file-e', 'file-d'])
+    })
+
+    test('returns IDs in SIZE sort order', async () => {
+      await seedSizeRecords()
+      // size values: e=1000, c=800, a=500, b=200, d=100
+      const ids = await fetchSortedFileIds(
+        { ...defaultParams, sortBy: 'SIZE', sortDir: 'DESC' },
+        5,
+        0,
+      )
+      expect(ids).toEqual(['file-e', 'file-c', 'file-a', 'file-b', 'file-d'])
     })
   })
 

--- a/apps/mobile/src/stores/fileCarousel.ts
+++ b/apps/mobile/src/stores/fileCarousel.ts
@@ -24,12 +24,13 @@ function buildDateCursorClause(
   alias: string,
   anchorValue: number,
   anchorId: string,
+  column: string = 'createdAt',
 ) {
   const isBefore = direction === 'before'
   const op = dir === 'ASC' ? (isBefore ? '<' : '>') : isBefore ? '>' : '<'
   const orderDirection = isBefore ? (dir === 'ASC' ? 'DESC' : 'ASC') : dir
   return {
-    clause: `(${alias}.createdAt ${op} ?) OR (${alias}.createdAt = ? AND ${alias}.id ${op} ?)`,
+    clause: `(${alias}.${column} ${op} ?) OR (${alias}.${column} = ? AND ${alias}.id ${op} ?)`,
     params: [anchorValue, anchorValue, anchorId],
     orderDirection,
   }
@@ -96,12 +97,6 @@ type VirtualListQueryParams = {
   query?: string
 }
 
-function buildOrderExpr(sortBy: SortBy, sortDir: SortDir, alias: string = 'f') {
-  return sortBy === 'NAME'
-    ? `(${alias}.name IS NULL) ASC, ${alias}.name COLLATE NOCASE ${sortDir}, ${alias}.id ${sortDir}`
-    : `${alias}.createdAt ${sortDir}, ${alias}.id ${sortDir}`
-}
-
 // Returns the total number of files matching the current filters.
 export async function fetchTotalCount(
   params: VirtualListQueryParams,
@@ -152,22 +147,34 @@ export async function fetchFilePosition(
     return 0
   }
 
-  const beforeCursor =
-    params.sortBy === 'NAME'
-      ? buildNameCursorClause(
-          params.sortDir,
-          'before',
-          'f',
-          anchorRow.name ?? null,
-          anchorRow.id,
-        )
-      : buildDateCursorClause(
-          params.sortDir,
-          'before',
-          'f',
-          anchorRow.createdAt,
-          anchorRow.id,
-        )
+  // Build a cursor clause that matches all rows sorted before the anchor,
+  // so COUNT(*) gives us the anchor's 0-indexed position.
+  let beforeCursor: ReturnType<typeof buildDateCursorClause>
+  if (params.sortBy === 'NAME') {
+    beforeCursor = buildNameCursorClause(
+      params.sortDir,
+      'before',
+      'f',
+      anchorRow.name ?? null,
+      anchorRow.id,
+    )
+  } else {
+    // Map sort mode to the corresponding DB column and anchor value.
+    const columnMap = {
+      ADDED: { column: 'addedAt', value: anchorRow.addedAt },
+      SIZE: { column: 'size', value: anchorRow.size },
+      DATE: { column: 'createdAt', value: anchorRow.createdAt },
+    } as const
+    const { column, value } = columnMap[params.sortBy] ?? columnMap.DATE
+    beforeCursor = buildDateCursorClause(
+      params.sortDir,
+      'before',
+      'f',
+      value,
+      anchorRow.id,
+      column,
+    )
+  }
 
   const result = await db().getFirstAsync<{ count: number }>(
     `SELECT COUNT(*) as count FROM files f ${
@@ -187,7 +194,11 @@ export async function fetchSortedFileIds(
   limit: number,
   offset: number,
 ): Promise<string[]> {
-  const { where, params: queryParams } = buildLibraryQueryParts({
+  const {
+    where,
+    params: queryParams,
+    orderExpr,
+  } = buildLibraryQueryParts({
     sortBy: params.sortBy,
     sortDir: params.sortDir,
     categories: params.categories,
@@ -197,7 +208,6 @@ export async function fetchSortedFileIds(
     tableAlias: 'f',
   })
 
-  const orderExpr = buildOrderExpr(params.sortBy, params.sortDir)
   const rows = await db().getAllAsync<{ id: string }>(
     `SELECT f.id FROM files f ${where ?? ''} ORDER BY ${orderExpr} LIMIT ? OFFSET ?`,
     ...queryParams,


### PR DESCRIPTION
Fixed carousel sort order for ADDED and SIZE sorts to match the gallery.