### PR TITLE
fix(mobile): skip redundant DB updates for existing files in syncNewPhotos

### DIFF
--- a/.changeset/fix-sync-loop-updatedAt.md
+++ b/.changeset/fix-sync-loop-updatedAt.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Fixed an issue where frequent new photos batches would trigger sync updates for the same files repeatedly.

--- a/apps/mobile/src/lib/processAssets.test.ts
+++ b/apps/mobile/src/lib/processAssets.test.ts
@@ -117,6 +117,51 @@ describe('processAssets', () => {
     })
     expect(copyFileToFs).toHaveBeenCalledTimes(0)
   })
+  it('skipExistingUpdates does not update existing records', async () => {
+    await createFileRecord(
+      {
+        id: 'existing-1',
+        name: 'old.jpg',
+        size: 5,
+        createdAt: 1,
+        updatedAt: 1,
+        type: 'image/jpeg',
+        kind: 'file',
+        localId: '1',
+        hash: '',
+        addedAt: 1,
+        trashedAt: null,
+        deletedAt: null,
+      },
+      false,
+    )
+
+    jest.mocked(getMediaLibraryUri).mockImplementation(async (localId) => {
+      if (localId === '1') return 'file://1'
+      return null
+    })
+    const assets = [
+      {
+        id: '1',
+        name: 'new.jpg',
+        sourceUri: 'file://1',
+        type: 'image/jpeg',
+        timestamp: '2021-01-01',
+      },
+    ]
+    const { files, updatedFiles } = await processAssets(assets, 'file', {
+      skipExistingUpdates: true,
+    })
+
+    expect(updatedFiles).toHaveLength(1)
+    expect(files).toHaveLength(0)
+    const record = await readFileRecord('existing-1')
+    expect(record).toMatchObject({
+      id: 'existing-1',
+      name: 'old.jpg',
+      updatedAt: 1,
+    })
+  })
   it('allowDuplicates bypasses localId dedup', async () => {
     await createFileRecord(
       {

--- a/apps/mobile/src/lib/processAssets.ts
+++ b/apps/mobile/src/lib/processAssets.ts
@@ -78,13 +78,28 @@ type CandidateFileRecord = {
  * @returns The resulting files and warnings.
  * @throws If the assets cannot be processed.
  */
+type ProcessAssetsOptions = {
+  /** Allow importing files that already exist by content hash. When true,
+   * localId is nulled out and dedup checks are skipped so every import
+   * creates a new file record. Used for manual imports (camera, picker). */
+  allowDuplicates?: boolean
+  /** Move newly imported media files into the configured photo import
+   * directory. Used by auto-sync and archive sync. */
+  addToImportDirectory?: boolean
+  /** Skip updating DB records for files that already exist. Prevents
+   * spurious updatedAt bumps when the same assets are re-encountered
+   * on every polling tick. Used by syncNewPhotos. */
+  skipExistingUpdates?: boolean
+}
+
 export async function processAssets(
   assets: Asset[] | undefined,
   defaultFileName: string = 'file',
   {
     allowDuplicates = false,
     addToImportDirectory = false,
-  }: { allowDuplicates?: boolean; addToImportDirectory?: boolean } = {},
+    skipExistingUpdates = false,
+  }: ProcessAssetsOptions = {},
 ) {
   const candidateFiles: CandidateFileRecord[] = await Promise.all(
     (assets ?? []).map(async (a) => ({
@@ -236,14 +251,16 @@ export async function processAssets(
     )
   }
 
-  await updateManyFileRecords(
-    existingFiles.map((f) => ({
-      id: f.id,
-      name: f.name,
-      type: f.type,
-      localId: f.localId,
-    })),
-  )
+  if (!skipExistingUpdates) {
+    await updateManyFileRecords(
+      existingFiles.map((f) => ({
+        id: f.id,
+        name: f.name,
+        type: f.type,
+        localId: f.localId,
+      })),
+    )
+  }
   await createManyFileRecords(newFiles)
 
   // Move media files to the configured photo import directory.

--- a/apps/mobile/src/managers/syncNewPhotos.test.ts
+++ b/apps/mobile/src/managers/syncNewPhotos.test.ts
@@ -126,7 +126,7 @@ describe('syncNewPhotos', () => {
         expect.objectContaining({ id: 'a3', name: 'exact.jpg' }),
       ],
       'file',
-      { addToImportDirectory: true },
+      { addToImportDirectory: true, skipExistingUpdates: true },
     )
   })
 
@@ -176,7 +176,7 @@ describe('syncNewPhotos', () => {
         }),
       ],
       'file',
-      { addToImportDirectory: true },
+      { addToImportDirectory: true, skipExistingUpdates: true },
     )
   })
 

--- a/apps/mobile/src/managers/syncNewPhotos.ts
+++ b/apps/mobile/src/managers/syncNewPhotos.ts
@@ -81,7 +81,7 @@ export async function workNew(signal?: AbortSignal): Promise<void> {
         ).toISOString(),
       })),
       'file',
-      { addToImportDirectory: true },
+      { addToImportDirectory: true, skipExistingUpdates: true },
     )
     if (files.length > 0) {
       await invalidateCacheLibraryAllStats()


### PR DESCRIPTION
- syncNewPhotos polls the same recent camera roll window every tick. processAssets would update every matched file's DB record even when nothing changed, triggering unnecessary sync cycles.
- Add a skipExistingUpdates option so syncNewPhotos skips these redundant writes.
