### PR TITLE
fix(mobile): stabilize effect dependencies to prevent infinite re-render loop

### DIFF
--- a/.changeset/fix-max-update-depth.md
+++ b/.changeset/fix-max-update-depth.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Fixed maximum update depth exceeded error during photo sync caused by unstable SWR effect dependencies.

--- a/apps/mobile/src/hooks/useIsOnline.ts
+++ b/apps/mobile/src/hooks/useIsOnline.ts
@@ -22,7 +22,7 @@ export function useIsOnline() {
       isOnline.mutate()
     })
     return () => unsubscribe()
-  }, [isOnline])
+  }, [isOnline.mutate])
 
   useEffect(() => {
     if (isOnline.isLoading) {

--- a/apps/mobile/src/hooks/useReconnectIndexer.ts
+++ b/apps/mobile/src/hooks/useReconnectIndexer.ts
@@ -23,7 +23,7 @@ export function useReconnectIndexer() {
 
   // Try to reconnect to the indexer when the app is online but not connected to the indexer.
   const isInitializing = useIsInitializing()
-  const isOnline = useIsOnline()
+  const { data: isOnline } = useIsOnline()
   const isIndexerConnected = useIsConnected()
   useEffect(() => {
     let interval: NodeJS.Timeout | null = null


### PR DESCRIPTION
- Noticed a max update depth exceeded error when running heavy sync activity. This appears to fix it.