### PR TITLE
fix(mobile): exit selection mode after bulk actions

### DIFF
--- a/.changeset/fix-exit-selection-after-bulk.md
+++ b/.changeset/fix-exit-selection-after-bulk.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Exit selection mode after completing bulk actions like move to folder or tag.

--- a/apps/mobile/src/components/BulkManageTagsSheet.tsx
+++ b/apps/mobile/src/components/BulkManageTagsSheet.tsx
@@ -17,7 +17,11 @@ import { palette, whiteA } from '../styles/colors'
 import { ModalSheet } from './ModalSheet'
 import { SpinnerIcon } from './SpinnerIcon'
 
-export function BulkManageTagsSheet() {
+type Props = {
+  onComplete?: () => void
+}
+
+export function BulkManageTagsSheet({ onComplete }: Props) {
   const toast = useToast()
   const isOpen = useSheetOpen('bulkManageTags')
   const selectedFileIds = useSelectedFileIds()
@@ -77,10 +81,12 @@ export function BulkManageTagsSheet() {
   )
 
   const handleClose = useCallback(() => {
+    const hasChanges = addedTagIds.size > 0
     setQuery('')
     Keyboard.dismiss()
     closeSheet()
-  }, [])
+    if (hasChanges) onComplete?.()
+  }, [addedTagIds.size, onComplete])
 
   const fileCount = selectedFileIds.size
 

--- a/apps/mobile/src/components/MoveToDirectorySheet.tsx
+++ b/apps/mobile/src/components/MoveToDirectorySheet.tsx
@@ -26,11 +26,13 @@ import { SpinnerIcon } from './SpinnerIcon'
 type Props = {
   fileIds: string[]
   sheetName?: string
+  onComplete?: () => void
 }
 
 export function MoveToDirectorySheet({
   fileIds,
   sheetName = 'moveToDirectory',
+  onComplete,
 }: Props) {
   const toast = useToast()
   const isOpen = useSheetOpen(sheetName)
@@ -90,11 +92,12 @@ export function MoveToDirectorySheet({
             ? `Moved to "${targetDir.name}"`
             : `Moved ${fileIds.length === 1 ? 'file' : 'files'} to folder`,
         )
+        onComplete?.()
       } finally {
         setLoadingDirId(null)
       }
     },
-    [fileIds, dirs, toast],
+    [fileIds, dirs, toast, onComplete],
   )
 
   const handleRemoveFromDirectory = useCallback(async () => {
@@ -107,10 +110,11 @@ export function MoveToDirectorySheet({
       }
       closeSheet()
       toast.show('Removed from folder')
+      onComplete?.()
     } finally {
       setLoadingDirId(null)
     }
-  }, [fileIds, toast])
+  }, [fileIds, toast, onComplete])
 
   const handleCreateAndMove = useCallback(
     async (name: string) => {

--- a/apps/mobile/src/components/SelectionBar.tsx
+++ b/apps/mobile/src/components/SelectionBar.tsx
@@ -167,7 +167,7 @@ export function SelectionBar({
           <OverflowActions actions={actions} sheetName="selectionOverflow" />
         </View>
       </BottomControlBar>
-      <BulkManageTagsSheet />
+      <BulkManageTagsSheet onComplete={onComplete} />
     </>
   )
 }

--- a/apps/mobile/src/screens/DirectoryScreen.tsx
+++ b/apps/mobile/src/screens/DirectoryScreen.tsx
@@ -420,6 +420,7 @@ export function DirectoryScreen({ route, navigation }: Props) {
       <MoveToDirectorySheet
         fileIds={actionSheetFileIds}
         sheetName="directoryMoveToDir"
+        onComplete={isSelectionMode ? handleBulkActionComplete : undefined}
       />
     </View>
   )

--- a/apps/mobile/src/screens/LibraryScreen.tsx
+++ b/apps/mobile/src/screens/LibraryScreen.tsx
@@ -397,7 +397,10 @@ export function LibraryScreen({ route, navigation }: Props) {
           ) : null}
         </>
       ) : null}
-      <MoveToDirectorySheet fileIds={actionSheetFileIds} />
+      <MoveToDirectorySheet
+        fileIds={actionSheetFileIds}
+        onComplete={isSelectionMode ? handleBulkActionComplete : undefined}
+      />
     </View>
   )
 }

--- a/apps/mobile/src/screens/SearchScreen.tsx
+++ b/apps/mobile/src/screens/SearchScreen.tsx
@@ -407,6 +407,7 @@ export function SearchScreen({ navigation }: Props) {
       <MoveToDirectorySheet
         fileIds={actionSheetFileIds}
         sheetName="searchMoveToDir"
+        onComplete={isSelectionMode ? handleBulkActionComplete : undefined}
       />
     </View>
   )

--- a/apps/mobile/src/screens/TagLibraryScreen.tsx
+++ b/apps/mobile/src/screens/TagLibraryScreen.tsx
@@ -408,6 +408,7 @@ export function TagLibraryScreen({ route, navigation }: Props) {
       <MoveToDirectorySheet
         fileIds={actionSheetFileIds}
         sheetName="tagLibraryMoveToDir"
+        onComplete={isSelectionMode ? handleBulkActionComplete : undefined}
       />
     </View>
   )


### PR DESCRIPTION
- Call onComplete (which triggers exitSelectionMode) after move-to-folder and bulk tag operations complete across all screens.
