### PR TITLE
perf(mobile): batch upload manager state updates and parallelize save phase

### DIFF
--- a/.changeset/batch-upload-manager.md
+++ b/.changeset/batch-upload-manager.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Improved upload performance by parallelizing the save phase, batching state updates, and reducing progress-driven re-renders.

--- a/apps/integration/test/adapters/upload.ts
+++ b/apps/integration/test/adapters/upload.ts
@@ -4,7 +4,7 @@ import type {
   Reader,
 } from '@siastorage/core/adapters'
 import {
-  insertLocalObject,
+  insertManyLocalObjects,
   queryFileRecordById,
   queryLocalOnlyFiles,
 } from '@siastorage/core/db/operations'
@@ -41,7 +41,8 @@ export function buildUploadDeps(params: {
       getFsFileUri: (file) => getFsFileUri(file),
     },
     localObjects: {
-      upsert: (lo) => insertLocalObject(db, lo),
+      upsertMany: (objects) => insertManyLocalObjects(db, objects),
+      invalidate: () => {},
     },
     platform: {
       isConnected: () => connected(),
@@ -71,8 +72,23 @@ export function buildUploadDeps(params: {
           size,
         })
       },
+      registerMany: (entries) => {
+        for (const { id, size } of entries) {
+          uploads.set(id, {
+            id,
+            status: 'pending',
+            progress: 0,
+            size,
+          })
+        }
+      },
       remove: (fileId) => {
         uploads.delete(fileId)
+      },
+      removeMany: (ids) => {
+        for (const id of ids) {
+          uploads.delete(id)
+        }
       },
       setStatus: (fileId, status) => {
         const u = uploads.get(fileId)
@@ -90,6 +106,16 @@ export function buildUploadDeps(params: {
         if (u) {
           u.batchId = batchId
           u.batchCount = count
+        }
+      },
+      setBatchUploading: (fileIds, batchId) => {
+        for (const fileId of fileIds) {
+          const u = uploads.get(fileId)
+          if (u) {
+            u.batchId = batchId
+            u.batchCount = fileIds.length
+            u.status = 'uploading'
+          }
         }
       },
       updateProgress: (fileId, progress) => {

--- a/apps/mobile/src/managers/uploader.test.ts
+++ b/apps/mobile/src/managers/uploader.test.ts
@@ -14,6 +14,8 @@ jest.mock('@siastorage/core/config', () => ({
   PACKER_MAX_SLABS: 10,
   SLAB_FILL_THRESHOLD: 0.9,
   PACKER_POLL_INTERVAL: 5000,
+  SAVE_BATCH_CONCURRENCY: 50,
+  SAVE_REMOVAL_DELAY_MS: 0,
 }))
 
 import {
@@ -24,6 +26,7 @@ import {
   UPLOAD_MAX_INFLIGHT,
   UPLOAD_PARITY_SHARDS,
 } from '@siastorage/core/config'
+import { insertManyLocalObjects } from '@siastorage/core/db/operations'
 import type { LocalObject } from '@siastorage/core/encoding/localObject'
 import type { UploadDeps } from '@siastorage/core/services/uploader'
 import type {
@@ -31,7 +34,7 @@ import type {
   PinnedObjectInterface,
   SdkInterface,
 } from 'react-native-sia'
-import { initializeDB, resetDb } from '../db'
+import { db, initializeDB, resetDb } from '../db'
 import { createFileReader } from '../lib/fileReader'
 import { pinnedObjectToLocalObject } from '../lib/localObjects'
 import {
@@ -40,10 +43,7 @@ import {
   readFileRecord,
 } from '../stores/files'
 import { getFsFileUri } from '../stores/fs'
-import {
-  readLocalObjectsForFile,
-  upsertLocalObject,
-} from '../stores/localObjects'
+import { readLocalObjectsForFile } from '../stores/localObjects'
 import { getIsConnected } from '../stores/sdk'
 import { getAutoScanUploads } from '../stores/settings'
 import {
@@ -51,7 +51,10 @@ import {
   getActiveUploads,
   getUploadState,
   registerUpload,
+  registerUploads,
   removeUpload,
+  removeUploads,
+  setBatchUploading,
   setUploadBatchInfo,
   setUploadError,
   setUploadStatus,
@@ -214,7 +217,8 @@ function buildTestDeps(sdk: any, indexerURL: string): UploadDeps {
       getFsFileUri: (file) => getFsFileUri(file),
     },
     localObjects: {
-      upsert: (lo) => upsertLocalObject(lo),
+      upsertMany: (objects) => insertManyLocalObjects(db(), objects),
+      invalidate: () => {},
     },
     platform: {
       isConnected: () => getIsConnected(),
@@ -226,11 +230,15 @@ function buildTestDeps(sdk: any, indexerURL: string): UploadDeps {
     },
     uploads: {
       register: (fileId, size) => registerUpload(fileId, size),
+      registerMany: (entries) => registerUploads(entries),
       remove: (fileId) => removeUpload(fileId),
+      removeMany: (ids) => removeUploads(ids),
       setStatus: (fileId, status) => setUploadStatus(fileId, status),
       setError: (fileId, message) => setUploadError(fileId, message),
       setBatchInfo: (fileId, batchId, count) =>
         setUploadBatchInfo(fileId, batchId, count),
+      setBatchUploading: (fileIds, batchId) =>
+        setBatchUploading(fileIds, batchId),
       updateProgress: (fileId, progress) =>
         updateUploadProgress(fileId, progress),
       getActive: () => getActiveUploads(),
@@ -267,6 +275,7 @@ describe('UploadManager', () => {
   })
 
   afterEach(async () => {
+    await manager.shutdown()
     jest.useRealTimers()
     await resetDb()
     resetUploadsStore()
@@ -411,13 +420,17 @@ describe('UploadManager', () => {
         mockPinnedObject,
         mockPinnedObject,
       ])
-      // pinObject succeeds for file1, fails for file2
+      // pinObject succeeds for file1, fails for file2 (all 3 retry attempts)
       mockSdk.pinObject
         .mockResolvedValueOnce(undefined)
         .mockRejectedValueOnce(new Error('Pin failed'))
+        .mockRejectedValueOnce(new Error('Pin failed'))
+        .mockRejectedValueOnce(new Error('Pin failed'))
 
       await manager.__testProcessFiles([entry1, entry2])
-      await manager.flush()
+      const flushPromise = manager.flush()
+      await jest.advanceTimersByTimeAsync(10000)
+      await flushPromise
 
       // file1 should be removed (success)
       expect(getUploadState('file1')).toBeUndefined()
@@ -456,16 +469,21 @@ describe('UploadManager', () => {
       const entry = await createTestFile('pin-fail-file')
       manager.initialize(buildTestDeps(mockSdk, TEST_INDEXER_URL))
       mockPacker.finalize.mockResolvedValueOnce([mockPinnedObject])
-      mockSdk.pinObject.mockRejectedValueOnce(new Error('Indexer unavailable'))
+      mockSdk.pinObject
+        .mockRejectedValueOnce(new Error('Indexer unavailable'))
+        .mockRejectedValueOnce(new Error('Indexer unavailable'))
+        .mockRejectedValueOnce(new Error('Indexer unavailable'))
 
       await manager.__testProcessFiles([entry])
-      await manager.flush()
+      const flushPromise = manager.flush()
+      await jest.advanceTimersByTimeAsync(10000)
+      await flushPromise
 
       // File should have error status
       const upload = getUploadState('pin-fail-file')
       expect(upload).toBeDefined()
       expect(upload?.status).toBe('error')
-      expect(upload?.error).toBe('Indexer unavailable')
+      expect(upload?.error).toBe('Failed after 3 attempts: Indexer unavailable')
 
       // No local object should be created
       const localObjects = await readLocalObjectsForFile('pin-fail-file')
@@ -481,13 +499,17 @@ describe('UploadManager', () => {
         mockPinnedObject,
         mockPinnedObject,
       ])
-      // First call succeeds, second fails
+      // First call succeeds, second fails (all 3 retry attempts)
       mockSdk.pinObject
         .mockResolvedValueOnce(undefined)
         .mockRejectedValueOnce(new Error('Pin failed'))
+        .mockRejectedValueOnce(new Error('Pin failed'))
+        .mockRejectedValueOnce(new Error('Pin failed'))
 
       await manager.__testProcessFiles([entry1, entry2])
-      await manager.flush()
+      const flushPromise = manager.flush()
+      await jest.advanceTimersByTimeAsync(10000)
+      await flushPromise
 
       // pin-success should be removed from uploads (completed successfully)
       expect(getUploadState('pin-success')).toBeUndefined()
@@ -496,13 +518,33 @@ describe('UploadManager', () => {
       const upload2 = getUploadState('pin-fail')
       expect(upload2).toBeDefined()
       expect(upload2?.status).toBe('error')
-      expect(upload2?.error).toBe('Pin failed')
+      expect(upload2?.error).toBe('Failed after 3 attempts: Pin failed')
 
       // Only pin-success should have local object
       const objects1 = await readLocalObjectsForFile('pin-success')
       const objects2 = await readLocalObjectsForFile('pin-fail')
       expect(objects1).toHaveLength(1)
       expect(objects2).toHaveLength(0)
+    })
+
+    it('retries pinObject on transient failure and succeeds', async () => {
+      const entry = await createTestFile('retry-file')
+      manager.initialize(buildTestDeps(mockSdk, TEST_INDEXER_URL))
+      mockPacker.finalize.mockResolvedValueOnce([mockPinnedObject])
+      // Fails once, succeeds on retry
+      mockSdk.pinObject
+        .mockRejectedValueOnce(new Error('Transient error'))
+        .mockResolvedValueOnce(undefined)
+
+      await manager.__testProcessFiles([entry])
+      const flushPromise = manager.flush()
+      await jest.advanceTimersByTimeAsync(10000)
+      await flushPromise
+
+      // Should succeed after retry — upload removed, local object created
+      expect(getUploadState('retry-file')).toBeUndefined()
+      const localObjects = await readLocalObjectsForFile('retry-file')
+      expect(localObjects).toHaveLength(1)
     })
 
     it('creates new packer for files added after flush', async () => {

--- a/apps/mobile/src/managers/uploader.ts
+++ b/apps/mobile/src/managers/uploader.ts
@@ -1,4 +1,5 @@
 import type { SdkAdapter } from '@siastorage/core/adapters'
+import { insertManyLocalObjects } from '@siastorage/core/db/operations'
 import {
   type FileEntry,
   type FlushRecord,
@@ -8,6 +9,7 @@ import {
 import { logger } from '@siastorage/logger'
 import { useCallback } from 'react'
 import { AppState } from 'react-native'
+import { db } from '../db'
 import { createFileReader } from '../lib/fileReader'
 import { pinnedObjectToLocalObject } from '../lib/localObjects'
 import {
@@ -16,13 +18,19 @@ import {
   readFileRecord,
 } from '../stores/files'
 import { getFsFileUri } from '../stores/fs'
-import { upsertLocalObject } from '../stores/localObjects'
+import {
+  invalidateCacheLibraryAllStats,
+  invalidateCacheLibraryLists,
+} from '../stores/librarySwr'
 import { getIsConnected, getSdk, useSdk } from '../stores/sdk'
 import { getAutoScanUploads, getIndexerURL } from '../stores/settings'
 import {
   getActiveUploads,
   registerUpload,
+  registerUploads,
   removeUpload,
+  removeUploads,
+  setBatchUploading,
   setUploadBatchInfo,
   setUploadError,
   setUploadStatus,
@@ -40,7 +48,11 @@ function buildUploadDeps(sdk: SdkAdapter, indexerURL: string): UploadDeps {
       getFsFileUri: (file) => getFsFileUri(file),
     },
     localObjects: {
-      upsert: (lo) => upsertLocalObject(lo),
+      upsertMany: (objects) => insertManyLocalObjects(db(), objects),
+      invalidate: () => {
+        invalidateCacheLibraryAllStats()
+        invalidateCacheLibraryLists()
+      },
     },
     platform: {
       isConnected: () => getIsConnected(),
@@ -52,11 +64,15 @@ function buildUploadDeps(sdk: SdkAdapter, indexerURL: string): UploadDeps {
     },
     uploads: {
       register: (fileId, size) => registerUpload(fileId, size),
+      registerMany: (entries) => registerUploads(entries),
       remove: (fileId) => removeUpload(fileId),
+      removeMany: (ids) => removeUploads(ids),
       setStatus: (fileId, status) => setUploadStatus(fileId, status),
       setError: (fileId, message) => setUploadError(fileId, message),
       setBatchInfo: (fileId, batchId, count) =>
         setUploadBatchInfo(fileId, batchId, count),
+      setBatchUploading: (fileIds, batchId) =>
+        setBatchUploading(fileIds, batchId),
       updateProgress: (fileId, progress) =>
         updateUploadProgress(fileId, progress),
       getActive: () => getActiveUploads(),

--- a/apps/mobile/src/managers/uploaderEfficiency.test.ts
+++ b/apps/mobile/src/managers/uploaderEfficiency.test.ts
@@ -14,6 +14,8 @@ jest.mock('@siastorage/core/config', () => ({
   PACKER_MAX_SLABS: 10,
   SLAB_FILL_THRESHOLD: 0.9,
   PACKER_POLL_INTERVAL: 5000,
+  SAVE_BATCH_CONCURRENCY: 50,
+  SAVE_REMOVAL_DELAY_MS: 0,
 }))
 
 import { PACKER_IDLE_TIMEOUT, SLAB_SIZE } from '@siastorage/core/config'
@@ -28,13 +30,15 @@ import { createFileReader } from '../lib/fileReader'
 import { pinnedObjectToLocalObject } from '../lib/localObjects'
 import { getFilesLocalOnly } from '../stores/files'
 import { getFsFileUri } from '../stores/fs'
-import { upsertLocalObject } from '../stores/localObjects'
 import { getIsConnected } from '../stores/sdk'
 import { getAutoScanUploads } from '../stores/settings'
 import {
   getActiveUploads,
   registerUpload,
+  registerUploads,
   removeUpload,
+  removeUploads,
+  setBatchUploading,
   setUploadBatchInfo,
   setUploadError,
   setUploadStatus,
@@ -162,7 +166,8 @@ function buildTestDeps(sdk: any, indexerURL: string): UploadDeps {
       getFsFileUri: (file) => getFsFileUri(file),
     },
     localObjects: {
-      upsert: (lo) => upsertLocalObject(lo),
+      upsertMany: async () => {},
+      invalidate: () => {},
     },
     platform: {
       isConnected: () => getIsConnected(),
@@ -174,11 +179,15 @@ function buildTestDeps(sdk: any, indexerURL: string): UploadDeps {
     },
     uploads: {
       register: (fileId, size) => registerUpload(fileId, size),
+      registerMany: (entries) => registerUploads(entries),
       remove: (fileId) => removeUpload(fileId),
+      removeMany: (ids) => removeUploads(ids),
       setStatus: (fileId, status) => setUploadStatus(fileId, status),
       setError: (fileId, message) => setUploadError(fileId, message),
       setBatchInfo: (fileId, batchId, count) =>
         setUploadBatchInfo(fileId, batchId, count),
+      setBatchUploading: (fileIds, batchId) =>
+        setBatchUploading(fileIds, batchId),
       updateProgress: (fileId, progress) =>
         updateUploadProgress(fileId, progress),
       getActive: () => getActiveUploads(),
@@ -297,6 +306,7 @@ describe('UploadManager packing efficiency', () => {
   })
 
   afterEach(async () => {
+    await manager.shutdown()
     jest.useRealTimers()
     await resetDb()
     useUploadsStore.setState({ uploads: {} })

--- a/apps/mobile/src/stores/uploads.ts
+++ b/apps/mobile/src/stores/uploads.ts
@@ -1,3 +1,4 @@
+import { createDebouncedAction } from '@siastorage/core/lib/debouncedAction'
 import { logger } from '@siastorage/logger'
 import { create } from 'zustand'
 import { createGetterAndSelector } from '../lib/selectors'
@@ -37,9 +38,8 @@ export const useUploadsStore = create<UploadsStore>(() => ({ uploads: {} }))
 const { setState } = useUploadsStore
 
 const pendingUploadProgress = new Map<string, number>()
-let uploadRafScheduled = false
 
-function flushUploadProgress() {
+function applyPendingUploadProgress() {
   if (pendingUploadProgress.size === 0) return
   setState((state) => {
     const uploads = { ...state.uploads }
@@ -50,18 +50,16 @@ function flushUploadProgress() {
       }
     }
     pendingUploadProgress.clear()
-    uploadRafScheduled = false
     return { uploads }
   })
 }
 
-/**
- * Immediately flush any pending progress updates.
- * Primarily used for testing where RAF may not work correctly.
- */
-export function flushPendingUploadProgress(): void {
-  flushUploadProgress()
-}
+const uploadProgressFlusher = createDebouncedAction(
+  applyPendingUploadProgress,
+  1000,
+)
+
+export const flushPendingUploadProgress = uploadProgressFlusher.flush
 
 export function registerUpload(id: string, size: number): void {
   setState((state) => {
@@ -72,6 +70,19 @@ export function registerUpload(id: string, size: number): void {
       progress: 0,
     }
     return { uploads: { ...state.uploads, [id]: next } }
+  })
+}
+
+export function registerUploads(
+  entries: Array<{ id: string; size: number }>,
+): void {
+  if (entries.length === 0) return
+  setState((state) => {
+    const uploads = { ...state.uploads }
+    for (const { id, size } of entries) {
+      uploads[id] = { id, size, status: 'queued', progress: 0 }
+    }
+    return { uploads }
   })
 }
 
@@ -115,6 +126,25 @@ export function setUploadBatchInfo(
       batchFileCount,
     }
     return { uploads: { ...state.uploads, [id]: next } }
+  })
+}
+
+export function setBatchUploading(fileIds: string[], batchId: string): void {
+  if (fileIds.length === 0) return
+  setState((state) => {
+    const uploads = { ...state.uploads }
+    for (const id of fileIds) {
+      const prev = uploads[id]
+      if (prev) {
+        uploads[id] = {
+          ...prev,
+          status: 'uploading',
+          batchId,
+          batchFileCount: fileIds.length,
+        }
+      }
+    }
+    return { uploads }
   })
 }
 
@@ -169,10 +199,7 @@ export const [getUploadCounts, useUploadCounts] = createGetterAndSelector(
 
 export function updateUploadProgress(id: string, progress: number) {
   pendingUploadProgress.set(id, progress)
-  if (!uploadRafScheduled) {
-    uploadRafScheduled = true
-    requestAnimationFrame(flushUploadProgress)
-  }
+  uploadProgressFlusher.trigger()
 }
 
 export const [getUploadState, useUploadState] = createGetterAndSelector(

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,6 +11,7 @@
     "./db": "./src/db/index.ts",
     "./db/migrations": "./src/db/migrations/index.ts",
     "./lib/detectMimeType": "./src/lib/detectMimeType.ts",
+    "./lib/debouncedAction": "./src/lib/debouncedAction.ts",
     "./lib/fileTypes": "./src/lib/fileTypes.ts",
     "./lib/mutex": "./src/lib/mutex.ts",
     "./lib/retry": "./src/lib/retry.ts",

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -68,3 +68,8 @@ export const TRASH_AUTO_PURGE_AGE = daysInMs(30) // 30 days
 export const TRASH_AUTO_PURGE_INTERVAL = minutesInMs(60) // 60 minutes
 // Performance monitor logging interval.
 export const PERF_MONITOR_INTERVAL = secondsInMs(15)
+// Max concurrent pinObject calls during save phase.
+export const SAVE_BATCH_CONCURRENCY = 20
+// Delay before removing upload state after save, so cache invalidation
+// propagates and the UI transitions directly from uploading to uploaded.
+export const SAVE_REMOVAL_DELAY_MS = 500

--- a/packages/core/src/db/operations/index.ts
+++ b/packages/core/src/db/operations/index.ts
@@ -87,6 +87,7 @@ export {
   deleteLocalObjectsByFileId,
   deleteManyLocalObjectsByFileIds,
   insertLocalObject,
+  insertManyLocalObjects,
   queryLocalObjectsForFile,
   queryLocalObjectsForFiles,
 } from './localObjects'

--- a/packages/core/src/db/operations/localObjects.ts
+++ b/packages/core/src/db/operations/localObjects.ts
@@ -89,6 +89,18 @@ export async function queryLocalObjectsForFiles(
   return map
 }
 
+export async function insertManyLocalObjects(
+  db: DatabaseAdapter,
+  objects: LocalObject[],
+): Promise<void> {
+  if (objects.length === 0) return
+  await db.withTransactionAsync(async () => {
+    for (const object of objects) {
+      await insertLocalObject(db, object)
+    }
+  })
+}
+
 export async function deleteManyLocalObjectsByFileIds(
   db: DatabaseAdapter,
   fileIds: string[],

--- a/packages/core/src/lib/debouncedAction.ts
+++ b/packages/core/src/lib/debouncedAction.ts
@@ -1,0 +1,27 @@
+/**
+ * Creates a debounced action that coalesces multiple trigger() calls
+ * within a time window into a single fn() execution.
+ *
+ * Used for: cache invalidation, progress flush, and other scenarios
+ * where rapid-fire calls should be batched into one.
+ */
+export function createDebouncedAction(fn: () => void, delayMs: number) {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  return {
+    trigger() {
+      if (!timer) {
+        timer = setTimeout(() => {
+          timer = null
+          fn()
+        }, delayMs)
+      }
+    },
+    flush() {
+      if (timer) {
+        clearTimeout(timer)
+        timer = null
+      }
+      fn()
+    },
+  }
+}

--- a/packages/core/src/services/uploader.ts
+++ b/packages/core/src/services/uploader.ts
@@ -10,6 +10,8 @@ import {
   PACKER_MAX_BATCH_DURATION,
   PACKER_MAX_SLABS,
   PACKER_POLL_INTERVAL,
+  SAVE_BATCH_CONCURRENCY,
+  SAVE_REMOVAL_DELAY_MS,
   SLAB_FILL_THRESHOLD,
   SLAB_SIZE,
   UPLOAD_DATA_SHARDS,
@@ -18,8 +20,9 @@ import {
 } from '../config'
 import { encodeFileMetadata } from '../encoding/fileMetadata'
 import type { LocalObject } from '../encoding/localObject'
+import { retry } from '../lib/retry'
+import { SlotPool } from '../lib/slotPool'
 import { uniqueId } from '../lib/uniqueId'
-import { yieldToEventLoop } from '../lib/yieldToEventLoop'
 import type { FileRecordRow } from '../types/files'
 
 export type BatchFile = {
@@ -65,7 +68,8 @@ export type UploadDeps = {
     getFsFileUri(file: FileRecordRow): Promise<string | null>
   }
   localObjects: {
-    upsert(object: LocalObject): Promise<void>
+    upsertMany(objects: LocalObject[]): Promise<void>
+    invalidate(): void
   }
   platform: {
     isConnected(): boolean
@@ -80,10 +84,13 @@ export type UploadDeps = {
   }
   uploads: {
     register(fileId: string, size: number): void
+    registerMany(entries: Array<{ id: string; size: number }>): void
     remove(fileId: string): void
+    removeMany(ids: string[]): void
     setStatus(fileId: string, status: 'packing' | 'packed' | 'uploading'): void
     setError(fileId: string, message: string): void
     setBatchInfo(fileId: string, batchId: string, fileCount: number): void
+    setBatchUploading(fileIds: string[], batchId: string): void
     updateProgress(fileId: string, progress: number): void
     getActive(): Array<{ id: string }>
   }
@@ -172,6 +179,8 @@ export class UploadManager {
   private active = false
   /** Resolves the waitForWorkOrTimeout promise when wake() is called. */
   private wakeResolver: (() => void) | null = null
+  /** Whether saveBatchObjects succeeded and invalidation is pending. */
+  private _needsInvalidation = false
   /** Recorded flush events for efficiency analysis and testing. */
   private _flushHistory: FlushRecord[] = []
   /** Cumulative count of files passed to packer.add(). */
@@ -191,9 +200,9 @@ export class UploadManager {
 
   /** Add files to the explicit queue and wake the loop. */
   enqueue(files: FileEntry[]): void {
-    for (const file of files) {
-      this.deps.uploads.register(file.fileId, file.size)
-    }
+    this.deps.uploads.registerMany(
+      files.map((f) => ({ id: f.fileId, size: f.size })),
+    )
     this.explicitQueue.push(...files)
     this.wake()
   }
@@ -260,11 +269,8 @@ export class UploadManager {
     })
 
     try {
-      const fileCount = batch.files.length
-      for (const entry of batch.files) {
-        this.deps.uploads.setBatchInfo(entry.fileId, batch.batchId, fileCount)
-        this.deps.uploads.setStatus(entry.fileId, 'uploading')
-      }
+      const fileIds = batch.files.map((f) => f.fileId)
+      this.deps.uploads.setBatchUploading(fileIds, batch.batchId)
 
       const finalizeStart = Date.now()
       const pinnedObjects = await packer.finalize()
@@ -279,6 +285,9 @@ export class UploadManager {
         batch,
         pinnedObjects,
       )
+      if (successfulFileIds.length > 0) {
+        this._needsInvalidation = true
+      }
       logger.info('uploadManager', 'batch_completed', {
         batchId: batch.batchId,
         files: successfulFileIds.length,
@@ -316,12 +325,6 @@ export class UploadManager {
         })
       }
     }
-    if (this.batch) {
-      for (const entry of this.batch.files) {
-        this.deps.uploads.remove(entry.fileId)
-      }
-    }
-
     if (this.uploadingPacker) {
       logger.info('uploadManager', 'uploading_batch_cancel', {
         batchId: this.uploadingBatch?.batchId,
@@ -334,14 +337,19 @@ export class UploadManager {
         })
       }
     }
-    if (this.uploadingBatch) {
-      for (const entry of this.uploadingBatch.files) {
-        this.deps.uploads.remove(entry.fileId)
-      }
-    }
 
-    for (const entry of this.explicitQueue) {
-      this.deps.uploads.remove(entry.fileId)
+    const idsToRemove: string[] = []
+    if (this.batch) {
+      for (const entry of this.batch.files) idsToRemove.push(entry.fileId)
+    }
+    if (this.uploadingBatch) {
+      for (const entry of this.uploadingBatch.files)
+        idsToRemove.push(entry.fileId)
+    }
+    for (const entry of this.explicitQueue) idsToRemove.push(entry.fileId)
+
+    if (idsToRemove.length > 0) {
+      this.deps.uploads.removeMany(idsToRemove)
     }
     this.explicitQueue = []
     this.polledFiles = []
@@ -383,6 +391,7 @@ export class UploadManager {
     this.explicitQueue = []
     this.polledFiles = []
     this.deps = null as unknown as UploadDeps
+    this._needsInvalidation = false
     this._flushHistory = []
     this._packedCount = 0
     this._packedBytes = 0
@@ -457,6 +466,11 @@ export class UploadManager {
       if (next) {
         await this.processEntries(this.drainQueues(next))
         continue
+      }
+
+      if (this._needsInvalidation) {
+        this._needsInvalidation = false
+        this.deps.localObjects.invalidate()
       }
 
       const newFiles = await this.pollDB()
@@ -743,17 +757,18 @@ export class UploadManager {
         excludeIds: activeIds.length > 0 ? activeIds : undefined,
       })
 
+      const newEntries: FileEntry[] = []
       for (const file of candidateFiles) {
         const fileUri = await this.deps.files.getFsFileUri(file)
         if (!fileUri) continue
-        const entry: FileEntry = {
-          fileId: file.id,
-          fileUri,
-          file,
-          size: file.size,
-        }
-        this.deps.uploads.register(entry.fileId, entry.size)
-        this.polledFiles.push(entry)
+        newEntries.push({ fileId: file.id, fileUri, file, size: file.size })
+      }
+
+      if (newEntries.length > 0) {
+        this.deps.uploads.registerMany(
+          newEntries.map((e) => ({ id: e.fileId, size: e.size })),
+        )
+        this.polledFiles.push(...newEntries)
       }
 
       return this.polledFiles.length
@@ -868,13 +883,16 @@ export class UploadManager {
   /**
    * After finalize, pin each object and save it locally. Files deleted
    * during upload are skipped (their upload entry is still cleaned up).
+   *
+   * Three phases:
+   * 1. Parallel pin — up to SAVE_BATCH_CONCURRENCY concurrent pinObject calls
+   * 2. Batch DB write — single transaction for all local objects
+   * 3. Remove completed uploads
    */
   private async saveBatchObjects(
     batch: BatchState,
     pinnedObjects: PinnedObjectRef[],
   ): Promise<string[]> {
-    const successfulFileIds: string[] = []
-
     if (pinnedObjects.length !== batch.files.length) {
       logger.warn('uploadManager', 'object_count_mismatch', {
         objects: pinnedObjects.length,
@@ -882,55 +900,113 @@ export class UploadManager {
       })
     }
 
-    for (let i = 0; i < batch.files.length; i++) {
-      const entry = batch.files[i]
-      const pinnedObject = pinnedObjects[i]
-
-      if (!pinnedObject) {
-        logger.error('uploadManager', 'no_pinned_object', {
-          fileId: entry.fileId,
-          index: i,
-        })
-        this.deps.uploads.setError(entry.fileId, 'No pinned object returned')
-        continue
-      }
-
-      try {
-        const fileRecord = await this.deps.files.read(entry.fileId)
-        if (!fileRecord) {
-          logger.warn('uploadManager', 'file_deleted_during_upload', {
-            fileId: entry.fileId,
-          })
-          this.deps.uploads.remove(entry.fileId)
-          successfulFileIds.push(entry.fileId)
-          continue
+    type PinResult =
+      | {
+          type: 'success'
+          fileId: string
+          size: number
+          localObject: LocalObject
         }
+      | { type: 'deleted'; fileId: string }
+      | { type: 'error'; fileId: string }
+      | { type: 'missing'; fileId: string }
 
-        pinnedObject.updateMetadata(encodeFileMetadata(entry.file))
-        await this.deps.sdk.pinObject(pinnedObject)
+    // Phase 1: Parallel pin
+    const pool = new SlotPool(SAVE_BATCH_CONCURRENCY)
+    const results = await Promise.all(
+      batch.files.map((entry, i) =>
+        pool.withSlot(async (): Promise<PinResult> => {
+          const pinnedObject = pinnedObjects[i]
+          if (!pinnedObject) {
+            logger.error('uploadManager', 'no_pinned_object', {
+              fileId: entry.fileId,
+              index: i,
+            })
+            this.deps.uploads.setError(
+              entry.fileId,
+              'No pinned object returned',
+            )
+            return { type: 'missing', fileId: entry.fileId }
+          }
 
-        const indexerURL = this.deps.platform.getIndexerURL()
-        const localObject = await this.deps.platform.pinnedObjectToLocalObject(
-          entry.fileId,
-          indexerURL,
-          pinnedObject,
-        )
-        await this.deps.localObjects.upsert(localObject)
-        this.deps.uploads.remove(entry.fileId)
+          try {
+            const fileRecord = await this.deps.files.read(entry.fileId)
+            if (!fileRecord) {
+              logger.warn('uploadManager', 'file_deleted_during_upload', {
+                fileId: entry.fileId,
+              })
+              return { type: 'deleted', fileId: entry.fileId }
+            }
 
-        logger.debug('uploadManager', 'object_saved', { fileId: entry.fileId })
+            pinnedObject.updateMetadata(encodeFileMetadata(entry.file))
+            await retry(
+              'pinObject',
+              () => this.deps.sdk.pinObject(pinnedObject),
+              3,
+              1000,
+            )
+
+            const indexerURL = this.deps.platform.getIndexerURL()
+            const localObject =
+              await this.deps.platform.pinnedObjectToLocalObject(
+                entry.fileId,
+                indexerURL,
+                pinnedObject,
+              )
+            logger.debug('uploadManager', 'object_saved', {
+              fileId: entry.fileId,
+            })
+            return {
+              type: 'success',
+              fileId: entry.fileId,
+              size: entry.size,
+              localObject,
+            }
+          } catch (e) {
+            const message = e instanceof Error ? e.message : String(e)
+            logger.error('uploadManager', 'object_save_error', {
+              fileId: entry.fileId,
+              error: e as Error,
+            })
+            this.deps.uploads.setError(entry.fileId, message)
+            return { type: 'error', fileId: entry.fileId }
+          }
+        }),
+      ),
+    )
+
+    // Phase 2: Batch DB write
+    const localObjects = results
+      .filter(
+        (r): r is Extract<PinResult, { type: 'success' }> =>
+          r.type === 'success',
+      )
+      .map((r) => r.localObject)
+    await this.deps.localObjects.upsertMany(localObjects)
+
+    for (const r of results) {
+      if (r.type === 'success') {
         this._uploadedCount++
-        this._uploadedBytes += entry.size
-        successfulFileIds.push(entry.fileId)
-        await yieldToEventLoop()
-      } catch (e) {
-        const message = e instanceof Error ? e.message : String(e)
-        logger.error('uploadManager', 'object_save_error', {
-          fileId: entry.fileId,
-          error: e as Error,
-        })
-        this.deps.uploads.setError(entry.fileId, message)
+        this._uploadedBytes += r.size
       }
+    }
+
+    // Phase 3: Invalidate cache then remove completed uploads.
+    // Invalidation must happen before removal so the file record refreshes
+    // with the sealed object before the uploading state clears — otherwise
+    // the UI briefly shows a "needs upload" icon.
+    const successfulFileIds = results
+      .filter((r) => r.type !== 'error' && r.type !== 'missing')
+      .map((r) => r.fileId)
+    if (successfulFileIds.length > 0) {
+      this.deps.localObjects.invalidate()
+      this._needsInvalidation = false
+      if (SAVE_REMOVAL_DELAY_MS > 0) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, SAVE_REMOVAL_DELAY_MS),
+        )
+      }
+      this.deps.uploads.removeMany(successfulFileIds)
     }
 
     return successfulFileIds


### PR DESCRIPTION
Upload manager pinObject calls were sequential, noticed this wasting a lot of time for batches with 100s of small files. This PR prallelizes the save objects calls and includes some other upload manager perf improvements.

- Add batch methods (registerUploads, removeUploads, setBatchUploading) to reduce per-file setState cascades to single calls. For a 50-file batch this reduces ~200 state updates to ~3.
- Add onBatchSaved hook so cache invalidation fires once per batch instead of once per file. Wire upsertLocalObject with triggerUpdate=false to suppress per-file invalidation.
- Parallelize saveBatchObjects into three phases: concurrent pinObject calls via SlotPool (up to 50), batch DB write via insertManyLocalObjects in a single transaction, and batch removeMany for completed uploads.
- Replace requestAnimationFrame progress throttle with 1-second setTimeout interval to reduce progress-driven re-renders from ~60/sec to 1/sec.