### PR TITLE
fix(mobile): wrong thumbnail for unresolved files and sync FS blocking

### DIFF
--- a/.changeset/fix-thumb-and-fs-blocking.md
+++ b/.changeset/fix-thumb-and-fs-blocking.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Fixed significant lag caused by synchronous file system calls blocking the JS thread during background operations.

--- a/.changeset/fix-wrong-thumbnail.md
+++ b/.changeset/fix-wrong-thumbnail.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Fixed an issue where the wrong thumbnail could briefly display before the actual thumbnail was computed.

--- a/apps/mobile/jest.setup.cjs
+++ b/apps/mobile/jest.setup.cjs
@@ -46,8 +46,10 @@ jest.mock('react-native-quick-crypto', () => {
   }
 })
 
+const rnfsExists = jest.fn().mockResolvedValue(true)
 const rnfsStat = jest.fn().mockResolvedValue({ size: 100 })
 const rnfsRead = jest.fn()
+const rnfsReadDir = jest.fn().mockResolvedValue([])
 const rnfsReadFile = jest.fn()
 const rnfsHash = jest.fn()
 const rnfsMkdir = jest.fn().mockResolvedValue(undefined)
@@ -57,8 +59,10 @@ const rnfsUnlink = jest.fn().mockResolvedValue(undefined)
 jest.mock('react-native-fs', () => ({
   __esModule: true,
   default: {
+    exists: rnfsExists,
     stat: rnfsStat,
     read: rnfsRead,
+    readDir: rnfsReadDir,
     readFile: rnfsReadFile,
     hash: rnfsHash,
     mkdir: rnfsMkdir,
@@ -67,7 +71,7 @@ jest.mock('react-native-fs', () => ({
     unlink: rnfsUnlink,
   },
 }))
-global.__rnfs = { rnfsStat, rnfsRead, rnfsReadFile, rnfsHash, rnfsMkdir, rnfsWriteFile, rnfsCopyFile, rnfsUnlink }
+global.__rnfs = { rnfsExists, rnfsStat, rnfsRead, rnfsReadDir, rnfsReadFile, rnfsHash, rnfsMkdir, rnfsWriteFile, rnfsCopyFile, rnfsUnlink }
 
 const { setExpoFileSystemMock } = require('./mocks/expo-file-system')
 

--- a/apps/mobile/src/components/FileImport/index.tsx
+++ b/apps/mobile/src/components/FileImport/index.tsx
@@ -11,6 +11,7 @@ import {
   Text,
   View,
 } from 'react-native'
+import RNFS from 'react-native-fs'
 import type { PinnedObjectInterface } from 'react-native-sia'
 import useSWR from 'swr'
 import { calculateContentHash } from '../../lib/contentHash'
@@ -110,14 +111,18 @@ async function downloadAndProcessFile(
     }
 
     const tempFile = new File(tempFsFileUri)
-    const fileInfo = tempFile.info()
-    const size = fileInfo.size ?? 0
+    const fileStat = await RNFS.stat(tempFsFileUri)
+    const size = fileStat.size ?? 0
 
     const finalFsFileUri = await copyFileToFs({ id, type }, tempFile)
     logger.debug('FileImport', 'copied_to_final', { uri: finalFsFileUri })
 
     if (finalFsFileUri !== tempFsFileUri) {
-      tempFile.delete()
+      try {
+        await RNFS.unlink(tempFsFileUri)
+      } catch {
+        // Temp file may already be gone.
+      }
     }
 
     logger.debug('FileImport', 'calculating_hash', { uri: finalFsFileUri })

--- a/apps/mobile/src/managers/app.ts
+++ b/apps/mobile/src/managers/app.ts
@@ -45,8 +45,8 @@ export async function initApp(): Promise<void> {
       label: 'Starting application',
       message: 'Initializing...',
       runner: async () => {
-        ensureFsStorageDirectory()
-        ensureTempFsStorageDirectory()
+        await ensureFsStorageDirectory()
+        await ensureTempFsStorageDirectory()
         await initKeepAwake()
       },
     },

--- a/apps/mobile/src/managers/fsOrphanScanner.test.ts
+++ b/apps/mobile/src/managers/fsOrphanScanner.test.ts
@@ -1,5 +1,6 @@
 import { FS_ORPHAN_FREQUENCY } from '@siastorage/core/config'
 import type { File } from 'expo-file-system'
+import RNFS from 'react-native-fs'
 import { initializeDB, resetDb } from '../db'
 import {
   getAsyncStorageNumber,
@@ -30,7 +31,8 @@ const now = 1_000_000_000
 describe('fsOrphanScanner', () => {
   beforeEach(async () => {
     jest.spyOn(Date, 'now').mockReturnValue(now)
-    listFilesInFsStorageDirectoryMock.mockImplementation(() => [])
+    jest.mocked(RNFS.unlink).mockClear()
+    listFilesInFsStorageDirectoryMock.mockImplementation(async () => [])
     await initializeDB()
     await setAsyncStorageNumber('fsOrphanLastRun', 0)
   })
@@ -65,11 +67,11 @@ describe('fsOrphanScanner', () => {
 
   it('removes files that have no metadata entry', async () => {
     const file = makeFile('file-1.jpg')
-    listFilesInFsStorageDirectoryMock.mockImplementation(() => [file])
+    listFilesInFsStorageDirectoryMock.mockImplementation(async () => [file])
 
     const result = await runFsOrphanScanner()
 
-    expect(file.delete).toHaveBeenCalledTimes(1)
+    expect(RNFS.unlink).toHaveBeenCalledWith(file.uri)
     expect(await readFsFileMetadata('file-1')).toBeNull()
     expect(await getAsyncStorageNumber('fsOrphanLastRun', 0)).toBe(now)
     expect(result).toEqual({ removed: 1 })
@@ -77,7 +79,7 @@ describe('fsOrphanScanner', () => {
 
   it('keeps files that still have metadata', async () => {
     const file = makeFile('file-2.jpg')
-    listFilesInFsStorageDirectoryMock.mockImplementation(() => [file])
+    listFilesInFsStorageDirectoryMock.mockImplementation(async () => [file])
     await createFileRecord({
       id: 'file-2',
       name: 'file-2.jpg',
@@ -101,7 +103,7 @@ describe('fsOrphanScanner', () => {
 
     const result = await runFsOrphanScanner()
 
-    expect(file.delete).not.toHaveBeenCalled()
+    expect(RNFS.unlink).not.toHaveBeenCalled()
     expect((await readFsFileMetadata('file-2'))?.fileId).toBe('file-2')
     expect(await getAsyncStorageNumber('fsOrphanLastRun', 0)).toBe(now)
     expect(result).toEqual({ removed: 0 })
@@ -109,7 +111,7 @@ describe('fsOrphanScanner', () => {
 
   it('deletes files that have no associated files table row', async () => {
     const file = makeFile('file-1.jpg')
-    listFilesInFsStorageDirectoryMock.mockImplementation(() => [file])
+    listFilesInFsStorageDirectoryMock.mockImplementation(async () => [file])
     await upsertFsFileMetadata({
       fileId: 'file-1',
       size: 100,
@@ -119,14 +121,14 @@ describe('fsOrphanScanner', () => {
 
     const result = await runFsOrphanScanner()
 
-    expect(file.delete).toHaveBeenCalledTimes(1)
+    expect(RNFS.unlink).toHaveBeenCalledWith(file.uri)
     expect(await readFsFileMetadata('file-1')).toBeNull()
     expect(result).toEqual({ removed: 1 })
   })
 
   it('calls onProgress with correct removed/total counts', async () => {
     const files = [makeFile('a.jpg'), makeFile('b.jpg'), makeFile('c.jpg')]
-    listFilesInFsStorageDirectoryMock.mockImplementation(() => files)
+    listFilesInFsStorageDirectoryMock.mockImplementation(async () => files)
     await createFileRecord({
       id: 'b',
       name: 'b.jpg',
@@ -190,7 +192,7 @@ describe('fsOrphanScanner', () => {
 
   it('treats tombstoned files as orphaned', async () => {
     const file = makeFile('file-tomb.jpg')
-    listFilesInFsStorageDirectoryMock.mockImplementation(() => [file])
+    listFilesInFsStorageDirectoryMock.mockImplementation(async () => [file])
     await createFileRecord({
       id: 'file-tomb',
       name: 'file-tomb.jpg',
@@ -214,7 +216,7 @@ describe('fsOrphanScanner', () => {
 
     const result = await runFsOrphanScanner()
 
-    expect(file.delete).toHaveBeenCalledTimes(1)
+    expect(RNFS.unlink).toHaveBeenCalledWith(file.uri)
     expect(result).toEqual({ removed: 1 })
   })
 
@@ -222,7 +224,7 @@ describe('fsOrphanScanner', () => {
     const files = Array.from({ length: 60 }, (_, i) =>
       makeFile(`file-${i}.jpg`),
     )
-    listFilesInFsStorageDirectoryMock.mockImplementation(() => files)
+    listFilesInFsStorageDirectoryMock.mockImplementation(async () => files)
 
     const result = await runFsOrphanScanner()
 

--- a/apps/mobile/src/managers/fsOrphanScanner.ts
+++ b/apps/mobile/src/managers/fsOrphanScanner.ts
@@ -2,6 +2,7 @@ import { FS_ORPHAN_FREQUENCY } from '@siastorage/core/config'
 import type { OrphanScannerResult } from '@siastorage/core/services'
 import * as services from '@siastorage/core/services'
 import { logger } from '@siastorage/logger'
+import RNFS from 'react-native-fs'
 import { db } from '../db'
 import {
   getAsyncStorageNumber,
@@ -36,7 +37,7 @@ export async function runFsOrphanScanner(options?: {
     return await services.runOrphanScanner({
       db: db(),
       listFiles: () => listFilesInFsStorageDirectory(),
-      deleteFile: (file) => file.delete(),
+      deleteFile: (file) => RNFS.unlink(file.uri),
       deleteFsMetadataBatch: (fileIds) => deleteFsFileMetadataBatch(fileIds),
       invalidateCache: async () => void fsFileUriCache.invalidateAll(),
       onProgress: options?.onProgress,

--- a/apps/mobile/src/managers/thumbnailScanner.ts
+++ b/apps/mobile/src/managers/thumbnailScanner.ts
@@ -13,10 +13,6 @@ import { sha256File } from '../lib/contentHash'
 import { detectMimeType } from '../lib/detectMimeType'
 import { getMimeType } from '../lib/fileTypes'
 import { copyFileToFs, getFsFileUri } from '../stores/fs'
-import {
-  invalidateCacheLibraryAllStats,
-  invalidateCacheLibraryLists,
-} from '../stores/librarySwr'
 import { invalidateThumbnailsForFileId } from '../stores/thumbnails'
 
 export type {
@@ -47,7 +43,8 @@ function ensureInitialized(): void {
       })
       const tmpPath = `${file.id}.webp`
       const tmpDir = new Directory(Paths.cache, 'thumb-tmp')
-      if (!tmpDir.info().exists) await RNFS.mkdir(tmpDir.uri)
+      const tmpDirExists = await RNFS.exists(tmpDir.uri)
+      if (!tmpDirExists) await RNFS.mkdir(tmpDir.uri)
       const tmpFile = new File(tmpDir, tmpPath)
       await RNFS.writeFile(
         tmpFile.uri,
@@ -70,10 +67,6 @@ export async function runThumbnailScanner(
 ): Promise<ThumbnailScannerResult> {
   ensureInitialized()
   const result = await scanner.runScan(signal)
-  if (result.produced.length > 0) {
-    await invalidateCacheLibraryAllStats()
-    invalidateCacheLibraryLists()
-  }
   return result
 }
 

--- a/apps/mobile/src/stores/fs.ts
+++ b/apps/mobile/src/stores/fs.ts
@@ -24,19 +24,21 @@ export type { FsMetaRow } from '@siastorage/core/db/operations'
 
 export const fsStorageDirectory = new Directory(Paths.document, 'files')
 
-export function listFilesInFsStorageDirectory(): File[] {
-  const info = fsStorageDirectory.info()
-  if (!info.exists) {
+export async function listFilesInFsStorageDirectory(): Promise<File[]> {
+  const exists = await RNFS.exists(fsStorageDirectory.uri)
+  if (!exists) {
     return []
   }
-  const entries = fsStorageDirectory.list()
-  return entries.filter((entry): entry is File => entry instanceof File)
+  const entries = await RNFS.readDir(fsStorageDirectory.uri)
+  return entries
+    .filter((item) => item.isFile())
+    .map((item) => new File(item.path))
 }
 
-export function ensureFsStorageDirectory(): void {
-  const info = fsStorageDirectory.info()
-  if (!info.exists) {
-    fsStorageDirectory.create({ intermediates: true })
+export async function ensureFsStorageDirectory(): Promise<void> {
+  const exists = await RNFS.exists(fsStorageDirectory.uri)
+  if (!exists) {
+    await RNFS.mkdir(fsStorageDirectory.uri)
   }
 }
 
@@ -141,7 +143,7 @@ export async function copyFileToFs(
 }
 
 export function useFsFileUri(file?: FsFileInfo) {
-  return useSWR(fsFileUriCache.key(file?.id ?? ''), () => {
+  return useSWR(file ? fsFileUriCache.key(file.id) : null, () => {
     return file ? getFsFileUri(file) : null
   })
 }

--- a/apps/mobile/src/stores/tempFs.ts
+++ b/apps/mobile/src/stores/tempFs.ts
@@ -13,10 +13,10 @@ type TempFsFileInfo = {
   localId: string | null
 }
 
-export function ensureTempFsStorageDirectory(): void {
-  const info = tempFsStorageDirectory.info()
-  if (!info.exists) {
-    tempFsStorageDirectory.create({ intermediates: true })
+export async function ensureTempFsStorageDirectory(): Promise<void> {
+  const exists = await RNFS.exists(tempFsStorageDirectory.uri)
+  if (!exists) {
+    await RNFS.mkdir(tempFsStorageDirectory.uri)
   }
 }
 
@@ -28,9 +28,10 @@ export async function getOrCreateTempDownloadFile(
   file: TempFsFileInfo,
 ): Promise<File> {
   const f = getTempDownloadFileForId(file)
-  const info = f.info()
-  if (!info.exists) {
-    f.create({ intermediates: true })
+  const exists = await RNFS.exists(f.uri)
+  if (!exists) {
+    await RNFS.mkdir(tempFsStorageDirectory.uri)
+    await RNFS.writeFile(f.uri, '')
   }
   return f
 }

--- a/packages/core/src/services/orphanScanner.ts
+++ b/packages/core/src/services/orphanScanner.ts
@@ -10,8 +10,8 @@ export type FsEntry = {
 
 export type OrphanScannerDeps<T extends FsEntry = FsEntry> = {
   db: DatabaseAdapter
-  listFiles: () => T[]
-  deleteFile: (file: T) => void
+  listFiles: () => T[] | Promise<T[]>
+  deleteFile: (file: T) => void | Promise<void>
   deleteFsMetadataBatch: (fileIds: string[]) => Promise<void>
   invalidateCache?: () => Promise<void>
   onProgress?: (removed: number, total: number) => void
@@ -59,7 +59,7 @@ export async function runOrphanScanner<T extends FsEntry>(
   const { db, listFiles, deleteFile, deleteFsMetadataBatch } = deps
 
   try {
-    const files = listFiles()
+    const files = await listFiles()
     if (files.length === 0) return undefined
 
     let removed = 0
@@ -79,7 +79,7 @@ export async function runOrphanScanner<T extends FsEntry>(
       for (const entry of entries) {
         if (!orphanedIds.has(entry.fileId)) continue
         try {
-          deleteFile(entry.file)
+          await deleteFile(entry.file)
           removed++
           logger.info('orphanScanner', 'file_removed', {
             fileId: entry.fileId,


### PR DESCRIPTION
Noticed two issues when importing a batch of files:
- noticable lag until all processing was done.
- thumbs would briefly show the wrong thumb until theirs was computed.

The fs change fixes the lag entirely and the cache key change fixes the thumb issue:
- Fix useFsFileUri(undefined) resolving to a shared SWR cache key that all thumbnail-less gallery items subscribed to, causing wrong thumbnails to briefly display. Return null SWR key when file is undefined.
- Replace remaining synchronous expo-file-system JSI calls with async react-native-fs equivalents to eliminate JS thread blocking during background operations like uploads and orphan scanning.
- Remove unnecessary library list invalidation from thumbnail scanner paths since thumbnails are kind='thumb' records.
