### PR TITLE
fix: defer SDK auth poll on Android until browser dismissal

### DIFF
--- a/.changeset/fix-android-auth-browser-close.md
+++ b/.changeset/fix-android-auth-browser-close.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Fixed Android auth browser closing with error due to background network restrictions killing SDK poll.

--- a/apps/mobile/src/screens/OnboardingIndexerScreen.tsx
+++ b/apps/mobile/src/screens/OnboardingIndexerScreen.tsx
@@ -1,7 +1,7 @@
-import { useNavigation } from '@react-navigation/native'
+import { useFocusEffect, useNavigation } from '@react-navigation/native'
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack'
 import { ArrowLeftIcon } from 'lucide-react-native'
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import { Pressable, StyleSheet, Text, View } from 'react-native'
 import {
   KeyboardAwareScrollView,
@@ -15,6 +15,7 @@ import { Button } from '../components/Button'
 import { IndexerSelector } from '../components/IndexerSelector'
 import { useChangeIndexer } from '../hooks/useChangeIndexer'
 import type { OnboardingStackParamList } from '../stacks/types'
+import { cancelAuth } from '../stores/sdk'
 import { palette } from '../styles/colors'
 
 export default function OnboardingIndexerScreen() {
@@ -24,12 +25,22 @@ export default function OnboardingIndexerScreen() {
   const { newIndexerInputProps, connectToIndexer, isWaiting, hasErrored } =
     useChangeIndexer()
   const [isNavigating, setIsNavigating] = useState(false)
+
+  // Reset after navigating back from a later screen (e.g. RecoveryPhrase).
+  useFocusEffect(
+    useCallback(() => {
+      setIsNavigating(false)
+    }, []),
+  )
+
   const trimmedValue = newIndexerInputProps.value.trim()
   const isInputEmpty = trimmedValue.length === 0
   const showWaiting = isWaiting || isNavigating
 
+  // Abort any in-flight auth poll before leaving.
   const handleBack = () => {
-    nav.navigate('Welcome')
+    cancelAuth()
+    nav.goBack()
   }
 
   const handleContinue = async () => {

--- a/apps/mobile/src/screens/OnboardingRecoveryPhraseScreen.tsx
+++ b/apps/mobile/src/screens/OnboardingRecoveryPhraseScreen.tsx
@@ -25,7 +25,7 @@ import { useToast } from '../lib/toastContext'
 import type { OnboardingStackParamList } from '../stacks/types'
 import { clearAppKeys } from '../stores/appKey'
 import { clearMnemonicHash } from '../stores/mnemonic'
-import { useSdkStore } from '../stores/sdk'
+import { cancelAuth, useSdkStore } from '../stores/sdk'
 import { palette } from '../styles/colors'
 
 export default function OnboardingRecoveryPhraseScreen() {
@@ -47,12 +47,11 @@ export default function OnboardingRecoveryPhraseScreen() {
 
   const { register, isSubmitting } = useRecoveryPhraseRegistration()
 
-  // Clear pendingApproval so the indexer screen runs a fresh auth flow.
-  // Navigate to ChooseIndexer (not goBack) to avoid returning to a stale
-  // "connecting" state from the previous auth attempt.
+  // Abort any in-flight auth poll and clear pending state before leaving.
   const handleBack = () => {
+    cancelAuth()
     useSdkStore.setState({ pendingApproval: null })
-    nav.navigate('ChooseIndexer')
+    nav.goBack()
   }
 
   // Ensure onboarding starts with a fresh app key and no stale mnemonic

--- a/apps/mobile/src/stores/sdk.test.ts
+++ b/apps/mobile/src/stores/sdk.test.ts
@@ -1,5 +1,5 @@
 import type { AppKey, BuilderInterface, SdkInterface } from 'react-native-sia'
-import { openAuthURL } from '../lib/openAuthUrl'
+import { closeAuthBrowser, openAuthURL } from '../lib/openAuthUrl'
 import { getAppKey, getAppKeyForIndexer, setAppKeyForIndexer } from './appKey'
 import { setMnemonicHash, validateMnemonic } from './mnemonic'
 import * as sdkStore from './sdk'
@@ -13,6 +13,25 @@ let mockRequestConnection: jest.Mock<Promise<BuilderInterface>>
 let mockResponseUrl: jest.Mock<string>
 let mockWaitForApproval: jest.Mock<Promise<BuilderInterface>>
 let mockInterfaceRegister: jest.Mock<Promise<SdkInterface>>
+
+// AppState mock
+let mockAppStateListeners: Array<(state: string) => void> = []
+const mockAppStateSubscription = { remove: jest.fn() }
+const mockPlatform = { OS: 'ios' as string }
+
+jest.mock('react-native', () => ({
+  get Platform() {
+    return mockPlatform
+  },
+  AppState: {
+    addEventListener: jest.fn(
+      (_event: string, handler: (state: string) => void) => {
+        mockAppStateListeners.push(handler)
+        return mockAppStateSubscription
+      },
+    ),
+  },
+}))
 
 jest.mock('react-native-sia', () => {
   mockConnected = jest.fn()
@@ -59,6 +78,55 @@ const mockValidateMnemonic = jest.mocked(validateMnemonic)
 const mockGetIndexerURL = jest.mocked(getIndexerURL)
 const mockSetIndexerURL = jest.mocked(setIndexerURL)
 const mockOpenAuthURL = jest.mocked(openAuthURL)
+const mockCloseAuthBrowser = jest.mocked(closeAuthBrowser)
+
+const BROWSER_CLOSE_GRACE_MS = 6_000
+
+/**
+ * Creates a realistic mock for builder.waitForApproval() that respects
+ * the AbortSignal parameter, just like the real SDK does.
+ *
+ * - If resolveAfterMs is provided, resolves with the given value after that delay.
+ * - If the signal is aborted before resolution, rejects with an AbortError.
+ * - If neither, the promise never resolves (simulates indefinite polling).
+ *
+ * Returns an object with:
+ * - impl: the mock implementation function
+ * - callCount: returns how many times the mock was invoked
+ */
+function createAbortAwareMock(
+  resolveValue: BuilderInterface,
+  resolveAfterMs?: number,
+) {
+  let calls = 0
+  const impl = (opts?: { signal: AbortSignal }) => {
+    calls++
+    return new Promise<BuilderInterface>((resolve, reject) => {
+      const signal = opts?.signal
+
+      if (signal?.aborted) {
+        reject(new DOMException('Aborted', 'AbortError'))
+        return
+      }
+
+      let timer: ReturnType<typeof setTimeout> | undefined
+      const onAbort = () => {
+        if (timer) clearTimeout(timer)
+        reject(new DOMException('Aborted', 'AbortError'))
+      }
+
+      signal?.addEventListener('abort', onAbort, { once: true })
+
+      if (resolveAfterMs !== undefined) {
+        timer = setTimeout(() => {
+          signal?.removeEventListener('abort', onAbort)
+          resolve(resolveValue)
+        }, resolveAfterMs)
+      }
+    })
+  }
+  return { impl, callCount: () => calls }
+}
 
 describe('sdk store', () => {
   let mockAppKey: AppKey
@@ -68,6 +136,10 @@ describe('sdk store', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     sdkStore.resetSdk()
+
+    mockPlatform.OS = 'ios'
+    mockAppStateListeners = []
+    mockAppStateSubscription.remove.mockClear()
 
     mockResponseUrl = jest.fn()
     mockWaitForApproval = jest.fn()
@@ -150,10 +222,8 @@ describe('sdk store', () => {
         mockConnected.mockImplementation(() => new Promise(() => {})) // Never resolves
 
         const initPromise = sdkStore.connectSdk()
-
         // Fast-forward past the timeout
         await jest.advanceTimersByTimeAsync(10_000)
-
         const sdk = await initPromise
 
         expect(sdk).toBeNull()
@@ -237,9 +307,7 @@ describe('sdk store', () => {
         mockConnected.mockImplementation(() => new Promise(() => {})) // Never resolves
 
         const reconnectPromise = sdkStore.reconnectIndexer()
-
         await jest.advanceTimersByTimeAsync(10_000)
-
         const result = await reconnectPromise
 
         expect(result).toBe(false)
@@ -256,93 +324,11 @@ describe('sdk store', () => {
     beforeEach(() => {
       mockRequestConnection.mockResolvedValue(mockBuilderInterface)
       mockResponseUrl.mockReturnValue('https://indexer.example.com/auth')
+      // Default: abort-aware mock that resolves instantly.
+      mockWaitForApproval.mockImplementation(
+        createAbortAwareMock(mockBuilderInterface, 0).impl,
+      )
       mockOpenAuthURL.mockResolvedValue(true)
-      mockWaitForApproval.mockResolvedValue(mockBuilderInterface)
-    })
-
-    describe('new user (no AppKey)', () => {
-      beforeEach(() => {
-        mockGetAppKeyForIndexer.mockResolvedValue(undefined)
-      })
-
-      it('runs browser auth, saves pending approval, returns alreadyConnected: false', async () => {
-        const [result, error] = await sdkStore.authenticateIndexer(indexerUrl)
-
-        expect(error).toBeNull()
-        expect(result?.alreadyConnected).toBe(false)
-        // Browser auth flow was run.
-        expect(mockRequestConnection).toHaveBeenCalled()
-        expect(mockOpenAuthURL).toHaveBeenCalled()
-        expect(mockWaitForApproval).toHaveBeenCalled()
-        // Pending approval saved for registerWithIndexer.
-        expect(sdkStore.useSdkStore.getState().pendingApproval).toEqual({
-          indexerURL: indexerUrl,
-          builder: mockBuilderInterface,
-        })
-        // SDK not set yet - waiting for registerWithIndexer.
-        expect(sdkStore.getSdk()).toBeNull()
-        expect(sdkStore.getIsConnected()).toBe(false)
-        // Indexer URL NOT saved yet - deferred to registerWithIndexer.
-        expect(mockSetIndexerURL).not.toHaveBeenCalled()
-        expectCleanAuthState()
-      })
-
-      it('returns cancelled when user cancels browser auth', async () => {
-        jest.useFakeTimers()
-        try {
-          mockOpenAuthURL.mockResolvedValue(false)
-          mockWaitForApproval.mockImplementation(() => new Promise(() => {}))
-
-          const promise = sdkStore.authenticateIndexer(indexerUrl)
-          await jest.advanceTimersByTimeAsync(3_000)
-          const [, error] = await promise
-
-          expect(error?.type).toBe('cancelled')
-          expectCleanAuthState()
-        } finally {
-          jest.useRealTimers()
-        }
-      })
-
-      it('succeeds when user closes browser manually after approving', async () => {
-        jest.useFakeTimers()
-        try {
-          // Browser closes without deep link, but approval resolves within grace period.
-          mockOpenAuthURL.mockResolvedValue(false)
-          mockWaitForApproval.mockImplementation(
-            () =>
-              new Promise((resolve) =>
-                setTimeout(() => resolve(mockBuilderInterface), 1_000),
-              ),
-          )
-
-          const promise = sdkStore.authenticateIndexer(indexerUrl)
-          await jest.advanceTimersByTimeAsync(1_000)
-          const [result, error] = await promise
-
-          expect(error).toBeNull()
-          expect(result?.alreadyConnected).toBe(false)
-          expect(sdkStore.useSdkStore.getState().pendingApproval).toEqual({
-            indexerURL: indexerUrl,
-            builder: mockBuilderInterface,
-          })
-          expectCleanAuthState()
-        } finally {
-          jest.useRealTimers()
-        }
-      })
-
-      it('returns error when builder.requestConnection() fails', async () => {
-        mockRequestConnection.mockRejectedValue(new Error('Request failed'))
-
-        const [, error] = await sdkStore.authenticateIndexer(indexerUrl)
-
-        expect(error?.type).toBe('error')
-        if (error?.type === 'error') {
-          expect(error.message).toBe('Request failed')
-        }
-        expectCleanAuthState()
-      })
     })
 
     describe('returning user (has AppKey)', () => {
@@ -357,12 +343,9 @@ describe('sdk store', () => {
 
         expect(error).toBeNull()
         expect(result?.alreadyConnected).toBe(true)
-        expect(mockGetAppKeyForIndexer).toHaveBeenCalledWith(indexerUrl)
         expect(mockConnected).toHaveBeenCalledWith(mockAppKey)
-        // No browser auth needed.
         expect(mockRequestConnection).not.toHaveBeenCalled()
         expect(mockOpenAuthURL).not.toHaveBeenCalled()
-        // SDK connected.
         expect(sdkStore.getSdk()).toBe(mockSdk)
         expect(sdkStore.getIsConnected()).toBe(true)
         expect(mockSetIndexerURL).toHaveBeenCalledWith(indexerUrl)
@@ -379,14 +362,11 @@ describe('sdk store', () => {
           expect(error.message).toBe('Connection failed')
         }
         expect(mockRequestConnection).not.toHaveBeenCalled()
-        expect(sdkStore.getSdk()).toBeNull()
-        expect(mockSetIndexerURL).not.toHaveBeenCalled()
         expectCleanAuthState()
       })
 
       it('returns error when builder.connected() times out', async () => {
         jest.useFakeTimers()
-
         try {
           mockConnected.mockImplementation(() => new Promise(() => {}))
 
@@ -398,8 +378,6 @@ describe('sdk store', () => {
           if (error?.type === 'error') {
             expect(error.message).toBe('Connection timed out')
           }
-          expect(sdkStore.getSdk()).toBeNull()
-          expect(mockSetIndexerURL).not.toHaveBeenCalled()
           expectCleanAuthState()
         } finally {
           jest.useRealTimers()
@@ -414,18 +392,457 @@ describe('sdk store', () => {
 
         expect(error).toBeNull()
         expect(result?.alreadyConnected).toBe(false)
-        // Should fall through to browser auth.
         expect(mockConnected).toHaveBeenCalledWith(mockAppKey)
+        // Should fall through to browser auth.
         expect(mockRequestConnection).toHaveBeenCalled()
-        expect(mockOpenAuthURL).toHaveBeenCalled()
-        expect(mockWaitForApproval).toHaveBeenCalled()
-        // Pending approval saved.
-        expect(sdkStore.useSdkStore.getState().pendingApproval).toEqual({
-          indexerURL: indexerUrl,
-          builder: mockBuilderInterface,
-        })
-        expect(sdkStore.getSdk()).toBeNull()
         expectCleanAuthState()
+      })
+    })
+
+    describe('new user — browser auth state machine (iOS)', () => {
+      beforeEach(() => {
+        mockGetAppKeyForIndexer.mockResolvedValue(undefined)
+      })
+
+      it('approval poll resolves before browser closes → ok, closes browser', async () => {
+        jest.useFakeTimers()
+        try {
+          // SDK poll detects approval at 3s. Browser still open.
+          mockWaitForApproval.mockImplementation(
+            createAbortAwareMock(mockBuilderInterface, 3_000).impl,
+          )
+          mockOpenAuthURL.mockImplementation(() => new Promise(() => {}))
+
+          const promise = sdkStore.authenticateIndexer(indexerUrl)
+          await jest.advanceTimersByTimeAsync(3_000)
+          const [result, error] = await promise
+
+          expect(error).toBeNull()
+          expect(result?.alreadyConnected).toBe(false)
+          expect(mockCloseAuthBrowser).toHaveBeenCalled()
+          // Pending approval saved for registerWithIndexer.
+          // SDK not set yet - waiting for registerWithIndexer.
+          expect(sdkStore.useSdkStore.getState().pendingApproval).toEqual({
+            indexerURL: indexerUrl,
+            builder: mockBuilderInterface,
+          })
+          expectCleanAuthState()
+        } finally {
+          jest.useRealTimers()
+        }
+      })
+
+      it('user approves at 3s, poll confirms at 5s → ok (within 6s grace)', async () => {
+        jest.useFakeTimers()
+        try {
+          // User approves at 3s (callback closes browser), poll confirms at 5s.
+          mockOpenAuthURL.mockImplementation(
+            () =>
+              new Promise((resolve) => setTimeout(() => resolve(true), 3_000)),
+          )
+          mockWaitForApproval.mockImplementation(
+            createAbortAwareMock(mockBuilderInterface, 5_000).impl,
+          )
+
+          const promise = sdkStore.authenticateIndexer(indexerUrl)
+          await jest.advanceTimersByTimeAsync(5_000)
+          const [result, error] = await promise
+
+          expect(error).toBeNull()
+          expect(result?.alreadyConnected).toBe(false)
+          expectCleanAuthState()
+        } finally {
+          jest.useRealTimers()
+        }
+      })
+
+      it('user approves at 3s, poll takes 20s → cancelled (6s grace expires)', async () => {
+        jest.useFakeTimers()
+        try {
+          // User approves at 3s (callback closes browser), poll too slow.
+          mockOpenAuthURL.mockImplementation(
+            () =>
+              new Promise((resolve) => setTimeout(() => resolve(true), 3_000)),
+          )
+          mockWaitForApproval.mockImplementation(
+            createAbortAwareMock(mockBuilderInterface, 20_000).impl,
+          )
+
+          const promise = sdkStore.authenticateIndexer(indexerUrl)
+          await jest.advanceTimersByTimeAsync(3_000 + BROWSER_CLOSE_GRACE_MS)
+          const [, error] = await promise
+
+          expect(error?.type).toBe('cancelled')
+          expectCleanAuthState()
+        } finally {
+          jest.useRealTimers()
+        }
+      })
+
+      it('user approves then closes browser manually, poll confirms at 5s → ok', async () => {
+        jest.useFakeTimers()
+        try {
+          // User approves on web, closes browser manually at 3s.
+          // Poll detects approval at 5s, within grace period.
+          mockOpenAuthURL.mockImplementation(
+            () =>
+              new Promise((resolve) => setTimeout(() => resolve(false), 3_000)),
+          )
+          mockWaitForApproval.mockImplementation(
+            createAbortAwareMock(mockBuilderInterface, 5_000).impl,
+          )
+
+          const promise = sdkStore.authenticateIndexer(indexerUrl)
+          await jest.advanceTimersByTimeAsync(5_000)
+          const [result, error] = await promise
+
+          expect(error).toBeNull()
+          expect(result?.alreadyConnected).toBe(false)
+          expectCleanAuthState()
+        } finally {
+          jest.useRealTimers()
+        }
+      })
+
+      it('user closes browser without approving, poll never resolves → cancelled after grace period', async () => {
+        jest.useFakeTimers()
+        try {
+          // User closes browser at 3s without approving. Poll runs but
+          // never finds approval. Grace period expires at 3s + 6s = 9s.
+          // AbortSignal fires, SDK poll is cancelled.
+          mockOpenAuthURL.mockImplementation(
+            () =>
+              new Promise((resolve) => setTimeout(() => resolve(false), 3_000)),
+          )
+          mockWaitForApproval.mockImplementation(
+            createAbortAwareMock(mockBuilderInterface).impl,
+          )
+
+          const promise = sdkStore.authenticateIndexer(indexerUrl)
+          await jest.advanceTimersByTimeAsync(3_000 + BROWSER_CLOSE_GRACE_MS)
+          const [, error] = await promise
+
+          expect(error?.type).toBe('cancelled')
+          expectCleanAuthState()
+        } finally {
+          jest.useRealTimers()
+        }
+      })
+
+      it('cancelAuth() during browser wait → cancelled immediately, browser closed', async () => {
+        jest.useFakeTimers()
+        try {
+          // Browser and poll both pending. User navigates away.
+          mockOpenAuthURL.mockImplementation(() => new Promise(() => {}))
+          mockWaitForApproval.mockImplementation(
+            createAbortAwareMock(mockBuilderInterface).impl,
+          )
+
+          const promise = sdkStore.authenticateIndexer(indexerUrl)
+          await jest.advanceTimersByTimeAsync(0)
+          sdkStore.cancelAuth()
+          await jest.advanceTimersByTimeAsync(0)
+          const [, error] = await promise
+
+          expect(error?.type).toBe('cancelled')
+          expect(mockCloseAuthBrowser).toHaveBeenCalled()
+          expectCleanAuthState()
+        } finally {
+          jest.useRealTimers()
+        }
+      })
+
+      it('cancelAuth() during grace period (callback) → cancelled, poll aborted', async () => {
+        jest.useFakeTimers()
+        try {
+          // User approves at 1s (callback closes browser), navigates away during grace.
+          mockOpenAuthURL.mockImplementation(
+            () =>
+              new Promise((resolve) => setTimeout(() => resolve(true), 1_000)),
+          )
+          mockWaitForApproval.mockImplementation(
+            createAbortAwareMock(mockBuilderInterface).impl,
+          )
+
+          const promise = sdkStore.authenticateIndexer(indexerUrl)
+          await jest.advanceTimersByTimeAsync(1_000)
+          await jest.advanceTimersByTimeAsync(0)
+          sdkStore.cancelAuth()
+          await jest.advanceTimersByTimeAsync(0)
+          const [, error] = await promise
+
+          expect(error?.type).toBe('cancelled')
+          expect(mockCloseAuthBrowser).toHaveBeenCalled()
+          expectCleanAuthState()
+        } finally {
+          jest.useRealTimers()
+        }
+      })
+
+      it('cancelAuth() during manual-close grace period → cancelled immediately', async () => {
+        jest.useFakeTimers()
+        try {
+          // Browser closes at 1s (manual), grace starts. User navigates away at 3s.
+          mockOpenAuthURL.mockImplementation(
+            () =>
+              new Promise((resolve) => setTimeout(() => resolve(false), 1_000)),
+          )
+          mockWaitForApproval.mockImplementation(
+            createAbortAwareMock(mockBuilderInterface).impl,
+          )
+
+          const promise = sdkStore.authenticateIndexer(indexerUrl)
+          await jest.advanceTimersByTimeAsync(1_000)
+          await jest.advanceTimersByTimeAsync(2_000)
+          sdkStore.cancelAuth()
+          await jest.advanceTimersByTimeAsync(0)
+          const [, error] = await promise
+
+          expect(error?.type).toBe('cancelled')
+          expect(mockCloseAuthBrowser).toHaveBeenCalled()
+          expectCleanAuthState()
+        } finally {
+          jest.useRealTimers()
+        }
+      })
+
+      it('SDK poll error wins race → browser closes with error (iOS-only, poll starts immediately)', async () => {
+        jest.useFakeTimers()
+        try {
+          mockOpenAuthURL.mockImplementation(() => new Promise(() => {}))
+          mockWaitForApproval.mockImplementation(() =>
+            Promise.reject(new Error('network failure')),
+          )
+
+          const promise = sdkStore.authenticateIndexer(indexerUrl)
+          await jest.advanceTimersByTimeAsync(0)
+          const [, error] = await promise
+
+          expect(error?.type).toBe('error')
+          if (error?.type === 'error') {
+            expect(error.message).toBe('network failure')
+          }
+          expect(mockCloseAuthBrowser).toHaveBeenCalled()
+          expectCleanAuthState()
+        } finally {
+          jest.useRealTimers()
+        }
+      })
+
+      it('requestConnection fails → error returned, no browser opened', async () => {
+        mockRequestConnection.mockRejectedValue(new Error('Request failed'))
+
+        const [, error] = await sdkStore.authenticateIndexer(indexerUrl)
+
+        expect(error?.type).toBe('error')
+        if (error?.type === 'error') {
+          expect(error.message).toBe('Request failed')
+        }
+        expect(mockOpenAuthURL).not.toHaveBeenCalled()
+        expectCleanAuthState()
+      })
+    })
+
+    describe('new user — browser auth state machine (Android)', () => {
+      beforeEach(() => {
+        mockGetAppKeyForIndexer.mockResolvedValue(undefined)
+        mockPlatform.OS = 'android'
+      })
+
+      it('SDK poll is deferred — not called while browser is open', async () => {
+        jest.useFakeTimers()
+        try {
+          const mock = createAbortAwareMock(mockBuilderInterface)
+          mockWaitForApproval.mockImplementation(mock.impl)
+          mockOpenAuthURL.mockImplementation(() => new Promise(() => {}))
+
+          sdkStore.authenticateIndexer(indexerUrl)
+          await jest.advanceTimersByTimeAsync(10_000)
+
+          expect(mock.callCount()).toBe(0)
+          expect(mockWaitForApproval).not.toHaveBeenCalled()
+
+          sdkStore.cancelAuth()
+          await jest.advanceTimersByTimeAsync(0)
+        } finally {
+          jest.useRealTimers()
+        }
+      })
+
+      it('user approves (callback) → deferred poll starts and confirms within grace', async () => {
+        jest.useFakeTimers()
+        try {
+          const mock = createAbortAwareMock(mockBuilderInterface, 2_000)
+          mockWaitForApproval.mockImplementation(mock.impl)
+          mockOpenAuthURL.mockImplementation(
+            () =>
+              new Promise((resolve) => setTimeout(() => resolve(true), 5_000)),
+          )
+
+          const promise = sdkStore.authenticateIndexer(indexerUrl)
+
+          // Before deep link fires, poll should not have started.
+          await jest.advanceTimersByTimeAsync(4_999)
+          expect(mock.callCount()).toBe(0)
+
+          // Deep link fires at 5s → poll starts.
+          await jest.advanceTimersByTimeAsync(1)
+          expect(mock.callCount()).toBe(1)
+
+          // Poll confirms after 2s.
+          await jest.advanceTimersByTimeAsync(2_000)
+          const [result, error] = await promise
+
+          expect(error).toBeNull()
+          expect(result?.alreadyConnected).toBe(false)
+          expect(mockAppStateSubscription.remove).toHaveBeenCalled()
+          expectCleanAuthState()
+        } finally {
+          jest.useRealTimers()
+        }
+      })
+
+      it('user approves and closes browser manually → deferred poll confirms within grace', async () => {
+        jest.useFakeTimers()
+        try {
+          const mock = createAbortAwareMock(mockBuilderInterface, 5_000)
+          mockWaitForApproval.mockImplementation(mock.impl)
+          mockOpenAuthURL.mockImplementation(
+            () =>
+              new Promise((resolve) => setTimeout(() => resolve(false), 3_000)),
+          )
+
+          const promise = sdkStore.authenticateIndexer(indexerUrl)
+
+          // Before browser closes, poll should not have started.
+          await jest.advanceTimersByTimeAsync(2_999)
+          expect(mock.callCount()).toBe(0)
+
+          // Browser closes at 3s → poll starts.
+          await jest.advanceTimersByTimeAsync(1)
+          expect(mock.callCount()).toBe(1)
+
+          // Poll confirms after 5s from invocation.
+          await jest.advanceTimersByTimeAsync(5_000)
+          const [result, error] = await promise
+
+          expect(error).toBeNull()
+          expect(result?.alreadyConnected).toBe(false)
+          expect(mockAppStateSubscription.remove).toHaveBeenCalled()
+          expectCleanAuthState()
+        } finally {
+          jest.useRealTimers()
+        }
+      })
+
+      it('user closes browser without approving → deferred poll starts, grace expires → cancelled', async () => {
+        jest.useFakeTimers()
+        try {
+          const mock = createAbortAwareMock(mockBuilderInterface)
+          mockWaitForApproval.mockImplementation(mock.impl)
+          mockOpenAuthURL.mockImplementation(
+            () =>
+              new Promise((resolve) => setTimeout(() => resolve(false), 3_000)),
+          )
+
+          const promise = sdkStore.authenticateIndexer(indexerUrl)
+          await jest.advanceTimersByTimeAsync(3_000)
+          await jest.advanceTimersByTimeAsync(0)
+          expect(mock.callCount()).toBe(1)
+
+          await jest.advanceTimersByTimeAsync(BROWSER_CLOSE_GRACE_MS)
+          const [, error] = await promise
+
+          expect(error?.type).toBe('cancelled')
+          expect(mockAppStateSubscription.remove).toHaveBeenCalled()
+          expectCleanAuthState()
+        } finally {
+          jest.useRealTimers()
+        }
+      })
+
+      it('AppState foreground → deferred poll starts and confirms', async () => {
+        jest.useFakeTimers()
+        try {
+          const mock = createAbortAwareMock(mockBuilderInterface, 2_000)
+          mockWaitForApproval.mockImplementation(mock.impl)
+          mockOpenAuthURL.mockImplementation(() => new Promise(() => {}))
+
+          const promise = sdkStore.authenticateIndexer(indexerUrl)
+          await jest.advanceTimersByTimeAsync(0)
+
+          expect(mockAppStateListeners.length).toBeGreaterThan(0)
+          expect(mock.callCount()).toBe(0)
+
+          mockAppStateListeners[0]('background')
+          mockAppStateListeners[0]('active')
+          await jest.advanceTimersByTimeAsync(0)
+
+          expect(mock.callCount()).toBe(1)
+
+          await jest.advanceTimersByTimeAsync(2_000)
+          const [result, error] = await promise
+
+          expect(error).toBeNull()
+          expect(result?.alreadyConnected).toBe(false)
+          expect(mockAppStateSubscription.remove).toHaveBeenCalled()
+          expectCleanAuthState()
+        } finally {
+          jest.useRealTimers()
+        }
+      })
+
+      it('AppState foreground, poll never resolves → cancelled after grace period', async () => {
+        jest.useFakeTimers()
+        try {
+          mockOpenAuthURL.mockImplementation(() => new Promise(() => {}))
+          mockWaitForApproval.mockImplementation(
+            createAbortAwareMock(mockBuilderInterface).impl,
+          )
+
+          const promise = sdkStore.authenticateIndexer(indexerUrl)
+          await jest.advanceTimersByTimeAsync(0)
+
+          mockAppStateListeners[0]('background')
+          mockAppStateListeners[0]('active')
+
+          await jest.advanceTimersByTimeAsync(BROWSER_CLOSE_GRACE_MS)
+          const [, error] = await promise
+
+          expect(error?.type).toBe('cancelled')
+          expect(mockAppStateSubscription.remove).toHaveBeenCalled()
+          expectCleanAuthState()
+        } finally {
+          jest.useRealTimers()
+        }
+      })
+
+      it('AppState foreground, then cancelAuth() during grace → cancelled immediately', async () => {
+        jest.useFakeTimers()
+        try {
+          mockOpenAuthURL.mockImplementation(() => new Promise(() => {}))
+          mockWaitForApproval.mockImplementation(
+            createAbortAwareMock(mockBuilderInterface).impl,
+          )
+
+          const promise = sdkStore.authenticateIndexer(indexerUrl)
+          await jest.advanceTimersByTimeAsync(0)
+
+          mockAppStateListeners[0]('background')
+          mockAppStateListeners[0]('active')
+          await jest.advanceTimersByTimeAsync(0)
+
+          sdkStore.cancelAuth()
+          await jest.advanceTimersByTimeAsync(0)
+          const [, error] = await promise
+
+          expect(error?.type).toBe('cancelled')
+          expect(mockCloseAuthBrowser).toHaveBeenCalled()
+          expect(mockAppStateSubscription.remove).toHaveBeenCalled()
+          expectCleanAuthState()
+        } finally {
+          jest.useRealTimers()
+        }
       })
     })
   })
@@ -438,14 +855,15 @@ describe('sdk store', () => {
     beforeEach(() => {
       mockRequestConnection.mockResolvedValue(mockBuilderInterface)
       mockResponseUrl.mockReturnValue('https://indexer.example.com/auth')
+      mockWaitForApproval.mockImplementation(
+        createAbortAwareMock(mockBuilderInterface, 0).impl,
+      )
       mockOpenAuthURL.mockResolvedValue(true)
-      mockWaitForApproval.mockResolvedValue(mockBuilderInterface)
       mockInterfaceRegister.mockResolvedValue(mockSdk)
     })
 
     describe('with pending approval from authenticateIndexer', () => {
       beforeEach(() => {
-        // Set pending approval as if authenticateIndexer was called.
         sdkStore.useSdkStore.setState({
           pendingApproval: {
             indexerURL: testIndexerURL,
@@ -496,7 +914,7 @@ describe('sdk store', () => {
       })
     })
 
-    describe('without pending approval (fallback)', () => {
+    describe('without pending approval (fallback browser auth)', () => {
       it('runs browser auth when no pending approval', async () => {
         const [, error] = await sdkStore.registerWithIndexer(
           mnemonic,
@@ -531,28 +949,72 @@ describe('sdk store', () => {
         expect(error).toBeNull()
         // Browser auth runs because indexer URL doesn't match.
         expect(mockRequestConnection).toHaveBeenCalled()
-        expect(mockOpenAuthURL).toHaveBeenCalled()
-        expect(mockWaitForApproval).toHaveBeenCalled()
         // Registration completes.
         expect(mockInterfaceRegister).toHaveBeenCalledWith(mnemonic)
-        expect(sdkStore.getSdk()).toBe(mockSdk)
         expectCleanAuthState()
       })
 
-      it('returns cancelled when user closes browser', async () => {
+      it('user closes browser without approving, grace expires → cancelled', async () => {
         jest.useFakeTimers()
         try {
           mockOpenAuthURL.mockResolvedValue(false)
-          mockWaitForApproval.mockImplementation(() => new Promise(() => {}))
+          mockWaitForApproval.mockImplementation(
+            createAbortAwareMock(mockBuilderInterface).impl,
+          )
+
+          const promise = sdkStore.registerWithIndexer(mnemonic, testIndexerURL)
+          await jest.advanceTimersByTimeAsync(BROWSER_CLOSE_GRACE_MS)
+          const [, error] = await promise
+
+          expect(error?.type).toBe('cancelled')
+          expect(mockInterfaceRegister).not.toHaveBeenCalled()
+          expectCleanAuthState()
+        } finally {
+          jest.useRealTimers()
+        }
+      })
+
+      it('user approves (callback), poll succeeds within grace → registers successfully', async () => {
+        jest.useFakeTimers()
+        try {
+          mockOpenAuthURL.mockImplementation(
+            () =>
+              new Promise((resolve) => setTimeout(() => resolve(true), 1_000)),
+          )
+          mockWaitForApproval.mockImplementation(
+            createAbortAwareMock(mockBuilderInterface, 3_000).impl,
+          )
 
           const promise = sdkStore.registerWithIndexer(mnemonic, testIndexerURL)
           await jest.advanceTimersByTimeAsync(3_000)
           const [, error] = await promise
 
+          expect(error).toBeNull()
+          expect(mockInterfaceRegister).toHaveBeenCalledWith(mnemonic)
+          expect(sdkStore.getSdk()).toBe(mockSdk)
+          expectCleanAuthState()
+        } finally {
+          jest.useRealTimers()
+        }
+      })
+
+      it('cancelAuth() cancels register flow', async () => {
+        jest.useFakeTimers()
+        try {
+          mockOpenAuthURL.mockImplementation(() => new Promise(() => {}))
+          mockWaitForApproval.mockImplementation(
+            createAbortAwareMock(mockBuilderInterface).impl,
+          )
+
+          const promise = sdkStore.registerWithIndexer(mnemonic, testIndexerURL)
+          await jest.advanceTimersByTimeAsync(0)
+          sdkStore.cancelAuth()
+          await jest.advanceTimersByTimeAsync(0)
+          const [, error] = await promise
+
           expect(error?.type).toBe('cancelled')
           expect(mockInterfaceRegister).not.toHaveBeenCalled()
-          expect(mockSetAppKeyForIndexer).not.toHaveBeenCalled()
-          expect(sdkStore.getSdk()).toBeNull()
+          expect(mockCloseAuthBrowser).toHaveBeenCalled()
           expectCleanAuthState()
         } finally {
           jest.useRealTimers()
@@ -574,7 +1036,6 @@ describe('sdk store', () => {
       }
       expect(mockSetAppKeyForIndexer).not.toHaveBeenCalled()
       expect(sdkStore.getSdk()).toBeNull()
-      expect(sdkStore.getIsConnected()).toBe(false)
       expectCleanAuthState()
     })
 
@@ -596,8 +1057,6 @@ describe('sdk store', () => {
           expect(error.message).toBe('Connection timed out')
         }
         expect(mockInterfaceRegister).not.toHaveBeenCalled()
-        expect(mockSetAppKeyForIndexer).not.toHaveBeenCalled()
-        expect(sdkStore.getSdk()).toBeNull()
         expectCleanAuthState()
       } finally {
         jest.useRealTimers()
@@ -622,139 +1081,10 @@ describe('sdk store', () => {
           expect(error.message).toBe('Connection timed out')
         }
         expect(mockSetAppKeyForIndexer).not.toHaveBeenCalled()
-        expect(mockSetMnemonicHash).not.toHaveBeenCalled()
-        expect(sdkStore.getSdk()).toBeNull()
         expectCleanAuthState()
       } finally {
         jest.useRealTimers()
       }
-    })
-
-    it('returns error when builder.waitForApproval() times out (fallback path)', async () => {
-      jest.useFakeTimers()
-
-      try {
-        mockWaitForApproval.mockImplementation(() => new Promise(() => {}))
-
-        const registerPromise = sdkStore.registerWithIndexer(
-          mnemonic,
-          testIndexerURL,
-        )
-        await jest.advanceTimersByTimeAsync(30 * 60 * 1_000)
-        const [, error] = await registerPromise
-
-        expect(error?.type).toBe('error')
-        if (error?.type === 'error') {
-          expect(error.message).toBe('Connection timed out')
-        }
-        expect(mockInterfaceRegister).not.toHaveBeenCalled()
-        expect(mockSetAppKeyForIndexer).not.toHaveBeenCalled()
-        expect(sdkStore.getSdk()).toBeNull()
-        expectCleanAuthState()
-      } finally {
-        jest.useRealTimers()
-      }
-    })
-  })
-
-  describe('switchIndexer', () => {
-    const indexerUrl = 'https://new-indexer.example.com'
-
-    describe('with stored AppKey for this indexer', () => {
-      beforeEach(() => {
-        mockGetAppKeyForIndexer.mockResolvedValue(mockAppKey)
-        mockConnected.mockResolvedValue(mockSdk)
-      })
-
-      it('connects immediately and returns success', async () => {
-        const [, error] = await sdkStore.switchIndexer(indexerUrl)
-
-        expect(error).toBeNull()
-        expect(mockGetAppKeyForIndexer).toHaveBeenCalledWith(indexerUrl)
-        expect(mockConnected).toHaveBeenCalledWith(mockAppKey)
-        expect(sdkStore.getSdk()).toBe(mockSdk)
-        expect(sdkStore.getIsConnected()).toBe(true)
-        expect(mockSetIndexerURL).toHaveBeenCalledWith(indexerUrl)
-        // No auth flow needed.
-        expect(mockRequestConnection).not.toHaveBeenCalled()
-        expect(mockOpenAuthURL).not.toHaveBeenCalled()
-      })
-    })
-
-    describe('without stored AppKey for this indexer', () => {
-      beforeEach(() => {
-        mockGetAppKeyForIndexer.mockResolvedValue(undefined)
-      })
-
-      it('returns needsReauth', async () => {
-        const [, error] = await sdkStore.switchIndexer(indexerUrl)
-
-        expect(error?.type).toBe('needsReauth')
-        expect(mockGetAppKeyForIndexer).toHaveBeenCalledWith(indexerUrl)
-        expect(mockConnected).not.toHaveBeenCalled()
-        expect(sdkStore.getSdk()).toBeNull()
-        expect(mockSetIndexerURL).not.toHaveBeenCalled()
-      })
-    })
-
-    describe('with stored AppKey but builder.connected() returns null', () => {
-      beforeEach(() => {
-        mockGetAppKeyForIndexer.mockResolvedValue(mockAppKey)
-        // builder.connected() returns null - unexpected, but handle gracefully.
-        mockConnected.mockResolvedValue(null)
-      })
-
-      it('returns needsReauth', async () => {
-        const [, error] = await sdkStore.switchIndexer(indexerUrl)
-
-        expect(error?.type).toBe('needsReauth')
-        expect(mockConnected).toHaveBeenCalledWith(mockAppKey)
-        expect(sdkStore.getSdk()).toBeNull()
-        expect(sdkStore.getIsConnected()).toBe(false)
-        expect(mockSetIndexerURL).not.toHaveBeenCalled()
-      })
-    })
-
-    describe('connection error', () => {
-      beforeEach(() => {
-        mockGetAppKeyForIndexer.mockResolvedValue(mockAppKey)
-        mockConnected.mockRejectedValue(new Error('Network error'))
-      })
-
-      it('returns error with message', async () => {
-        const [, error] = await sdkStore.switchIndexer(indexerUrl)
-
-        expect(error?.type).toBe('error')
-        if (error?.type === 'error') {
-          expect(error.message).toBe('Network error')
-        }
-        expect(sdkStore.getSdk()).toBeNull()
-        expect(mockSetIndexerURL).not.toHaveBeenCalled()
-      })
-    })
-
-    describe('timeout', () => {
-      it('returns error when builder.connected() times out', async () => {
-        jest.useFakeTimers()
-
-        try {
-          mockGetAppKeyForIndexer.mockResolvedValue(mockAppKey)
-          mockConnected.mockImplementation(() => new Promise(() => {}))
-
-          const switchPromise = sdkStore.switchIndexer(indexerUrl)
-          await jest.advanceTimersByTimeAsync(10_000)
-          const [, error] = await switchPromise
-
-          expect(error?.type).toBe('error')
-          if (error?.type === 'error') {
-            expect(error.message).toBe('Connection timed out')
-          }
-          expect(sdkStore.getSdk()).toBeNull()
-          expect(mockSetIndexerURL).not.toHaveBeenCalled()
-        } finally {
-          jest.useRealTimers()
-        }
-      })
     })
   })
 })

--- a/apps/mobile/src/stores/sdk.ts
+++ b/apps/mobile/src/stores/sdk.ts
@@ -21,6 +21,7 @@ import { err, hexToUint8, ok, type Result } from '@siastorage/core'
 import { APP_KEY } from '@siastorage/core/config'
 import { withTimeout } from '@siastorage/core/lib/timeout'
 import { logger } from '@siastorage/logger'
+import { AppState, Platform } from 'react-native'
 import {
   type AppKey,
   Builder,
@@ -68,7 +69,6 @@ export const useSdkStore = create<SdkState>(() => {
 const { getState, setState } = useSdkStore
 
 const CONNECTION_TIMEOUT_MS = 10_000
-const AUTH_TIMEOUT_MS = 30 * 60 * 1_000
 
 /**
  * Sets SDK and manages uploader lifecycle.
@@ -188,12 +188,6 @@ export type RegisterError =
 
 export type RegisterResult = Result<void, RegisterError>
 
-export type SwitchError =
-  | { type: 'error'; message: string }
-  | { type: 'needsReauth' }
-
-export type SwitchResult = Result<void, SwitchError>
-
 /**
  * Authenticates with an indexer during onboarding.
  *
@@ -259,51 +253,6 @@ export function setIsConnected(connected: boolean) {
 
 export function setSdk(sdk: SdkInterface | null) {
   return useSdkStore.setState({ sdk, isConnected: sdk !== null })
-}
-
-/**
- * Switches to a new indexer using stored credentials for that specific indexer.
- * Used from settings when changing indexers.
- *
- * AppKeys are unique per indexer URL. If we have a stored AppKey for this
- * specific indexer, we can connect instantly. If not, the user must enter
- * their mnemonic to register with the new indexer.
- *
- * @returns success if connected, `needsReauth` if mnemonic entry required
- */
-export async function switchIndexer(
-  newIndexerURL: string,
-): Promise<SwitchResult> {
-  logger.info('sdk', 'indexer_switch', { indexerURL: newIndexerURL })
-
-  // First, check if we have an AppKey specifically for this indexer.
-  const appKeyForIndexer = await getAppKeyForIndexer(newIndexerURL)
-  if (appKeyForIndexer) {
-    const builder = new Builder(newIndexerURL)
-    const [sdk, connectedErr] = await builderConnected(
-      builder,
-      appKeyForIndexer,
-    )
-
-    if (connectedErr) {
-      logger.error('sdk', 'stored_key_connect_error', {
-        error: connectedErr as Error,
-      })
-      return err({ type: 'error', message: connectedErr.message })
-    }
-
-    if (sdk) {
-      logger.info('sdk', 'stored_key_connected')
-      setIndexerURL(newIndexerURL)
-      await setSdkWithUploader(sdk)
-      setState({ isConnected: true })
-      return ok(undefined)
-    }
-  }
-
-  // No stored AppKey for this indexer - user needs to enter mnemonic.
-  logger.info('sdk', 'no_stored_key')
-  return err({ type: 'needsReauth' })
 }
 
 /**
@@ -417,19 +366,19 @@ async function builderRequestConnection(
   }
 }
 
+// Slightly longer than the SDK's 5s poll interval so one full cycle can complete.
+const BROWSER_CLOSE_GRACE_MS = 6_000
+
+let authAbortController: AbortController | null = null
+
 /**
- * Waits for the indexer to confirm app approval.
+ * Cancels any in-flight auth flow. Aborts the SDK's waitForApproval poll
+ * via AbortSignal and closes the auth browser.
  */
-async function builderWaitForApproval(
-  builder: BuilderInterface,
-): Promise<Result<BuilderInterface>> {
-  try {
-    logger.debug('sdk', 'waiting_for_approval')
-    const result = await withTimeout(builder.waitForApproval(), AUTH_TIMEOUT_MS)
-    return ok(result)
-  } catch (e) {
-    return err(e as Error)
-  }
+export function cancelAuth() {
+  authAbortController?.abort()
+  authAbortController = null
+  closeAuthBrowser()
 }
 
 /**
@@ -452,58 +401,143 @@ async function builderRegister(
 }
 
 /**
- * Opens auth URL and polls for approval in parallel.
- * When polling confirms approval, the browser is closed automatically.
- * If the user closes the browser before approval, returns cancelled.
+ * Resolves when the app returns to foreground after being backgrounded.
+ * Defensive fallback for Android in case a Chrome Custom Tab dismissal
+ * doesn't cause openAuthURL() to resolve on some devices.
+ */
+function createAppStateDismissal() {
+  let resolve: () => void
+  const promise = new Promise<void>((r) => {
+    resolve = r
+  })
+  let wasBackground = false
+  const subscription = AppState.addEventListener('change', (state) => {
+    if (state === 'background') {
+      wasBackground = true
+    } else if (state === 'active' && wasBackground) {
+      resolve()
+    }
+  })
+  return { promise, subscription }
+}
+
+/**
+ * Browser auth state machine. Races three concurrent signals:
+ *
+ * 1. SDK approval poll — builder.waitForApproval() (internal 5s poll loop)
+ * 2. Browser dismissal — openAuthURL() resolves true (deep link) or false (manual close)
+ * 3. Android AppState   — foreground after background (Chrome Custom Tab backstop)
+ *
+ * The SDK's waitForApproval() accepts an AbortSignal, which we use to cancel
+ * the poll cleanly when the user navigates away or a grace period expires.
+ *
+ * Signal handling:
+ * - Approval poll resolves → close browser, return result
+ * - Browser dismissed       → wait for poll up to 6s, then cancel
+ * - cancelAuth()            → abort poll immediately, return cancelled
  */
 async function waitForUserApproval(
   builder: BuilderInterface,
 ): Promise<Result<BuilderInterface, AuthError>> {
   const responseUrl = builder.responseUrl()
 
-  let approved: BuilderInterface | null = null
-  let approvalError: string | null = null
+  const abortController = new AbortController()
+  authAbortController = abortController
+  const { signal } = abortController
 
-  const approvalPromise = builderWaitForApproval(builder).then(
-    ([result, waitErr]) => {
-      if (waitErr) {
-        approvalError = waitErr.message
-      } else {
-        approved = result
-      }
-      closeAuthBrowser()
-    },
+  type ApprovalOutcome =
+    | { ok: true; result: BuilderInterface }
+    | { ok: false; error: Error }
+
+  const startApprovalPoll = (): Promise<ApprovalOutcome> =>
+    builder
+      .waitForApproval({ signal })
+      .then((result): ApprovalOutcome => ({ ok: true, result }))
+      .catch((e): ApprovalOutcome => ({ ok: false, error: e as Error }))
+
+  const isAndroid = Platform.OS === 'android'
+
+  // iOS: start polling immediately (app stays in foreground).
+  // Android: defer polling until user returns — background network is unreliable.
+  let approvalPromise: Promise<ApprovalOutcome> | null = isAndroid
+    ? null
+    : startApprovalPoll()
+
+  const browserPromise = openAuthURL(responseUrl)
+
+  // Android backstop: detect foreground via AppState in case Chrome Custom
+  // Tab dismissal doesn't cause openAuthURL to resolve on some devices.
+  const androidDismissal = isAndroid ? createAppStateDismissal() : null
+
+  // Dismissal = browser closed (deep link or manual) OR Android AppState foreground.
+  // Swallow any rejection from openAuthURL so dismissalPromise never rejects.
+  const browserResult: { error: Error | null } = { error: null }
+  const dismissalPromise = Promise.race(
+    [
+      browserPromise.then(
+        () => {},
+        (e) => {
+          browserResult.error = e as Error
+        },
+      ),
+      androidDismissal?.promise,
+    ].filter(Boolean),
   )
 
-  const deepLinkReceived = await openAuthURL(responseUrl)
-
-  if (approved) {
-    return ok(approved)
-  }
-
-  if (!deepLinkReceived) {
-    // Browser closed without a deep link — give the approval poll a brief
-    // window to resolve in case the user approved but closed the browser
-    // manually before the redirect fired.
-    await Promise.race([
-      approvalPromise,
-      new Promise((r) => setTimeout(r, 3_000)),
-    ])
-    if (approved) {
-      return ok(approved)
+  try {
+    // Race: on iOS the approval poll can win; on Android only dismissal wins
+    // because the poll is deferred until the browser is dismissed.
+    const raceCandidates: Promise<'dismissed' | 'approval'>[] = [
+      dismissalPromise.then(() => 'dismissed' as const),
+    ]
+    if (approvalPromise) {
+      raceCandidates.push(approvalPromise.then(() => 'approval' as const))
     }
+    const winner = await Promise.race(raceCandidates)
+
+    if (signal.aborted) return err({ type: 'cancelled' })
+    if (browserResult.error)
+      return err({ type: 'error', message: browserResult.error.message })
+
+    // iOS only: approval poll resolved before browser was dismissed.
+    if (winner === 'approval') {
+      closeAuthBrowser()
+      const outcome = await approvalPromise!
+      if (outcome.ok) return ok(outcome.result)
+      return err({ type: 'error', message: outcome.error.message })
+    }
+
+    // Browser dismissed (deep link, manual close, or AppState foreground).
+    // Start deferred poll (Android) or reuse existing (iOS).
+    if (!approvalPromise) {
+      approvalPromise = startApprovalPoll()
+    }
+
+    // Give the poll one cycle (6s) to confirm approval, then cancel.
+    const grace = await Promise.race([
+      approvalPromise.then(() => 'approved' as const),
+      new Promise<'timeout'>((r) =>
+        setTimeout(() => r('timeout'), BROWSER_CLOSE_GRACE_MS),
+      ),
+    ])
+
+    if (signal.aborted) return err({ type: 'cancelled' })
+
+    if (grace === 'approved') {
+      const outcome = await approvalPromise
+      if (outcome.ok) return ok(outcome.result)
+      return err({ type: 'error', message: outcome.error.message })
+    }
+
+    // Grace period expired — abort the SDK poll and cancel.
+    abortController.abort()
     return err({ type: 'cancelled' })
+  } finally {
+    androidDismissal?.subscription.remove()
+    if (authAbortController === abortController) {
+      authAbortController = null
+    }
   }
-
-  await approvalPromise
-
-  if (approvalError) {
-    return err({ type: 'error', message: approvalError })
-  }
-  if (approved) {
-    return ok(approved)
-  }
-  return err({ type: 'cancelled' })
 }
 
 /**

--- a/bun.lock
+++ b/bun.lock
@@ -1934,12 +1934,6 @@
 
     "@react-native/codegen/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
-    "@react-native/community-cli-plugin/metro": ["metro@0.83.5", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/core": "^7.25.2", "@babel/generator": "^7.29.1", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "accepts": "^2.0.0", "chalk": "^4.0.0", "ci-info": "^2.0.0", "connect": "^3.6.5", "debug": "^4.4.0", "error-stack-parser": "^2.0.6", "flow-enums-runtime": "^0.0.6", "graceful-fs": "^4.2.4", "hermes-parser": "0.33.3", "image-size": "^1.0.2", "invariant": "^2.2.4", "jest-worker": "^29.7.0", "jsc-safe-url": "^0.2.2", "lodash.throttle": "^4.1.1", "metro-babel-transformer": "0.83.5", "metro-cache": "0.83.5", "metro-cache-key": "0.83.5", "metro-config": "0.83.5", "metro-core": "0.83.5", "metro-file-map": "0.83.5", "metro-resolver": "0.83.5", "metro-runtime": "0.83.5", "metro-source-map": "0.83.5", "metro-symbolicate": "0.83.5", "metro-transform-plugins": "0.83.5", "metro-transform-worker": "0.83.5", "mime-types": "^3.0.1", "nullthrows": "^1.1.1", "serialize-error": "^2.1.0", "source-map": "^0.5.6", "throat": "^5.0.0", "ws": "^7.5.10", "yargs": "^17.6.2" }, "bin": { "metro": "src/cli.js" } }, "sha512-BgsXevY1MBac/3ZYv/RfNFf/4iuW9X7f4H8ZNkiH+r667HD9sVujxcmu4jvEzGCAm4/WyKdZCuyhAcyhTHOucQ=="],
-
-    "@react-native/community-cli-plugin/metro-config": ["metro-config@0.83.5", "", { "dependencies": { "connect": "^3.6.5", "flow-enums-runtime": "^0.0.6", "jest-validate": "^29.7.0", "metro": "0.83.5", "metro-cache": "0.83.5", "metro-core": "0.83.5", "metro-runtime": "0.83.5", "yaml": "^2.6.1" } }, "sha512-JQ/PAASXH7yczgV6OCUSRhZYME+NU8NYjI2RcaG5ga4QfQ3T/XdiLzpSb3awWZYlDCcQb36l4Vl7i0Zw7/Tf9w=="],
-
-    "@react-native/community-cli-plugin/metro-core": ["metro-core@0.83.5", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "lodash.throttle": "^4.1.1", "metro-resolver": "0.83.5" } }, "sha512-YcVcLCrf0ed4mdLa82Qob0VxYqfhmlRxUS8+TO4gosZo/gLwSvtdeOjc/Vt0pe/lvMNrBap9LlmvZM8FIsMgJQ=="],
-
     "@types/jest/pretty-format": ["pretty-format@29.7.0", "", { "dependencies": { "@jest/schemas": "^29.6.3", "ansi-styles": "^5.0.0", "react-is": "^18.0.0" } }, "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ=="],
 
     "ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
@@ -1953,8 +1947,6 @@
     "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "compressible/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "compression/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
@@ -2250,36 +2242,6 @@
 
     "@react-native/codegen/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
-    "@react-native/community-cli-plugin/metro/accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
-
-    "@react-native/community-cli-plugin/metro/ci-info": ["ci-info@2.0.0", "", {}, "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="],
-
-    "@react-native/community-cli-plugin/metro/hermes-parser": ["hermes-parser@0.33.3", "", { "dependencies": { "hermes-estree": "0.33.3" } }, "sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA=="],
-
-    "@react-native/community-cli-plugin/metro/jest-worker": ["jest-worker@29.7.0", "", { "dependencies": { "@types/node": "*", "jest-util": "^29.7.0", "merge-stream": "^2.0.0", "supports-color": "^8.0.0" } }, "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw=="],
-
-    "@react-native/community-cli-plugin/metro/metro-babel-transformer": ["metro-babel-transformer@0.83.5", "", { "dependencies": { "@babel/core": "^7.25.2", "flow-enums-runtime": "^0.0.6", "hermes-parser": "0.33.3", "nullthrows": "^1.1.1" } }, "sha512-d9FfmgUEVejTiSb7bkQeLRGl6aeno2UpuPm3bo3rCYwxewj03ymvOn8s8vnS4fBqAPQ+cE9iQM40wh7nGXR+eA=="],
-
-    "@react-native/community-cli-plugin/metro/metro-cache": ["metro-cache@0.83.5", "", { "dependencies": { "exponential-backoff": "^3.1.1", "flow-enums-runtime": "^0.0.6", "https-proxy-agent": "^7.0.5", "metro-core": "0.83.5" } }, "sha512-oH+s4U+IfZyg8J42bne2Skc90rcuESIYf86dYittcdWQtPfcaFXWpByPyTuWk3rR1Zz3Eh5HOrcVImfEhhJLng=="],
-
-    "@react-native/community-cli-plugin/metro/metro-cache-key": ["metro-cache-key@0.83.5", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-Ycl8PBajB7bhbAI7Rt0xEyiF8oJ0RWX8EKkolV1KfCUlC++V/GStMSGpPLwnnBZXZWkCC5edBPzv1Hz1Yi0Euw=="],
-
-    "@react-native/community-cli-plugin/metro/metro-file-map": ["metro-file-map@0.83.5", "", { "dependencies": { "debug": "^4.4.0", "fb-watchman": "^2.0.0", "flow-enums-runtime": "^0.0.6", "graceful-fs": "^4.2.4", "invariant": "^2.2.4", "jest-worker": "^29.7.0", "micromatch": "^4.0.4", "nullthrows": "^1.1.1", "walker": "^1.0.7" } }, "sha512-ZEt8s3a1cnYbn40nyCD+CsZdYSlwtFh2kFym4lo+uvfM+UMMH+r/BsrC6rbNClSrt+B7rU9T+Te/sh/NL8ZZKQ=="],
-
-    "@react-native/community-cli-plugin/metro/metro-resolver": ["metro-resolver@0.83.5", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-7p3GtzVUpbAweJeCcUJihJeOQl1bDuimO5ueo1K0BUpUtR41q5EilbQ3klt16UTPPMpA+tISWBtsrqU556mY1A=="],
-
-    "@react-native/community-cli-plugin/metro/metro-transform-plugins": ["metro-transform-plugins@0.83.5", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/generator": "^7.29.1", "@babel/template": "^7.28.6", "@babel/traverse": "^7.29.0", "flow-enums-runtime": "^0.0.6", "nullthrows": "^1.1.1" } }, "sha512-KxYKzZL+lt3Os5H2nx7YkbkWVduLZL5kPrE/Yq+Prm/DE1VLhpfnO6HtPs8vimYFKOa58ncl60GpoX0h7Wm0Vw=="],
-
-    "@react-native/community-cli-plugin/metro/metro-transform-worker": ["metro-transform-worker@0.83.5", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/generator": "^7.29.1", "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "flow-enums-runtime": "^0.0.6", "metro": "0.83.5", "metro-babel-transformer": "0.83.5", "metro-cache": "0.83.5", "metro-cache-key": "0.83.5", "metro-minify-terser": "0.83.5", "metro-source-map": "0.83.5", "metro-transform-plugins": "0.83.5", "nullthrows": "^1.1.1" } }, "sha512-8N4pjkNXc6ytlP9oAM6MwqkvUepNSW39LKYl9NjUMpRDazBQ7oBpQDc8Sz4aI8jnH6AGhF7s1m/ayxkN1t04yA=="],
-
-    "@react-native/community-cli-plugin/metro/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
-
-    "@react-native/community-cli-plugin/metro/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
-
-    "@react-native/community-cli-plugin/metro-config/metro-cache": ["metro-cache@0.83.5", "", { "dependencies": { "exponential-backoff": "^3.1.1", "flow-enums-runtime": "^0.0.6", "https-proxy-agent": "^7.0.5", "metro-core": "0.83.5" } }, "sha512-oH+s4U+IfZyg8J42bne2Skc90rcuESIYf86dYittcdWQtPfcaFXWpByPyTuWk3rR1Zz3Eh5HOrcVImfEhhJLng=="],
-
-    "@react-native/community-cli-plugin/metro-core/metro-resolver": ["metro-resolver@0.83.5", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-7p3GtzVUpbAweJeCcUJihJeOQl1bDuimO5ueo1K0BUpUtR41q5EilbQ3klt16UTPPMpA+tISWBtsrqU556mY1A=="],
-
     "@types/jest/pretty-format/@jest/schemas": ["@jest/schemas@29.6.3", "", { "dependencies": { "@sinclair/typebox": "^0.27.8" } }, "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA=="],
 
     "@types/jest/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
@@ -2488,20 +2450,6 @@
 
     "@react-native/codegen/glob/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
-    "@react-native/community-cli-plugin/metro-config/metro-cache/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
-
-    "@react-native/community-cli-plugin/metro/accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
-
-    "@react-native/community-cli-plugin/metro/hermes-parser/hermes-estree": ["hermes-estree@0.33.3", "", {}, "sha512-6kzYZHCk8Fy1Uc+t3HGYyJn3OL4aeqKLTyina4UFtWl8I0kSL7OmKThaiX+Uh2f8nGw3mo4Ifxg0M5Zk3/Oeqg=="],
-
-    "@react-native/community-cli-plugin/metro/jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
-
-    "@react-native/community-cli-plugin/metro/metro-cache/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
-
-    "@react-native/community-cli-plugin/metro/metro-transform-worker/metro-minify-terser": ["metro-minify-terser@0.83.5", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "terser": "^5.15.0" } }, "sha512-Toe4Md1wS1PBqbvB0cFxBzKEVyyuYTUb0sgifAZh/mSvLH84qA1NAWik9sISWatzvfWf3rOGoUoO5E3f193a3Q=="],
-
-    "@react-native/community-cli-plugin/metro/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
-
     "@types/jest/pretty-format/@jest/schemas/@sinclair/typebox": ["@sinclair/typebox@0.27.10", "", {}, "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA=="],
 
     "expect/jest-matcher-utils/pretty-format/@jest/schemas": ["@jest/schemas@29.6.3", "", { "dependencies": { "@sinclair/typebox": "^0.27.8" } }, "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA=="],
@@ -2603,10 +2551,6 @@
     "@jest/core/@jest/transform/babel-plugin-istanbul/istanbul-lib-instrument/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@jest/reporters/@jest/transform/babel-plugin-istanbul/istanbul-lib-instrument/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
-    "@react-native/community-cli-plugin/metro-config/metro-cache/https-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
-
-    "@react-native/community-cli-plugin/metro/metro-cache/https-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "expect/jest-matcher-utils/pretty-format/@jest/schemas/@sinclair/typebox": ["@sinclair/typebox@0.27.10", "", {}, "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA=="],
 


### PR DESCRIPTION
On Android, Chrome Custom Tabs put the RN app in the background where network requests get killed after ~10s. The SDK poll rejection was winning the Promise.race, closing the browser, and surfacing an error while the user was still in the auth flow. This PR exhuastively covers and tests every possible state on both platforms.

- Defer waitForApproval polling on Android until after a dismissal signal (deep-link, manual close, or AppState foreground).
- Replace the 30-minute overall auth timeout with a 6s grace period after browser dismissal (up from 3s).
- Cancel auth on back navigation during onboarding.