### PR TITLE
fix(mobile): redesign multi-select bar with overflow actions

### DIFF
--- a/.changeset/fix-consistent-file-action-labels.md
+++ b/.changeset/fix-consistent-file-action-labels.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Redesigned multi-select bar with count on the left and dynamic overflow action icons. Download and upload actions only appear when applicable. Consistent action labels across single and multi-select menus.

--- a/apps/mobile/src/components/FileActionsSheet.tsx
+++ b/apps/mobile/src/components/FileActionsSheet.tsx
@@ -15,16 +15,16 @@ import { StyleSheet, Text } from 'react-native'
 import useSWR from 'swr'
 import { useShareAction } from '../hooks/useShareAction'
 import { trashFiles } from '../lib/deleteFile'
-import { fileHasASealedObject, useFileStatus } from '../lib/file'
+import {
+  fetchBulkCounts,
+  fileHasASealedObject,
+  useFileStatus,
+} from '../lib/file'
 import { useToast } from '../lib/toastContext'
 import { downloadFile, useDownload } from '../managers/downloader'
 import { queueUploadForFileId, useReuploadFile } from '../managers/uploader'
 import type { MainStackParamList } from '../stacks/types'
-import {
-  type FileRecord,
-  readFileRecord,
-  useFileDetails,
-} from '../stores/files'
+import { useFileDetails } from '../stores/files'
 import { getFsFileUri } from '../stores/fs'
 import { closeSheet, openSheet, useSheetOpen } from '../stores/sheets'
 import { toggleFavorite, useIsFavorite } from '../stores/tags'
@@ -159,7 +159,7 @@ function SingleFileActionsSheet({
             icon={<ArrowDownToLineIcon size={18} />}
             onPress={handlePressAndClose(handleDownload)}
           >
-            Download file
+            Download to device
           </ActionSheetButton>
         )}
       {!status.data?.isUploaded &&
@@ -170,7 +170,7 @@ function SingleFileActionsSheet({
             icon={<CloudUploadIcon size={18} />}
             onPress={handlePressAndClose(handleReupload)}
           >
-            Upload file
+            Upload to network
           </ActionSheetButton>
         )}
       <ActionSheetButton
@@ -211,7 +211,7 @@ function SingleFileActionsSheet({
         icon={<Trash2Icon size={18} />}
         onPress={handlePressAndClose(handleDelete)}
       >
-        Delete file
+        Move to trash
       </ActionSheetButton>
     </ActionSheet>
   )
@@ -221,47 +221,6 @@ type BulkFileProps = {
   sheetName: string
   fileIds: string[]
   onComplete?: () => void
-}
-
-type BulkCounts = {
-  onNetwork: number
-  downloadable: number // on network but not on device
-  uploadable: number // on device but not on network
-  total: number
-  files: FileRecord[]
-}
-
-async function fetchBulkCounts(fileIds: string[]): Promise<BulkCounts> {
-  const files: FileRecord[] = []
-  let onNetwork = 0
-  let downloadable = 0
-  let uploadable = 0
-
-  for (const id of fileIds) {
-    const file = await readFileRecord(id)
-    if (file) {
-      files.push(file)
-      const hasSealed = fileHasASealedObject(file)
-      const uri = await getFsFileUri(file)
-      if (hasSealed) {
-        onNetwork++
-      }
-      if (hasSealed && !uri) {
-        downloadable++
-      }
-      if (uri && !hasSealed) {
-        uploadable++
-      }
-    }
-  }
-
-  return {
-    onNetwork,
-    downloadable,
-    uploadable,
-    total: files.length,
-    files,
-  }
 }
 
 function BulkFileActionsSheet({

--- a/apps/mobile/src/components/SelectionBar.tsx
+++ b/apps/mobile/src/components/SelectionBar.tsx
@@ -1,66 +1,170 @@
-import { FolderIcon, TagIcon, Trash2Icon } from 'lucide-react-native'
+import { logger } from '@siastorage/logger'
+import {
+  ArrowDownToLineIcon,
+  CloudUploadIcon,
+  FolderIcon,
+  TagIcon,
+  Trash2Icon,
+} from 'lucide-react-native'
+import { useCallback, useMemo } from 'react'
 import { StyleSheet, Text, View } from 'react-native'
-import { useSelectedCount } from '../stores/fileSelection'
+import useSWR from 'swr'
+import { trashFiles } from '../lib/deleteFile'
+import { fetchBulkCounts, fileHasASealedObject } from '../lib/file'
+import { useToast } from '../lib/toastContext'
+import { downloadFile } from '../managers/downloader'
+import { queueUploadForFileId } from '../managers/uploader'
+import { useSelectedCount, useSelectedFileIds } from '../stores/fileSelection'
+import { getFsFileUri } from '../stores/fs'
 import { openSheet } from '../stores/sheets'
 import { palette } from '../styles/colors'
 import { BottomControlBar, iconColors } from './BottomControlBar'
 import { BulkManageTagsSheet } from './BulkManageTagsSheet'
-import { IconButton } from './IconButton'
+import { type OverflowAction, OverflowActions } from './OverflowActions'
 
 type Props = {
-  onOpenSelectionActions: () => void
   moveToDirectorySheet?: string
+  onComplete?: () => void
 }
 
 export function SelectionBar({
-  onOpenSelectionActions,
   moveToDirectorySheet = 'moveToDirectory',
+  onComplete,
 }: Props) {
   const selectedCount = useSelectedCount()
+  const selectedFileIds = useSelectedFileIds()
+  const toast = useToast()
+
+  const disabled = selectedCount === 0
+  const ids = useMemo(() => Array.from(selectedFileIds), [selectedFileIds])
+
+  const { data: counts } = useSWR(
+    ids.length > 0 ? ['selectionCounts', ...ids] : null,
+    () => fetchBulkCounts(ids),
+  )
+
+  const handleTag = useCallback(() => {
+    openSheet('bulkManageTags')
+  }, [])
+
+  const handleMoveToFolder = useCallback(() => {
+    openSheet(moveToDirectorySheet)
+  }, [moveToDirectorySheet])
+
+  const handleDownload = useCallback(async () => {
+    if (!counts) return
+    try {
+      for (const file of counts.files) {
+        const hasSealed = fileHasASealedObject(file)
+        const uri = await getFsFileUri(file)
+        if (hasSealed && !uri) {
+          void downloadFile(file)
+        }
+      }
+      if (counts.downloadable > 0) {
+        toast.show(`Downloading ${counts.downloadable} files`)
+      }
+      onComplete?.()
+    } catch (e) {
+      logger.error('SelectionBar', 'download_failed', { error: e as Error })
+      toast.show('Failed to start downloads')
+    }
+  }, [counts, onComplete, toast])
+
+  const handleUpload = useCallback(async () => {
+    if (!counts) return
+    try {
+      for (const file of counts.files) {
+        const hasSealed = fileHasASealedObject(file)
+        const uri = await getFsFileUri(file)
+        if (uri && !hasSealed) {
+          queueUploadForFileId(file.id)
+        }
+      }
+      if (counts.uploadable > 0) {
+        toast.show(`Queued ${counts.uploadable} uploads`)
+      }
+      onComplete?.()
+    } catch (e) {
+      logger.error('SelectionBar', 'upload_failed', { error: e as Error })
+      toast.show('Failed to start uploads')
+    }
+  }, [counts, onComplete, toast])
+
+  const handleTrash = useCallback(async () => {
+    if (!counts) return
+    try {
+      await trashFiles(counts.files.map((f) => f.id))
+      toast.show(`Moved ${counts.total} files to trash`)
+      onComplete?.()
+    } catch (e) {
+      logger.error('SelectionBar', 'trash_failed', { error: e as Error })
+      toast.show('Failed to move files to trash')
+    }
+  }, [counts, onComplete, toast])
+
+  const actions: OverflowAction[] = useMemo(() => {
+    const list: OverflowAction[] = [
+      {
+        key: 'tag',
+        icon: <TagIcon color={iconColors.white} size={20} />,
+        label: 'Add to tag',
+        onPress: handleTag,
+        disabled,
+      },
+      {
+        key: 'folder',
+        icon: <FolderIcon color={iconColors.white} size={20} />,
+        label: 'Move to folder',
+        onPress: handleMoveToFolder,
+        disabled,
+      },
+    ]
+    if (counts && counts.downloadable > 0) {
+      list.push({
+        key: 'download',
+        icon: <ArrowDownToLineIcon color={iconColors.white} size={20} />,
+        label: 'Download to device',
+        onPress: handleDownload,
+        disabled,
+      })
+    }
+    if (counts && counts.uploadable > 0) {
+      list.push({
+        key: 'upload',
+        icon: <CloudUploadIcon color={iconColors.white} size={20} />,
+        label: 'Upload to network',
+        onPress: handleUpload,
+        disabled,
+      })
+    }
+    list.push({
+      key: 'trash',
+      icon: <Trash2Icon color={palette.red[500]} size={20} />,
+      label: 'Move to trash',
+      onPress: handleTrash,
+      variant: 'danger' as const,
+      disabled,
+    })
+    return list
+  }, [
+    disabled,
+    counts,
+    handleTag,
+    handleMoveToFolder,
+    handleDownload,
+    handleUpload,
+    handleTrash,
+  ])
 
   return (
     <>
       <BottomControlBar style={styles.bar}>
         <View style={styles.container}>
-          <View style={styles.leftButtons}>
-            <IconButton
-              onPress={() => openSheet('bulkManageTags')}
-              disabled={selectedCount === 0}
-              accessibilityLabel="Add tag"
-            >
-              <TagIcon
-                color={
-                  selectedCount > 0 ? iconColors.white : iconColors.inactive
-                }
-                size={20}
-              />
-            </IconButton>
-            <IconButton
-              onPress={() => openSheet(moveToDirectorySheet)}
-              disabled={selectedCount === 0}
-              accessibilityLabel="Move to folder"
-            >
-              <FolderIcon
-                color={
-                  selectedCount > 0 ? iconColors.white : iconColors.inactive
-                }
-                size={20}
-              />
-            </IconButton>
-          </View>
           <Text style={styles.count}>
             {selectedCount > 0 ? `${selectedCount} selected` : 'Select items'}
           </Text>
-          <IconButton
-            onPress={onOpenSelectionActions}
-            disabled={selectedCount === 0}
-            accessibilityLabel="Delete"
-          >
-            <Trash2Icon
-              color={selectedCount > 0 ? palette.red[500] : iconColors.inactive}
-              size={20}
-            />
-          </IconButton>
+          <OverflowActions actions={actions} sheetName="selectionOverflow" />
         </View>
       </BottomControlBar>
       <BulkManageTagsSheet />
@@ -76,17 +180,14 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     flexDirection: 'row',
-    justifyContent: 'space-between',
     alignItems: 'center',
-  },
-  leftButtons: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 4,
+    gap: 8,
   },
   count: {
     color: palette.gray[50],
     fontSize: 14,
     fontWeight: '600',
+    paddingHorizontal: 8,
+    fontVariant: ['tabular-nums'],
   },
 })

--- a/apps/mobile/src/lib/file.ts
+++ b/apps/mobile/src/lib/file.ts
@@ -7,8 +7,8 @@ import {
 } from 'react-native-sia'
 import { getAppKeyForIndexer } from '../stores/appKey'
 import { type DownloadState, useDownloadState } from '../stores/downloads'
-import type { FileRecord } from '../stores/files'
-import { useFsFileUri } from '../stores/fs'
+import { type FileRecord, readFileRecord } from '../stores/files'
+import { getFsFileUri, useFsFileUri } from '../stores/fs'
 import { type UploadState, useUploadState } from '../stores/uploads'
 
 export function fileHasASealedObject(file?: FileRecord): boolean {
@@ -107,6 +107,41 @@ export function useFileStatus(
   ])
 
   return { data, isLoading: fileUri.isLoading }
+}
+
+export type BulkCounts = {
+  onNetwork: number
+  downloadable: number
+  uploadable: number
+  total: number
+  files: FileRecord[]
+}
+
+export async function fetchBulkCounts(fileIds: string[]): Promise<BulkCounts> {
+  const files: FileRecord[] = []
+  let onNetwork = 0
+  let downloadable = 0
+  let uploadable = 0
+
+  for (const id of fileIds) {
+    const file = await readFileRecord(id)
+    if (file) {
+      files.push(file)
+      const hasSealed = fileHasASealedObject(file)
+      const uri = await getFsFileUri(file)
+      if (hasSealed) {
+        onNetwork++
+      }
+      if (hasSealed && !uri) {
+        downloadable++
+      }
+      if (uri && !hasSealed) {
+        uploadable++
+      }
+    }
+  }
+
+  return { onNetwork, downloadable, uploadable, total: files.length, files }
 }
 
 export function getFileTypeName(

--- a/apps/mobile/src/screens/DirectoryScreen.tsx
+++ b/apps/mobile/src/screens/DirectoryScreen.tsx
@@ -157,10 +157,6 @@ export function DirectoryScreen({ route, navigation }: Props) {
     setIsCarouselDetail(false)
   }, [])
 
-  const handleOpenSelectionActions = useCallback(() => {
-    openSheet('directoryFileActions')
-  }, [])
-
   const handleBulkActionComplete = useCallback(() => {
     exitSelectionMode()
   }, [])
@@ -304,7 +300,7 @@ export function DirectoryScreen({ route, navigation }: Props) {
       />
       {isSelectionMode ? (
         <SelectionBar
-          onOpenSelectionActions={handleOpenSelectionActions}
+          onComplete={handleBulkActionComplete}
           moveToDirectorySheet="directoryMoveToDir"
         />
       ) : (

--- a/apps/mobile/src/screens/LibraryScreen.tsx
+++ b/apps/mobile/src/screens/LibraryScreen.tsx
@@ -328,7 +328,7 @@ export function LibraryScreen({ route, navigation }: Props) {
       <CreateTagSheet />
       <LibraryStatusSheet />
       {isSelectionMode ? (
-        <SelectionBar onOpenSelectionActions={handleOpenSelectionActions} />
+        <SelectionBar onComplete={handleBulkActionComplete} />
       ) : (
         <LibraryTabBar
           activeTab={activeTab}

--- a/apps/mobile/src/screens/SearchScreen.tsx
+++ b/apps/mobile/src/screens/SearchScreen.tsx
@@ -161,10 +161,6 @@ export function SearchScreen({ navigation }: Props) {
     setIsCarouselDetail(false)
   }, [])
 
-  const handleOpenSelectionActions = useCallback(() => {
-    openSheet('searchFileActions')
-  }, [])
-
   const handleBulkActionComplete = useCallback(() => {
     exitSelectionMode()
   }, [])
@@ -286,7 +282,7 @@ export function SearchScreen({ navigation }: Props) {
       />
       {isSelectionMode ? (
         <SelectionBar
-          onOpenSelectionActions={handleOpenSelectionActions}
+          onComplete={handleBulkActionComplete}
           moveToDirectorySheet="searchMoveToDir"
         />
       ) : (

--- a/apps/mobile/src/screens/TagLibraryScreen.tsx
+++ b/apps/mobile/src/screens/TagLibraryScreen.tsx
@@ -150,10 +150,6 @@ export function TagLibraryScreen({ route, navigation }: Props) {
     setIsCarouselDetail(false)
   }, [])
 
-  const handleOpenSelectionActions = useCallback(() => {
-    openSheet('tagLibraryFileActions')
-  }, [])
-
   const handleBulkActionComplete = useCallback(() => {
     exitSelectionMode()
   }, [])
@@ -297,7 +293,7 @@ export function TagLibraryScreen({ route, navigation }: Props) {
       />
       {isSelectionMode ? (
         <SelectionBar
-          onOpenSelectionActions={handleOpenSelectionActions}
+          onComplete={handleBulkActionComplete}
           moveToDirectorySheet="tagLibraryMoveToDir"
         />
       ) : (


### PR DESCRIPTION
- Consistent action labels across single and multi-select menus.
- Replace the hardcoded tag/folder/trash icon bar with a dynamic OverflowActions layout showing selection count on the left and contextual action icons on the right.
- Download and upload actions only appear when applicable files are selected.
