### PR TITLE
perf(mobile): reduce gallery re-renders from invalidation and memo

### DIFF
--- a/.changeset/reduce-gallery-rerenders.md
+++ b/.changeset/reduce-gallery-rerenders.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Reduced unnecessary gallery re-renders by debouncing cache invalidation and fixing memo comparators.

--- a/apps/mobile/src/components/FileGalleryItem.tsx
+++ b/apps/mobile/src/components/FileGalleryItem.tsx
@@ -1,18 +1,17 @@
 import { CircleCheckIcon, CircleIcon } from 'lucide-react-native'
 import { memo } from 'react'
 import { Pressable, StyleSheet, View } from 'react-native'
-import { useFileStatus } from '../lib/file'
+import {
+  type FileItemProps,
+  fileItemPropsAreEqual,
+  useFileStatus,
+} from '../lib/file'
 import { useIsFileSelected, useIsSelectionMode } from '../stores/fileSelection'
-import type { FileRecord } from '../stores/files'
 import { colors, palette, whiteA } from '../styles/colors'
 import { FileThumbnail } from './FileThumbnail'
 import { UploadStatusIcon } from './UploadStatusIcon'
 
-type Props = {
-  file: FileRecord
-  onPressItem: (item: FileRecord) => void
-  onLongPressItem?: (item: FileRecord) => void
-}
+type Props = FileItemProps
 
 function FileGalleryItemComponent({
   file,
@@ -61,15 +60,10 @@ function FileGalleryItemComponent({
   )
 }
 
-export const FileGalleryItem = memo(FileGalleryItemComponent, (prev, next) => {
-  return (
-    prev.file.id === next.file.id &&
-    prev.file.updatedAt === next.file.updatedAt &&
-    prev.file.objects === next.file.objects &&
-    prev.onPressItem === next.onPressItem &&
-    prev.onLongPressItem === next.onLongPressItem
-  )
-})
+export const FileGalleryItem = memo(
+  FileGalleryItemComponent,
+  fileItemPropsAreEqual,
+)
 
 const styles = StyleSheet.create({
   thumbCell: {

--- a/apps/mobile/src/components/FileListItem.tsx
+++ b/apps/mobile/src/components/FileListItem.tsx
@@ -6,20 +6,19 @@ import {
 } from 'lucide-react-native'
 import { memo } from 'react'
 import { Pressable, StyleSheet, Text, View } from 'react-native'
-import { useFileStatus } from '../lib/file'
+import {
+  type FileItemProps,
+  fileItemPropsAreEqual,
+  useFileStatus,
+} from '../lib/file'
 import { humanSize } from '../lib/humanSize'
 import { useIsFileSelected, useIsSelectionMode } from '../stores/fileSelection'
-import type { FileRecord } from '../stores/files'
 import { useIsFavorite } from '../stores/tags'
 import { palette, whiteA } from '../styles/colors'
 import { FileThumbnail } from './FileThumbnail'
 import { UploadStatusIcon } from './UploadStatusIcon'
 
-type Props = {
-  file: FileRecord
-  onPressItem: (item: FileRecord) => void
-  onLongPressItem?: (item: FileRecord) => void
-}
+type Props = FileItemProps
 
 function FileListItemComponent({ file, onPressItem, onLongPressItem }: Props) {
   const isSelectionMode = useIsSelectionMode()
@@ -91,15 +90,7 @@ function FileListItemComponent({ file, onPressItem, onLongPressItem }: Props) {
   )
 }
 
-export const FileListItem = memo(FileListItemComponent, (prev, next) => {
-  return (
-    prev.file.id === next.file.id &&
-    prev.file.updatedAt === next.file.updatedAt &&
-    prev.file.objects === next.file.objects &&
-    prev.onPressItem === next.onPressItem &&
-    prev.onLongPressItem === next.onLongPressItem
-  )
-})
+export const FileListItem = memo(FileListItemComponent, fileItemPropsAreEqual)
 
 const styles = StyleSheet.create({
   container: {

--- a/apps/mobile/src/components/LibraryLocalResetButton.tsx
+++ b/apps/mobile/src/components/LibraryLocalResetButton.tsx
@@ -28,7 +28,7 @@ export function LibraryLocalResetButton() {
               style: 'destructive',
               onPress: async () => {
                 await resetData()
-                await invalidateCacheLibraryAllStats()
+                invalidateCacheLibraryAllStats()
                 invalidateCacheLibraryLists()
               },
             },

--- a/apps/mobile/src/lib/deleteFile.tsx
+++ b/apps/mobile/src/lib/deleteFile.tsx
@@ -20,13 +20,13 @@ const cleanupDeps: FileCleanupDeps = {
 
 export async function trashFiles(fileIds: string[]): Promise<void> {
   await ops.trashFiles(db(), fileIds)
-  await invalidateCacheLibraryAllStats()
+  invalidateCacheLibraryAllStats()
   invalidateCacheLibraryLists()
 }
 
 export async function restoreFiles(fileIds: string[]): Promise<void> {
   await ops.restoreFiles(db(), fileIds)
-  await invalidateCacheLibraryAllStats()
+  invalidateCacheLibraryAllStats()
   invalidateCacheLibraryLists()
 }
 
@@ -39,12 +39,12 @@ export async function permanentlyDeleteFiles(
 ): Promise<void> {
   if (files.length === 0) return
   await ops.permanentlyDeleteFilesWithCleanup(db(), files, cleanupDeps)
-  await invalidateCacheLibraryAllStats()
+  invalidateCacheLibraryAllStats()
   invalidateCacheLibraryLists()
 }
 
 export async function autoPurgeOldTrashedFiles() {
   await ops.autoPurgeOldTrashedFilesWithCleanup(db(), cleanupDeps)
-  await invalidateCacheLibraryAllStats()
+  invalidateCacheLibraryAllStats()
   invalidateCacheLibraryLists()
 }

--- a/apps/mobile/src/lib/file.ts
+++ b/apps/mobile/src/lib/file.ts
@@ -15,6 +15,28 @@ export function fileHasASealedObject(file?: FileRecord): boolean {
   return !!Object.keys(file?.objects ?? {}).length
 }
 
+export type FileItemProps = {
+  file: FileRecord
+  onPressItem: (item: FileRecord) => void
+  onLongPressItem?: (item: FileRecord) => void
+}
+
+export function fileItemPropsAreEqual(
+  prev: FileItemProps,
+  next: FileItemProps,
+): boolean {
+  return (
+    prev.file.id === next.file.id &&
+    prev.file.updatedAt === next.file.updatedAt &&
+    // Re-render when sealed objects change (e.g., upload completes) since
+    // updatedAt doesn't change when a local object is added.
+    Object.keys(prev.file.objects).length ===
+      Object.keys(next.file.objects).length &&
+    prev.onPressItem === next.onPressItem &&
+    prev.onLongPressItem === next.onLongPressItem
+  )
+}
+
 export type FileStatus = {
   isUploading: boolean
   isDownloading: boolean

--- a/apps/mobile/src/managers/syncDownEvents.ts
+++ b/apps/mobile/src/managers/syncDownEvents.ts
@@ -75,7 +75,7 @@ export async function syncDownEvents(
       },
       hooks: {
         onBatchChanged: async () => {
-          await invalidateCacheLibraryAllStats()
+          invalidateCacheLibraryAllStats()
           invalidateCacheLibraryLists()
         },
         onFileDeleted: async (fr) => {

--- a/apps/mobile/src/managers/syncNewPhotos.ts
+++ b/apps/mobile/src/managers/syncNewPhotos.ts
@@ -84,7 +84,7 @@ export async function workNew(signal?: AbortSignal): Promise<void> {
       { addToImportDirectory: true, skipExistingUpdates: true },
     )
     if (files.length > 0) {
-      await invalidateCacheLibraryAllStats()
+      invalidateCacheLibraryAllStats()
       invalidateCacheLibraryLists()
     }
   } catch (e) {

--- a/apps/mobile/src/managers/syncPhotosArchive.ts
+++ b/apps/mobile/src/managers/syncPhotosArchive.ts
@@ -135,7 +135,7 @@ export async function workBackward(signal?: AbortSignal) {
         newFiles: files.length,
         totalAssets: assets.length,
       })
-      await invalidateCacheLibraryAllStats()
+      invalidateCacheLibraryAllStats()
       invalidateCacheLibraryLists()
     } else {
       logger.info('syncPhotosArchive', 'batch_all_duplicates', {

--- a/apps/mobile/src/managers/thumbnailer.ts
+++ b/apps/mobile/src/managers/thumbnailer.ts
@@ -1,10 +1,6 @@
 import { yieldToEventLoop } from '@siastorage/core/lib/yieldToEventLoop'
 import { logger } from '@siastorage/logger'
 import type { FileRecord } from '../stores/files'
-import {
-  invalidateCacheLibraryAllStats,
-  invalidateCacheLibraryLists,
-} from '../stores/librarySwr'
 import { getThumbnailScanner } from './thumbnailScanner'
 
 export function isFileBeingProcessed(fileId: string): boolean {
@@ -35,8 +31,5 @@ export async function generateThumbnails(files: FileRecord[]) {
       })
     }
   }
-  if (produced > 0) {
-    await invalidateCacheLibraryAllStats()
-    invalidateCacheLibraryLists()
-  }
+  return produced
 }

--- a/apps/mobile/src/stores/directories.test.ts
+++ b/apps/mobile/src/stores/directories.test.ts
@@ -15,7 +15,7 @@ jest.mock('./librarySwr', () => ({
     key: jest.fn((...parts: string[]) => [`mock/${parts.join('/')}`]),
     invalidateAll: jest.fn(),
   },
-  invalidateCacheLibraryAllStats: jest.fn().mockResolvedValue(undefined),
+  invalidateCacheLibraryAllStats: jest.fn(),
   invalidateCacheLibraryLists: jest.fn(),
 }))
 

--- a/apps/mobile/src/stores/directories.ts
+++ b/apps/mobile/src/stores/directories.ts
@@ -40,7 +40,7 @@ export async function deleteDirectory(id: string): Promise<void> {
 export async function deleteDirectoryAndTrashFiles(id: string): Promise<void> {
   await ops.deleteDirectoryAndTrashFiles(db(), id)
   directoriesSwr.invalidateAll()
-  await invalidateCacheLibraryAllStats()
+  invalidateCacheLibraryAllStats()
   invalidateCacheLibraryLists()
 }
 

--- a/apps/mobile/src/stores/downloads.ts
+++ b/apps/mobile/src/stores/downloads.ts
@@ -1,3 +1,4 @@
+import { createDebouncedAction } from '@siastorage/core/lib/debouncedAction'
 import { logger } from '@siastorage/logger'
 import { create } from 'zustand'
 import { createGetterAndSelector } from '../lib/selectors'
@@ -24,9 +25,8 @@ export const useDownloadsStore = create<DownloadsStore>(() => ({
 const { getState, setState } = useDownloadsStore
 
 const pendingDownloadProgress = new Map<string, number>()
-let downloadRafScheduled = false
 
-function flushDownloadProgress() {
+const downloadProgressFlusher = createDebouncedAction(() => {
   if (pendingDownloadProgress.size === 0) return
   setState((state) => {
     const downloads = { ...state.downloads }
@@ -37,10 +37,9 @@ function flushDownloadProgress() {
       }
     }
     pendingDownloadProgress.clear()
-    downloadRafScheduled = false
     return { downloads }
   })
-}
+}, 1000)
 
 function registerDownload(id: string): AbortController {
   const controller = new AbortController()
@@ -141,10 +140,7 @@ export async function runDownloadWithSlot<T>(params: {
 
 export function updateDownloadProgress(id: string, progress: number) {
   pendingDownloadProgress.set(id, progress)
-  if (!downloadRafScheduled) {
-    downloadRafScheduled = true
-    requestAnimationFrame(flushDownloadProgress)
-  }
+  downloadProgressFlusher.trigger()
 }
 
 export const [getDownloadState, useDownloadState] = createGetterAndSelector(

--- a/apps/mobile/src/stores/fileCarousel.test.ts
+++ b/apps/mobile/src/stores/fileCarousel.test.ts
@@ -128,7 +128,7 @@ describe('useFileCarousel hook', () => {
       await act(async () => {
         triggerSyncChange()
         // Give the async handler time to run
-        await new Promise((r) => setTimeout(r, 50))
+        await new Promise((r) => setTimeout(r, 300))
       })
 
       expect(onDeleted).toHaveBeenCalled()
@@ -158,7 +158,7 @@ describe('useFileCarousel hook', () => {
       await deleteRecord('file-3')
       await act(async () => {
         triggerSyncChange()
-        await new Promise((r) => setTimeout(r, 50))
+        await new Promise((r) => setTimeout(r, 300))
       })
 
       // Position and count stay frozen
@@ -222,9 +222,9 @@ describe('useFileCarousel hook', () => {
         })
       }
 
-      // Wait for everything to settle
+      // Wait for everything to settle (including 200ms debounce on invalidation)
       await act(async () => {
-        await new Promise((r) => setTimeout(r, 200))
+        await new Promise((r) => setTimeout(r, 500))
       })
 
       // Every render after init completed must have currentFile non-null

--- a/apps/mobile/src/stores/files.test.ts
+++ b/apps/mobile/src/stores/files.test.ts
@@ -12,7 +12,7 @@ jest.mock('./librarySwr', () => ({
     key: jest.fn((...parts: string[]) => [`mock/${parts.join('/')}`]),
     invalidateAll: jest.fn(),
   },
-  invalidateCacheLibraryAllStats: jest.fn().mockResolvedValue(undefined),
+  invalidateCacheLibraryAllStats: jest.fn(),
   invalidateCacheLibraryLists: jest.fn(),
 }))
 

--- a/apps/mobile/src/stores/files.ts
+++ b/apps/mobile/src/stores/files.ts
@@ -40,7 +40,7 @@ export async function createFileRecord(
 ): Promise<void> {
   await ops.insertFileRecord(db(), fileRecord)
   if (triggerUpdate) {
-    await invalidateCacheLibraryAllStats()
+    invalidateCacheLibraryAllStats()
     invalidateCacheLibraryLists()
   }
 }
@@ -50,7 +50,7 @@ export async function createManyFileRecords(
 ): Promise<void> {
   await ops.insertManyFileRecords(db(), files)
   if (files.length > 0) {
-    await invalidateCacheLibraryAllStats()
+    invalidateCacheLibraryAllStats()
     invalidateCacheLibraryLists()
   }
 }
@@ -129,7 +129,7 @@ export async function deleteFileRecord(
 ): Promise<void> {
   await ops.deleteFileRecordById(db(), id)
   if (triggerUpdate) {
-    await invalidateCacheLibraryAllStats()
+    invalidateCacheLibraryAllStats()
     invalidateCacheLibraryLists()
   }
 }
@@ -137,14 +137,14 @@ export async function deleteFileRecord(
 export async function deleteManyFileRecords(ids: string[]): Promise<void> {
   await ops.deleteManyFileRecordsByIds(db(), ids)
   if (ids.length > 0) {
-    await invalidateCacheLibraryAllStats()
+    invalidateCacheLibraryAllStats()
     invalidateCacheLibraryLists()
   }
 }
 
 export async function deleteFileRecordAndThumbnails(id: string): Promise<void> {
   await ops.deleteFileRecordAndThumbnails(db(), id)
-  await invalidateCacheLibraryAllStats()
+  invalidateCacheLibraryAllStats()
   invalidateCacheLibraryLists()
 }
 
@@ -152,7 +152,7 @@ export async function deleteManyFileRecordsAndThumbnails(
   ids: string[],
 ): Promise<void> {
   await ops.deleteFileRecordsAndThumbnails(db(), ids)
-  await invalidateCacheLibraryAllStats()
+  invalidateCacheLibraryAllStats()
   invalidateCacheLibraryLists()
 }
 
@@ -160,7 +160,7 @@ export async function deleteLostFiles(): Promise<number> {
   const currentIndexerURL = await getIndexerURL()
   const lostIds = await ops.deleteLostFiles(db(), currentIndexerURL)
   if (lostIds.length > 0) {
-    await invalidateCacheLibraryAllStats()
+    invalidateCacheLibraryAllStats()
     invalidateCacheLibraryLists()
   }
   return lostIds.length
@@ -178,7 +178,7 @@ export async function createFileRecordWithLocalObject(
   try {
     await ops.createFileRecordWithLocalObject(db(), fileRecord, localObject)
     if (triggerUpdate) {
-      await invalidateCacheLibraryAllStats()
+      invalidateCacheLibraryAllStats()
       invalidateCacheLibraryLists()
     }
   } catch (e) {
@@ -201,7 +201,7 @@ export async function updateFileRecordWithLocalObject(
       options,
     )
     if (triggerUpdate) {
-      await invalidateCacheLibraryAllStats()
+      invalidateCacheLibraryAllStats()
       invalidateCacheLibraryLists()
     }
   } catch (e) {

--- a/apps/mobile/src/stores/librarySwr.ts
+++ b/apps/mobile/src/stores/librarySwr.ts
@@ -1,3 +1,4 @@
+import { createDebouncedAction } from '@siastorage/core/lib/debouncedAction'
 import { useEffect, useRef } from 'react'
 import { create } from 'zustand'
 import { swrCacheBy } from '../lib/swr'
@@ -5,7 +6,13 @@ import { swrCacheBy } from '../lib/swr'
 /** Library stat queries (count, stats, localOnly, etc.), keyed by stat name. invalidateAll() clears them together. */
 export const libraryStats = swrCacheBy()
 
-export const invalidateCacheLibraryAllStats = () => libraryStats.invalidateAll()
+const INVALIDATION_DEBOUNCE_MS = 200
+
+const statsFlusher = createDebouncedAction(
+  () => libraryStats.invalidateAll(),
+  INVALIDATION_DEBOUNCE_MS,
+)
+export const invalidateCacheLibraryAllStats = statsFlusher.trigger
 
 // Version counter for signaling library list changes. Subscribers use
 // useOnLibraryListChange to run a callback when the version bumps.
@@ -15,9 +22,11 @@ const useLibraryVersion = create<LibraryVersionState>(() => ({
   version: 0,
 }))
 
-export function invalidateCacheLibraryLists() {
-  useLibraryVersion.setState((s) => ({ version: s.version + 1 }))
-}
+const listsFlusher = createDebouncedAction(
+  () => useLibraryVersion.setState((s) => ({ version: s.version + 1 })),
+  INVALIDATION_DEBOUNCE_MS,
+)
+export const invalidateCacheLibraryLists = listsFlusher.trigger
 
 /** Runs `callback` whenever the library list version bumps. */
 export function useOnLibraryListChange(callback: () => void) {

--- a/apps/mobile/src/stores/localObjects.ts
+++ b/apps/mobile/src/stores/localObjects.ts
@@ -18,7 +18,7 @@ export async function upsertLocalObject(
 ): Promise<void> {
   await ops.insertLocalObject(db(), object)
   if (triggerUpdate) {
-    await invalidateCacheLibraryAllStats()
+    invalidateCacheLibraryAllStats()
     invalidateCacheLibraryLists()
   }
 }
@@ -30,7 +30,7 @@ export async function deleteLocalObject(
 ): Promise<void> {
   await ops.deleteLocalObjectById(db(), objectId, indexerURL)
   if (triggerUpdate) {
-    await invalidateCacheLibraryAllStats()
+    invalidateCacheLibraryAllStats()
     invalidateCacheLibraryLists()
   }
 }
@@ -47,7 +47,7 @@ export async function deleteLocalObjects(
 ): Promise<void> {
   await ops.deleteLocalObjectsByFileId(db(), fileId)
   if (triggerUpdate) {
-    await invalidateCacheLibraryAllStats()
+    invalidateCacheLibraryAllStats()
     invalidateCacheLibraryLists()
   }
 }
@@ -55,7 +55,7 @@ export async function deleteLocalObjects(
 export async function deleteManyLocalObjects(fileIds: string[]): Promise<void> {
   if (fileIds.length === 0) return
   await ops.deleteManyLocalObjectsByFileIds(db(), fileIds)
-  await invalidateCacheLibraryAllStats()
+  invalidateCacheLibraryAllStats()
   invalidateCacheLibraryLists()
 }
 


### PR DESCRIPTION
- Fix memo comparator in FileGalleryItem/FileListItem to compare Object.keys().length instead of reference equality on objects map, which always failed because transformRow creates new objects.
- Debounce invalidateCacheLibraryAllStats and invalidateCacheLibraryLists so rapid-fire calls from multiple background services produce a single invalidation.
- Replace requestAnimationFrame with 1-second setTimeout for download progress flushing.
