### PR TITLE
fix: auto-recover from expo-sqlite native handle invalidation on Android

### DIFF
--- a/.changeset/fix-android-sqlite-npe-recovery.md
+++ b/.changeset/fix-android-sqlite-npe-recovery.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Fixed Android expo-sqlite NullPointerException crashes by automatically recovering the database connection.

--- a/apps/mobile/src/db/index.ts
+++ b/apps/mobile/src/db/index.ts
@@ -15,19 +15,86 @@ export async function initializeDB(options?: {
   databaseName?: string
 }): Promise<void> {
   const name = options?.databaseName ?? dbName
+  dbName = name
   logger.info('db', 'initializing', { name })
   database = await SQLite.openDatabaseAsync(name)
-  await database.execAsync('PRAGMA foreign_keys = ON')
-  await runMigrations(database, migrations, {
+  await db().execAsync('PRAGMA busy_timeout = 5000; PRAGMA foreign_keys = ON')
+  await runMigrations(db(), migrations, {
     log: logger,
     onProgress: options?.onProgress,
   })
   dbInitialized = true
-  dbName = name
   logger.info('db', 'initialized')
 }
 
-/** Close the database connection (for test cleanup) */
+/**
+ * Detects expo-sqlite Android NullPointerException where the native
+ * database handle becomes invalid while operations are still in flight.
+ * The exact cause is unconfirmed — possibly related to SharedObject
+ * lifecycle or native resource management on Android.
+ */
+function isNativeHandleError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message.includes('has been rejected') &&
+    error.message.includes('NullPointerException')
+  )
+}
+
+let recovering: Promise<boolean> | null = null
+
+/**
+ * Reopens the database connection after a native handle invalidation.
+ * The database file is intact — only the native handle needs replacing.
+ * Serializes concurrent recovery attempts.
+ */
+async function reopenDb(): Promise<boolean> {
+  if (recovering) return recovering
+  recovering = (async () => {
+    try {
+      dbInitialized = false
+      logger.warn('db', 'native_handle_invalidated_reopening')
+      // Close old connection to release its cache entry (expected to fail).
+      try {
+        await database.closeAsync()
+      } catch {}
+      // useNewConnection bypasses expo-sqlite's per-name connection cache.
+      database = await SQLite.openDatabaseAsync(dbName, {
+        useNewConnection: true,
+      })
+      await database.execAsync(
+        'PRAGMA busy_timeout = 5000; PRAGMA foreign_keys = ON',
+      )
+      dbInitialized = true
+      logger.warn('db', 'reopened_successfully')
+      return true
+    } catch (e) {
+      logger.error('db', 'reopen_failed', { error: e as Error })
+      dbInitialized = false
+      return false
+    } finally {
+      recovering = null
+    }
+  })()
+  return recovering
+}
+
+/**
+ * Runs a database operation with automatic recovery from native handle
+ * invalidation. On failure, reopens the connection and retries once.
+ */
+export async function withRecovery<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn()
+  } catch (error) {
+    if (isNativeHandleError(error) && (await reopenDb())) {
+      return await fn()
+    }
+    throw error
+  }
+}
+
+/** Close the database connection (for test cleanup). */
 export async function closeDb(): Promise<void> {
   if (database && dbInitialized) {
     try {
@@ -39,7 +106,8 @@ export async function closeDb(): Promise<void> {
   }
 }
 
-// Drop all tables and run migrations again
+// Drop all tables and run migrations again.
+// Uses `database` directly — recovery doesn't apply during a destructive reset.
 export async function resetDb() {
   // Disable log appender before dropping tables to prevent "no such table: logs" errors
   dbInitialized = false
@@ -62,19 +130,57 @@ export async function resetDb() {
   await runMigrations(database, migrations, { log: logger })
 }
 
-export function db() {
-  return database
+const RECOVERY_METHODS = new Set([
+  'getAllAsync',
+  'getFirstAsync',
+  'getEachAsync',
+  'runAsync',
+  'execAsync',
+  'prepareAsync',
+])
+
+let _dbProxy: SQLite.SQLiteDatabase | null = null
+
+/**
+ * Returns a proxy around the current database connection that automatically
+ * retries operations on native handle invalidation (Android NPE).
+ * All async query/exec methods are wrapped with recovery; other methods
+ * (like withTransactionAsync) pass through directly.
+ */
+export function db(): SQLite.SQLiteDatabase {
+  if (!_dbProxy) {
+    _dbProxy = new Proxy({} as SQLite.SQLiteDatabase, {
+      get(_, prop) {
+        const value = (database as any)[prop]
+        if (typeof prop === 'string' && RECOVERY_METHODS.has(prop)) {
+          return (...args: unknown[]) =>
+            withRecovery(() => (database as any)[prop](...args))
+        }
+        if (typeof value === 'function') {
+          return value.bind(database)
+        }
+        return value
+      },
+    })
+  }
+  return _dbProxy
 }
 
 const txMutex = new Mutex()
 
-/** Run operations in a transaction and serialize all database transactions across the app. */
+/**
+ * Run operations in a transaction and serialize all database transactions across the app.
+ * Uses `database` directly for withTransactionAsync — transaction lifecycle can't be
+ * retried at the method level. The outer withRecovery retries the entire transaction.
+ */
 export async function withTransactionLock<T>(fn: () => Promise<T>): Promise<T> {
-  return txMutex.runExclusive(async () => {
-    let out!: T
-    await db().withTransactionAsync(async () => {
-      out = await fn()
-    })
-    return out
-  })
+  return txMutex.runExclusive(() =>
+    withRecovery(async () => {
+      let out!: T
+      await database.withTransactionAsync(async () => {
+        out = await fn()
+      })
+      return out
+    }),
+  )
 }

--- a/apps/mobile/src/db/recovery.test.ts
+++ b/apps/mobile/src/db/recovery.test.ts
@@ -1,0 +1,66 @@
+import { database, db, initializeDB, resetDb, withRecovery } from '.'
+
+const NPE_MESSAGE =
+  'Call to function has been rejected. java.lang.NullPointerException'
+
+beforeEach(async () => {
+  await initializeDB({ databaseName: ':memory:' })
+})
+
+afterEach(async () => {
+  await resetDb()
+})
+
+describe('withRecovery', () => {
+  it('returns the result on success', async () => {
+    const result = await withRecovery(async () => 42)
+    expect(result).toBe(42)
+  })
+
+  it('throws non-NPE errors without retrying', async () => {
+    const fn = jest.fn().mockRejectedValue(new Error('UNIQUE constraint'))
+    await expect(withRecovery(fn)).rejects.toThrow('UNIQUE constraint')
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries once on NPE and returns the retry result', async () => {
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(new Error(NPE_MESSAGE))
+      .mockResolvedValueOnce('recovered')
+    const result = await withRecovery(fn)
+    expect(result).toBe('recovered')
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('throws if retry also fails', async () => {
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(new Error(NPE_MESSAGE))
+      .mockRejectedValueOnce(new Error('second failure'))
+    await expect(withRecovery(fn)).rejects.toThrow('second failure')
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('db() proxy recovery', () => {
+  it('recovers from NPE on a query method', async () => {
+    // Make the current database throw NPE on first call.
+    jest
+      .spyOn(database, 'getAllAsync')
+      .mockRejectedValueOnce(new Error(NPE_MESSAGE))
+
+    // The proxy should detect NPE, reopen the connection, and retry.
+    // After reopening, the new database handles the query.
+    const rows = await db().getAllAsync<{ value: number }>('SELECT 1 as value')
+    expect(rows).toEqual([{ value: 1 }])
+  })
+
+  it('does not recover from non-NPE errors', async () => {
+    jest
+      .spyOn(database, 'getAllAsync')
+      .mockRejectedValueOnce(new Error('disk I/O error'))
+
+    await expect(db().getAllAsync('SELECT 1')).rejects.toThrow('disk I/O error')
+  })
+})

--- a/apps/mobile/src/stores/fileCarousel.test.ts
+++ b/apps/mobile/src/stores/fileCarousel.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook, waitFor } from '@testing-library/react-native'
-import { db, initializeDB, resetDb } from '../db'
+import { database, db, initializeDB, resetDb } from '../db'
 import {
   fetchFilePosition,
   fetchFilesByIDs,
@@ -658,7 +658,6 @@ describe('useFileCarousel hook', () => {
       expect(initDoneIndex).toBeGreaterThanOrEqual(0)
 
       // Add DB delays to simulate real async behavior
-      const database = db()
       const origFirst = database.getFirstAsync.bind(database)
       const origAll = database.getAllAsync.bind(database)
       jest
@@ -730,7 +729,6 @@ describe('useFileCarousel hook', () => {
       expect(result.current.currentFile?.id).toBe('file-2')
 
       // Add async delays to DB methods to simulate real expo-sqlite behavior.
-      const database = db()
       const origFirst = database.getFirstAsync.bind(database)
       const origAll = database.getAllAsync.bind(database)
       jest

--- a/apps/mobile/src/stores/logs.ts
+++ b/apps/mobile/src/stores/logs.ts
@@ -142,7 +142,7 @@ async function appendLogToDb(entry: LogEntry): Promise<void> {
       createdAt: Date.now(),
     })
   } catch (error) {
-    console.error('[logs] Failed to append log:', error)
+    console.warn('[logs] Failed to append log:', error)
   }
 }
 


### PR DESCRIPTION
On Android, expo-sqlite's native database handle can become invalid (NullPointerException) while operations are in flight. The database file is intact but the native handle needs replacing. The following changes allow for a graceful recovery and for the app to continue functioning. Its not clear what causes the issue but this appears to work around it. I will keep an eye out for further db errors on Android.

- `db()` returns a Proxy that wraps async query/exec methods with automatic NPE detection and single-retry recovery
- `reopenDb()` bypasses expo-sqlite's per-name connection cache via `useNewConnection: true` to get a fresh native handle
- Set `PRAGMA busy_timeout = 5000` on initial and recovered connections to handle transient lock contention during the recovery window
- Downgrade `appendLogToDb` catch to `console.warn` to avoid red error overlay in dev mode for best-effort log writes