### PR TITLE
fix(mobile): use modal onShow for input focus

### DIFF
--- a/.changeset/fix-keyboard-flash-sheets.md
+++ b/.changeset/fix-keyboard-flash-sheets.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Fixed keyboard briefly flashing when opening sheet modals by using the modal's onShow callback for input focus.

--- a/apps/mobile/src/components/BulkManageTagsSheet.tsx
+++ b/apps/mobile/src/components/BulkManageTagsSheet.tsx
@@ -37,10 +37,12 @@ export function BulkManageTagsSheet() {
     query.trim().length > 0 &&
     allTagList.some((t) => t.name.toLowerCase() === query.trim().toLowerCase())
 
+  const handleShow = useCallback(() => {
+    inputRef.current?.focus()
+  }, [])
+
   useEffect(() => {
-    if (isOpen) {
-      setTimeout(() => inputRef.current?.focus(), 400)
-    } else {
+    if (!isOpen) {
       setQuery('')
       setAddedTagIds(new Set())
       setLoadingTagNames(new Set())
@@ -83,6 +85,7 @@ export function BulkManageTagsSheet() {
     <ModalSheet
       visible={isOpen}
       onRequestClose={handleClose}
+      onShow={handleShow}
       title={`Add ${fileCount} ${fileCount === 1 ? 'file' : 'files'} to tag`}
     >
       <View style={styles.inputRow}>

--- a/apps/mobile/src/components/CreateDirectorySheet.tsx
+++ b/apps/mobile/src/components/CreateDirectorySheet.tsx
@@ -23,10 +23,12 @@ export function CreateDirectorySheet({ onCreated }: Props) {
   const [error, setError] = useState('')
   const inputRef = useRef<TextInput | null>(null)
 
+  const handleShow = useCallback(() => {
+    inputRef.current?.focus()
+  }, [])
+
   useEffect(() => {
-    if (isOpen) {
-      setTimeout(() => inputRef.current?.focus(), 400)
-    } else {
+    if (!isOpen) {
       setName('')
       setError('')
     }
@@ -57,6 +59,7 @@ export function CreateDirectorySheet({ onCreated }: Props) {
     <ModalSheet
       visible={isOpen}
       onRequestClose={handleClose}
+      onShow={handleShow}
       title="New Folder"
       presentationStyle="formSheet"
       headerRight={

--- a/apps/mobile/src/components/CreateTagSheet.tsx
+++ b/apps/mobile/src/components/CreateTagSheet.tsx
@@ -19,10 +19,12 @@ export function CreateTagSheet() {
   const [error, setError] = useState('')
   const inputRef = useRef<TextInput | null>(null)
 
+  const handleShow = useCallback(() => {
+    inputRef.current?.focus()
+  }, [])
+
   useEffect(() => {
-    if (isOpen) {
-      setTimeout(() => inputRef.current?.focus(), 400)
-    } else {
+    if (!isOpen) {
       setName('')
       setError('')
     }
@@ -52,6 +54,7 @@ export function CreateTagSheet() {
     <ModalSheet
       visible={isOpen}
       onRequestClose={handleClose}
+      onShow={handleShow}
       title="Create Tag"
       presentationStyle="formSheet"
       headerRight={

--- a/apps/mobile/src/components/ManageTagsSheet.tsx
+++ b/apps/mobile/src/components/ManageTagsSheet.tsx
@@ -49,10 +49,12 @@ export function ManageTagsSheet({ fileId, sheetName }: Props) {
     query.trim().length > 0 &&
     allTagList.some((t) => t.name.toLowerCase() === query.trim().toLowerCase())
 
+  const handleShow = useCallback(() => {
+    inputRef.current?.focus()
+  }, [])
+
   useEffect(() => {
-    if (isOpen) {
-      setTimeout(() => inputRef.current?.focus(), 400)
-    } else {
+    if (!isOpen) {
       setQuery('')
       setLoadingTagIds(new Set())
       setLoadingTagNames(new Set())
@@ -113,7 +115,12 @@ export function ManageTagsSheet({ fileId, sheetName }: Props) {
   )
 
   return (
-    <ModalSheet visible={isOpen} onRequestClose={handleClose} title="Tags">
+    <ModalSheet
+      visible={isOpen}
+      onRequestClose={handleClose}
+      onShow={handleShow}
+      title="Tags"
+    >
       <View style={styles.inputRow}>
         {userFileTags.map((tag) => (
           <TagPill

--- a/apps/mobile/src/components/ModalSheet.tsx
+++ b/apps/mobile/src/components/ModalSheet.tsx
@@ -13,6 +13,7 @@ import { colors, palette } from '../styles/colors'
 type Props = {
   visible: boolean
   onRequestClose: () => void
+  onShow?: () => void
   title: string
   headerRight?: ReactNode
   presentationStyle?: 'pageSheet' | 'formSheet'
@@ -22,6 +23,7 @@ type Props = {
 export function ModalSheet({
   visible,
   onRequestClose,
+  onShow,
   title,
   headerRight,
   presentationStyle = 'pageSheet',
@@ -36,6 +38,7 @@ export function ModalSheet({
       presentationStyle={presentationStyle}
       onRequestClose={onRequestClose}
       onDismiss={onRequestClose}
+      onShow={onShow}
     >
       <View style={styles.container}>
         <View

--- a/apps/mobile/src/components/MoveToDirectorySheet.tsx
+++ b/apps/mobile/src/components/MoveToDirectorySheet.tsx
@@ -51,9 +51,12 @@ export function MoveToDirectorySheet({
     query.trim().length > 0 &&
     dirs.some((d) => d.name.toLowerCase() === query.trim().toLowerCase())
 
+  const handleShow = useCallback(() => {
+    inputRef.current?.focus()
+  }, [])
+
   useEffect(() => {
     if (isOpen) {
-      setTimeout(() => inputRef.current?.focus(), 400)
       if (isSingleFile) {
         readDirectoryNameForFile(fileIds[0]).then((name) =>
           setCurrentDirName(name ?? null),
@@ -135,6 +138,7 @@ export function MoveToDirectorySheet({
     <ModalSheet
       visible={isOpen}
       onRequestClose={handleClose}
+      onShow={handleShow}
       title={`Move ${fileCount} ${fileCount === 1 ? 'file' : 'files'} to folder`}
       headerRight={
         <Pressable

--- a/apps/mobile/src/components/RenameSheet.tsx
+++ b/apps/mobile/src/components/RenameSheet.tsx
@@ -32,10 +32,13 @@ export function RenameSheet({
   const [error, setError] = useState('')
   const inputRef = useRef<TextInput | null>(null)
 
+  const handleShow = useCallback(() => {
+    inputRef.current?.focus()
+  }, [])
+
   useEffect(() => {
     if (isOpen) {
       setName(initialValue)
-      setTimeout(() => inputRef.current?.focus(), 400)
     } else {
       setError('')
     }
@@ -64,6 +67,7 @@ export function RenameSheet({
     <ModalSheet
       visible={isOpen}
       onRequestClose={handleClose}
+      onShow={handleShow}
       title={title}
       presentationStyle="formSheet"
       headerRight={

--- a/apps/mobile/src/components/SelectDirectorySheet.tsx
+++ b/apps/mobile/src/components/SelectDirectorySheet.tsx
@@ -43,10 +43,12 @@ export function SelectDirectorySheet({
     query.trim().length > 0 &&
     dirs.some((d) => d.name.toLowerCase() === query.trim().toLowerCase())
 
+  const handleShow = useCallback(() => {
+    inputRef.current?.focus()
+  }, [])
+
   useEffect(() => {
-    if (isOpen) {
-      setTimeout(() => inputRef.current?.focus(), 400)
-    } else {
+    if (!isOpen) {
       setQuery('')
     }
   }, [isOpen])
@@ -95,6 +97,7 @@ export function SelectDirectorySheet({
     <ModalSheet
       visible={isOpen}
       onRequestClose={handleClose}
+      onShow={handleShow}
       title="Import folder"
       headerRight={
         <Pressable


### PR DESCRIPTION
- Replace setTimeout-based auto-focus with the modal's onShow callback to prevent keyboard flash during sheet presentation animation.
