### PR TITLE
feat: add trash and soft delete with cross-device sync

### DIFF
--- a/.changeset/feat-trash-and-soft-delete.md
+++ b/.changeset/feat-trash-and-soft-delete.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Added trash and soft delete with cross-device sync support.

--- a/apps/mobile/src/components/FileActionsSheet.tsx
+++ b/apps/mobile/src/components/FileActionsSheet.tsx
@@ -2,7 +2,6 @@ import type { NativeStackScreenProps } from '@react-navigation/native-stack'
 import { logger } from '@siastorage/logger'
 import {
   ArrowDownToLineIcon,
-  CloudOffIcon,
   CloudUploadIcon,
   EraserIcon,
   FolderIcon,
@@ -16,11 +15,7 @@ import { useCallback } from 'react'
 import { StyleSheet, Text } from 'react-native'
 import useSWR from 'swr'
 import { useShareAction } from '../hooks/useShareAction'
-import {
-  deleteFileFromNetwork,
-  permanentlyDeleteFile,
-  permanentlyDeleteFiles,
-} from '../lib/deleteFile'
+import { trashFiles } from '../lib/deleteFile'
 import { fileHasASealedObject, useFileStatus } from '../lib/file'
 import { useToast } from '../lib/toastContext'
 import { downloadFile, useDownload } from '../managers/downloader'
@@ -136,32 +131,18 @@ function SingleFileActionsSheet({
     }
   }, [file?.id, toast, onComplete, file, reupload])
 
-  const handleRemoveFromNetwork = useCallback(async () => {
-    if (!file) return
-    try {
-      await deleteFileFromNetwork(file)
-      toast.show('Removed from network')
-      onComplete?.()
-    } catch (e) {
-      logger.error('FileActionsSheet', 'remove_from_network_failed', {
-        error: e as Error,
-      })
-      toast.show('Failed to remove from network')
-    }
-  }, [file?.id, toast, onComplete, file])
-
   const handleDelete = useCallback(async () => {
     if (!file) return
     try {
-      await permanentlyDeleteFile(file)
+      await trashFiles([file.id])
       if (navigation) navigation.goBack()
-      toast.show('File deleted')
+      toast.show('Moved to trash')
       onComplete?.()
     } catch (e) {
       logger.error('FileActionsSheet', 'delete_file_failed', {
         error: e as Error,
       })
-      toast.show('Failed to delete file')
+      toast.show('Failed to move to trash')
     }
   }, [file, navigation, toast, onComplete])
 
@@ -214,15 +195,6 @@ function SingleFileActionsSheet({
           onPress={handlePressAndClose(handleRemoveLocalFile)}
         >
           Remove from device
-        </ActionSheetButton>
-      )}
-      {status.data?.isUploaded && (
-        <ActionSheetButton
-          variant="primary"
-          icon={<CloudOffIcon size={18} />}
-          onPress={handlePressAndClose(handleRemoveFromNetwork)}
-        >
-          Remove from network
         </ActionSheetButton>
       )}
       <ActionSheetButton
@@ -383,26 +355,6 @@ function BulkFileActionsSheet({
     }
   }, [counts, toast, onComplete])
 
-  const handleRemoveFromNetwork = useCallback(async () => {
-    if (!counts) return
-    try {
-      let removed = 0
-      for (const file of counts.files) {
-        if (fileHasASealedObject(file)) {
-          await deleteFileFromNetwork(file)
-          removed++
-        }
-      }
-      toast.show(`Removed ${removed} files from network`)
-      onComplete?.()
-    } catch (e) {
-      logger.error('FileActionsSheet', 'remove_files_from_network_failed', {
-        error: e as Error,
-      })
-      toast.show('Failed to remove files from network')
-    }
-  }, [counts, toast, onComplete])
-
   const handleUploadToNetwork = useCallback(async () => {
     if (!counts) return
     try {
@@ -428,14 +380,14 @@ function BulkFileActionsSheet({
   const handleDeleteAll = useCallback(async () => {
     if (!counts) return
     try {
-      await permanentlyDeleteFiles(counts.files)
-      toast.show(`Deleted ${counts.total} files`)
+      await trashFiles(counts.files.map((f) => f.id))
+      toast.show(`Moved ${counts.total} files to trash`)
       onComplete?.()
     } catch (e) {
       logger.error('FileActionsSheet', 'delete_files_failed', {
         error: e as Error,
       })
-      toast.show('Failed to delete files')
+      toast.show('Failed to move files to trash')
     }
   }, [counts, toast, onComplete])
 
@@ -470,14 +422,6 @@ function BulkFileActionsSheet({
       </ActionSheetButton>
       <ActionSheetButton
         variant="primary"
-        icon={<CloudOffIcon size={18} />}
-        onPress={handlePressAndClose(handleRemoveFromNetwork)}
-        disabled={!counts || counts.onNetwork === 0}
-      >
-        Remove from network{counts ? ` (${counts.onNetwork})` : ''}
-      </ActionSheetButton>
-      <ActionSheetButton
-        variant="primary"
         icon={<FolderIcon size={18} />}
         onPress={() => {
           closeSheet()
@@ -492,7 +436,7 @@ function BulkFileActionsSheet({
         onPress={handlePressAndClose(handleDeleteAll)}
         disabled={!counts}
       >
-        Delete {total} files
+        Move {total} files to trash
       </ActionSheetButton>
     </ActionSheet>
   )

--- a/apps/mobile/src/components/FileImport/index.tsx
+++ b/apps/mobile/src/components/FileImport/index.tsx
@@ -137,6 +137,8 @@ async function downloadAndProcessFile(
       hash: hash ?? '',
       createdAt: Date.now(),
       updatedAt: Date.now(),
+      trashedAt: null,
+      deletedAt: null,
       objects: {},
     } satisfies FileRecord
   } catch (e) {
@@ -224,6 +226,8 @@ export function FileImport({
       hash: '', // Placeholder until calculated.
       createdAt: Date.now(),
       updatedAt: Date.now(),
+      trashedAt: null,
+      deletedAt: null,
       objects: {},
     } satisfies FileRecord
   }, [sharedObject.data, id, fileSize, detectedType.data])

--- a/apps/mobile/src/encoding/fileMetadata.test.ts
+++ b/apps/mobile/src/encoding/fileMetadata.test.ts
@@ -31,6 +31,7 @@ const baseFile: FileMetadata = {
   hash: 'abc123',
   createdAt: 1000,
   updatedAt: 2000,
+  trashedAt: null,
 }
 
 const baseThumb: FileMetadata = {
@@ -42,6 +43,7 @@ const baseThumb: FileMetadata = {
   hash: 'thumb-hash',
   thumbForId: 'file-1',
   thumbSize: 64,
+  trashedAt: null,
   createdAt: 1000,
   updatedAt: 2000,
 }
@@ -71,6 +73,7 @@ describe('fileMetadata', () => {
         hash: 'abc123',
         createdAt: 1000,
         updatedAt: 2000,
+        trashedAt: null,
       })
     })
 
@@ -125,33 +128,39 @@ describe('fileMetadata', () => {
       it('decodes a v1 file', () => {
         const buf = encodeFileMetadata(baseFile)
         const result = decodeFileMetadata(buf)
-        expect(result).toEqual({
-          id: 'file-1',
-          name: 'photo.jpg',
-          type: 'image/jpeg',
-          kind: 'file',
-          size: 1024,
-          hash: 'abc123',
-          createdAt: 1000,
-          updatedAt: 2000,
-        })
+        expect(result).toEqual(
+          expect.objectContaining({
+            id: 'file-1',
+            name: 'photo.jpg',
+            type: 'image/jpeg',
+            kind: 'file',
+            size: 1024,
+            hash: 'abc123',
+            createdAt: 1000,
+            updatedAt: 2000,
+            trashedAt: null,
+          }),
+        )
       })
 
       it('decodes a v1 thumbnail with thumbForId', () => {
         const buf = encodeFileMetadata(baseThumb)
         const result = decodeFileMetadata(buf)
-        expect(result).toEqual({
-          id: 'thumb-1',
-          name: 'photo.jpg',
-          type: 'image/jpeg',
-          kind: 'thumb',
-          size: 512,
-          hash: 'thumb-hash',
-          thumbForId: 'file-1',
-          thumbSize: 64,
-          createdAt: 1000,
-          updatedAt: 2000,
-        })
+        expect(result).toEqual(
+          expect.objectContaining({
+            id: 'thumb-1',
+            name: 'photo.jpg',
+            type: 'image/jpeg',
+            kind: 'thumb',
+            size: 512,
+            hash: 'thumb-hash',
+            thumbForId: 'file-1',
+            thumbSize: 64,
+            createdAt: 1000,
+            updatedAt: 2000,
+            trashedAt: null,
+          }),
+        )
       })
 
       it('preserves thumbForHash when present in v1 thumb metadata', () => {
@@ -184,6 +193,7 @@ describe('fileMetadata', () => {
           hash: 'v0-hash',
           createdAt: 100,
           updatedAt: 200,
+          trashedAt: null,
           thumbForHash: undefined,
           thumbForId: undefined,
           thumbSize: undefined,
@@ -307,16 +317,19 @@ describe('fileMetadata', () => {
       it('file round-trips cleanly', () => {
         const encoded = encodeFileMetadata(baseFile)
         const decoded = decodeFileMetadata(encoded)
-        expect(decoded).toEqual({
-          id: baseFile.id,
-          name: baseFile.name,
-          type: baseFile.type,
-          kind: baseFile.kind,
-          size: baseFile.size,
-          hash: baseFile.hash,
-          createdAt: baseFile.createdAt,
-          updatedAt: baseFile.updatedAt,
-        })
+        expect(decoded).toEqual(
+          expect.objectContaining({
+            id: baseFile.id,
+            name: baseFile.name,
+            type: baseFile.type,
+            kind: baseFile.kind,
+            size: baseFile.size,
+            hash: baseFile.hash,
+            createdAt: baseFile.createdAt,
+            updatedAt: baseFile.updatedAt,
+            trashedAt: null,
+          }),
+        )
       })
 
       it('thumbnail round-trips cleanly', () => {

--- a/apps/mobile/src/lib/deleteFile.test.ts
+++ b/apps/mobile/src/lib/deleteFile.test.ts
@@ -1,0 +1,325 @@
+jest.mock('../stores/fs', () => ({
+  removeFsFile: jest.fn().mockResolvedValue(undefined),
+}))
+jest.mock('../stores/tempFs', () => ({
+  removeTempDownloadFile: jest.fn().mockResolvedValue(undefined),
+}))
+jest.mock('../stores/uploads', () => ({
+  removeUploads: jest.fn(),
+}))
+
+import { initializeDB, resetDb } from '../db'
+import {
+  createFileRecord,
+  type FileRecord,
+  readFileRecord,
+} from '../stores/files'
+import { removeFsFile } from '../stores/fs'
+import { removeTempDownloadFile } from '../stores/tempFs'
+import { permanentlyDeleteFiles, restoreFiles, trashFiles } from './deleteFile'
+
+describe('deleteFile', () => {
+  beforeEach(async () => {
+    await initializeDB()
+  })
+
+  afterEach(async () => {
+    await resetDb()
+    jest.clearAllMocks()
+  })
+
+  test('trashFiles sets trashedAt and bumps updatedAt', async () => {
+    await createFileRecord({
+      id: 'file-1',
+      name: 'test1.jpg',
+      type: 'image/jpeg',
+      kind: 'file',
+      size: 100,
+      hash: 'hash-1',
+      createdAt: 1000,
+      updatedAt: 1000,
+      localId: null,
+      addedAt: 1000,
+      thumbForId: undefined,
+      thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
+    })
+    await createFileRecord({
+      id: 'file-2',
+      name: 'test2.jpg',
+      type: 'image/jpeg',
+      kind: 'file',
+      size: 100,
+      hash: 'hash-2',
+      createdAt: 1000,
+      updatedAt: 1000,
+      localId: null,
+      addedAt: 1000,
+      thumbForId: undefined,
+      thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
+    })
+    await createFileRecord({
+      id: 'thumb-1',
+      name: 'thumb1.jpg',
+      type: 'image/jpeg',
+      kind: 'thumb',
+      size: 50,
+      hash: 'hash-thumb-1',
+      createdAt: 1000,
+      updatedAt: 1000,
+      localId: null,
+      addedAt: 1000,
+      thumbForId: 'file-1',
+      thumbSize: 64,
+      trashedAt: null,
+      deletedAt: null,
+    })
+
+    await trashFiles(['file-1', 'file-2'])
+
+    const file1 = await readFileRecord('file-1')
+    const file2 = await readFileRecord('file-2')
+    const thumb = await readFileRecord('thumb-1')
+
+    expect(file1?.trashedAt).not.toBeNull()
+    expect(file1?.updatedAt).toBeGreaterThan(1000)
+    expect(file1?.deletedAt).toBeNull()
+
+    expect(file2?.trashedAt).not.toBeNull()
+    expect(file2?.updatedAt).toBeGreaterThan(1000)
+    expect(file2?.deletedAt).toBeNull()
+
+    expect(thumb?.trashedAt).not.toBeNull()
+    expect(thumb?.updatedAt).toBeGreaterThan(1000)
+  })
+
+  test('restoreFiles clears trashedAt and bumps updatedAt', async () => {
+    await createFileRecord({
+      id: 'file-1',
+      name: 'test1.jpg',
+      type: 'image/jpeg',
+      kind: 'file',
+      size: 100,
+      hash: 'hash-1',
+      createdAt: 1000,
+      updatedAt: 1000,
+      localId: null,
+      addedAt: 1000,
+      thumbForId: undefined,
+      thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
+    })
+
+    await trashFiles(['file-1'])
+
+    await createFileRecord({
+      id: 'thumb-1',
+      name: 'thumb1.jpg',
+      type: 'image/jpeg',
+      kind: 'thumb',
+      size: 50,
+      hash: 'hash-thumb-1',
+      createdAt: 1000,
+      updatedAt: 1000,
+      localId: null,
+      addedAt: 1000,
+      thumbForId: 'file-1',
+      thumbSize: 64,
+      trashedAt: null,
+      deletedAt: null,
+    })
+
+    await trashFiles(['thumb-1'])
+
+    const trashedFile = await readFileRecord('file-1')
+    const trashedThumb = await readFileRecord('thumb-1')
+    const trashedAt = trashedFile?.updatedAt ?? 0
+
+    expect(trashedFile?.trashedAt).not.toBeNull()
+    expect(trashedThumb?.trashedAt).not.toBeNull()
+
+    await restoreFiles(['file-1'])
+
+    const file1 = await readFileRecord('file-1')
+    const thumb = await readFileRecord('thumb-1')
+
+    expect(file1?.trashedAt).toBeNull()
+    expect(file1?.updatedAt).toBeGreaterThanOrEqual(trashedAt)
+
+    expect(thumb?.trashedAt).toBeNull()
+  })
+
+  test('permanentlyDeleteFiles sets tombstone without remote calls', async () => {
+    await createFileRecord({
+      id: 'file-1',
+      name: 'test1.jpg',
+      type: 'image/jpeg',
+      kind: 'file',
+      size: 100,
+      hash: 'hash-1',
+      createdAt: 1000,
+      updatedAt: 1000,
+      localId: null,
+      addedAt: 1000,
+      thumbForId: undefined,
+      thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
+    })
+    await createFileRecord({
+      id: 'file-2',
+      name: 'test2.jpg',
+      type: 'image/jpeg',
+      kind: 'file',
+      size: 100,
+      hash: 'hash-2',
+      createdAt: 1000,
+      updatedAt: 1000,
+      localId: null,
+      addedAt: 1000,
+      thumbForId: undefined,
+      thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
+    })
+    await createFileRecord({
+      id: 'thumb-1',
+      name: 'thumb1.jpg',
+      type: 'image/jpeg',
+      kind: 'thumb',
+      size: 50,
+      hash: 'hash-thumb-1',
+      createdAt: 1000,
+      updatedAt: 1000,
+      localId: null,
+      addedAt: 1000,
+      thumbForId: 'file-1',
+      thumbSize: 64,
+      trashedAt: null,
+      deletedAt: null,
+    })
+
+    const file1: FileRecord = {
+      id: 'file-1',
+      name: 'test1.jpg',
+      type: 'image/jpeg',
+      kind: 'file',
+      size: 100,
+      hash: 'hash-1',
+      createdAt: 1000,
+      updatedAt: 1000,
+      localId: null,
+      addedAt: 1000,
+      thumbForId: undefined,
+      thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
+      objects: {},
+    }
+    const file2: FileRecord = {
+      id: 'file-2',
+      name: 'test2.jpg',
+      type: 'image/jpeg',
+      kind: 'file',
+      size: 100,
+      hash: 'hash-2',
+      createdAt: 1000,
+      updatedAt: 1000,
+      localId: null,
+      addedAt: 1000,
+      thumbForId: undefined,
+      thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
+      objects: {},
+    }
+
+    await permanentlyDeleteFiles([file1, file2])
+
+    const result1 = await readFileRecord('file-1')
+    const result2 = await readFileRecord('file-2')
+    const thumb = await readFileRecord('thumb-1')
+
+    expect(result1?.deletedAt).not.toBeNull()
+    expect(result1?.trashedAt).not.toBeNull()
+    expect(result1?.updatedAt).toBeGreaterThan(1000)
+
+    expect(result2?.deletedAt).not.toBeNull()
+    expect(result2?.trashedAt).not.toBeNull()
+    expect(result2?.updatedAt).toBeGreaterThan(1000)
+
+    expect(thumb?.deletedAt).not.toBeNull()
+    expect(thumb?.trashedAt).not.toBeNull()
+
+    expect(removeFsFile).toHaveBeenCalledTimes(3)
+    expect(removeFsFile).toHaveBeenCalledWith(file1)
+    expect(removeFsFile).toHaveBeenCalledWith(file2)
+    expect(removeFsFile).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'thumb-1', type: 'image/jpeg' }),
+    )
+
+    expect(removeTempDownloadFile).toHaveBeenCalledTimes(3)
+    expect(removeTempDownloadFile).toHaveBeenCalledWith(file1)
+    expect(removeTempDownloadFile).toHaveBeenCalledWith(file2)
+    expect(removeTempDownloadFile).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'thumb-1', type: 'image/jpeg' }),
+    )
+  })
+
+  test('trash and restore cycle covers both files and thumbnails', async () => {
+    await createFileRecord({
+      id: 'file-1',
+      name: 'test1.jpg',
+      type: 'image/jpeg',
+      kind: 'file',
+      size: 100,
+      hash: 'hash-1',
+      createdAt: 1000,
+      updatedAt: 1000,
+      localId: null,
+      addedAt: 1000,
+      thumbForId: undefined,
+      thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
+    })
+    await createFileRecord({
+      id: 'thumb-1',
+      name: 'thumb1.webp',
+      type: 'image/webp',
+      kind: 'thumb',
+      size: 50,
+      hash: 'hash-thumb-1',
+      createdAt: 1000,
+      updatedAt: 1000,
+      localId: null,
+      addedAt: 1000,
+      thumbForId: 'file-1',
+      thumbSize: 64,
+      trashedAt: null,
+      deletedAt: null,
+    })
+
+    await trashFiles(['file-1'])
+    let file = await readFileRecord('file-1')
+    let thumb = await readFileRecord('thumb-1')
+    expect(file?.trashedAt).not.toBeNull()
+    expect(thumb?.trashedAt).not.toBeNull()
+
+    await restoreFiles(['file-1'])
+    file = await readFileRecord('file-1')
+    thumb = await readFileRecord('thumb-1')
+    expect(file?.trashedAt).toBeNull()
+    expect(thumb?.trashedAt).toBeNull()
+
+    await trashFiles(['file-1'])
+    file = await readFileRecord('file-1')
+    thumb = await readFileRecord('thumb-1')
+    expect(file?.trashedAt).not.toBeNull()
+    expect(thumb?.trashedAt).not.toBeNull()
+  })
+})

--- a/apps/mobile/src/lib/deleteFile.tsx
+++ b/apps/mobile/src/lib/deleteFile.tsx
@@ -1,48 +1,82 @@
-import { tryCatch } from '@siastorage/core'
-import type { LocalObject } from '@siastorage/core/encoding/localObject'
+import { TRASH_AUTO_PURGE_AGE } from '@siastorage/core/config'
 import { logger } from '@siastorage/logger'
-import {
-  deleteFileRecordAndThumbnails,
-  deleteManyFileRecordsAndThumbnails,
-  type FileRecord,
-} from '../stores/files'
+import { db, withTransactionLock } from '../db'
+import type { FileRecord } from '../stores/files'
+import { readFileRecordsByIds } from '../stores/files'
 import { removeFsFile } from '../stores/fs'
 import {
-  deleteLocalObjects,
-  deleteManyLocalObjects,
-} from '../stores/localObjects'
-import { getSdk } from '../stores/sdk'
+  invalidateCacheLibraryAllStats,
+  invalidateCacheLibraryLists,
+} from '../stores/librarySwr'
 import { removeTempDownloadFile } from '../stores/tempFs'
 import { removeUploads } from '../stores/uploads'
 
-async function tryStep<T>(
-  step: string,
-  id: string,
-  fn: () => Promise<T>,
-): Promise<void> {
-  const [, err] = await tryCatch(fn)
-  if (err) {
-    logger.error('deleteFile', 'step_failed', { step, id, error: err as Error })
-  }
+/**
+ * Move files to trash by setting trashedAt. Trashed files are hidden from
+ * the library but can be restored. The updatedAt timestamp is bumped so
+ * syncUp pushes the change to the indexer. Associated thumbnails are also
+ * trashed.
+ */
+export async function trashFiles(fileIds: string[]): Promise<void> {
+  if (fileIds.length === 0) return
+  const now = Date.now()
+  const placeholders = fileIds.map(() => '?').join(',')
+  await withTransactionLock(async () => {
+    await db().runAsync(
+      `UPDATE files SET trashedAt = ?, updatedAt = ? WHERE id IN (${placeholders})`,
+      now,
+      now,
+      ...fileIds,
+    )
+    await db().runAsync(
+      `UPDATE files SET trashedAt = ?, updatedAt = ? WHERE thumbForId IN (${placeholders})`,
+      now,
+      now,
+      ...fileIds,
+    )
+  })
+  await invalidateCacheLibraryAllStats()
+  invalidateCacheLibraryLists()
+}
+
+/**
+ * Restore trashed files by clearing trashedAt. The updatedAt timestamp is
+ * bumped so syncUp pushes the change to the indexer. Associated thumbnails
+ * are also restored.
+ */
+export async function restoreFiles(fileIds: string[]): Promise<void> {
+  if (fileIds.length === 0) return
+  const now = Date.now()
+  const placeholders = fileIds.map(() => '?').join(',')
+  await withTransactionLock(async () => {
+    await db().runAsync(
+      `UPDATE files SET trashedAt = NULL, updatedAt = ? WHERE id IN (${placeholders})`,
+      now,
+      ...fileIds,
+    )
+    await db().runAsync(
+      `UPDATE files SET trashedAt = NULL, updatedAt = ? WHERE thumbForId IN (${placeholders})`,
+      now,
+      ...fileIds,
+    )
+  })
+  await invalidateCacheLibraryAllStats()
+  invalidateCacheLibraryLists()
 }
 
 export async function permanentlyDeleteFile(file: FileRecord) {
-  removeUploads([file.id])
-  await tryStep('deleteFileRecord', file.id, () =>
-    deleteFileRecordAndThumbnails(file.id),
-  )
-  await tryStep('deleteAllIndexerObjects', file.id, () =>
-    deleteAllIndexerObjects(file),
-  )
-  await tryStep('deleteLocalObjects', file.id, () =>
-    deleteLocalObjects(file.id),
-  )
-  await tryStep('removeFsFile', file.id, () => removeFsFile(file))
-  await tryStep('removeTempDownloadFile', file.id, () =>
-    removeTempDownloadFile(file),
-  )
+  await permanentlyDeleteFiles([file])
 }
 
+/**
+ * Permanently delete files by setting the deletedAt tombstone. Tombstoned
+ * files are hidden from the UI and will never be resurrected by sync. The
+ * actual remote object deletion is handled by syncUp, which calls
+ * sdk.deleteObject() for each tombstoned file's objects on the next cycle.
+ *
+ * Local filesystem files are removed immediately. Any active uploads for
+ * the files are cancelled.
+ */
 export async function permanentlyDeleteFiles(
   files: FileRecord[],
 ): Promise<void> {
@@ -52,64 +86,63 @@ export async function permanentlyDeleteFiles(
 
   removeUploads(ids)
 
-  // Batch DB deletes (single transaction, single SWR trigger)
-  // Also delete thumbnails for these files
-  await deleteManyFileRecordsAndThumbnails(ids)
-  await deleteManyLocalObjects(ids)
+  const now = Date.now()
+  const placeholders = ids.map(() => '?').join(',')
+  await withTransactionLock(async () => {
+    await db().runAsync(
+      `UPDATE files SET deletedAt = ?, trashedAt = COALESCE(trashedAt, ?), updatedAt = ? WHERE id IN (${placeholders})`,
+      now,
+      now,
+      now,
+      ...ids,
+    )
+    await db().runAsync(
+      `UPDATE files SET deletedAt = ?, trashedAt = COALESCE(trashedAt, ?), updatedAt = ? WHERE thumbForId IN (${placeholders})`,
+      now,
+      now,
+      now,
+      ...ids,
+    )
+  })
+  await invalidateCacheLibraryAllStats()
+  invalidateCacheLibraryLists()
 
-  // Network deletions in parallel
-  await deleteAllIndexerObjectsForFiles(files)
-
-  // Filesystem deletions in parallel
+  const thumbs = await db().getAllAsync<{
+    id: string
+    type: string
+    localId: string | null
+  }>(
+    `SELECT id, type, localId FROM files WHERE thumbForId IN (${placeholders})`,
+    ...ids,
+  )
   await Promise.all(
-    files.flatMap((f) => [removeFsFile(f), removeTempDownloadFile(f)]),
+    [...files, ...thumbs].flatMap((f) => [
+      removeFsFile(f),
+      removeTempDownloadFile(f),
+    ]),
   )
 }
 
-async function deleteAllIndexerObjectsForFiles(
-  files: FileRecord[],
-): Promise<void> {
-  const sdk = getSdk()
-  if (!sdk) return
-
-  const objectIds = files.flatMap((f) =>
-    Object.values(f.objects ?? {})
-      .map((o) => o.id)
-      .filter(Boolean),
-  )
-
-  // Fire off all deletions in parallel (best effort)
-  await Promise.all(
-    objectIds.map((id) =>
-      sdk.deleteObject(id).catch(() => {
-        // Swallow errors - best effort deletion
-      }),
-    ),
-  )
-}
-
-export async function deleteFileFromNetwork(file: FileRecord) {
-  await tryStep('deleteAllIndexerObjects', file.id, () =>
-    deleteAllIndexerObjects(file),
-  )
-  await tryStep('deleteLocalObjects', file.id, () =>
-    deleteLocalObjects(file.id),
-  )
-}
-
-// TODO: in the future if a file is synced with multiple indexers,
-// we will need to init and use an sdk for each indexer.
-export async function deleteAllIndexerObjects(file: {
-  objects?: Record<string, LocalObject>
-}) {
-  if (!file.objects) return
-  const sdk = getSdk()
-  if (!sdk) return
-  for (const [_, object] of Object.entries(file.objects)) {
-    if (object.id) {
-      await tryStep('sdk.deleteObject', object.id, () =>
-        sdk.deleteObject(object.id),
-      )
+/**
+ * Permanently delete files that have been in the trash longer than
+ * TRASH_AUTO_PURGE_AGE (30 days). Sets the deletedAt tombstone so
+ * syncUp will handle remote object cleanup on the next tick.
+ */
+export async function autoPurgeOldTrashedFiles() {
+  try {
+    const cutoff = Date.now() - TRASH_AUTO_PURGE_AGE
+    const rows = await db().getAllAsync<{ id: string }>(
+      `SELECT id FROM files WHERE trashedAt IS NOT NULL AND trashedAt < ? AND deletedAt IS NULL AND kind = 'file'`,
+      cutoff,
+    )
+    if (rows.length === 0) return
+    const ids = rows.map((r) => r.id)
+    const files = await readFileRecordsByIds(ids)
+    if (files.length > 0) {
+      logger.info('deleteFile', 'auto_purge_trashed', { count: files.length })
+      await permanentlyDeleteFiles(files)
     }
+  } catch (error) {
+    logger.error('deleteFile', 'auto_purge_failed', { error: error as Error })
   }
 }

--- a/apps/mobile/src/lib/exportLogs.ts
+++ b/apps/mobile/src/lib/exportLogs.ts
@@ -86,6 +86,8 @@ export async function exportLogs(): Promise<string | null> {
       addedAt: now,
       localId: null,
       kind: 'file',
+      trashedAt: null,
+      deletedAt: null,
       thumbForId: undefined,
       thumbSize: undefined,
     })

--- a/apps/mobile/src/lib/processAssets.test.ts
+++ b/apps/mobile/src/lib/processAssets.test.ts
@@ -76,6 +76,8 @@ describe('processAssets', () => {
         localId: '1',
         hash: '',
         addedAt: 1,
+        trashedAt: null,
+        deletedAt: null,
       },
       false,
     )
@@ -122,6 +124,8 @@ describe('processAssets', () => {
         localId: '1',
         hash: '',
         addedAt: 1,
+        trashedAt: null,
+        deletedAt: null,
       },
       false,
     )
@@ -160,6 +164,8 @@ describe('processAssets', () => {
         hash: 'sha256:existing-hash',
         localId: null,
         addedAt: 1,
+        trashedAt: null,
+        deletedAt: null,
       },
       false,
     )
@@ -195,6 +201,8 @@ describe('processAssets', () => {
         hash: 'sha256:existing-hash',
         localId: null,
         addedAt: 1,
+        trashedAt: null,
+        deletedAt: null,
       },
       false,
     )

--- a/apps/mobile/src/lib/processAssets.ts
+++ b/apps/mobile/src/lib/processAssets.ts
@@ -204,6 +204,8 @@ export async function processAssets(
       kind: 'file' as const,
       size: f.size!,
       hash: f.hash!,
+      trashedAt: null,
+      deletedAt: null,
       objects: {},
     }))
   const incompleteFiles = candidateFiles.filter(
@@ -225,7 +227,14 @@ export async function processAssets(
     )
   }
 
-  await updateManyFileRecords(existingFiles)
+  await updateManyFileRecords(
+    existingFiles.map((f) => ({
+      id: f.id,
+      name: f.name,
+      type: f.type,
+      localId: f.localId,
+    })),
+  )
   await createManyFileRecords(newFiles)
 
   // Move media files to the configured photo import directory.

--- a/apps/mobile/src/managers/app.ts
+++ b/apps/mobile/src/managers/app.ts
@@ -2,6 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 import { shutdownAllServiceIntervals } from '@siastorage/core/lib/serviceInterval'
 import { mutate } from 'swr'
 import { initializeDB, resetDb } from '../db'
+import { autoPurgeOldTrashedFiles } from '../lib/deleteFile'
 import { type InitStep, setAppState } from '../stores/app'
 import { clearAppKeys } from '../stores/appKey'
 import { useAuthWebViewStore } from '../stores/authWebView'
@@ -83,6 +84,7 @@ export async function initApp(): Promise<void> {
       label: 'Cleaning up old files',
       message: 'Cleaning up old files...',
       runner: async (updateMessage) => {
+        await autoPurgeOldTrashedFiles()
         await runFsOrphanScanner({
           onProgress: (removed) => {
             updateMessage(`Cleaning up old files... ${removed} removed`)

--- a/apps/mobile/src/managers/downloader.ts
+++ b/apps/mobile/src/managers/downloader.ts
@@ -125,6 +125,8 @@ export function useDownloadFromShareURL() {
             updatedAt: Date.now(),
             localId: null,
             addedAt: Date.now(),
+            trashedAt: null,
+            deletedAt: null,
             objects: {},
           }
 

--- a/apps/mobile/src/managers/fsEvictionScanner.test.ts
+++ b/apps/mobile/src/managers/fsEvictionScanner.test.ts
@@ -167,6 +167,8 @@ function makeFileRecord(id: string, size: number): FileRecord {
     updatedAt: now,
     addedAt: now,
     localId: null,
+    trashedAt: null,
+    deletedAt: null,
     objects: {},
   }
 }

--- a/apps/mobile/src/managers/fsOrphanScanner.test.ts
+++ b/apps/mobile/src/managers/fsOrphanScanner.test.ts
@@ -89,6 +89,8 @@ describe('fsOrphanScanner', () => {
       updatedAt: now,
       addedAt: now,
       localId: null,
+      trashedAt: null,
+      deletedAt: null,
     })
     await upsertFsFileMetadata({
       fileId: 'file-2',
@@ -136,6 +138,8 @@ describe('fsOrphanScanner', () => {
       updatedAt: now,
       addedAt: now,
       localId: null,
+      trashedAt: null,
+      deletedAt: null,
     })
     await upsertFsFileMetadata({
       fileId: 'b',
@@ -162,6 +166,8 @@ describe('fsOrphanScanner', () => {
       updatedAt: now,
       addedAt: now,
       localId: null,
+      trashedAt: null,
+      deletedAt: null,
     })
     await upsertFsFileMetadata({
       fileId: 'keep-1',
@@ -180,6 +186,36 @@ describe('fsOrphanScanner', () => {
     expect(orphaned.has('orphan-1')).toBe(true)
     expect(orphaned.has('orphan-2')).toBe(true)
     expect(orphaned.size).toBe(2)
+  })
+
+  it('treats tombstoned files as orphaned', async () => {
+    const file = makeFile('file-tomb.jpg')
+    listFilesInFsStorageDirectoryMock.mockImplementation(() => [file])
+    await createFileRecord({
+      id: 'file-tomb',
+      name: 'file-tomb.jpg',
+      type: 'image/jpeg',
+      kind: 'file',
+      size: 100,
+      hash: 'hash-tomb',
+      createdAt: now,
+      updatedAt: now,
+      addedAt: now,
+      localId: null,
+      trashedAt: now,
+      deletedAt: now,
+    })
+    await upsertFsFileMetadata({
+      fileId: 'file-tomb',
+      size: 100,
+      addedAt: now,
+      usedAt: now,
+    })
+
+    const result = await runFsOrphanScanner()
+
+    expect(file.delete).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ removed: 1 })
   })
 
   it('yields between batches via setTimeout', async () => {

--- a/apps/mobile/src/managers/fsOrphanScanner.ts
+++ b/apps/mobile/src/managers/fsOrphanScanner.ts
@@ -100,7 +100,7 @@ export async function findOrphanedFileIds(
      WHERE NOT EXISTS (
        SELECT 1 FROM fs WHERE fs.fileId = value
      ) OR NOT EXISTS (
-       SELECT 1 FROM files WHERE files.id = value
+       SELECT 1 FROM files WHERE files.id = value AND files.deletedAt IS NULL
      )`,
     JSON.stringify(fileIds),
   )

--- a/apps/mobile/src/managers/syncDownEvents.test.ts
+++ b/apps/mobile/src/managers/syncDownEvents.test.ts
@@ -9,6 +9,7 @@ import {
   type FileRecord,
   readFileRecord,
   readFileRecordByObjectId,
+  updateFileRecord,
 } from '../stores/files'
 import { removeFsFile } from '../stores/fs'
 import {
@@ -175,6 +176,7 @@ describe('syncDownEvents', () => {
       updatedAt: NOW_BASE,
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
     }
 
     const metadata2: FileMetadata = {
@@ -188,6 +190,7 @@ describe('syncDownEvents', () => {
       updatedAt: NOW_BASE + 1,
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
     }
 
     const events: ObjectEvent[] = [
@@ -242,6 +245,7 @@ describe('syncDownEvents', () => {
       updatedAt: NOW_BASE,
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
     }
 
     const events: ObjectEvent[] = [
@@ -282,6 +286,8 @@ describe('syncDownEvents', () => {
       addedAt: NOW_BASE,
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
     }
     await createFileRecordWithLocalObject(
       file,
@@ -334,6 +340,8 @@ describe('syncDownEvents', () => {
       addedAt: NOW_BASE,
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
     }
     await createFileRecordWithLocalObject(
       file,
@@ -357,6 +365,7 @@ describe('syncDownEvents', () => {
       updatedAt: NOW_BASE + 1,
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
     }
 
     const events: ObjectEvent[] = [
@@ -390,6 +399,7 @@ describe('syncDownEvents', () => {
       updatedAt: NOW_BASE,
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
     }
 
     const events: ObjectEvent[] = [
@@ -425,6 +435,8 @@ describe('syncDownEvents', () => {
       addedAt: NOW_BASE,
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
     }
     await createFileRecordWithLocalObject(
       file,
@@ -449,6 +461,7 @@ describe('syncDownEvents', () => {
       updatedAt: NOW_BASE + 100, // Newer timestamp.
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
     }
 
     const events: ObjectEvent[] = [
@@ -507,6 +520,8 @@ describe('syncDownEvents', () => {
       addedAt: NOW_BASE,
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
     }
     await createFileRecordWithLocalObject(
       file,
@@ -531,6 +546,7 @@ describe('syncDownEvents', () => {
       updatedAt: NOW_BASE, // Older timestamp.
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
     }
 
     const events: ObjectEvent[] = [
@@ -574,6 +590,7 @@ describe('syncDownEvents', () => {
       updatedAt: 0,
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
     }
 
     const events: ObjectEvent[] = [
@@ -609,6 +626,8 @@ describe('syncDownEvents', () => {
       addedAt: NOW_BASE,
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
     }
     await createFileRecordWithLocalObject(
       file,
@@ -675,6 +694,7 @@ describe('syncDownEvents', () => {
       updatedAt: NOW_BASE,
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
     }
 
     const metadata2: FileMetadata = {
@@ -688,6 +708,7 @@ describe('syncDownEvents', () => {
       updatedAt: NOW_BASE + 1,
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
     }
 
     const events: ObjectEvent[] = [
@@ -733,6 +754,7 @@ describe('syncDownEvents', () => {
       hash: 'hash-thumb',
       createdAt: NOW_BASE,
       updatedAt: NOW_BASE,
+      trashedAt: null,
     }
 
     const events: ObjectEvent[] = [
@@ -767,6 +789,7 @@ describe('syncDownEvents', () => {
       updatedAt: NOW_BASE,
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
     }
     const events1: ObjectEvent[] = [
       makeObjectEvent({
@@ -788,6 +811,7 @@ describe('syncDownEvents', () => {
       updatedAt: NOW_BASE + 1,
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
     }
     // Second run should use cursor from first run.
     const events2: ObjectEvent[] = [
@@ -849,6 +873,7 @@ describe('syncDownEvents', () => {
       updatedAt: NOW_BASE,
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
     }
 
     const metadata2: FileMetadata = {
@@ -862,6 +887,7 @@ describe('syncDownEvents', () => {
       updatedAt: NOW_BASE + 1,
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
     }
 
     const events: ObjectEvent[] = [
@@ -897,6 +923,7 @@ describe('syncDownEvents', () => {
       updatedAt: NOW_BASE,
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
     }
 
     const events: ObjectEvent[] = [
@@ -934,6 +961,7 @@ describe('syncDownEvents', () => {
       hash: 'same-hash',
       createdAt: NOW_BASE,
       updatedAt: NOW_BASE,
+      trashedAt: null,
     }
 
     const metadata2: FileMetadata = {
@@ -945,6 +973,7 @@ describe('syncDownEvents', () => {
       hash: 'same-hash',
       createdAt: NOW_BASE + 1,
       updatedAt: NOW_BASE + 1,
+      trashedAt: null,
     }
 
     const events: ObjectEvent[] = [
@@ -987,6 +1016,8 @@ describe('syncDownEvents', () => {
       updatedAt: NOW_BASE,
       localId: null,
       addedAt: NOW_BASE,
+      trashedAt: null,
+      deletedAt: null,
     }
     await createFileRecordWithLocalObject(
       fileA,
@@ -1009,6 +1040,7 @@ describe('syncDownEvents', () => {
       hash: 'same-hash',
       createdAt: NOW_BASE + 1,
       updatedAt: NOW_BASE + 1,
+      trashedAt: null,
     }
 
     const events: ObjectEvent[] = [
@@ -1046,6 +1078,7 @@ describe('syncDownEvents', () => {
       thumbSize: 64,
       createdAt: NOW_BASE,
       updatedAt: NOW_BASE,
+      trashedAt: null,
     }
 
     const thumb2: FileMetadata = {
@@ -1059,6 +1092,7 @@ describe('syncDownEvents', () => {
       thumbSize: 64,
       createdAt: NOW_BASE + 1,
       updatedAt: NOW_BASE + 1,
+      trashedAt: null,
     }
 
     const events: ObjectEvent[] = [
@@ -1098,6 +1132,7 @@ describe('syncDownEvents', () => {
       hash: 'abc123',
       createdAt: NOW_BASE,
       updatedAt: NOW_BASE,
+      trashedAt: null,
     }
 
     // Two different objects on the indexer share the same metadata.id
@@ -1150,6 +1185,8 @@ describe('syncDownEvents', () => {
       addedAt: NOW_BASE,
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
     }
     await createFileRecordWithLocalObject(
       parent,
@@ -1175,6 +1212,8 @@ describe('syncDownEvents', () => {
       addedAt: NOW_BASE,
       thumbForId: undefined, // NULL — migration couldn't resolve
       thumbSize: 64,
+      trashedAt: null,
+      deletedAt: null,
     }
     await createFileRecordWithLocalObject(
       thumb,
@@ -1275,6 +1314,8 @@ describe('syncDownEvents', () => {
       addedAt: NOW_BASE,
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
     }
     await createFileRecordWithLocalObject(
       file,
@@ -1296,6 +1337,7 @@ describe('syncDownEvents', () => {
       hash: 'hash-1',
       createdAt: NOW_BASE,
       updatedAt: NOW_BASE + 1,
+      trashedAt: null,
     }
 
     const events: ObjectEvent[] = [
@@ -1338,6 +1380,8 @@ describe('syncDownEvents', () => {
       addedAt: NOW_BASE - 500,
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
     }
     await createFileRecordWithLocalObject(
       file,
@@ -1359,6 +1403,7 @@ describe('syncDownEvents', () => {
       hash: 'hash-1',
       createdAt: NOW_BASE,
       updatedAt: NOW_BASE + 1,
+      trashedAt: null,
     }
 
     const events: ObjectEvent[] = [
@@ -1396,6 +1441,8 @@ describe('syncDownEvents', () => {
       addedAt: NOW_BASE,
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
     }
     await createFileRecordWithLocalObject(
       file,
@@ -1427,6 +1474,7 @@ describe('syncDownEvents', () => {
       hash: 'hash-1',
       createdAt: NOW_BASE,
       updatedAt: NOW_BASE + 1,
+      trashedAt: null,
     }
 
     const events: ObjectEvent[] = [
@@ -1484,6 +1532,8 @@ describe('syncDownEvents', () => {
       addedAt: NOW_BASE,
       thumbForId: 'parent-file',
       thumbSize: 64,
+      trashedAt: null,
+      deletedAt: null,
     }
     await createFileRecordWithLocalObject(
       thumb,
@@ -1507,6 +1557,7 @@ describe('syncDownEvents', () => {
       updatedAt: NOW_BASE + 1,
       thumbForId: 'parent-file',
       thumbSize: 64,
+      trashedAt: null,
     }
 
     const events: ObjectEvent[] = [
@@ -1551,6 +1602,8 @@ describe('syncDownEvents', () => {
       addedAt: NOW_BASE,
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
     }
     await createFileRecordWithLocalObject(
       file,
@@ -1587,9 +1640,10 @@ describe('syncDownEvents', () => {
 
     await syncDownEvents(new AbortController().signal)
 
-    // The file record should still exist because the other indexer's object remains.
+    // Tombstoned file row must persist — tombstones are never removed.
     const fileRecord = await readFileRecord('file-1')
     expect(fileRecord).not.toBeNull()
+    expect(fileRecord!.deletedAt).not.toBeNull()
 
     // The other indexer's object should still be present.
     const objects = await readLocalObjectsForFile('file-1')
@@ -1612,6 +1666,8 @@ describe('syncDownEvents', () => {
       addedAt: NOW_BASE,
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
     }
     await createFileRecordWithLocalObject(
       file,
@@ -1636,6 +1692,7 @@ describe('syncDownEvents', () => {
       hash: 'hash-1',
       createdAt: NOW_BASE,
       updatedAt: NOW_BASE + 1,
+      trashedAt: null,
     }
 
     const events: ObjectEvent[] = [
@@ -1657,5 +1714,190 @@ describe('syncDownEvents', () => {
     expect(fileRecord).not.toBeNull()
     const objects = await readLocalObjectsForFile('file-1')
     expect(objects).toHaveLength(2)
+  })
+
+  test('delete event sets deletedAt tombstone on file when other objects remain', async () => {
+    // Create a file with two objects: one on the current indexer, one on another.
+    const file: Omit<FileRecord, 'objects'> = {
+      id: 'file-1',
+      name: 'photo.jpg',
+      type: 'image/jpeg',
+      kind: 'file',
+      size: 1024,
+      hash: 'hash-1',
+      createdAt: NOW_BASE,
+      updatedAt: NOW_BASE,
+      localId: null,
+      addedAt: NOW_BASE,
+      thumbForId: undefined,
+      thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
+    }
+    await createFileRecordWithLocalObject(
+      file,
+      makeLocalObject({
+        fileId: file.id,
+        objectId: 'obj-current',
+        indexerURL: INDEXER_URL,
+        createdAt: NOW_BASE,
+        updatedAt: NOW_BASE,
+      }),
+    )
+    await upsertLocalObject(
+      makeLocalObject({
+        fileId: file.id,
+        objectId: 'obj-other',
+        indexerURL: 'other-indexer',
+        createdAt: NOW_BASE,
+        updatedAt: NOW_BASE,
+      }),
+    )
+
+    const events: ObjectEvent[] = [
+      makeObjectEvent({
+        id: 'obj-current',
+        updatedAt: new Date(NOW_BASE + 1),
+        deleted: true,
+      }),
+    ]
+
+    getSdkMock.mockReturnValue({
+      objectEvents: jest.fn().mockResolvedValueOnce(events),
+    } as any)
+
+    await syncDownEvents(new AbortController().signal)
+
+    // Tombstoned file row must persist — tombstones are never removed.
+    const fileRecord = await readFileRecord('file-1')
+    expect(fileRecord).not.toBeNull()
+    expect(fileRecord!.deletedAt).not.toBeNull()
+
+    // Only the other indexer's object should remain.
+    const remainingObjects = await readLocalObjectsForFile('file-1')
+    expect(remainingObjects).toHaveLength(1)
+    expect(remainingObjects[0].indexerURL).toBe('other-indexer')
+  })
+
+  test('delete event on already-tombstoned file preserves tombstone when no objects remain', async () => {
+    const file: Omit<FileRecord, 'objects'> = {
+      id: 'file-1',
+      name: 'photo.jpg',
+      type: 'image/jpeg',
+      kind: 'file',
+      size: 1024,
+      hash: 'hash-1',
+      createdAt: NOW_BASE,
+      updatedAt: NOW_BASE,
+      localId: null,
+      addedAt: NOW_BASE,
+      thumbForId: undefined,
+      thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
+    }
+    await createFileRecordWithLocalObject(
+      file,
+      makeLocalObject({
+        fileId: file.id,
+        objectId: 'obj-1',
+        indexerURL: INDEXER_URL,
+        createdAt: NOW_BASE,
+        updatedAt: NOW_BASE,
+      }),
+    )
+
+    await updateFileRecord({ id: 'file-1', deletedAt: 5000 })
+
+    const events: ObjectEvent[] = [
+      makeObjectEvent({
+        id: 'obj-1',
+        updatedAt: new Date(NOW_BASE + 1),
+        deleted: true,
+      }),
+    ]
+
+    getSdkMock.mockReturnValue({
+      objectEvents: jest.fn().mockResolvedValueOnce(events),
+    } as any)
+
+    await syncDownEvents(new AbortController().signal)
+
+    // Object row should be gone.
+    const deletedFile = await readFileRecordByObjectId('obj-1', INDEXER_URL)
+    expect(deletedFile).toBeNull()
+
+    // Tombstoned file row must persist even with zero objects remaining.
+    const fileRecord = await readFileRecord('file-1')
+    expect(fileRecord).not.toBeNull()
+    expect(fileRecord!.deletedAt).toBe(5000)
+  })
+
+  test('tombstone blocks syncDown from clearing deletedAt via metadata update', async () => {
+    // Create a file with a single object.
+    const file: Omit<FileRecord, 'objects'> = {
+      id: 'file-1',
+      name: 'photo.jpg',
+      type: 'image/jpeg',
+      kind: 'file',
+      size: 1024,
+      hash: 'hash-1',
+      createdAt: NOW_BASE,
+      updatedAt: NOW_BASE,
+      localId: null,
+      addedAt: NOW_BASE,
+      thumbForId: undefined,
+      thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
+    }
+    await createFileRecordWithLocalObject(
+      file,
+      makeLocalObject({
+        fileId: file.id,
+        objectId: 'obj-1',
+        indexerURL: INDEXER_URL,
+        createdAt: NOW_BASE,
+        updatedAt: NOW_BASE,
+      }),
+    )
+
+    // Tombstone the file.
+    await updateFileRecord({ id: 'file-1', deletedAt: 5000 })
+
+    // Inject a metadata UPDATE event for the same object with a newer updatedAt.
+    const updatedMetadata: FileMetadata = {
+      id: 'file-1',
+      name: 'photo.jpg',
+      type: 'image/jpeg',
+      kind: 'file',
+      size: 1024,
+      hash: 'hash-1',
+      createdAt: NOW_BASE,
+      updatedAt: NOW_BASE + 100,
+      thumbForId: undefined,
+      thumbSize: undefined,
+      trashedAt: null,
+    }
+
+    const events: ObjectEvent[] = [
+      makeObjectEvent({
+        id: 'obj-1',
+        updatedAt: new Date(NOW_BASE + 100),
+        object: makeMockPinnedObject(updatedMetadata, 'obj-1'),
+      }),
+    ]
+
+    getSdkMock.mockReturnValue({
+      objectEvents: jest.fn().mockResolvedValueOnce(events),
+    } as any)
+
+    await syncDownEvents(new AbortController().signal)
+
+    // The tombstone must NOT be cleared by the metadata merge, because
+    // toFileRecordFields does not include deletedAt.
+    const fileRecord = await readFileRecord('file-1')
+    expect(fileRecord).not.toBeNull()
+    expect(fileRecord!.deletedAt).not.toBeNull()
   })
 })

--- a/apps/mobile/src/managers/syncUpMetadata.test.ts
+++ b/apps/mobile/src/managers/syncUpMetadata.test.ts
@@ -3,6 +3,7 @@ import { initializeDB, resetDb } from '../db'
 import {
   createFileRecordWithLocalObject,
   type FileRecord,
+  updateFileRecord,
 } from '../stores/files'
 import {
   getSyncUpCursor,
@@ -53,6 +54,7 @@ describe('syncUpMetadata', () => {
   const INDEXER_URL = 'indexer-url'
   const NOW_BASE = 400
   const mockUpdateObjectMetadata = jest.fn()
+  const mockDeleteObject = jest.fn()
 
   beforeEach(async () => {
     await initializeDB()
@@ -62,6 +64,7 @@ describe('syncUpMetadata', () => {
     sdk.getIsConnected.mockReturnValue(true)
     sdk.getSdk.mockReturnValue({
       updateObjectMetadata: mockUpdateObjectMetadata,
+      deleteObject: mockDeleteObject,
     })
   })
 
@@ -86,6 +89,8 @@ describe('syncUpMetadata', () => {
       addedAt: 100,
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
     }
     await createFileRecordWithLocalObject(
       localA,
@@ -112,6 +117,8 @@ describe('syncUpMetadata', () => {
       addedAt: 110,
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
     }
     await createFileRecordWithLocalObject(
       localB,
@@ -192,6 +199,8 @@ describe('syncUpMetadata', () => {
         addedAt: NOW_BASE + i,
         thumbForId: undefined,
         thumbSize: undefined,
+        trashedAt: null,
+        deletedAt: null,
       }
       await createFileRecordWithLocalObject(
         file,
@@ -247,6 +256,8 @@ describe('syncUpMetadata', () => {
         addedAt: NOW_BASE + i,
         thumbForId: undefined,
         thumbSize: undefined,
+        trashedAt: null,
+        deletedAt: null,
       }
       await createFileRecordWithLocalObject(
         file,
@@ -302,6 +313,8 @@ describe('syncUpMetadata', () => {
         addedAt: NOW_BASE,
         thumbForId: undefined,
         thumbSize: undefined,
+        trashedAt: null,
+        deletedAt: null,
       },
       {
         id: 'file-1',
@@ -316,6 +329,8 @@ describe('syncUpMetadata', () => {
         addedAt: NOW_BASE + 1,
         thumbForId: undefined,
         thumbSize: undefined,
+        trashedAt: null,
+        deletedAt: null,
       },
       {
         id: 'file-2',
@@ -330,6 +345,8 @@ describe('syncUpMetadata', () => {
         addedAt: NOW_BASE + 2,
         thumbForId: undefined,
         thumbSize: undefined,
+        trashedAt: null,
+        deletedAt: null,
       },
     ]
 
@@ -383,6 +400,8 @@ describe('syncUpMetadata', () => {
       addedAt: 100,
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
     }
     await createFileRecordWithLocalObject(
       localFile,
@@ -411,6 +430,7 @@ describe('syncUpMetadata', () => {
       updatedAt: 200,
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
     })
 
     await runSyncUpMetadata(5)
@@ -434,6 +454,8 @@ describe('syncUpMetadata', () => {
       addedAt: NOW_BASE,
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
     }
     await createFileRecordWithLocalObject(
       file,
@@ -470,6 +492,8 @@ describe('syncUpMetadata', () => {
         addedAt: NOW_BASE + i,
         thumbForId: undefined,
         thumbSize: undefined,
+        trashedAt: null,
+        deletedAt: null,
       }
       await createFileRecordWithLocalObject(
         file,
@@ -523,6 +547,8 @@ describe('syncUpMetadata', () => {
       addedAt: 100,
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
     }
     await createFileRecordWithLocalObject(
       localFile,
@@ -559,5 +585,236 @@ describe('syncUpMetadata', () => {
       expect.objectContaining({ id: 'remote-id', name: 'renamed.jpg' }),
       { thumbForHash: undefined },
     )
+  })
+
+  test('syncUp calls deleteObject for tombstoned files', async () => {
+    sdk.getIsConnected.mockReturnValue(true)
+
+    const file: Omit<FileRecord, 'objects'> = {
+      id: 'file-tomb',
+      name: 'photo.jpg',
+      type: 'image/jpeg',
+      kind: 'file',
+      size: 100,
+      hash: 'hash-tomb',
+      createdAt: NOW_BASE,
+      updatedAt: NOW_BASE,
+      localId: null,
+      addedAt: NOW_BASE,
+      thumbForId: undefined,
+      thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
+    }
+    await createFileRecordWithLocalObject(
+      file,
+      makeLocalObject({
+        fileId: file.id,
+        objectId: 'obj-tomb',
+        indexerURL: INDEXER_URL,
+        createdAt: NOW_BASE,
+        updatedAt: NOW_BASE,
+      }),
+    )
+    await updateFileRecord({ id: file.id, deletedAt: Date.now() }, false, {
+      includeUpdatedAt: false,
+    })
+
+    mockDeleteObject.mockResolvedValue(undefined)
+
+    await runSyncUpMetadata(5)
+
+    expect(mockDeleteObject).toHaveBeenCalledWith('obj-tomb')
+  })
+
+  test('syncUp advances cursor after successful deleteObject for tombstoned files', async () => {
+    sdk.getIsConnected.mockReturnValue(true)
+
+    const file: Omit<FileRecord, 'objects'> = {
+      id: 'file-tomb2',
+      name: 'photo2.jpg',
+      type: 'image/jpeg',
+      kind: 'file',
+      size: 100,
+      hash: 'hash-tomb2',
+      createdAt: NOW_BASE,
+      updatedAt: NOW_BASE,
+      localId: null,
+      addedAt: NOW_BASE,
+      thumbForId: undefined,
+      thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
+    }
+    await createFileRecordWithLocalObject(
+      file,
+      makeLocalObject({
+        fileId: file.id,
+        objectId: 'obj-tomb2',
+        indexerURL: INDEXER_URL,
+        createdAt: NOW_BASE,
+        updatedAt: NOW_BASE,
+      }),
+    )
+    await updateFileRecord({ id: file.id, deletedAt: Date.now() }, false, {
+      includeUpdatedAt: false,
+    })
+
+    mockDeleteObject.mockResolvedValue(undefined)
+
+    await runSyncUpMetadata(5)
+
+    const cur = await getSyncUpCursor()
+    expect(cur).toBeDefined()
+  })
+
+  test('syncUp stalls on network error for tombstoned file', async () => {
+    sdk.getIsConnected.mockReturnValue(true)
+
+    const file: Omit<FileRecord, 'objects'> = {
+      id: 'file-tomb3',
+      name: 'photo3.jpg',
+      type: 'image/jpeg',
+      kind: 'file',
+      size: 100,
+      hash: 'hash-tomb3',
+      createdAt: NOW_BASE,
+      updatedAt: NOW_BASE,
+      localId: null,
+      addedAt: NOW_BASE,
+      thumbForId: undefined,
+      thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
+    }
+    await createFileRecordWithLocalObject(
+      file,
+      makeLocalObject({
+        fileId: file.id,
+        objectId: 'obj-tomb3',
+        indexerURL: INDEXER_URL,
+        createdAt: NOW_BASE,
+        updatedAt: NOW_BASE,
+      }),
+    )
+    await updateFileRecord({ id: file.id, deletedAt: Date.now() }, false, {
+      includeUpdatedAt: false,
+    })
+
+    mockDeleteObject.mockRejectedValue(new Error('network error'))
+
+    await runSyncUpMetadata(5)
+
+    const cur = await getSyncUpCursor()
+    expect(cur).toBeUndefined()
+  })
+
+  test('syncUp skips metadata path and only calls deleteObject for tombstoned files', async () => {
+    sdk.getIsConnected.mockReturnValue(true)
+
+    const file: Omit<FileRecord, 'objects'> = {
+      id: 'file-tomb4',
+      name: 'photo4.jpg',
+      type: 'image/jpeg',
+      kind: 'file',
+      size: 100,
+      hash: 'hash-tomb4',
+      createdAt: NOW_BASE,
+      updatedAt: NOW_BASE,
+      localId: null,
+      addedAt: NOW_BASE,
+      thumbForId: undefined,
+      thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
+    }
+    await createFileRecordWithLocalObject(
+      file,
+      makeLocalObject({
+        fileId: file.id,
+        objectId: 'obj-tomb4',
+        indexerURL: INDEXER_URL,
+        createdAt: NOW_BASE,
+        updatedAt: NOW_BASE,
+      }),
+    )
+    await updateFileRecord({ id: file.id, deletedAt: Date.now() }, false, {
+      includeUpdatedAt: false,
+    })
+
+    mockDeleteObject.mockResolvedValue(undefined)
+
+    await runSyncUpMetadata(5)
+
+    expect(sdk.getPinnedObject).not.toHaveBeenCalled()
+    expect(mockUpdateObjectMetadata).not.toHaveBeenCalled()
+    expect(mockDeleteObject).toHaveBeenCalledWith('obj-tomb4')
+  })
+
+  test('tombstoned file with object on another indexer leaves that object row dangling', async () => {
+    sdk.getIsConnected.mockReturnValue(true)
+    const OTHER_INDEXER = 'other-indexer-url'
+
+    const file: Omit<FileRecord, 'objects'> = {
+      id: 'file-multi-idx',
+      name: 'multi.jpg',
+      type: 'image/jpeg',
+      kind: 'file',
+      size: 100,
+      hash: 'hash-multi-idx',
+      createdAt: NOW_BASE,
+      updatedAt: NOW_BASE,
+      localId: null,
+      addedAt: NOW_BASE,
+      thumbForId: undefined,
+      thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
+    }
+
+    // Create file with objects on both the current indexer and another indexer.
+    await createFileRecordWithLocalObject(
+      file,
+      makeLocalObject({
+        fileId: file.id,
+        objectId: 'obj-current',
+        indexerURL: INDEXER_URL,
+        createdAt: NOW_BASE,
+        updatedAt: NOW_BASE,
+      }),
+    )
+    const { upsertLocalObject } = require('../stores/localObjects')
+    await upsertLocalObject(
+      makeLocalObject({
+        fileId: file.id,
+        objectId: 'obj-other',
+        indexerURL: OTHER_INDEXER,
+        createdAt: NOW_BASE,
+        updatedAt: NOW_BASE,
+      }),
+      false,
+    )
+
+    // Tombstone the file.
+    await updateFileRecord({ id: file.id, deletedAt: Date.now() }, false, {
+      includeUpdatedAt: false,
+    })
+
+    mockDeleteObject.mockResolvedValue(undefined)
+    await runSyncUpMetadata(5)
+
+    // syncUp only deletes the current indexer's object.
+    expect(mockDeleteObject).toHaveBeenCalledTimes(1)
+    expect(mockDeleteObject).toHaveBeenCalledWith('obj-current')
+
+    // The other indexer's object row persists locally. This is a known
+    // limitation: we can only connect to one indexer at a time, so we
+    // can't delete objects on other indexers. A future cleanup service
+    // is needed to handle this (see TODO in syncUpMetadata.ts).
+    const { readLocalObjectsForFile } = require('../stores/localObjects')
+    const remaining = await readLocalObjectsForFile(file.id)
+    expect(remaining).toHaveLength(1)
+    expect(remaining[0].id).toBe('obj-other')
+    expect(remaining[0].indexerURL).toBe(OTHER_INDEXER)
   })
 })

--- a/apps/mobile/src/managers/syncUpMetadata.ts
+++ b/apps/mobile/src/managers/syncUpMetadata.ts
@@ -9,6 +9,10 @@ import { z } from 'zod'
 import { getAsyncStorageJSON, setAsyncStorageJSON } from '../stores/asyncStore'
 import { readDirectoryNameForFile } from '../stores/directories'
 import { readAllFileRecords, readAllFileRecordsCount } from '../stores/files'
+import {
+  countLocalObjectsForFile,
+  deleteLocalObject,
+} from '../stores/localObjects'
 import { getIsConnected, getPinnedObject, getSdk } from '../stores/sdk'
 import { getIndexerURL } from '../stores/settings'
 import {
@@ -68,10 +72,20 @@ export async function runSyncUpMetadata(
           if (!sdk) throw new Error('SDK not initialized')
           await sdk.updateObjectMetadata(pinnedObject)
         },
+        deleteObject: async (objectId) => {
+          const sdk = getSdk()
+          if (!sdk) throw new Error('SDK not initialized')
+          await sdk.deleteObject(objectId)
+        },
       },
       files: {
         readAll: readAllFileRecords,
         readAllCount: readAllFileRecordsCount,
+      },
+      localObjects: {
+        delete: (objectId, indexerURL) =>
+          deleteLocalObject(objectId, indexerURL, false),
+        countForFile: countLocalObjectsForFile,
       },
       tags: { readNamesForFile: readTagNamesForFile },
       directories: { readNameForFile: readDirectoryNameForFile },

--- a/apps/mobile/src/managers/thumbnailScanner.test.ts
+++ b/apps/mobile/src/managers/thumbnailScanner.test.ts
@@ -89,6 +89,8 @@ describe('thumbnailScanner', () => {
       updatedAt: now,
       addedAt: now,
       localId: 'local-file1',
+      trashedAt: null,
+      deletedAt: null,
     })
     getFsFileUriMock.mockResolvedValue(null)
     const result = await runThumbnailScanner()
@@ -109,6 +111,8 @@ describe('thumbnailScanner', () => {
       updatedAt: now,
       addedAt: now,
       localId: 'local-file1',
+      trashedAt: null,
+      deletedAt: null,
     })
     for (const size of ThumbSizes) {
       await createFileRecord({
@@ -124,6 +128,8 @@ describe('thumbnailScanner', () => {
         localId: null,
         thumbForId: 'file1',
         thumbSize: size,
+        trashedAt: null,
+        deletedAt: null,
       })
     }
     getFsFileUriMock.mockResolvedValue('file://test.jpg')
@@ -147,6 +153,8 @@ describe('thumbnailScanner', () => {
       updatedAt: now,
       addedAt: now,
       localId: 'local-file1',
+      trashedAt: null,
+      deletedAt: null,
     })
     for (const size of ThumbSizes) {
       if (size === 64) continue
@@ -163,6 +171,8 @@ describe('thumbnailScanner', () => {
         localId: null,
         thumbForId: 'file1',
         thumbSize: size,
+        trashedAt: null,
+        deletedAt: null,
       })
     }
     getFsFileUriMock.mockResolvedValue('file://test.jpg')
@@ -195,6 +205,8 @@ describe('thumbnailScanner', () => {
         updatedAt: now - i,
         addedAt: now - i,
         localId: `local-nosource-${i}`,
+        trashedAt: null,
+        deletedAt: null,
       })
     }
 
@@ -211,6 +223,8 @@ describe('thumbnailScanner', () => {
         updatedAt: now - 100 - i,
         addedAt: now - 100 - i,
         localId: `local-covered-${i}`,
+        trashedAt: null,
+        deletedAt: null,
       })
       for (const size of ThumbSizes) {
         await createFileRecord({
@@ -226,6 +240,8 @@ describe('thumbnailScanner', () => {
           localId: null,
           thumbForId: `covered-${i}`,
           thumbSize: size,
+          trashedAt: null,
+          deletedAt: null,
         })
       }
     }
@@ -241,6 +257,8 @@ describe('thumbnailScanner', () => {
       updatedAt: now - 500,
       addedAt: now - 500,
       localId: 'local-eligible-1',
+      trashedAt: null,
+      deletedAt: null,
     })
 
     getFsFileUriMock.mockImplementation(async ({ id }: { id: string }) => {
@@ -275,6 +293,8 @@ describe('thumbnailScanner', () => {
       updatedAt: now,
       addedAt: now,
       localId: null,
+      trashedAt: null,
+      deletedAt: null,
     })
     await createFileRecord({
       id: 'thumb-64',
@@ -289,6 +309,8 @@ describe('thumbnailScanner', () => {
       localId: null,
       thumbForId: 'file1',
       thumbSize: 64,
+      trashedAt: null,
+      deletedAt: null,
     })
     getFsFileUriMock.mockResolvedValue('file://test.jpg')
     const result = await runThumbnailScanner()
@@ -309,6 +331,8 @@ describe('thumbnailScanner', () => {
       updatedAt: now,
       addedAt: now,
       localId: 'local-video1',
+      trashedAt: null,
+      deletedAt: null,
     })
     let counter = 0
     calculateContentHashMock.mockImplementation(
@@ -341,6 +365,8 @@ describe('thumbnailScanner', () => {
         updatedAt: now,
         addedAt: now,
         localId: `local-${i}`,
+        trashedAt: null,
+        deletedAt: null,
       })
     }
     getFsFileUriMock.mockResolvedValue('file://test.jpg')
@@ -365,6 +391,8 @@ describe('thumbnailScanner', () => {
       updatedAt: now,
       addedAt: now,
       localId: 'local-file1',
+      trashedAt: null,
+      deletedAt: null,
     })
     getFsFileUriMock.mockResolvedValue('file://test.jpg')
     imageGetSizeMock.mockImplementation((_, _ok, err) => {
@@ -402,6 +430,8 @@ describe('thumbnailScanner', () => {
       updatedAt: now,
       addedAt: now,
       localId: 'local-file1',
+      trashedAt: null,
+      deletedAt: null,
     })
     getFsFileUriMock.mockResolvedValue('file://test.jpg')
 
@@ -427,6 +457,8 @@ describe('thumbnailScanner', () => {
         updatedAt: now - i,
         addedAt: now - i,
         localId: `local-${i}`,
+        trashedAt: null,
+        deletedAt: null,
       })
     }
     getFsFileUriMock.mockResolvedValue('file://test.jpg')
@@ -471,6 +503,8 @@ describe('thumbnailScanner', () => {
       updatedAt: now,
       addedAt: now,
       localId: 'local-file1',
+      trashedAt: null,
+      deletedAt: null,
     })
     getFsFileUriMock.mockResolvedValue('file://test.jpg')
     imageGetSizeMock.mockImplementation((_, ok) => {

--- a/apps/mobile/src/managers/thumbnailScanner.ts
+++ b/apps/mobile/src/managers/thumbnailScanner.ts
@@ -40,10 +40,10 @@ export type ThumbnailScannerResult = {
 async function logOverallProgress() {
   try {
     const originalsRow = await db().getFirstAsync<{ count: number }>(
-      `SELECT COUNT(*) as count FROM files WHERE (type LIKE 'image/%' OR type LIKE 'video/%') AND kind = 'file'`,
+      `SELECT COUNT(*) as count FROM files WHERE (type LIKE 'image/%' OR type LIKE 'video/%') AND kind = 'file' AND trashedAt IS NULL AND deletedAt IS NULL`,
     )
     const thumbsRow = await db().getFirstAsync<{ count: number }>(
-      `SELECT COUNT(*) as count FROM files WHERE kind = 'thumb' AND thumbSize IN (${ThumbSizes.join(
+      `SELECT COUNT(*) as count FROM files WHERE kind = 'thumb' AND deletedAt IS NULL AND thumbSize IN (${ThumbSizes.join(
         ',',
       )})`,
     )
@@ -104,6 +104,7 @@ async function queryCandidateOriginals(
         AND t.thumbSize IN (${ThumbSizes.join(',')})
        WHERE (f.type LIKE 'image/%' OR f.type LIKE 'video/%')
          AND f.kind = 'file'
+         AND f.trashedAt IS NULL AND f.deletedAt IS NULL
          ${cursorClause}
        GROUP BY f.id
        HAVING COUNT(DISTINCT t.thumbSize) < ${ThumbSizes.length}

--- a/apps/mobile/src/managers/thumbnailer.ts
+++ b/apps/mobile/src/managers/thumbnailer.ts
@@ -265,6 +265,8 @@ export async function ensureThumbnailForSize(params: {
         localId: null,
         thumbForId: fileId,
         thumbSize: size,
+        trashedAt: null,
+        deletedAt: null,
       },
       true,
     )

--- a/apps/mobile/src/managers/uploader.test.ts
+++ b/apps/mobile/src/managers/uploader.test.ts
@@ -121,6 +121,8 @@ async function createTestFile(id: string, size = 1000): Promise<FileEntry> {
     updatedAt: now,
     localId: null,
     addedAt: now,
+    trashedAt: null,
+    deletedAt: null,
   })
 
   const file = await readFileRecord(id)
@@ -149,6 +151,8 @@ function createFileEntry(id: string, size = 1000): FileEntry {
       updatedAt: Date.now(),
       localId: null,
       addedAt: Date.now(),
+      trashedAt: null,
+      deletedAt: null,
     },
     size,
   }

--- a/apps/mobile/src/managers/uploaderEfficiency.test.ts
+++ b/apps/mobile/src/managers/uploaderEfficiency.test.ts
@@ -102,6 +102,8 @@ function createFileEntry(id: string, size = 1000): FileEntry {
       updatedAt: Date.now(),
       localId: null,
       addedAt: Date.now(),
+      trashedAt: null,
+      deletedAt: null,
     },
     size,
   }

--- a/apps/mobile/src/stores/directories.test.ts
+++ b/apps/mobile/src/stores/directories.test.ts
@@ -44,6 +44,8 @@ describe('directories store', () => {
       updatedAt: 1000,
       localId: null,
       addedAt: 1000,
+      trashedAt: null,
+      deletedAt: null,
     })
   }
 

--- a/apps/mobile/src/stores/directories.ts
+++ b/apps/mobile/src/stores/directories.ts
@@ -2,6 +2,7 @@ import { uniqueId } from '@siastorage/core/lib/uniqueId'
 import useSWR from 'swr'
 import { db } from '../db'
 import { sqlDelete, sqlInsert, sqlUpdate } from '../db/sql'
+import { trashFiles } from '../lib/deleteFile'
 import { swrCacheBy } from '../lib/swr'
 import { invalidateCacheLibraryLists } from './librarySwr'
 
@@ -82,7 +83,7 @@ export async function readAllDirectoriesWithCounts(): Promise<
   return db().getAllAsync<DirectoryWithCount>(
     `SELECT d.id, d.name, d.createdAt, COUNT(f.id) as fileCount
      FROM directories d
-     LEFT JOIN files f ON f.directoryId = d.id AND f.kind = 'file'
+     LEFT JOIN files f ON f.directoryId = d.id AND f.kind = 'file' AND f.trashedAt IS NULL AND f.deletedAt IS NULL
      GROUP BY d.id
      ORDER BY d.name COLLATE NOCASE`,
   )
@@ -90,6 +91,20 @@ export async function readAllDirectoriesWithCounts(): Promise<
 
 export async function deleteDirectory(id: string): Promise<void> {
   await sqlUpdate('files', { directoryId: null }, { directoryId: id })
+  await sqlDelete('directories', { id })
+  directoriesSwr.invalidateAll()
+  invalidateCacheLibraryLists()
+}
+
+export async function deleteDirectoryAndTrashFiles(id: string): Promise<void> {
+  const files = await db().getAllAsync<{ id: string }>(
+    `SELECT id FROM files WHERE directoryId = ? AND kind = 'file'`,
+    id,
+  )
+  const fileIds = files.map((f) => f.id)
+  if (fileIds.length > 0) {
+    await trashFiles(fileIds)
+  }
   await sqlDelete('directories', { id })
   directoriesSwr.invalidateAll()
   invalidateCacheLibraryLists()

--- a/apps/mobile/src/stores/fileCarousel.test.ts
+++ b/apps/mobile/src/stores/fileCarousel.test.ts
@@ -43,6 +43,8 @@ describe('fileCarousel virtual list functions', () => {
       updatedAt: params.createdAt,
       localId: null,
       addedAt: params.addedAt ?? params.createdAt,
+      trashedAt: null,
+      deletedAt: null,
     })
   }
 
@@ -552,6 +554,8 @@ describe('useFileCarousel hook', () => {
       updatedAt: params.createdAt,
       localId: null,
       addedAt: params.createdAt,
+      trashedAt: null,
+      deletedAt: null,
     })
   }
 
@@ -793,6 +797,8 @@ describe('useFileCarousel hook', () => {
         addedAt: base + 20,
         thumbForId: undefined,
         thumbSize: undefined,
+        trashedAt: null,
+        deletedAt: null,
         objects: {},
         objectsHash: '',
       }

--- a/apps/mobile/src/stores/fileStats.ts
+++ b/apps/mobile/src/stores/fileStats.ts
@@ -75,12 +75,13 @@ async function counts(
 /** Get upload stats for the library with category breakdown. */
 export async function getUploadStats(): Promise<UploadStats> {
   const indexerURL = await getIndexerURL()
-  const photosWhere = `f.kind = 'file' AND f.type LIKE 'image/%'`
-  const videosWhere = `f.kind = 'file' AND f.type LIKE 'video/%'`
-  const audioWhere = `f.kind = 'file' AND f.type LIKE 'audio/%'`
-  const docsWhere = `f.kind = 'file' AND (f.type LIKE 'text/%' OR f.type LIKE 'application/%')`
-  const otherWhere = `f.kind = 'file' AND f.type NOT LIKE 'image/%' AND f.type NOT LIKE 'video/%' AND f.type NOT LIKE 'audio/%' AND f.type NOT LIKE 'text/%' AND f.type NOT LIKE 'application/%'`
-  const thumbsWhere = `f.kind = 'thumb'`
+  const active = `f.trashedAt IS NULL AND f.deletedAt IS NULL`
+  const photosWhere = `f.kind = 'file' AND ${active} AND f.type LIKE 'image/%'`
+  const videosWhere = `f.kind = 'file' AND ${active} AND f.type LIKE 'video/%'`
+  const audioWhere = `f.kind = 'file' AND ${active} AND f.type LIKE 'audio/%'`
+  const docsWhere = `f.kind = 'file' AND ${active} AND (f.type LIKE 'text/%' OR f.type LIKE 'application/%')`
+  const otherWhere = `f.kind = 'file' AND ${active} AND f.type NOT LIKE 'image/%' AND f.type NOT LIKE 'video/%' AND f.type NOT LIKE 'audio/%' AND f.type NOT LIKE 'text/%' AND f.type NOT LIKE 'application/%'`
+  const thumbsWhere = `f.kind = 'thumb' AND ${active}`
 
   const [photosC, videosC, audioC, docsC, otherC, thumbsC] = await Promise.all([
     counts(photosWhere, indexerURL),

--- a/apps/mobile/src/stores/files.test.ts
+++ b/apps/mobile/src/stores/files.test.ts
@@ -4,6 +4,7 @@ import {
   readAllFileRecords,
   readAllFileRecordsCount,
   readFileRecord,
+  readFileRecordsByIds,
   updateFileRecord,
 } from './files'
 import { upsertFsFileMetadata } from './fs'
@@ -38,6 +39,8 @@ describe('files store queries', () => {
       addedAt: params.createdAt,
       thumbForId: undefined,
       thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
     })
   }
 
@@ -211,6 +214,8 @@ describe('updateFileRecord', () => {
       updatedAt: 100,
       localId: null,
       addedAt: 100,
+      trashedAt: null,
+      deletedAt: null,
     })
     await updateFileRecord({
       id: 'file-new',
@@ -237,6 +242,8 @@ describe('updateFileRecord', () => {
       updatedAt: 100,
       localId: null,
       addedAt: 100,
+      trashedAt: null,
+      deletedAt: null,
     })
     await updateFileRecord(
       {
@@ -250,5 +257,94 @@ describe('updateFileRecord', () => {
     const record = await readFileRecord('file-new')
     expect(record).toMatchObject({ name: 'new name', updatedAt: 4444 })
     expect(nowSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('activeOnly filter and null handling', () => {
+  const base = 2_000
+
+  beforeEach(async () => {
+    await initializeDB()
+  })
+
+  afterEach(async () => {
+    await resetDb()
+    jest.clearAllMocks()
+  })
+
+  async function createRecord(params: { id: string; createdAt: number }) {
+    await createFileRecord({
+      id: params.id,
+      name: `${params.id}.jpg`,
+      type: 'image/jpeg',
+      kind: 'file',
+      size: 100,
+      hash: `hash-${params.id}`,
+      createdAt: params.createdAt,
+      updatedAt: params.createdAt,
+      localId: null,
+      addedAt: params.createdAt,
+      thumbForId: undefined,
+      thumbSize: undefined,
+      trashedAt: null,
+      deletedAt: null,
+    })
+  }
+
+  test('trashedAt filter excludes trashed files from active queries', async () => {
+    await createRecord({ id: 'file-a', createdAt: base })
+
+    const before = await readAllFileRecords({ order: 'ASC', activeOnly: true })
+    expect(before.map((r) => r.id)).toContain('file-a')
+
+    await updateFileRecord({ id: 'file-a', trashedAt: base + 1 })
+
+    const afterActive = await readAllFileRecords({
+      order: 'ASC',
+      activeOnly: true,
+    })
+    expect(afterActive.map((r) => r.id)).not.toContain('file-a')
+
+    const afterAll = await readAllFileRecords({ order: 'ASC' })
+    expect(afterAll.map((r) => r.id)).toContain('file-a')
+  })
+
+  test('deletedAt filter excludes tombstones from active queries', async () => {
+    await createRecord({ id: 'file-b', createdAt: base })
+
+    const before = await readAllFileRecords({ order: 'ASC', activeOnly: true })
+    expect(before.map((r) => r.id)).toContain('file-b')
+
+    await updateFileRecord({ id: 'file-b', deletedAt: base + 1 })
+
+    const afterActive = await readAllFileRecords({
+      order: 'ASC',
+      activeOnly: true,
+    })
+    expect(afterActive.map((r) => r.id)).not.toContain('file-b')
+
+    const afterAll = await readAllFileRecords({ order: 'ASC' })
+    expect(afterAll.map((r) => r.id)).toContain('file-b')
+  })
+
+  test('updateFileRecord writes null values correctly', async () => {
+    await createRecord({ id: 'file-c', createdAt: base })
+    await updateFileRecord({ id: 'file-c', trashedAt: base + 1 })
+
+    const trashed = await readFileRecord('file-c')
+    expect(trashed?.trashedAt).toBe(base + 1)
+
+    await updateFileRecord({ id: 'file-c', trashedAt: null })
+
+    const restored = await readFileRecord('file-c')
+    expect(restored?.trashedAt).toBeNull()
+  })
+
+  test('readFileRecordsByIds returns tombstoned files', async () => {
+    await createRecord({ id: 'file-d', createdAt: base })
+    await updateFileRecord({ id: 'file-d', deletedAt: base + 1 })
+
+    const results = await readFileRecordsByIds(['file-d'])
+    expect(results.map((r) => r.id)).toContain('file-d')
   })
 })

--- a/apps/mobile/src/stores/files.ts
+++ b/apps/mobile/src/stores/files.ts
@@ -54,6 +54,8 @@ export async function createFileRecord(
     addedAt,
     thumbForId,
     thumbSize,
+    trashedAt,
+    deletedAt,
   } = fileRecord
   await sqlInsert('files', {
     id,
@@ -68,6 +70,8 @@ export async function createFileRecord(
     addedAt,
     thumbForId,
     thumbSize,
+    trashedAt,
+    deletedAt,
   })
   if (triggerUpdate) {
     await invalidateCacheLibraryAllStats()
@@ -102,6 +106,7 @@ type FileRecordsQueryOpts = {
   }
   fileExistsLocally?: boolean
   excludeIds?: string[]
+  activeOnly?: boolean
 }
 
 function buildFileRecordsQuery(
@@ -121,12 +126,18 @@ function buildFileRecordsQuery(
     orderBy,
     fileExistsLocally,
     excludeIds,
+    activeOnly,
   } = opts
   const sortColumn: FileRecordCursorColumn = orderBy ?? 'createdAt'
 
   const params: (string | number)[] = []
 
   const whereClauses: string[] = []
+
+  if (activeOnly) {
+    whereClauses.push(`${tableAlias}.trashedAt IS NULL`)
+    whereClauses.push(`${tableAlias}.deletedAt IS NULL`)
+  }
 
   if (after) {
     if (order === 'ASC') {
@@ -222,7 +233,7 @@ export async function readAllFileRecords(
         objectUpdatedAt: number
       }
   >(
-    `SELECT f.id, f.name, f.size, f.createdAt, f.updatedAt, f.type, f.kind, f.localId, f.hash, f.addedAt, f.thumbForId, f.thumbSize,
+    `SELECT f.id, f.name, f.size, f.createdAt, f.updatedAt, f.type, f.kind, f.localId, f.hash, f.addedAt, f.thumbForId, f.thumbSize, f.trashedAt, f.deletedAt,
             o.fileId as fileId, o.indexerURL as indexerURL, o.id as objectId, o.slabs as slabs,
             o.encryptedDataKey as encryptedDataKey, o.encryptedMetadataKey as encryptedMetadataKey,
             o.encryptedMetadata as encryptedMetadata, o.dataSignature as dataSignature,
@@ -260,12 +271,62 @@ export async function readAllFileRecords(
   })
 }
 
+export async function readFileRecordsByIds(
+  ids: string[],
+): Promise<FileRecord[]> {
+  if (ids.length === 0) return []
+  const placeholders = ids.map(() => '?').join(',')
+  const joined = await db().getAllAsync<
+    FileRecordRow &
+      LocalObjectRow & {
+        objectId: string
+        objectCreatedAt: number
+        objectUpdatedAt: number
+      }
+  >(
+    `SELECT f.id, f.name, f.size, f.createdAt, f.updatedAt, f.type, f.kind, f.localId, f.hash, f.addedAt, f.thumbForId, f.thumbSize, f.trashedAt, f.deletedAt,
+            o.fileId as fileId, o.indexerURL as indexerURL, o.id as objectId, o.slabs as slabs,
+            o.encryptedDataKey as encryptedDataKey, o.encryptedMetadataKey as encryptedMetadataKey,
+            o.encryptedMetadata as encryptedMetadata, o.dataSignature as dataSignature,
+            o.metadataSignature as metadataSignature, o.createdAt as objectCreatedAt, o.updatedAt as objectUpdatedAt
+     FROM files f
+     LEFT JOIN objects o ON o.fileId = f.id
+     WHERE f.id IN (${placeholders})`,
+    ...ids,
+  )
+
+  const byId: Map<string, FileRecordRow> = new Map()
+  const objectsById: Map<string, LocalObject[]> = new Map()
+
+  for (const r of joined) {
+    if (!byId.has(r.id)) {
+      byId.set(r.id, r)
+    }
+    if (r.fileId && r.indexerURL) {
+      const arr = objectsById.get(r.id) || []
+      arr.push(
+        localObjectFromStorageRow({
+          ...r,
+          id: r.objectId,
+          createdAt: r.objectCreatedAt,
+          updatedAt: r.objectUpdatedAt,
+        }),
+      )
+      objectsById.set(r.id, arr)
+    }
+  }
+
+  return Array.from(byId.values()).map((row) => {
+    return transformRow(row, objectsById.get(row.id))
+  })
+}
+
 export async function readFileRecordByObjectId(
   objectId: string,
   indexerURL: string,
 ): Promise<FileRecord | null> {
   const row = await db().getFirstAsync<FileRecordRow>(
-    `SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize FROM files WHERE id IN (SELECT fileId FROM objects WHERE id = ? AND indexerURL = ?) LIMIT 1`,
+    `SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize, trashedAt, deletedAt FROM files WHERE id IN (SELECT fileId FROM objects WHERE id = ? AND indexerURL = ?) LIMIT 1`,
     objectId,
     indexerURL,
   )
@@ -276,7 +337,7 @@ export async function readFileRecordByObjectId(
 
 export async function readFileRecordsByLocalIds(localIds: string[]) {
   const rows = await db().getAllAsync<FileRecordRow>(
-    `SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize FROM files WHERE localId IN (${localIds
+    `SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize, trashedAt, deletedAt FROM files WHERE deletedAt IS NULL AND localId IN (${localIds
       .map((_) => `?`)
       .join(',')})`,
     ...localIds,
@@ -288,7 +349,7 @@ export async function readFileRecordsByLocalIds(localIds: string[]) {
 
 export async function readFileRecordsByContentHashes(contentHashes: string[]) {
   const rows = await db().getAllAsync<FileRecordRow>(
-    `SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize FROM files WHERE hash IN (${contentHashes
+    `SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize, trashedAt, deletedAt FROM files WHERE deletedAt IS NULL AND hash IN (${contentHashes
       .map((_) => `?`)
       .join(',')})`,
     ...contentHashes,
@@ -300,7 +361,7 @@ export async function readFileRecordsByContentHashes(contentHashes: string[]) {
 
 export async function readFileRecordByContentHash(hash: string) {
   const row = await db().getFirstAsync<FileRecordRow>(
-    'SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize FROM files WHERE hash = ?',
+    'SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize, trashedAt, deletedAt FROM files WHERE hash = ?',
     hash,
   )
   if (!row) {
@@ -313,7 +374,7 @@ export async function readFileRecordByContentHash(hash: string) {
 
 export async function readFileRecord(id: string): Promise<FileRecord | null> {
   const row = await db().getFirstAsync<FileRecordRow>(
-    'SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize FROM files WHERE id = ?',
+    'SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize, trashedAt, deletedAt FROM files WHERE id = ?',
     id,
   )
   if (!row) {
@@ -342,13 +403,15 @@ export async function updateFileRecord(
     'thumbForId',
     'thumbSize',
     'localId',
+    'trashedAt',
+    'deletedAt',
   ]
   if (options.includeUpdatedAt) {
     updatableFields.push('updatedAt')
   }
   for (const field of updatableFields) {
     const value = update[field]
-    if (value === undefined || value === null) {
+    if (value === undefined) {
       continue
     }
     assignments[field] = value
@@ -444,6 +507,7 @@ export async function deleteLostFiles(): Promise<number> {
       isPinned: false,
     },
     fileExistsLocally: false,
+    activeOnly: true,
   })
   if (lost.length === 0) return 0
   await deleteManyFileRecordsAndThumbnails(lost.map((f) => f.id))
@@ -518,6 +582,8 @@ export function transformRow(
     hash: row.hash,
     thumbForId: row.thumbForId ?? undefined,
     thumbSize: row.thumbSize ?? undefined,
+    trashedAt: row.trashedAt ?? null,
+    deletedAt: row.deletedAt ?? null,
     objects: objectsMap,
   }
 }
@@ -528,6 +594,7 @@ export function useFileCountAll() {
       limit: undefined,
       after: undefined,
       order: 'ASC',
+      activeOnly: true,
     }),
   )
 }
@@ -538,6 +605,7 @@ export function useFileStatsAll() {
       limit: undefined,
       after: undefined,
       order: 'ASC',
+      activeOnly: true,
     }),
   )
 }
@@ -567,6 +635,7 @@ export const [getFilesLocalOnly, useFilesLocalOnly] = createGetterAndSWRHook(
         isPinned: false,
       },
       fileExistsLocally: true,
+      activeOnly: true,
     })
   },
 )
@@ -582,6 +651,7 @@ export const [getFileCountLost, useFileCountLost] = createGetterAndSWRHook(
         isPinned: false,
       },
       fileExistsLocally: false,
+      activeOnly: true,
     })
   },
 )
@@ -597,6 +667,7 @@ export const [getFileStatsLost, useFileStatsLost] = createGetterAndSWRHook(
         isPinned: false,
       },
       fileExistsLocally: false,
+      activeOnly: true,
     })
   },
 )
@@ -612,6 +683,7 @@ export const [getFileCountLocal, useFileCountLocal] = createGetterAndSWRHook(
         isPinned: !localOnly,
       },
       fileExistsLocally: true,
+      activeOnly: true,
     })
   },
 )
@@ -627,6 +699,7 @@ export const [getFileStatsLocal, useFileStatsLocal] = createGetterAndSWRHook(
         isPinned: !localOnly,
       },
       fileExistsLocally: true,
+      activeOnly: true,
     })
   },
 )

--- a/apps/mobile/src/stores/library.test.ts
+++ b/apps/mobile/src/stores/library.test.ts
@@ -29,6 +29,8 @@ describe('library tag filtering', () => {
       updatedAt: 1000,
       localId: null,
       addedAt: 1000,
+      trashedAt: null,
+      deletedAt: null,
     })
   }
 

--- a/apps/mobile/src/stores/library.ts
+++ b/apps/mobile/src/stores/library.ts
@@ -56,7 +56,7 @@ async function readOrderedFileRecords(
   }
 
   const rows = await db().getAllAsync<FileRecordRow>(
-    `SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize
+    `SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize, trashedAt, deletedAt
      FROM files
      ${where}
      ORDER BY ${orderExpr}${pageClause}`,
@@ -147,7 +147,7 @@ export function useFileList(params: FileListParams) {
 export function useLibraryCount() {
   return useSWR(libraryStats.key('countNoThumbs'), async () => {
     const row = await db().getFirstAsync<{ count: number }>(
-      `SELECT COUNT(*) as count FROM files WHERE kind = 'file'`,
+      `SELECT COUNT(*) as count FROM files WHERE kind = 'file' AND trashedAt IS NULL AND deletedAt IS NULL`,
     )
     return row?.count ?? 0
   })
@@ -159,6 +159,7 @@ export function useMediaCount() {
     const row = await db().getFirstAsync<{ count: number }>(
       `SELECT COUNT(*) as count FROM files
        WHERE kind = 'file'
+         AND trashedAt IS NULL AND deletedAt IS NULL
          AND (type LIKE 'image/%' OR type LIKE 'video/%' OR type LIKE 'audio/%')`,
     )
     return row?.count ?? 0
@@ -171,7 +172,7 @@ export function useTagFileCount(tagId: string) {
     const row = await db().getFirstAsync<{ count: number }>(
       `SELECT COUNT(*) as count FROM files f
        INNER JOIN file_tags ft ON ft.fileId = f.id
-       WHERE ft.tagId = ? AND f.kind = 'file'`,
+       WHERE ft.tagId = ? AND f.kind = 'file' AND f.trashedAt IS NULL AND f.deletedAt IS NULL`,
       tagId,
     )
     return row?.count ?? 0
@@ -184,13 +185,13 @@ export function useDirectoryFileCount(directoryId: string) {
     if (directoryId === UNFILED_DIRECTORY_ID) {
       const row = await db().getFirstAsync<{ count: number }>(
         `SELECT COUNT(*) as count FROM files
-         WHERE directoryId IS NULL AND kind = 'file'`,
+         WHERE directoryId IS NULL AND kind = 'file' AND trashedAt IS NULL AND deletedAt IS NULL`,
       )
       return row?.count ?? 0
     }
     const row = await db().getFirstAsync<{ count: number }>(
       `SELECT COUNT(*) as count FROM files
-       WHERE directoryId = ? AND kind = 'file'`,
+       WHERE directoryId = ? AND kind = 'file' AND trashedAt IS NULL AND deletedAt IS NULL`,
       directoryId,
     )
     return row?.count ?? 0
@@ -201,7 +202,7 @@ export function useUnfiledFileCount() {
   return useSWR(libraryStats.key('unfiledCount'), async () => {
     const row = await db().getFirstAsync<{ count: number }>(
       `SELECT COUNT(*) as count FROM files
-       WHERE directoryId IS NULL AND kind = 'file'`,
+       WHERE directoryId IS NULL AND kind = 'file' AND trashedAt IS NULL AND deletedAt IS NULL`,
     )
     return row?.count ?? 0
   })
@@ -250,8 +251,9 @@ export function buildLibraryQueryParts(
 
   const whereParts: string[] = []
   const params: (string | number)[] = []
-  // Exclude thumbnails from library lists.
   whereParts.push(`${tableAlias}.kind = 'file'`)
+  whereParts.push(`${tableAlias}.trashedAt IS NULL`)
+  whereParts.push(`${tableAlias}.deletedAt IS NULL`)
 
   if (!allSelected && (mediaCategories.length > 0 || includesFiles)) {
     const categoryConditions: string[] = []

--- a/apps/mobile/src/stores/tags.test.ts
+++ b/apps/mobile/src/stores/tags.test.ts
@@ -52,6 +52,8 @@ describe('tags store', () => {
       updatedAt: 1000,
       localId: null,
       addedAt: 1000,
+      trashedAt: null,
+      deletedAt: null,
     })
   }
 

--- a/apps/mobile/src/stores/tags.ts
+++ b/apps/mobile/src/stores/tags.ts
@@ -171,7 +171,7 @@ export async function readAllTagsWithCounts(): Promise<TagWithCount[]> {
     `SELECT t.id, t.name, t.createdAt, t.usedAt, t.system, COUNT(f.id) as fileCount
      FROM tags t
      LEFT JOIN file_tags ft ON ft.tagId = t.id
-     LEFT JOIN files f ON f.id = ft.fileId AND f.kind = 'file'
+     LEFT JOIN files f ON f.id = ft.fileId AND f.kind = 'file' AND f.trashedAt IS NULL AND f.deletedAt IS NULL
      GROUP BY t.id
      ORDER BY t.system DESC, t.name COLLATE NOCASE`,
   )

--- a/apps/mobile/test/full-lifecycle.test.ts
+++ b/apps/mobile/test/full-lifecycle.test.ts
@@ -92,18 +92,19 @@ describe('Full File Lifecycle', () => {
     // STEP 4: User deletes file on another device
     harness.sdk.injectDeleteEvent(objectId)
 
-    // Wait for syncDownEvents service to process the deletion
+    // Wait for syncDown to tombstone the file
     await waitForCondition(
       async () => {
         const deletedFile = await readFileRecord(file.id)
-        return deletedFile === null
+        return deletedFile?.deletedAt != null
       },
-      { timeout: 10_000, message: 'File to be deleted' },
+      { timeout: 10_000, message: 'File to be tombstoned' },
     )
 
-    // Verify: File removed everywhere
+    // Verify: file is tombstoned, object row cleaned up
     dbFile = await readFileRecord(file.id)
-    expect(dbFile).toBeNull()
+    expect(dbFile).not.toBeNull()
+    expect(dbFile!.deletedAt).not.toBeNull()
     objects = await readLocalObjectsForFile(file.id)
     expect(objects).toHaveLength(0)
     // The file's object should be gone from remote

--- a/apps/mobile/test/multi-device-convergence.test.ts
+++ b/apps/mobile/test/multi-device-convergence.test.ts
@@ -14,12 +14,14 @@
 import './utils/setup'
 
 import { decodeFileMetadata } from '@siastorage/core/encoding/fileMetadata'
+import { permanentlyDeleteFiles, trashFiles } from '../src/lib/deleteFile'
 import {
   createDirectory,
   moveFileToDirectory,
   readDirectoryNameForFile,
 } from '../src/stores/directories'
 import { readAllFileRecords, readFileRecord } from '../src/stores/files'
+import { readLocalObjectsForFile } from '../src/stores/localObjects'
 import { addTagToFile, readTagsForFile } from '../src/stores/tags'
 import { readThumbnailsByFileId } from '../src/stores/thumbnails'
 import {
@@ -272,6 +274,7 @@ describe('Multi-Device Convergence', () => {
         updatedAt: Date.now(),
         thumbForId: parentFileId,
         thumbSize: 64,
+        trashedAt: null,
       },
     })
 
@@ -623,6 +626,7 @@ describe('Multi-Device Convergence', () => {
         updatedAt: Date.now(),
         thumbForId: parentFileId,
         thumbSize: 64,
+        trashedAt: null,
       },
     })
 
@@ -785,23 +789,22 @@ describe('Multi-Device Convergence', () => {
 
     await waitForCondition(
       async () => {
-        const files = await readAllFileRecords({ order: 'ASC' })
-        return files.length === 2
+        const file = await readFileRecord(deviceAFiles[0].id)
+        return file?.deletedAt != null
       },
-      { timeout: 15_000, message: 'Device B to sync delete' },
+      { timeout: 15_000, message: 'Device B to tombstone deleted file' },
     )
 
-    const remainingFiles = await readAllFileRecords({ order: 'ASC' })
-    expect(remainingFiles).toHaveLength(2)
-
-    // The deleted file should be gone
+    // The deleted file should be tombstoned, not removed
     const deletedFile = await readFileRecord(deviceAFiles[0].id)
-    expect(deletedFile).toBeNull()
+    expect(deletedFile).not.toBeNull()
+    expect(deletedFile!.deletedAt).not.toBeNull()
 
-    // The other two files should still exist
+    // The other two files should still be active
     for (const file of deviceAFiles.slice(1)) {
       const remaining = await readFileRecord(file.id)
       expect(remaining).not.toBeNull()
+      expect(remaining!.deletedAt).toBeNull()
     }
 
     await harnessB.shutdown()
@@ -989,6 +992,158 @@ describe('Multi-Device Convergence', () => {
 
     await harnessB.shutdown()
   }, 90_000)
+
+  it('trash and tombstone converge across two devices', async () => {
+    const sharedStorage = createEmptyStorage()
+
+    // Device A: upload 2 data files
+    const sdkA = new MockSdk(sharedStorage)
+    const harnessA = createHarness({ sdk: sdkA })
+    await harnessA.start()
+
+    const fileFactories = generateTestFiles(2, { type: 'data' })
+    const testFiles = await addTestFilesToHarness(harnessA, fileFactories)
+    await harnessA.waitForNoActiveUploads()
+    await waitForAllObjectsV1(sharedStorage, 2)
+
+    const fileIdA = testFiles[0].id
+    const fileIdB = testFiles[1].id
+
+    await harnessA.shutdown()
+
+    // Device B: sync both files
+    const sdkB = new MockSdk(sharedStorage)
+    const harnessB = createHarness({ sdk: sdkB })
+    await harnessB.start()
+
+    await harnessB.waitForFileCount(2)
+
+    // Both files are active
+    let file1 = await readFileRecord(fileIdA)
+    let file2 = await readFileRecord(fileIdB)
+    expect(file1!.trashedAt).toBeNull()
+    expect(file1!.deletedAt).toBeNull()
+    expect(file2!.trashedAt).toBeNull()
+    expect(file2!.deletedAt).toBeNull()
+
+    // Simulate Device A trashing file 1 (metadata update with trashedAt)
+    harnessB.pause()
+    const objectEntries = Array.from(sharedStorage.objects.entries())
+    const obj1Entry = objectEntries.find(([_, obj]) => {
+      try {
+        const meta = decodeFileMetadata(obj.metadata)
+        return meta.id === fileIdA
+      } catch {
+        return false
+      }
+    })!
+    const obj2Entry = objectEntries.find(([_, obj]) => {
+      try {
+        const meta = decodeFileMetadata(obj.metadata)
+        return meta.id === fileIdB
+      } catch {
+        return false
+      }
+    })!
+
+    const trashTime = Date.now() + 5000
+    sdkB.injectMetadataChange(obj1Entry[0], {
+      trashedAt: trashTime,
+      updatedAt: trashTime,
+    })
+    harnessB.resume()
+
+    // Device B sees the trash via syncDown
+    await waitForCondition(
+      async () => {
+        const file = await readFileRecord(fileIdA)
+        return file?.trashedAt != null
+      },
+      { timeout: 15_000, message: 'Device B to see trashedAt on file 1' },
+    )
+
+    file1 = await readFileRecord(fileIdA)
+    expect(file1!.trashedAt).not.toBeNull()
+    expect(file1!.deletedAt).toBeNull()
+
+    // Device B trashes file 2 locally
+    await trashFiles([fileIdB])
+    file2 = await readFileRecord(fileIdB)
+    expect(file2!.trashedAt).not.toBeNull()
+    expect(file2!.deletedAt).toBeNull()
+
+    // Wait for Device B's syncUp to push trashedAt for file 2
+    await waitForCondition(
+      () => {
+        try {
+          const meta = decodeFileMetadata(
+            sharedStorage.objects.get(obj2Entry[0])!.metadata,
+          )
+          return meta.trashedAt != null
+        } catch {
+          return false
+        }
+      },
+      {
+        timeout: 15_000,
+        message: 'Device B syncUp to push trashedAt for file 2',
+      },
+    )
+
+    // Simulate Device A permanently deleting file 1 (object deleted from indexer)
+    harnessB.pause()
+    const deleteSdk = new MockSdk(sharedStorage)
+    await deleteSdk.deleteObject(obj1Entry[0])
+    harnessB.resume()
+
+    // Device B processes the delete event → tombstone
+    await waitForCondition(
+      async () => {
+        const file = await readFileRecord(fileIdA)
+        return file?.deletedAt != null
+      },
+      { timeout: 15_000, message: 'Device B to tombstone file 1' },
+    )
+
+    file1 = await readFileRecord(fileIdA)
+    expect(file1!.deletedAt).not.toBeNull()
+
+    // Local object row cleaned up
+    const objects1 = await readLocalObjectsForFile(fileIdA)
+    expect(objects1).toHaveLength(0)
+
+    // File row persists as tombstone
+    expect(await readFileRecord(fileIdA)).not.toBeNull()
+
+    // Device B permanently deletes file 2
+    file2 = (await readFileRecord(fileIdB))!
+    await permanentlyDeleteFiles([file2])
+
+    file2 = (await readFileRecord(fileIdB))!
+    expect(file2.deletedAt).not.toBeNull()
+
+    // Wait for Device B's syncUp to call deleteObject for file 2
+    await waitForCondition(() => !sharedStorage.objects.has(obj2Entry[0]), {
+      timeout: 15_000,
+      message: 'Device B syncUp to delete file 2 object',
+    })
+
+    // Delete event was pushed to shared storage
+    const deleteEvents = sharedStorage.events.filter(
+      (e) => e.id === obj2Entry[0] && e.deleted,
+    )
+    expect(deleteEvents.length).toBeGreaterThan(0)
+
+    // Local object row cleaned up for file 2
+    const objects2 = await readLocalObjectsForFile(fileIdB)
+    expect(objects2).toHaveLength(0)
+
+    // Both files are tombstoned
+    expect((await readFileRecord(fileIdA))!.deletedAt).not.toBeNull()
+    expect((await readFileRecord(fileIdB))!.deletedAt).not.toBeNull()
+
+    await harnessB.shutdown()
+  }, 60_000)
 
   it('v0 node overwrites v1: tags and directory preserved, syncUp repairs', async () => {
     const sharedStorage = createEmptyStorage()

--- a/apps/mobile/test/multi-device-sync.test.ts
+++ b/apps/mobile/test/multi-device-sync.test.ts
@@ -144,17 +144,19 @@ describe('Multi-Device Sync', () => {
     // Phone deletes the file
     harness.sdk.injectDeleteEvent(objectId)
 
-    // Wait for syncDownEvents service to process the deletion
+    // Wait for syncDown to tombstone the file
     await waitForCondition(
       async () => {
         const dbFile = await readFileRecord(file.id)
-        return dbFile === null
+        return dbFile?.deletedAt != null
       },
-      { timeout: 10_000, message: 'File to be deleted' },
+      { timeout: 10_000, message: 'File to be tombstoned' },
     )
 
-    // Verify: File removed locally
-    expect(await readFileRecord(file.id)).toBeNull()
+    // Verify: file is tombstoned, object row cleaned up
+    const dbFile = await readFileRecord(file.id)
+    expect(dbFile).not.toBeNull()
+    expect(dbFile!.deletedAt).not.toBeNull()
     const objects = await readLocalObjectsForFile(file.id)
     expect(objects).toHaveLength(0)
   }, 30_000)

--- a/apps/mobile/test/sync-down.test.ts
+++ b/apps/mobile/test/sync-down.test.ts
@@ -113,13 +113,13 @@ describe('Sync Down Integration', () => {
     // Inject delete event
     harness.sdk.injectDeleteEvent(stored.id)
 
-    // Wait for delete to sync
+    // Wait for syncDown to tombstone the file
     await waitForCondition(
       async () => {
         const files = await readAllFileRecords({ order: 'ASC' })
-        return files.length === 0
+        return files.length === 1 && files[0].deletedAt != null
       },
-      { timeout: 10_000, message: 'File to be deleted' },
+      { timeout: 10_000, message: 'File to be tombstoned' },
     )
   })
 

--- a/apps/mobile/test/utils/harness.ts
+++ b/apps/mobile/test/utils/harness.ts
@@ -487,6 +487,8 @@ export async function addTestFilesToHarness(
       updatedAt: now,
       localId: null,
       addedAt: now,
+      trashedAt: null,
+      deletedAt: null,
     })
 
     // Add fs metadata entry so the file is detected as "local"

--- a/apps/mobile/test/utils/mockSdk.ts
+++ b/apps/mobile/test/utils/mockSdk.ts
@@ -707,6 +707,7 @@ export function generateMockFileMetadata(
     hash: `hash-${index}`,
     createdAt: now - index * 1000,
     updatedAt: now - index * 1000,
+    trashedAt: null,
     ...overrides,
   }
 }

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -62,5 +62,7 @@ export const SYNC_UP_METADATA_BATCH_SIZE = 500 // 500 files
 export const SYNC_UP_METADATA_CONCURRENCY = 30
 // Auto-download threshold for shared file imports.
 export const SHARED_FILE_AUTO_DOWNLOAD_THRESHOLD = 5 * 1024 * 1024 // 5 MB
+// Auto-purge trashed files older than this threshold.
+export const TRASH_AUTO_PURGE_AGE = daysInMs(30) // 30 days
 // Performance monitor logging interval.
 export const PERF_MONITOR_INTERVAL = secondsInMs(15)

--- a/packages/core/src/db/migrations/0007_soft_delete.ts
+++ b/packages/core/src/db/migrations/0007_soft_delete.ts
@@ -1,0 +1,23 @@
+import type { DatabaseAdapter } from '../../adapters/db'
+import type { Migration } from '../types'
+
+async function up(db: DatabaseAdapter): Promise<void> {
+  await db.execAsync(
+    'ALTER TABLE files ADD COLUMN trashedAt INTEGER;',
+  )
+  await db.execAsync(
+    'ALTER TABLE files ADD COLUMN deletedAt INTEGER;',
+  )
+  await db.execAsync(
+    'CREATE INDEX IF NOT EXISTS idx_files_trashedAt ON files(trashedAt);',
+  )
+  await db.execAsync(
+    'CREATE INDEX IF NOT EXISTS idx_files_deletedAt ON files(deletedAt);',
+  )
+}
+
+export const migration_0007_soft_delete: Migration = {
+  id: '0007_soft_delete',
+  description: 'Add trashedAt and deletedAt columns for soft delete and tombstone support.',
+  up,
+}

--- a/packages/core/src/db/migrations/index.ts
+++ b/packages/core/src/db/migrations/index.ts
@@ -3,12 +3,14 @@ import { migration_0001_init_schema } from './0001_init_schema'
 import { migration_0003_logs_data_column } from './0003_logs_data_column'
 import { migration_0004_hash_and_thumbs } from './0004_hash_and_thumbs'
 import { migration_0006_add_tags_and_directories } from './0006_add_tags_and_directories'
+import { migration_0007_soft_delete } from './0007_soft_delete'
 
 export const coreMigrations: Migration[] = [
   migration_0001_init_schema,
   migration_0003_logs_data_column,
   migration_0004_hash_and_thumbs,
   migration_0006_add_tags_and_directories,
+  migration_0007_soft_delete,
 ]
 
 export function sortMigrations(migrations: Migration[]): Migration[] {

--- a/packages/core/src/db/operations/files.ts
+++ b/packages/core/src/db/operations/files.ts
@@ -29,6 +29,8 @@ export function transformRow(
     hash: row.hash,
     thumbForId: row.thumbForId ?? undefined,
     thumbSize: row.thumbSize ?? undefined,
+    trashedAt: row.trashedAt ?? null,
+    deletedAt: row.deletedAt ?? null,
     objects: objectsMap,
   }
 }
@@ -50,6 +52,8 @@ export async function insertFileRecord(
     addedAt,
     thumbForId,
     thumbSize,
+    trashedAt,
+    deletedAt,
   } = fileRecord
   await sqlInsert(db, 'files', {
     id,
@@ -64,6 +68,8 @@ export async function insertFileRecord(
     addedAt,
     thumbForId,
     thumbSize,
+    trashedAt,
+    deletedAt,
   })
 }
 
@@ -80,6 +86,7 @@ export type FileRecordsQueryOpts = {
   }
   fileExistsLocally?: boolean
   excludeIds?: string[]
+  activeOnly?: boolean
 }
 
 function buildFileRecordsQuery(
@@ -99,12 +106,18 @@ function buildFileRecordsQuery(
     orderBy,
     fileExistsLocally,
     excludeIds,
+    activeOnly,
   } = opts
   const sortColumn: FileRecordCursorColumn = orderBy ?? 'createdAt'
 
   const params: (string | number)[] = []
 
   const whereClauses: string[] = []
+
+  if (activeOnly) {
+    whereClauses.push(`${tableAlias}.trashedAt IS NULL`)
+    whereClauses.push(`${tableAlias}.deletedAt IS NULL`)
+  }
 
   if (after) {
     if (order === 'ASC') {
@@ -201,7 +214,7 @@ export async function queryFileRecords(
         objectUpdatedAt: number
       }
   >(
-    `SELECT f.id, f.name, f.size, f.createdAt, f.updatedAt, f.type, f.kind, f.localId, f.hash, f.addedAt, f.thumbForId, f.thumbSize,
+    `SELECT f.id, f.name, f.size, f.createdAt, f.updatedAt, f.type, f.kind, f.localId, f.hash, f.addedAt, f.thumbForId, f.thumbSize, f.trashedAt, f.deletedAt,
             o.fileId as fileId, o.indexerURL as indexerURL, o.id as objectId, o.slabs as slabs,
             o.encryptedDataKey as encryptedDataKey, o.encryptedMetadataKey as encryptedMetadataKey,
             o.encryptedMetadata as encryptedMetadata, o.dataSignature as dataSignature,
@@ -245,7 +258,7 @@ export async function queryFileRecordByObjectId(
   indexerURL: string,
 ): Promise<FileRecordRow | null> {
   return db.getFirstAsync<FileRecordRow>(
-    `SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize FROM files WHERE id IN (SELECT fileId FROM objects WHERE id = ? AND indexerURL = ?) LIMIT 1`,
+    `SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize, trashedAt, deletedAt FROM files WHERE id IN (SELECT fileId FROM objects WHERE id = ? AND indexerURL = ?) LIMIT 1`,
     objectId,
     indexerURL,
   )
@@ -256,7 +269,7 @@ export async function queryFileRecordsByLocalIds(
   localIds: string[],
 ): Promise<FileRecordRow[]> {
   return db.getAllAsync<FileRecordRow>(
-    `SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize FROM files WHERE localId IN (${localIds
+    `SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize, trashedAt, deletedAt FROM files WHERE localId IN (${localIds
       .map((_) => `?`)
       .join(',')})`,
     ...localIds,
@@ -268,7 +281,7 @@ export async function queryFileRecordsByContentHashes(
   contentHashes: string[],
 ): Promise<FileRecordRow[]> {
   return db.getAllAsync<FileRecordRow>(
-    `SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize FROM files WHERE hash IN (${contentHashes
+    `SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize, trashedAt, deletedAt FROM files WHERE hash IN (${contentHashes
       .map((_) => `?`)
       .join(',')})`,
     ...contentHashes,
@@ -280,7 +293,7 @@ export async function queryFileRecordByContentHash(
   hash: string,
 ): Promise<FileRecordRow | null> {
   const row = await db.getFirstAsync<FileRecordRow>(
-    'SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize FROM files WHERE hash = ?',
+    'SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize, trashedAt, deletedAt FROM files WHERE hash = ?',
     hash,
   )
   if (!row) {
@@ -294,7 +307,7 @@ export async function queryFileRecordById(
   id: string,
 ): Promise<FileRecordRow | null> {
   const row = await db.getFirstAsync<FileRecordRow>(
-    'SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize FROM files WHERE id = ?',
+    'SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize, trashedAt, deletedAt FROM files WHERE id = ?',
     id,
   )
   if (!row) {
@@ -320,13 +333,15 @@ export async function updateFileRecordFields(
     'thumbForId',
     'thumbSize',
     'localId',
+    'trashedAt',
+    'deletedAt',
   ]
   if (options.includeUpdatedAt) {
     updatableFields.push('updatedAt')
   }
   for (const field of updatableFields) {
     const value = update[field]
-    if (value === undefined || value === null) {
+    if (value === undefined) {
       continue
     }
     assignments[field] = value

--- a/packages/core/src/encoding/fileMetadata.ts
+++ b/packages/core/src/encoding/fileMetadata.ts
@@ -35,6 +35,7 @@ const FileV1Schema = z.object({
   kind: z.literal('file'),
   tags: z.array(z.string()).optional(),
   directory: z.string().optional(),
+  trashedAt: z.number().nullable().optional(),
 })
 
 const ThumbV1Schema = z.object({
@@ -68,6 +69,7 @@ const FutureVersionSchema = z.object({
   thumbSize: z.number().optional(),
   tags: z.array(z.string()).optional(),
   directory: z.string().optional(),
+  trashedAt: z.number().nullable().optional(),
 })
 
 // Pre-versioned metadata format (no version, id, or kind fields).
@@ -110,6 +112,7 @@ export function encodeFileMetadata(
   if (meta.kind === 'file') {
     if (meta.tags) payload.tags = meta.tags
     if (meta.directory) payload.directory = meta.directory
+    payload.trashedAt = meta.trashedAt
   } else if (meta.kind === 'thumb') {
     payload.thumbForId = meta.thumbForId
     payload.thumbSize = meta.thumbSize
@@ -185,6 +188,9 @@ export function decodeFileMetadata(buffer?: ArrayBuffer): DecodedFileMetadata {
       hash: v0.hash,
       createdAt: v0.createdAt,
       updatedAt: v0.updatedAt,
+      // Safe to default: v0 updates go through toV0SafeFileRecordFields
+      // which preserves existing.trashedAt from the local record.
+      trashedAt: null,
       thumbForHash: v0.thumbForHash,
       thumbForId: undefined,
       thumbSize: v0.thumbSize as ThumbSize | undefined,
@@ -232,10 +238,12 @@ function toDecodedMetadata(
     hash: data.hash,
     createdAt: data.createdAt,
     updatedAt: data.updatedAt,
+    trashedAt: null,
   }
   if (kind === 'file') {
     result.tags = d.tags as string[] | undefined
     result.directory = d.directory as string | undefined
+    result.trashedAt = (d.trashedAt as number | null | undefined) ?? null
   } else if (kind === 'thumb') {
     result.thumbForId = d.thumbForId as string | undefined
     result.thumbForHash = d.thumbForHash as string | undefined
@@ -254,5 +262,6 @@ function emptyMetadata(): DecodedFileMetadata {
     hash: '',
     createdAt: 0,
     updatedAt: 0,
+    trashedAt: null,
   }
 }

--- a/packages/core/src/services/syncDownEvents.ts
+++ b/packages/core/src/services/syncDownEvents.ts
@@ -89,6 +89,9 @@ export type SyncDownDeps = {
       record: Partial<FileRecordRow> & { id: string },
       options?: { includeUpdatedAt?: boolean },
     ): Promise<void>
+    // Only used by adopt to clean up local-only duplicate records after
+    // re-parenting to the canonical remote ID. Not for user-initiated
+    // deletes — those are tombstoned, never removed.
     delete(id: string): Promise<void>
   }
   localObjects: {
@@ -289,14 +292,37 @@ async function processBatch(
             counts.existing++
             break
           case 'delete':
-            // A file can have multiple objects (same file pinned to
-            // multiple indexers, or duplicate pins from v1 migration).
-            // Only delete the file record when no objects remain.
+            // Delete event: the remote object was deleted from this indexer.
+            //
+            // 1. Remove the local object row for this indexer.
+            // 2. Tombstone the file (set deletedAt) so it's hidden from the
+            //    UI and won't be resurrected by future sync events.
+            //
+            // File rows are NEVER removed from the database. In our
+            // event-log sync model, the tombstone is the permanent record
+            // that this file was deleted. Without it, a future sync event
+            // from another device or indexer would recreate the file.
+            // This is the same principle as CRDT tombstones.
+            //
+            // If the file has objects on other indexers, syncUp will
+            // eventually process the tombstone and call deleteObject for
+            // each remaining object. The object rows get cleaned up but
+            // the file row with its tombstone persists indefinitely.
             await deps.localObjects.delete(event.objectId, event.indexerURL)
+            if (!event.fileRecord.deletedAt) {
+              const now = Date.now()
+              await deps.files.update(
+                {
+                  id: event.fileId,
+                  deletedAt: now,
+                  trashedAt: event.fileRecord.trashedAt ?? now,
+                },
+                { includeUpdatedAt: false },
+              )
+            }
             if (
               (await deps.localObjects.countForFile(event.fileId)) === 0
             ) {
-              await deps.files.delete(event.fileId)
               deletedFileIds.add(event.fileId)
               counts.deleted++
             }
@@ -590,6 +616,7 @@ async function prepareFileRecord(
     id: fileId,
     localId: null,
     addedAt: Date.now(),
+    deletedAt: null,
   }
   return {
     kind: 'create',
@@ -632,6 +659,7 @@ async function prepareAdopt(
     id: fileId,
     localId: oldFile.localId,
     addedAt: oldFile.addedAt,
+    deletedAt: null,
   }
   return {
     kind: 'adopt',
@@ -649,7 +677,7 @@ async function prepareAdopt(
 /** Map decoded metadata to file record fields (all v1 fields preserved). */
 function toFileRecordFields(
   metadata: DecodedFileMetadata,
-): Omit<FileRecordRow, 'id' | 'localId' | 'addedAt'> {
+): Omit<FileRecordRow, 'id' | 'localId' | 'addedAt' | 'deletedAt'> {
   return {
     name: metadata.name,
     type: metadata.type,
@@ -660,6 +688,7 @@ function toFileRecordFields(
     updatedAt: metadata.updatedAt,
     thumbForId: metadata.thumbForId,
     thumbSize: metadata.thumbSize,
+    trashedAt: metadata.trashedAt ?? null,
   }
 }
 
@@ -681,7 +710,7 @@ function toFileRecordFields(
 function toV0SafeFileRecordFields(
   metadata: DecodedFileMetadata,
   existing: FileRecordRow,
-): Omit<FileRecordRow, 'id' | 'localId' | 'addedAt'> {
+): Omit<FileRecordRow, 'id' | 'localId' | 'addedAt' | 'deletedAt'> {
   return {
     name: metadata.name,
     type: metadata.type,
@@ -692,5 +721,6 @@ function toV0SafeFileRecordFields(
     updatedAt: Math.max(Date.now(), metadata.updatedAt, existing.updatedAt) + 1,
     thumbForId: existing.thumbForId,
     thumbSize: metadata.thumbSize,
+    trashedAt: existing.trashedAt ?? null,
   }
 }

--- a/packages/core/src/services/syncUpMetadata.ts
+++ b/packages/core/src/services/syncUpMetadata.ts
@@ -18,8 +18,8 @@ export function diffFileMetadata(
 ): Record<string, DiffEntry> {
   const diffs: Record<string, DiffEntry> = {}
   for (const key of fileMetadataKeys) {
-    const l = localMeta[key]
-    const r = remoteMeta[key]
+    const l = localMeta[key] ?? null
+    const r = remoteMeta[key] ?? null
     if (l !== r) {
       diffs[key] = { local: l, remote: r }
     }
@@ -42,10 +42,15 @@ export type SyncUpDeps = {
   sdk: {
     getPinnedObject(objectId: string): Promise<PinnedObjectRef>
     updateObjectMetadata(pinnedObject: PinnedObjectRef): Promise<void>
+    deleteObject(objectId: string): Promise<void>
   }
   files: {
     readAll(opts: FileRecordsQueryOpts): Promise<FileRecord[]>
     readAllCount(opts: FileRecordsQueryOpts): Promise<number>
+  }
+  localObjects: {
+    delete(objectId: string, indexerURL: string): Promise<void>
+    countForFile(fileId: string): Promise<number>
   }
   tags: {
     readNamesForFile(fileId: string): Promise<string[] | undefined>
@@ -86,6 +91,16 @@ async function tryWithLog<T>(
  * diff against local file metadata, and if local is newer, push to remote.
  * This function processes files with updatedAt after the cursor, to pick
  * up any unsynced changes.
+ *
+ * TODO: Multi-indexer cleanup gap. Currently we only connect to one indexer
+ * at a time, so this function only deletes objects for the current indexer.
+ * If a file has objects on Indexer A and B, and gets tombstoned while
+ * connected to A, only A's object is deleted. B's object row persists
+ * locally. Switching to B won't help because the syncUp cursor (which is
+ * global, not per-indexer) has already advanced past the file. A future
+ * cleanup service should scan for tombstoned files that still have object
+ * rows on non-current indexers. Alternatively, the cursor could be reset
+ * or stored per-indexer when multi-indexer support is added.
  */
 export async function runSyncUpMetadataBatch(
   batchSize: number,
@@ -144,6 +159,33 @@ export async function runSyncUpMetadataBatch(
       return pool.withSlot(async () => {
         if (signal.aborted) return
         const ctx = { fileId: f.id, objectId: obj.id, fileName: f.name }
+
+        // Tombstoned files: delete the remote object and clean up the
+        // local object row. The file row itself is never removed — the
+        // tombstone is the permanent record of deletion, required for
+        // convergence across devices in our event-log sync model.
+        //
+        // This only deletes the object for the currently connected
+        // indexer. If the file has objects on other indexers, those
+        // object rows persist locally until the user connects to that
+        // indexer. See TODO below about the cleanup gap.
+        //
+        // If deleteObject fails, we must NOT clean up the local object
+        // row — we'd lose the reference to the remote object and could
+        // never retry. The batch stalls and retries on the next tick.
+        if (f.deletedAt) {
+          const result = await tryWithLog(
+            () => deps.sdk.deleteObject(obj.id),
+            'deleteObject',
+            ctx,
+          )
+          if (result === null) {
+            hasErrors = true
+            return
+          }
+          await deps.localObjects.delete(obj.id, indexerURL)
+          return
+        }
 
         const remote = await tryWithLog(
           () => deps.sdk.getPinnedObject(obj.id),

--- a/packages/core/src/types/files.ts
+++ b/packages/core/src/types/files.ts
@@ -19,6 +19,7 @@ export type FileMetadata = {
   thumbSize?: ThumbSize
   tags?: string[]
   directory?: string
+  trashedAt: number | null
   createdAt: number
   updatedAt: number
 }
@@ -38,17 +39,20 @@ export const fileMetadataKeys = keysOf<
   'updatedAt',
   'thumbForId',
   'thumbSize',
+  'trashedAt',
 ])
 
 /** Fields that are stored only in the local database. */
 export type FileLocalMetadata = {
   localId: string | null
   addedAt: number
+  deletedAt: number | null
 }
 
 export const fileLocalMetadataKeys = keysOf<FileLocalMetadata>()([
   'localId',
   'addedAt',
+  'deletedAt',
 ])
 
 export type FileRecordRow = Omit<FileMetadata, 'tags' | 'directory'> &


### PR DESCRIPTION
- Files are now trashed instead of permanently deleted. The default "Delete" action in the file actions sheet moves files to trash, and the toast says "Moved to trash." Trashing is reversible via restoreFiles.
- Permanent delete sets a deletedAt tombstone on the file row instead of removing it. The tombstone ensures deleted files are never resurrected by sync — even if the device is offline when the delete happens and reconnects later.
- syncUp now handles remote object cleanup for tombstoned files, calling sdk.deleteObject() on each tick instead of making ad-hoc network calls at delete time. This means deletes are retried automatically and survive app restarts.
- syncDown creates tombstones when it receives deleted: true events from the indexer, instead of hard-deleting the file row. The file row persists as a permanent record of deletion.
- trashedAt syncs across devices via object metadata (v1 encoding). Trashing a file on one device propagates to all others through the normal sync cycle.
- Files in trash for more than 30 days are auto-purged to tombstones on app boot.
- Adds migration 0007_soft_delete with trashedAt and deletedAt columns plus indexes.
- Removes the ad-hoc deleteFileFromNetwork, deleteAllIndexerObjects, and "remove from network" UI option — all remote cleanup is now owned by syncUp.
- Closes https://github.com/SiaFoundation/sia-mobile/issues/46 