### PR TITLE
feat(mobile): polish tag, directory, and search screen headers

### DIFF
--- a/.changeset/favorites-heart-icon.md
+++ b/.changeset/favorites-heart-icon.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+The favorites system tag now displays a heart icon in the tags grid and screen header.

--- a/.changeset/fix-system-tag-check.md
+++ b/.changeset/fix-system-tag-check.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Fixed system tag detection using wrong prefix, which allowed rename and delete actions on system tags.

--- a/.changeset/hide-list-scrollbars.md
+++ b/.changeset/hide-list-scrollbars.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Hide scroll bars on folder and tag lists.

--- a/.changeset/restyle-folder-rows.md
+++ b/.changeset/restyle-folder-rows.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Restyle folder rows from cards to simple rows with hairline separators.

--- a/.changeset/screen-header-icons.md
+++ b/.changeset/screen-header-icons.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Tag and directory screens now show their respective icons in the header.

--- a/.changeset/search-back-button.md
+++ b/.changeset/search-back-button.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Added a back button to the SearchScreen header for easier navigation.

--- a/apps/mobile/src/components/DirectoriesGrid.tsx
+++ b/apps/mobile/src/components/DirectoriesGrid.tsx
@@ -63,7 +63,7 @@ export function DirectoriesGrid({ onSelectDirectory }: Props) {
       data={listData}
       keyExtractor={(dir) => dir.id}
       contentContainerStyle={styles.grid}
-      ItemSeparatorComponent={() => <View style={styles.separator} />}
+      showsVerticalScrollIndicator={false}
       renderItem={({ item }) => (
         <DirectoryCard
           dir={item}
@@ -114,16 +114,12 @@ const styles = StyleSheet.create({
     paddingTop: 140,
     paddingBottom: 120,
   },
-  separator: {
-    height: 12,
-  },
   card: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: overlay.panelMedium,
-    borderRadius: 16,
-    padding: 16,
-    borderWidth: StyleSheet.hairlineWidth,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderBottomWidth: StyleSheet.hairlineWidth,
     borderColor: whiteA.a10,
     gap: 12,
   },

--- a/apps/mobile/src/components/ScreenHeaderTitle.tsx
+++ b/apps/mobile/src/components/ScreenHeaderTitle.tsx
@@ -1,0 +1,40 @@
+import type React from 'react'
+import { StyleSheet, Text, View } from 'react-native'
+import { palette, whiteA } from '../styles/colors'
+
+type Props = {
+  title: string
+  subtitle: string
+  icon: React.ReactElement
+}
+
+export function ScreenHeaderTitle({ title, subtitle, icon }: Props) {
+  return (
+    <>
+      {icon}
+      <View style={styles.text}>
+        <Text style={styles.title} numberOfLines={1}>
+          {title}
+        </Text>
+        <Text style={styles.subtitle}>{subtitle}</Text>
+      </View>
+    </>
+  )
+}
+
+const styles = StyleSheet.create({
+  text: {
+    flex: 1,
+  },
+  title: {
+    color: palette.gray[50],
+    fontSize: 24,
+    fontWeight: '800',
+  },
+  subtitle: {
+    color: whiteA.a50,
+    fontSize: 13,
+    fontWeight: '600',
+    marginTop: 2,
+  },
+})

--- a/apps/mobile/src/components/TagsGrid.tsx
+++ b/apps/mobile/src/components/TagsGrid.tsx
@@ -1,4 +1,4 @@
-import { TagIcon } from 'lucide-react-native'
+import { HeartIcon, TagIcon } from 'lucide-react-native'
 import { useMemo } from 'react'
 import {
   ActivityIndicator,
@@ -8,7 +8,7 @@ import {
   Text,
   View,
 } from 'react-native'
-import { type TagWithCount, useAllTags } from '../stores/tags'
+import { SYSTEM_TAGS, type TagWithCount, useAllTags } from '../stores/tags'
 import { overlay, palette, whiteA } from '../styles/colors'
 
 type TagOrSpacer = TagWithCount | { id: '__spacer' }
@@ -53,6 +53,7 @@ export function TagsGrid({ onSelectTag }: Props) {
       numColumns={2}
       contentContainerStyle={styles.grid}
       columnWrapperStyle={styles.row}
+      showsVerticalScrollIndicator={false}
       renderItem={({ item }) =>
         item.id === '__spacer' ? (
           <View style={styles.spacer} />
@@ -74,7 +75,11 @@ function TagCard({ tag, onPress }: { tag: TagWithCount; onPress: () => void }) {
       onPress={onPress}
       style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}
     >
-      <TagIcon color={palette.blue[400]} size={24} />
+      {tag.id === SYSTEM_TAGS.favorites.id ? (
+        <HeartIcon color={palette.red[500]} fill={palette.red[500]} size={24} />
+      ) : (
+        <TagIcon color={palette.blue[400]} size={24} />
+      )}
       <View style={styles.cardText}>
         <Text style={styles.tagName} numberOfLines={1}>
           {tag.name}

--- a/apps/mobile/src/screens/DirectoryScreen.tsx
+++ b/apps/mobile/src/screens/DirectoryScreen.tsx
@@ -2,6 +2,7 @@ import type { NativeStackScreenProps } from '@react-navigation/native-stack'
 import {
   ArrowLeftIcon,
   FilePlusIcon,
+  FolderIcon,
   ListFilterIcon,
   MoreVerticalIcon,
   PencilIcon,
@@ -35,6 +36,7 @@ import { ManageTagsSheet } from '../components/ManageTagsSheet'
 import { MoveToDirectorySheet } from '../components/MoveToDirectorySheet'
 import { RenameSheet } from '../components/RenameSheet'
 import { ScreenHeader } from '../components/ScreenHeader'
+import { ScreenHeaderTitle } from '../components/ScreenHeaderTitle'
 import { SelectionBar } from '../components/SelectionBar'
 import { ViewSettingsMenu } from '../components/ViewSettingsMenu'
 import { useToast } from '../lib/toastContext'
@@ -234,12 +236,11 @@ export function DirectoryScreen({ route, navigation }: Props) {
           >
             <ArrowLeftIcon color={palette.gray[50]} size={22} />
           </IconButton>
-          <View>
-            <Text style={styles.titleLarge} numberOfLines={1}>
-              {directoryName}
-            </Text>
-            <Text style={styles.subtitle}>{subtitle}</Text>
-          </View>
+          <ScreenHeaderTitle
+            title={directoryName}
+            subtitle={subtitle}
+            icon={<FolderIcon color={palette.blue[400]} size={22} />}
+          />
         </View>
         <View style={styles.buttonRow}>
           <ViewSettingsMenu scope={scope}>
@@ -442,17 +443,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: 8,
     flex: 1,
-  },
-  titleLarge: {
-    color: palette.gray[50],
-    fontSize: 24,
-    fontWeight: '800',
-  },
-  subtitle: {
-    color: whiteA.a50,
-    fontSize: 13,
-    fontWeight: '600',
-    marginTop: 2,
   },
   buttonRow: {
     flexDirection: 'row',

--- a/apps/mobile/src/screens/SearchScreen.tsx
+++ b/apps/mobile/src/screens/SearchScreen.tsx
@@ -1,5 +1,10 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack'
-import { ListFilterIcon, SearchIcon, XIcon } from 'lucide-react-native'
+import {
+  ArrowLeftIcon,
+  ListFilterIcon,
+  SearchIcon,
+  XIcon,
+} from 'lucide-react-native'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   Animated,
@@ -216,7 +221,10 @@ export function SearchScreen({ navigation }: Props) {
         style={styles.topBlur}
       />
       <ScreenHeader>
-        <View style={styles.titles}>
+        <View style={styles.headerLeft}>
+          <IconButton onPress={handleExit} accessibilityLabel="Back">
+            <ArrowLeftIcon color={palette.gray[50]} size={22} />
+          </IconButton>
           <Text style={styles.titleLarge} pointerEvents="none">
             Search
           </Text>
@@ -427,8 +435,10 @@ const styles = StyleSheet.create({
     top: 0,
     height: 180,
   },
-  titles: {
-    flexDirection: 'column',
+  headerLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
   },
   titleLarge: {
     color: palette.gray[50],

--- a/apps/mobile/src/screens/TagLibraryScreen.tsx
+++ b/apps/mobile/src/screens/TagLibraryScreen.tsx
@@ -2,9 +2,11 @@ import type { NativeStackScreenProps } from '@react-navigation/native-stack'
 import {
   ArrowLeftIcon,
   FilePlusIcon,
+  HeartIcon,
   ListFilterIcon,
   MoreVerticalIcon,
   PencilIcon,
+  TagIcon,
   Trash2Icon,
   XIcon,
 } from 'lucide-react-native'
@@ -34,6 +36,7 @@ import { ManageTagsSheet } from '../components/ManageTagsSheet'
 import { MoveToDirectorySheet } from '../components/MoveToDirectorySheet'
 import { RenameSheet } from '../components/RenameSheet'
 import { ScreenHeader } from '../components/ScreenHeader'
+import { ScreenHeaderTitle } from '../components/ScreenHeaderTitle'
 import { SelectionBar } from '../components/SelectionBar'
 import { ViewSettingsMenu } from '../components/ViewSettingsMenu'
 import { useToast } from '../lib/toastContext'
@@ -52,7 +55,12 @@ import {
   useTagFileCount,
 } from '../stores/library'
 import { closeSheet, openSheet, useSheetOpen } from '../stores/sheets'
-import { addTagToFiles, deleteTag, renameTag } from '../stores/tags'
+import {
+  addTagToFiles,
+  deleteTag,
+  renameTag,
+  SYSTEM_TAGS,
+} from '../stores/tags'
 import { useViewSettings } from '../stores/viewSettings'
 import { colors, overlay, palette, whiteA } from '../styles/colors'
 
@@ -177,7 +185,8 @@ export function TagLibraryScreen({ route, navigation }: Props) {
   const tagCount = useTagFileCount(tagId)
   const fileCount = tagCount.data ?? 0
   const subtitle = `${fileCount.toLocaleString()} ${fileCount === 1 ? 'file' : 'files'}`
-  const isSystemTag = tagId.startsWith('sys_')
+  const isFavoritesTag = tagId === SYSTEM_TAGS.favorites.id
+  const isSystemTag = tagId.startsWith('sys:')
   const tagActionsOpen = useSheetOpen('tagActions')
 
   const handleRenameTag = useCallback(
@@ -227,12 +236,21 @@ export function TagLibraryScreen({ route, navigation }: Props) {
           >
             <ArrowLeftIcon color={palette.gray[50]} size={22} />
           </IconButton>
-          <View>
-            <Text style={styles.titleLarge} numberOfLines={1}>
-              {tagName}
-            </Text>
-            <Text style={styles.subtitle}>{subtitle}</Text>
-          </View>
+          <ScreenHeaderTitle
+            title={tagName}
+            subtitle={subtitle}
+            icon={
+              isFavoritesTag ? (
+                <HeartIcon
+                  color={palette.red[500]}
+                  fill={palette.red[500]}
+                  size={22}
+                />
+              ) : (
+                <TagIcon color={palette.blue[400]} size={22} />
+              )
+            }
+          />
         </View>
         <View style={styles.buttonRow}>
           <ViewSettingsMenu scope={scope}>
@@ -430,17 +448,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: 8,
     flex: 1,
-  },
-  titleLarge: {
-    color: palette.gray[50],
-    fontSize: 24,
-    fontWeight: '800',
-  },
-  subtitle: {
-    color: whiteA.a50,
-    fontSize: 13,
-    fontWeight: '600',
-    marginTop: 2,
   },
   buttonRow: {
     flexDirection: 'row',


### PR DESCRIPTION
- Add heart icon for favorites system tag in tags grid and screen header.
- Add folder and tag icons to directory and tag screen headers via shared ScreenHeaderTitle component.
- Restyle folder rows as a flat list.
- Hide scroll indicators on folder and tag lists.
- Add back button to search screen
- Fix system tag prefix check from sys_ to sys:.
