### PR TITLE
perf(mobile): replace synchronous FS calls with async RNFS APIs

### DIFF
--- a/.changeset/async-fs-hot-paths.md
+++ b/.changeset/async-fs-hot-paths.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Replaced synchronous Expo FS calls with async RNFS APIs in hot-path file operations to reduce JS thread blocking.

--- a/apps/mobile/jest.setup.cjs
+++ b/apps/mobile/jest.setup.cjs
@@ -46,12 +46,14 @@ jest.mock('react-native-quick-crypto', () => {
   }
 })
 
-const rnfsStat = jest.fn()
+const rnfsStat = jest.fn().mockResolvedValue({ size: 100 })
 const rnfsRead = jest.fn()
 const rnfsReadFile = jest.fn()
 const rnfsHash = jest.fn()
 const rnfsMkdir = jest.fn().mockResolvedValue(undefined)
 const rnfsWriteFile = jest.fn().mockResolvedValue(undefined)
+const rnfsCopyFile = jest.fn().mockResolvedValue(undefined)
+const rnfsUnlink = jest.fn().mockResolvedValue(undefined)
 jest.mock('react-native-fs', () => ({
   __esModule: true,
   default: {
@@ -61,9 +63,11 @@ jest.mock('react-native-fs', () => ({
     hash: rnfsHash,
     mkdir: rnfsMkdir,
     writeFile: rnfsWriteFile,
+    copyFile: rnfsCopyFile,
+    unlink: rnfsUnlink,
   },
 }))
-global.__rnfs = { rnfsStat, rnfsRead, rnfsReadFile, rnfsHash, rnfsMkdir, rnfsWriteFile }
+global.__rnfs = { rnfsStat, rnfsRead, rnfsReadFile, rnfsHash, rnfsMkdir, rnfsWriteFile, rnfsCopyFile, rnfsUnlink }
 
 const { setExpoFileSystemMock } = require('./mocks/expo-file-system')
 

--- a/apps/mobile/src/lib/processAssets.test.ts
+++ b/apps/mobile/src/lib/processAssets.test.ts
@@ -1,4 +1,3 @@
-import { setExpoFileSystemMockMethods } from '../../mocks/expo-file-system'
 import { db, initializeDB, resetDb } from '../db'
 import { readAllDirectoriesWithCounts } from '../stores/directories'
 import {
@@ -440,11 +439,10 @@ describe('processAssets', () => {
     })
   })
   it('adds file size to new files', async () => {
-    setExpoFileSystemMockMethods({
-      File: {
-        info: jest.fn((uri) => ({ exists: true, size: 333, uri })),
-      },
-    })
+    const { rnfsStat } = (
+      global as unknown as { __rnfs: { rnfsStat: jest.Mock } }
+    ).__rnfs
+    rnfsStat.mockResolvedValue({ size: 333 })
     const assets = [
       {
         id: undefined,

--- a/apps/mobile/src/lib/processAssets.ts
+++ b/apps/mobile/src/lib/processAssets.ts
@@ -2,6 +2,7 @@ import { uniqueId } from '@siastorage/core/lib/uniqueId'
 import { yieldToEventLoop } from '@siastorage/core/lib/yieldToEventLoop'
 import { logger } from '@siastorage/logger'
 import { File } from 'expo-file-system'
+import RNFS from 'react-native-fs'
 import { generateThumbnails } from '../managers/thumbnailer'
 import {
   getOrCreateDirectory,
@@ -183,7 +184,7 @@ export async function processAssets(
       }
       f.hash = hash
 
-      const size = getFileSize(fileUri)
+      const size = await getFileSize(fileUri)
       if (!size) {
         f.status = 'incomplete'
         f.statusDetails = 'noFileSize'
@@ -291,7 +292,11 @@ export async function processAssets(
   }
 }
 
-function getFileSize(fileUri: string) {
-  const info = new File(fileUri).info()
-  return info.size ?? null
+async function getFileSize(fileUri: string) {
+  try {
+    const stat = await RNFS.stat(fileUri)
+    return stat.size ?? null
+  } catch {
+    return null
+  }
 }

--- a/apps/mobile/src/stores/fs.ts
+++ b/apps/mobile/src/stores/fs.ts
@@ -2,6 +2,7 @@ import type { FsMetaRow } from '@siastorage/core/db/operations'
 import * as ops from '@siastorage/core/db/operations'
 import { logger } from '@siastorage/logger'
 import { Directory, File, Paths } from 'expo-file-system'
+import RNFS from 'react-native-fs'
 import useSWR from 'swr'
 import { db } from '../db'
 import { extFromMime } from '../lib/fileTypes'
@@ -49,24 +50,26 @@ const USED_AT_UPDATE_INTERVAL_MS = 60 * 60 * 1000 // 1 hour
 export async function getFsFileUri(file: FsFileInfo): Promise<string | null> {
   const existingMeta = await readFsFileMetadata(file.id)
   const fsFile = getFsFileForId(file)
-  const info = fsFile.info()
 
-  if (!info.exists) {
-    // If the file no longer exists, remove the metadata.
+  let size: number | null = null
+  try {
+    const stat = await RNFS.stat(fsFile.uri)
+    size = stat.size
+  } catch {
+    // File does not exist on disk.
     if (existingMeta) {
       await deleteFsFileMetadata(file.id)
     }
     return null
   }
 
-  const size = info.size ?? existingMeta?.size ?? 0
   const now = Date.now()
 
   // If the file is not tracked yet, insert the metadata.
   if (!existingMeta) {
     await upsertFsFileMetadata({
       fileId: file.id,
-      size,
+      size: size ?? 0,
       addedAt: now,
       usedAt: now,
     })
@@ -83,11 +86,12 @@ export async function getFsFileUri(file: FsFileInfo): Promise<string | null> {
 
 export async function removeFsFile(file: FsFileInfo): Promise<void> {
   const fsFile = getFsFileForId(file)
-  const info = fsFile.info()
   let changed = false
-  if (info.exists) {
-    fsFile.delete()
+  try {
+    await RNFS.unlink(fsFile.uri)
     changed = true
+  } catch {
+    // File does not exist, nothing to delete.
   }
   const meta = await readFsFileMetadata(file.id)
   if (meta) {
@@ -105,15 +109,27 @@ export async function copyFileToFs(
 ): Promise<string> {
   logger.debug('fs', 'copy_file', { fileId: file.id, uri: sourceFile.uri })
   const target = getFsFileForId(file)
-  const targetInfo = target.info()
-  if (targetInfo.exists) {
-    target.delete()
+  try {
+    await RNFS.unlink(target.uri)
+  } catch {
+    // Target does not exist yet, nothing to remove.
   }
-  sourceFile.copy(target)
-  const destinationInfo = target.info()
-  const sourceInfo = sourceFile.info()
+  await RNFS.copyFile(sourceFile.uri, target.uri)
+  let size = 0
+  try {
+    const stat = await RNFS.stat(target.uri)
+    size = stat.size
+  } catch {
+    // Fallback to source stat or metadata.
+    try {
+      const sourceStat = await RNFS.stat(sourceFile.uri)
+      size = sourceStat.size
+    } catch {
+      const previous = await readFsFileMetadata(file.id)
+      size = previous?.size ?? 0
+    }
+  }
   const previous = await readFsFileMetadata(file.id)
-  const size = destinationInfo.size ?? sourceInfo.size ?? previous?.size ?? 0
   await upsertFsFileMetadata({
     fileId: file.id,
     size,

--- a/apps/mobile/src/stores/tempFs.ts
+++ b/apps/mobile/src/stores/tempFs.ts
@@ -1,4 +1,5 @@
 import { Directory, File, Paths } from 'expo-file-system'
+import RNFS from 'react-native-fs'
 
 /**
  * Temporary file system used for in-progress file downloads.
@@ -38,8 +39,9 @@ export async function removeTempDownloadFile(
   file: TempFsFileInfo,
 ): Promise<void> {
   const f = getTempDownloadFileForId(file)
-  const info = f.info()
-  if (info.exists) {
-    f.delete()
+  try {
+    await RNFS.unlink(f.uri)
+  } catch {
+    // File does not exist, nothing to delete.
   }
 }


### PR DESCRIPTION
- Convert getFsFileUri, copyFileToFs, removeFsFile, removeTempDownloadFile, and getFileSize from synchronous Expo FS calls to async RNFS equivalents.