### PR TITLE
perf(mobile): reduce thumbnail scanner JS thread overhead

### DIFF
--- a/.changeset/thumbnail-scanner-perf.md
+++ b/.changeset/thumbnail-scanner-perf.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Improved thumbnail scanner rendering performance by batching cache invalidation and moving hashing off the JS thread.

--- a/apps/integration/test/adapters/fs.ts
+++ b/apps/integration/test/adapters/fs.ts
@@ -8,6 +8,7 @@ import {
   getFsFileUri as coreGetFsFileUri,
   type FsFileUriAdapter,
 } from '@siastorage/core/services/fsFileUri'
+import * as crypto from 'crypto'
 import * as nodeFs from 'fs'
 import * as path from 'path'
 
@@ -58,9 +59,11 @@ export function buildFsDeps(params: { db: DatabaseAdapter; tempDir: string }) {
   async function copyToFs(
     file: { id: string; type: string },
     data: ArrayBuffer,
-  ): Promise<{ uri: string; size: number }> {
+  ): Promise<{ uri: string; size: number; hash: string }> {
     const fp = fsFilePath(file.id, file.type)
-    nodeFs.writeFileSync(fp, Buffer.from(data))
+    const buf = Buffer.from(data)
+    nodeFs.writeFileSync(fp, buf)
+    const hash = crypto.createHash('sha256').update(buf).digest('hex')
     const now = Date.now()
     await upsertFsFileMetadata(db, {
       fileId: file.id,
@@ -68,7 +71,7 @@ export function buildFsDeps(params: { db: DatabaseAdapter; tempDir: string }) {
       addedAt: now,
       usedAt: now,
     })
-    return { uri: `file://${fp}`, size: data.byteLength }
+    return { uri: `file://${fp}`, size: data.byteLength, hash }
   }
 
   return {

--- a/apps/integration/test/adapters/thumbnail.ts
+++ b/apps/integration/test/adapters/thumbnail.ts
@@ -1,7 +1,6 @@
 import type { DatabaseAdapter } from '@siastorage/core/adapters'
 import { detectMimeType } from '@siastorage/core/lib/detectMimeType'
 import type { ThumbnailDeps } from '@siastorage/core/services/thumbnailScanner'
-import { createNodeCryptoAdapter } from '@siastorage/node-adapters/crypto'
 import type { buildFsDeps } from './fs'
 
 export function buildThumbnailDeps(params: {
@@ -45,7 +44,6 @@ export function buildThumbnailDeps(params: {
         }
       },
     },
-    cryptoAdapter: createNodeCryptoAdapter(),
     async detectMimeType(filePath: string): Promise<string | null> {
       const resolved = filePath.replace('file://', '')
       const result = detectMimeType({ fileName: resolved })

--- a/apps/integration/test/thumbnail-scanner.test.ts
+++ b/apps/integration/test/thumbnail-scanner.test.ts
@@ -27,11 +27,6 @@ function createMockDeps(overrides?: Partial<ThumbnailDeps>): ThumbnailDeps {
         return { data: new ArrayBuffer(64), mimeType: 'image/webp' }
       },
     },
-    cryptoAdapter: {
-      async sha256() {
-        return `thumb-hash-${++hashCounter}`
-      },
-    },
     async detectMimeType() {
       return 'image/jpeg'
     },
@@ -39,7 +34,11 @@ function createMockDeps(overrides?: Partial<ThumbnailDeps>): ThumbnailDeps {
       return 'file://source.jpg'
     },
     async copyToFs(_file, data) {
-      return { uri: 'file://thumb.webp', size: data.byteLength }
+      return {
+        uri: 'file://thumb.webp',
+        size: data.byteLength,
+        hash: `thumb-hash-${++hashCounter}`,
+      }
     },
     ...overrides,
   }

--- a/apps/mobile/jest.setup.cjs
+++ b/apps/mobile/jest.setup.cjs
@@ -50,6 +50,8 @@ const rnfsStat = jest.fn()
 const rnfsRead = jest.fn()
 const rnfsReadFile = jest.fn()
 const rnfsHash = jest.fn()
+const rnfsMkdir = jest.fn().mockResolvedValue(undefined)
+const rnfsWriteFile = jest.fn().mockResolvedValue(undefined)
 jest.mock('react-native-fs', () => ({
   __esModule: true,
   default: {
@@ -57,9 +59,11 @@ jest.mock('react-native-fs', () => ({
     read: rnfsRead,
     readFile: rnfsReadFile,
     hash: rnfsHash,
+    mkdir: rnfsMkdir,
+    writeFile: rnfsWriteFile,
   },
 }))
-global.__rnfs = { rnfsStat, rnfsRead, rnfsReadFile, rnfsHash }
+global.__rnfs = { rnfsStat, rnfsRead, rnfsReadFile, rnfsHash, rnfsMkdir, rnfsWriteFile }
 
 const { setExpoFileSystemMock } = require('./mocks/expo-file-system')
 

--- a/apps/mobile/src/managers/thumbnailScanner.test.ts
+++ b/apps/mobile/src/managers/thumbnailScanner.test.ts
@@ -5,7 +5,7 @@ import {
 import * as VideoThumbnails from 'expo-video-thumbnails'
 import { Image } from 'react-native'
 import { initializeDB, resetDb } from '../db'
-import { calculateContentHash } from '../lib/contentHash'
+import { sha256File } from '../lib/contentHash'
 import {
   createFileRecord,
   readAllFileRecordsCount,
@@ -22,10 +22,12 @@ jest.mock('expo-image-manipulator', () => ({
 jest.mock('expo-video-thumbnails', () => ({
   getThumbnailAsync: jest.fn(),
 }))
-jest.mock('../lib/contentHash', () => ({ calculateContentHash: jest.fn() }))
+jest.mock('../lib/contentHash', () => ({
+  sha256File: jest.fn(),
+}))
 
 const getFsFileUriMock = jest.mocked(getFsFileUri)
-const calculateContentHashMock = jest.mocked(calculateContentHash)
+const sha256FileMock = jest.mocked(sha256File)
 const imageGetSizeMock = jest.mocked(Image.getSize)
 const imageManipulatorMock = jest.mocked(ImageManipulator.manipulate)
 const videoThumbMock = jest.mocked(VideoThumbnails.getThumbnailAsync)
@@ -37,9 +39,11 @@ beforeEach(async () => {
 
   getFsFileUriMock.mockResolvedValue('file://source.jpg')
   let hashCounter = 0
-  calculateContentHashMock.mockImplementation(
-    async () => `sha256:thumb-hash-${++hashCounter}`,
-  )
+  sha256FileMock.mockImplementation(async () => `thumb-hash-${++hashCounter}`)
+  const { rnfsStat } = (
+    global as unknown as { __rnfs: { rnfsStat: jest.Mock } }
+  ).__rnfs
+  rnfsStat.mockResolvedValue({ size: 100 })
 
   imageGetSizeMock.mockImplementation((_, ok) => {
     ok?.(1920, 1080)
@@ -177,7 +181,7 @@ describe('thumbnailScanner', () => {
       })
     }
     getFsFileUriMock.mockResolvedValue('file://test.jpg')
-    calculateContentHashMock.mockResolvedValue('sha256:thumb-64')
+    sha256FileMock.mockResolvedValue('thumb-64')
     const result = await runThumbnailScanner()
     const producedSizes = result.produced
       .filter((p) => p.originalId === 'file1')
@@ -336,9 +340,7 @@ describe('thumbnailScanner', () => {
       deletedAt: null,
     })
     let counter = 0
-    calculateContentHashMock.mockImplementation(
-      async () => `sha256:video-thumb-${++counter}`,
-    )
+    sha256FileMock.mockImplementation(async () => `video-thumb-${++counter}`)
 
     const result = await runThumbnailScanner()
 
@@ -372,9 +374,7 @@ describe('thumbnailScanner', () => {
     }
     getFsFileUriMock.mockResolvedValue('file://test.jpg')
     let counter = 0
-    calculateContentHashMock.mockImplementation(
-      async () => `sha256:thumb-hash-${++counter}`,
-    )
+    sha256FileMock.mockImplementation(async () => `thumb-hash-${++counter}`)
     const result = await runThumbnailScanner()
     expect(result.produced).toHaveLength(10)
   })
@@ -413,7 +413,7 @@ describe('thumbnailScanner', () => {
     imageManipulatorMock.mockReturnValue(
       ctx as unknown as ImageManipulatorContext,
     )
-    calculateContentHashMock.mockResolvedValue('sha256:thumb-hash')
+    sha256FileMock.mockResolvedValue('thumb-hash')
     await runThumbnailScanner()
     expect(ctx.resize).toHaveBeenCalledWith({ width: 64, height: undefined })
   })
@@ -464,9 +464,7 @@ describe('thumbnailScanner', () => {
     }
     getFsFileUriMock.mockResolvedValue('file://test.jpg')
     let counter = 0
-    calculateContentHashMock.mockImplementation(
-      async () => `sha256:thumb-hash-${++counter}`,
-    )
+    sha256FileMock.mockImplementation(async () => `thumb-hash-${++counter}`)
 
     const ac = new AbortController()
     let manipCalls = 0

--- a/apps/mobile/src/managers/thumbnailScanner.ts
+++ b/apps/mobile/src/managers/thumbnailScanner.ts
@@ -4,10 +4,12 @@ import {
   ThumbnailScanner,
   type ThumbnailScannerResult,
 } from '@siastorage/core/services/thumbnailScanner'
+import { Buffer } from 'buffer'
 import { Directory, File, Paths } from 'expo-file-system'
-import QuickCrypto from 'react-native-quick-crypto'
+import RNFS from 'react-native-fs'
 import { createMobileThumbnailAdapter } from '../adapters/thumbnail'
 import { db } from '../db'
+import { sha256File } from '../lib/contentHash'
 import { detectMimeType } from '../lib/detectMimeType'
 import { getMimeType } from '../lib/fileTypes'
 import { copyFileToFs, getFsFileUri } from '../stores/fs'
@@ -36,13 +38,6 @@ function ensureInitialized(): void {
   scanner.initialize({
     db: db(),
     thumbnailAdapter: createMobileThumbnailAdapter(),
-    cryptoAdapter: {
-      async sha256(data: ArrayBuffer): Promise<string> {
-        const h = QuickCrypto.createHash('sha256')
-        h.update(data)
-        return h.digest('hex')
-      },
-    },
     detectMimeType: (path: string) => detectMimeType(path),
     getFsFileUri: (file) => getFsFileUri(file),
     async copyToFs(file, data) {
@@ -52,18 +47,20 @@ function ensureInitialized(): void {
       })
       const tmpPath = `${file.id}.webp`
       const tmpDir = new Directory(Paths.cache, 'thumb-tmp')
-      const tmpDirInfo = tmpDir.info()
-      if (!tmpDirInfo.exists) tmpDir.create({ intermediates: true })
+      if (!tmpDir.info().exists) await RNFS.mkdir(tmpDir.uri)
       const tmpFile = new File(tmpDir, tmpPath)
-      tmpFile.write(new Uint8Array(data))
+      await RNFS.writeFile(
+        tmpFile.uri,
+        Buffer.from(data).toString('base64'),
+        'base64',
+      )
+      const hash = await sha256File(tmpFile.uri)
       const uri = await copyFileToFs({ id: file.id, type }, tmpFile)
-      const info = new File(uri).info()
-      return { uri, size: info.size ?? data.byteLength }
+      const stat = await RNFS.stat(uri)
+      return { uri, size: stat.size ?? data.byteLength, hash }
     },
     async invalidateCache(fileId) {
       invalidateThumbnailsForFileId(fileId)
-      await invalidateCacheLibraryAllStats()
-      invalidateCacheLibraryLists()
     },
   })
 }
@@ -72,7 +69,12 @@ export async function runThumbnailScanner(
   signal?: AbortSignal,
 ): Promise<ThumbnailScannerResult> {
   ensureInitialized()
-  return scanner.runScan(signal)
+  const result = await scanner.runScan(signal)
+  if (result.produced.length > 0) {
+    await invalidateCacheLibraryAllStats()
+    invalidateCacheLibraryLists()
+  }
+  return result
 }
 
 export const { init: initThumbnailScanner } = createServiceInterval({

--- a/apps/mobile/src/managers/thumbnailer.ts
+++ b/apps/mobile/src/managers/thumbnailer.ts
@@ -1,6 +1,10 @@
 import { yieldToEventLoop } from '@siastorage/core/lib/yieldToEventLoop'
 import { logger } from '@siastorage/logger'
 import type { FileRecord } from '../stores/files'
+import {
+  invalidateCacheLibraryAllStats,
+  invalidateCacheLibraryLists,
+} from '../stores/librarySwr'
 import { getThumbnailScanner } from './thumbnailScanner'
 
 export function isFileBeingProcessed(fileId: string): boolean {
@@ -18,9 +22,11 @@ export async function generateThumbnailsForFile(
 }
 
 export async function generateThumbnails(files: FileRecord[]) {
+  let produced = 0
   for (const file of files) {
     try {
       await generateThumbnailsForFile(file)
+      produced++
       await yieldToEventLoop()
     } catch (error) {
       logger.error('generateThumbnails', 'generation_error', {
@@ -28,5 +34,9 @@ export async function generateThumbnails(files: FileRecord[]) {
         error: error as Error,
       })
     }
+  }
+  if (produced > 0) {
+    await invalidateCacheLibraryAllStats()
+    invalidateCacheLibraryLists()
   }
 }

--- a/packages/core/src/services/thumbnailScanner.ts
+++ b/packages/core/src/services/thumbnailScanner.ts
@@ -1,5 +1,4 @@
 import { logger } from '@siastorage/logger'
-import type { CryptoAdapter } from '../adapters/crypto'
 import type { DatabaseAdapter } from '../adapters/db'
 import type { ThumbnailAdapter } from '../adapters/thumbnail'
 import { insertFileRecord } from '../db/operations/files'
@@ -15,13 +14,12 @@ import { ThumbSizes } from '../types/files'
 export type ThumbnailDeps = {
   db: DatabaseAdapter
   thumbnailAdapter: ThumbnailAdapter
-  cryptoAdapter: CryptoAdapter
   detectMimeType(path: string): Promise<string | null>
   getFsFileUri(file: { id: string; type: string }): Promise<string | null>
   copyToFs(
     file: { id: string; type: string },
     data: ArrayBuffer,
-  ): Promise<{ uri: string; size: number }>
+  ): Promise<{ uri: string; size: number; hash: string }>
   invalidateCache?(fileId: string): Promise<void>
 }
 
@@ -288,7 +286,6 @@ export class ThumbnailScanner {
     }
 
     try {
-      const thumbHash = await deps.cryptoAdapter.sha256(result.data)
       const thumbId = uniqueId()
       const thumbFileInfo = {
         id: thumbId,
@@ -303,7 +300,7 @@ export class ThumbnailScanner {
         type: result.mimeType,
         kind: 'thumb',
         size: copied.size,
-        hash: `sha256:${thumbHash}`,
+        hash: `sha256:${copied.hash}`,
         createdAt: now,
         updatedAt: now,
         addedAt: now,


### PR DESCRIPTION
- Batch cache invalidation to once per scan instead of per thumbnail
- Replace synchronous QuickCrypto hashing with native RNFS.hash via sha256File
- Switch synchronous Expo FS file writes to async RNFS APIs in the thumbnail copyToFs path.