### PR TITLE
fix(mobile): add success toasts to all user-facing actions

### DIFF
--- a/.changeset/fix-toast-after-move.md
+++ b/.changeset/fix-toast-after-move.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Added success toast confirmations to all user-facing actions: create/rename/delete folders and tags, add/remove tags, toggle favorites, and move files to folders.

--- a/apps/mobile/src/components/BulkManageTagsSheet.tsx
+++ b/apps/mobile/src/components/BulkManageTagsSheet.tsx
@@ -9,6 +9,7 @@ import {
   TextInput,
   View,
 } from 'react-native'
+import { useToast } from '../lib/toastContext'
 import { useSelectedFileIds } from '../stores/fileSelection'
 import { closeSheet, useSheetOpen } from '../stores/sheets'
 import { addTagToFiles, useAllTags } from '../stores/tags'
@@ -17,6 +18,7 @@ import { ModalSheet } from './ModalSheet'
 import { SpinnerIcon } from './SpinnerIcon'
 
 export function BulkManageTagsSheet() {
+  const toast = useToast()
   const isOpen = useSheetOpen('bulkManageTags')
   const selectedFileIds = useSelectedFileIds()
   const allTags = useAllTags()
@@ -57,6 +59,7 @@ export function BulkManageTagsSheet() {
       setLoadingTagNames((prev) => new Set([...prev, key]))
       try {
         await addTagToFiles(Array.from(selectedFileIds), trimmed)
+        toast.show(`Added "${trimmed}" to ${selectedFileIds.size} files`)
         const tag = allTagList.find((t) => t.name.toLowerCase() === key)
         if (tag) {
           setAddedTagIds((prev) => new Set([...prev, tag.id]))
@@ -70,7 +73,7 @@ export function BulkManageTagsSheet() {
         })
       }
     },
-    [selectedFileIds, allTagList],
+    [selectedFileIds, allTagList, toast],
   )
 
   const handleClose = useCallback(() => {

--- a/apps/mobile/src/components/CreateDirectorySheet.tsx
+++ b/apps/mobile/src/components/CreateDirectorySheet.tsx
@@ -8,6 +8,7 @@ import {
   TextInput,
   View,
 } from 'react-native'
+import { useToast } from '../lib/toastContext'
 import { createDirectory } from '../stores/directories'
 import { closeSheet, useSheetOpen } from '../stores/sheets'
 import { overlay, palette, whiteA } from '../styles/colors'
@@ -18,6 +19,7 @@ type Props = {
 }
 
 export function CreateDirectorySheet({ onCreated }: Props) {
+  const toast = useToast()
   const isOpen = useSheetOpen('createDirectory')
   const [name, setName] = useState('')
   const [error, setError] = useState('')
@@ -49,11 +51,12 @@ export function CreateDirectorySheet({ onCreated }: Props) {
       setName('')
       setError('')
       closeSheet()
+      toast.show(`Created "${dir.name}"`)
       onCreated?.(dir.id, dir.name)
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to create folder')
     }
-  }, [name, onCreated])
+  }, [name, onCreated, toast])
 
   return (
     <ModalSheet

--- a/apps/mobile/src/components/CreateTagSheet.tsx
+++ b/apps/mobile/src/components/CreateTagSheet.tsx
@@ -8,12 +8,14 @@ import {
   TextInput,
   View,
 } from 'react-native'
+import { useToast } from '../lib/toastContext'
 import { closeSheet, useSheetOpen } from '../stores/sheets'
 import { createTag } from '../stores/tags'
 import { overlay, palette, whiteA } from '../styles/colors'
 import { ModalSheet } from './ModalSheet'
 
 export function CreateTagSheet() {
+  const toast = useToast()
   const isOpen = useSheetOpen('createTag')
   const [name, setName] = useState('')
   const [error, setError] = useState('')
@@ -45,10 +47,11 @@ export function CreateTagSheet() {
       setName('')
       setError('')
       closeSheet()
+      toast.show(`Created "${trimmed}"`)
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to create tag')
     }
-  }, [name])
+  }, [name, toast])
 
   return (
     <ModalSheet

--- a/apps/mobile/src/components/FileActionsSheet.tsx
+++ b/apps/mobile/src/components/FileActionsSheet.tsx
@@ -90,10 +90,12 @@ function SingleFileActionsSheet({
   })
   const favorite = useIsFavorite(isOpen ? fileId : null)
 
-  const handleToggleFavorite = useCallback(() => {
+  const handleToggleFavorite = useCallback(async () => {
+    const wasFavorite = favorite.data
     closeSheet(sheetName)
-    void toggleFavorite(fileId)
-  }, [fileId, sheetName])
+    await toggleFavorite(fileId)
+    toast.show(wasFavorite ? 'Removed from Favorites' : 'Added to Favorites')
+  }, [fileId, sheetName, favorite.data, toast])
 
   const handlePressAndClose = useCallback(
     (action: () => void | Promise<void>) => () => {

--- a/apps/mobile/src/components/ManageTagsSheet.tsx
+++ b/apps/mobile/src/components/ManageTagsSheet.tsx
@@ -9,6 +9,7 @@ import {
   TextInput,
   View,
 } from 'react-native'
+import { useToast } from '../lib/toastContext'
 import { closeSheet, useSheetOpen } from '../stores/sheets'
 import {
   addTagToFile,
@@ -27,6 +28,7 @@ type Props = {
 }
 
 export function ManageTagsSheet({ fileId, sheetName }: Props) {
+  const toast = useToast()
   const isOpen = useSheetOpen(sheetName)
   const fileTags = useTagsForFile(fileId)
   const allTags = useAllTags()
@@ -70,6 +72,7 @@ export function ManageTagsSheet({ fileId, sheetName }: Props) {
       try {
         await addTagToFile(fileId, trimmed)
         setQuery('')
+        toast.show(`Added "${trimmed}"`)
       } finally {
         setLoadingTagNames((prev) => {
           const next = new Set(prev)
@@ -78,7 +81,7 @@ export function ManageTagsSheet({ fileId, sheetName }: Props) {
         })
       }
     },
-    [fileId],
+    [fileId, toast],
   )
 
   const handleRemoveTag = useCallback(
@@ -86,6 +89,7 @@ export function ManageTagsSheet({ fileId, sheetName }: Props) {
       setLoadingTagIds((prev) => new Set([...prev, tagId]))
       try {
         await removeTagFromFile(fileId, tagId)
+        toast.show('Tag removed')
       } finally {
         setLoadingTagIds((prev) => {
           const next = new Set(prev)
@@ -94,7 +98,7 @@ export function ManageTagsSheet({ fileId, sheetName }: Props) {
         })
       }
     },
-    [fileId],
+    [fileId, toast],
   )
 
   const handleClose = useCallback(() => {

--- a/apps/mobile/src/components/MoveToDirectorySheet.tsx
+++ b/apps/mobile/src/components/MoveToDirectorySheet.tsx
@@ -9,6 +9,7 @@ import {
   TextInput,
   View,
 } from 'react-native'
+import { useToast } from '../lib/toastContext'
 import {
   countFilesWithDirectories,
   createDirectory,
@@ -31,6 +32,7 @@ export function MoveToDirectorySheet({
   fileIds,
   sheetName = 'moveToDirectory',
 }: Props) {
+  const toast = useToast()
   const isOpen = useSheetOpen(sheetName)
   const allDirs = useAllDirectories()
   const [query, setQuery] = useState('')
@@ -76,17 +78,23 @@ export function MoveToDirectorySheet({
     async (directoryId: string) => {
       setLoadingDirId(directoryId)
       try {
+        const targetDir = dirs.find((d) => d.id === directoryId)
         if (fileIds.length === 1) {
           await moveFileToDirectory(fileIds[0], directoryId)
         } else if (fileIds.length > 1) {
           await moveFilesToDirectory(fileIds, directoryId)
         }
         closeSheet()
+        toast.show(
+          targetDir
+            ? `Moved to "${targetDir.name}"`
+            : `Moved ${fileIds.length === 1 ? 'file' : 'files'} to folder`,
+        )
       } finally {
         setLoadingDirId(null)
       }
     },
-    [fileIds],
+    [fileIds, dirs, toast],
   )
 
   const handleRemoveFromDirectory = useCallback(async () => {
@@ -98,10 +106,11 @@ export function MoveToDirectorySheet({
         await moveFilesToDirectory(fileIds, null)
       }
       closeSheet()
+      toast.show('Removed from folder')
     } finally {
       setLoadingDirId(null)
     }
-  }, [fileIds])
+  }, [fileIds, toast])
 
   const handleCreateAndMove = useCallback(
     async (name: string) => {

--- a/apps/mobile/src/screens/DirectoryScreen.tsx
+++ b/apps/mobile/src/screens/DirectoryScreen.tsx
@@ -37,6 +37,7 @@ import { RenameSheet } from '../components/RenameSheet'
 import { ScreenHeader } from '../components/ScreenHeader'
 import { SelectionBar } from '../components/SelectionBar'
 import { ViewSettingsMenu } from '../components/ViewSettingsMenu'
+import { useToast } from '../lib/toastContext'
 import type { MainStackParamList } from '../stacks/types'
 import {
   deleteDirectoryAndTrashFiles,
@@ -64,6 +65,7 @@ import { colors, overlay, palette, whiteA } from '../styles/colors'
 type Props = NativeStackScreenProps<MainStackParamList, 'DirectoryScreen'>
 
 export function DirectoryScreen({ route, navigation }: Props) {
+  const toast = useToast()
   const { directoryId, directoryName: initialDirectoryName } = route.params
   const [directoryName, setDirectoryName] = useState(initialDirectoryName)
   const isUnfiled = directoryId === UNFILED_DIRECTORY_ID
@@ -189,8 +191,9 @@ export function DirectoryScreen({ route, navigation }: Props) {
     async (newName: string) => {
       await renameDirectory(directoryId, newName)
       setDirectoryName(newName)
+      toast.show(`Renamed to "${newName}"`)
     },
-    [directoryId],
+    [directoryId, toast],
   )
 
   const handleDeleteDirectory = useCallback(() => {
@@ -207,12 +210,13 @@ export function DirectoryScreen({ route, navigation }: Props) {
             onPress: async () => {
               await deleteDirectoryAndTrashFiles(directoryId)
               navigation.goBack()
+              toast.show(`Deleted "${directoryName}"`)
             },
           },
         ],
       )
     }, 300)
-  }, [directoryId, directoryName, navigation])
+  }, [directoryId, directoryName, navigation, toast])
 
   return (
     <View style={styles.container}>

--- a/apps/mobile/src/screens/TagLibraryScreen.tsx
+++ b/apps/mobile/src/screens/TagLibraryScreen.tsx
@@ -36,6 +36,7 @@ import { RenameSheet } from '../components/RenameSheet'
 import { ScreenHeader } from '../components/ScreenHeader'
 import { SelectionBar } from '../components/SelectionBar'
 import { ViewSettingsMenu } from '../components/ViewSettingsMenu'
+import { useToast } from '../lib/toastContext'
 import type { MainStackParamList } from '../stacks/types'
 import {
   enterSelectionMode,
@@ -58,6 +59,7 @@ import { colors, overlay, palette, whiteA } from '../styles/colors'
 type Props = NativeStackScreenProps<MainStackParamList, 'TagLibrary'>
 
 export function TagLibraryScreen({ route, navigation }: Props) {
+  const toast = useToast()
   const { tagId, tagName: initialTagName } = route.params
   const [tagName, setTagName] = useState(initialTagName)
   const scope = `tag.${tagId}`
@@ -182,8 +184,9 @@ export function TagLibraryScreen({ route, navigation }: Props) {
     async (newName: string) => {
       await renameTag(tagId, newName)
       setTagName(newName)
+      toast.show(`Renamed to "${newName}"`)
     },
-    [tagId],
+    [tagId, toast],
   )
 
   const handleDeleteTag = useCallback(() => {
@@ -200,12 +203,13 @@ export function TagLibraryScreen({ route, navigation }: Props) {
             onPress: async () => {
               await deleteTag(tagId)
               navigation.goBack()
+              toast.show(`Deleted "${tagName}"`)
             },
           },
         ],
       )
     }, 300)
-  }, [tagId, tagName, navigation])
+  }, [tagId, tagName, navigation, toast])
 
   return (
     <View style={styles.container}>


### PR DESCRIPTION
- Show toast confirmation after creating, renaming, and deleting folders and tags. Add toasts for tag add/remove, favorite toggle, and moving files to folders.
