### PR TITLE
fix(mobile): skip non-file URI byte reading and re-detect MIME type from local file

### DIFF
--- a/.changeset/fix-ph-uri-errors.md
+++ b/.changeset/fix-ph-uri-errors.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Fixed noisy error logs from ph:// and content:// URIs during photo sync, and added MIME re-detection from local file when initial detection returns octet-stream.

--- a/apps/mobile/src/lib/processAssets.test.ts
+++ b/apps/mobile/src/lib/processAssets.test.ts
@@ -9,6 +9,7 @@ import {
 import { copyFileToFs, readFsFileMetadata } from '../stores/fs'
 import { setPhotoImportDirectory } from '../stores/settings'
 import { calculateContentHash } from './contentHash'
+import { getMimeType } from './fileTypes'
 import { getMediaLibraryUri } from './mediaLibrary'
 import { processAssets } from './processAssets'
 
@@ -19,11 +20,15 @@ jest.mock('./mediaLibrary', () => ({
   getMediaLibraryUri: jest.fn(),
 }))
 jest.mock('./contentHash', () => ({
-  calculateContentHash: jest.fn(async (uri: string) => `sha256:hash:${uri}`),
+  calculateContentHash: jest.fn(async (uri) => `sha256:hash:${uri}`),
 }))
 jest.mock('../managers/thumbnailer', () => ({
   generateThumbnails: jest.fn(),
 }))
+jest.mock('./fileTypes', () => {
+  const actual = jest.requireActual('./fileTypes')
+  return { ...actual, getMimeType: jest.fn(actual.getMimeType) }
+})
 
 beforeEach(async () => {
   await initializeDB()
@@ -85,12 +90,10 @@ describe('processAssets', () => {
       false,
     )
 
-    jest
-      .mocked(getMediaLibraryUri)
-      .mockImplementation(async (localId: string | null) => {
-        if (localId === '1') return 'file://1'
-        return null
-      })
+    jest.mocked(getMediaLibraryUri).mockImplementation(async (localId) => {
+      if (localId === '1') return 'file://1'
+      return null
+    })
     const assets = [
       {
         id: '1',
@@ -133,12 +136,10 @@ describe('processAssets', () => {
       false,
     )
 
-    jest
-      .mocked(getMediaLibraryUri)
-      .mockImplementation(async (localId: string | null) => {
-        if (localId === '1') return 'file://1'
-        return null
-      })
+    jest.mocked(getMediaLibraryUri).mockImplementation(async (localId) => {
+      if (localId === '1') return 'file://1'
+      return null
+    })
     const assets = [
       {
         id: '1',
@@ -360,10 +361,43 @@ describe('processAssets', () => {
     expect(dirs).toHaveLength(1)
     expect(dirs[0].name).toBe('Camera Roll')
   })
+  it('re-detects MIME type from local file when initial detection returns octet-stream', async () => {
+    jest.mocked(getMediaLibraryUri).mockImplementation(async () => {
+      return 'file:///local/photo'
+    })
+    jest
+      .mocked(getMimeType)
+      .mockResolvedValueOnce('application/octet-stream')
+      .mockResolvedValueOnce('image/jpeg')
+
+    const assets = [
+      {
+        id: '1',
+        name: 'data',
+        sourceUri: 'ph://asset-123',
+        type: undefined,
+        timestamp: '2021-01-01',
+      },
+    ]
+
+    const { files } = await processAssets(assets)
+    expect(files).toHaveLength(1)
+    expect(files[0].type).toBe('image/jpeg')
+    expect(getMimeType).toHaveBeenCalledTimes(2)
+    expect(getMimeType).toHaveBeenNthCalledWith(1, {
+      type: undefined,
+      name: 'data',
+      uri: 'ph://asset-123',
+    })
+    expect(getMimeType).toHaveBeenNthCalledWith(2, {
+      name: 'data',
+      uri: 'file:///local/photo',
+    })
+  })
   it('adds file size to new files', async () => {
     setExpoFileSystemMockMethods({
       File: {
-        info: jest.fn((uri: string) => ({ exists: true, size: 333, uri })),
+        info: jest.fn((uri) => ({ exists: true, size: 333, uri })),
       },
     })
     const assets = [

--- a/apps/mobile/src/lib/processAssets.ts
+++ b/apps/mobile/src/lib/processAssets.ts
@@ -143,6 +143,13 @@ export async function processAssets(
         return
       }
 
+      // The initial MIME detection may have returned octet-stream because the
+      // source URI was a ph:// or content:// asset reference that can't be read
+      // directly. Now that we have a local file:// URI, retry with byte detection.
+      if (f.type === 'application/octet-stream') {
+        f.type = await getMimeType({ name: f.name, uri: bestUri })
+      }
+
       // Copy the file to the app's file cache.
       const fileUri = await copyFileToFs(f, new File(bestUri))
       if (!fileUri) {

--- a/apps/mobile/src/lib/readFileBytes.ts
+++ b/apps/mobile/src/lib/readFileBytes.ts
@@ -1,6 +1,12 @@
 import { logger } from '@siastorage/logger'
 import { File } from 'expo-file-system'
 
+function isFileUri(uri: string): boolean {
+  if (uri.startsWith('/') || uri.startsWith('file://')) return true
+  const colon = uri.indexOf(':')
+  return colon === -1
+}
+
 /**
  * Read the first N bytes from a file.
  * Handles variable chunk sizes by reading multiple chunks if needed.
@@ -9,6 +15,9 @@ export async function readFileBytes(
   uri: string,
   byteCount: number,
 ): Promise<Uint8Array | null> {
+  if (!isFileUri(uri)) {
+    return null
+  }
   try {
     const file = new File(uri)
     const readable = file.readableStream()


### PR DESCRIPTION
- Fixed noisy error logs from ph:// and content:// URIs during photo sync
- Added MIME re-detection from local file when initial detection returns octet-stream