### PR TITLE
perf(mobile): optimize thumbnail generation with batch adapter and concurrency

### DIFF
--- a/.changeset/optimize-thumbnail-generation.md
+++ b/.changeset/optimize-thumbnail-generation.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Optimized thumbnail generation to decode each image fewer times using a batch adapter with size cascading and concurrent file processing.

--- a/apps/integration/test/adapters/thumbnail.ts
+++ b/apps/integration/test/adapters/thumbnail.ts
@@ -33,6 +33,24 @@ export function buildThumbnailDeps(params: {
           mimeType: 'image/webp',
         }
       },
+      async generateImageThumbnails(sourcePath: string, sizes: number[]) {
+        const results = new Map()
+        for (const size of sizes) {
+          const filePath = sourcePath.replace('file://', '')
+          const buf = await sharp(filePath)
+            .resize(size, size, { fit: 'inside' })
+            .webp({ quality: 80 })
+            .toBuffer()
+          results.set(size, {
+            data: buf.buffer.slice(
+              buf.byteOffset,
+              buf.byteOffset + buf.byteLength,
+            ),
+            mimeType: 'image/webp',
+          })
+        }
+        return results
+      },
       async generateVideoThumbnail(_sourcePath: string, _targetSize: number) {
         const placeholder = Buffer.alloc(64)
         return {

--- a/apps/integration/test/thumbnail-scanner.test.ts
+++ b/apps/integration/test/thumbnail-scanner.test.ts
@@ -23,6 +23,16 @@ function createMockDeps(overrides?: Partial<ThumbnailDeps>): ThumbnailDeps {
       async generateImageThumbnail() {
         return { data: new ArrayBuffer(64), mimeType: 'image/webp' }
       },
+      async generateImageThumbnails(_sourcePath: string, sizes: number[]) {
+        const results = new Map()
+        for (const size of sizes) {
+          results.set(size, {
+            data: new ArrayBuffer(64),
+            mimeType: 'image/webp',
+          })
+        }
+        return results
+      },
       async generateVideoThumbnail() {
         return { data: new ArrayBuffer(64), mimeType: 'image/webp' }
       },
@@ -333,6 +343,7 @@ describe('ThumbnailScanner', () => {
         data: new ArrayBuffer(64),
         mimeType: 'image/webp',
       }),
+      generateImageThumbnails: jest.fn().mockResolvedValue(new Map()),
       generateVideoThumbnail: jest.fn().mockResolvedValue({
         data: new ArrayBuffer(64),
         mimeType: 'image/webp',
@@ -381,7 +392,7 @@ describe('ThumbnailScanner', () => {
     }
     scanner.initialize(createMockDeps())
     const result = await scanner.runScan()
-    expect(result.produced).toHaveLength(10)
+    expect(result.produced).toHaveLength(20)
   })
 
   it('stops immediately when signal is already aborted', async () => {
@@ -402,6 +413,7 @@ describe('ThumbnailScanner', () => {
     })
     const adapter = {
       generateImageThumbnail: jest.fn(),
+      generateImageThumbnails: jest.fn(),
       generateVideoThumbnail: jest.fn(),
     }
     scanner.initialize(createMockDeps({ thumbnailAdapter: adapter }))
@@ -443,6 +455,9 @@ describe('ThumbnailScanner', () => {
             if (calls >= 2) ac.abort()
             return { data: new ArrayBuffer(64), mimeType: 'image/webp' }
           },
+          async generateImageThumbnails() {
+            return new Map()
+          },
           async generateVideoThumbnail() {
             return { data: new ArrayBuffer(64), mimeType: 'image/webp' }
           },
@@ -476,6 +491,9 @@ describe('ThumbnailScanner', () => {
         thumbnailAdapter: {
           async generateImageThumbnail() {
             throw new Error('Manipulation failed')
+          },
+          async generateImageThumbnails() {
+            return new Map()
           },
           async generateVideoThumbnail() {
             throw new Error('Manipulation failed')

--- a/apps/mobile/src/adapters/thumbnail.ts
+++ b/apps/mobile/src/adapters/thumbnail.ts
@@ -14,28 +14,53 @@ function getImageSize(uri: string): Promise<{ width: number; height: number }> {
   })
 }
 
+/**
+ * Resize an image to fit within maxSize while preserving aspect ratio,
+ * applying EXIF orientation correction if needed.
+ *
+ * For the source image (first call), we detect EXIF rotation by comparing
+ * Image.getSize (EXIF-corrected) against the raw pixel dimensions from a
+ * single renderAsync. The rotation + resize are applied in the same
+ * ImageManipulator chain, so only 1 native decode happens.
+ *
+ * For cascaded calls (resizing from a previously saved thumbnail), set
+ * skipOrientationDetection=true to avoid the unnecessary EXIF check.
+ */
 async function resizeToWebP(
   inputUri: string,
   maxSize: number,
-): Promise<ThumbnailResult> {
+  skipOrientationDetection?: boolean,
+): Promise<{ result: ThumbnailResult; savedUri: string }> {
   const ctx = ImageManipulator.manipulate(inputUri)
-  const rendered = await ctx.renderAsync()
-  let isPortrait = rendered.height > rendered.width
 
-  // RCTImageLoader on iOS does not apply EXIF orientation when loading
-  // full-size images, so raw pixel dimensions may differ from the visual
-  // orientation. Image.getSize returns EXIF-corrected dimensions — compare
-  // to detect the mismatch and apply a corrective rotation.
-  try {
-    const exifSize = await getImageSize(inputUri)
-    const rawIsLandscape = rendered.width >= rendered.height
-    const exifIsLandscape = exifSize.width >= exifSize.height
-    if (rawIsLandscape !== exifIsLandscape) {
-      ctx.rotate(90)
+  let isPortrait: boolean
+  if (skipOrientationDetection) {
+    // Input is an already-oriented thumbnail — just check dimensions via
+    // a lightweight getImageSize call (no pixel decode).
+    try {
+      const size = await getImageSize(inputUri)
+      isPortrait = size.height > size.width
+    } catch {
+      isPortrait = false
     }
-    isPortrait = exifSize.height > exifSize.width
-  } catch {
-    // Fall back to raw dimensions if Image.getSize fails
+  } else {
+    // First resize from the original source: detect EXIF orientation.
+    // renderAsync decodes the full image — we use the same ctx for the
+    // subsequent resize so this is the only decode.
+    const rendered = await ctx.renderAsync()
+    isPortrait = rendered.height > rendered.width
+
+    try {
+      const exifSize = await getImageSize(inputUri)
+      const rawIsLandscape = rendered.width >= rendered.height
+      const exifIsLandscape = exifSize.width >= exifSize.height
+      if (rawIsLandscape !== exifIsLandscape) {
+        ctx.rotate(90)
+      }
+      isPortrait = exifSize.height > exifSize.width
+    } catch {
+      // Fall back to raw dimensions if Image.getSize fails
+    }
   }
 
   if (isPortrait) {
@@ -44,15 +69,21 @@ async function resizeToWebP(
     ctx.resize({ width: maxSize })
   }
   const resized = await ctx.renderAsync()
-  const result = await resized.saveAsync({
+  const saved = await resized.saveAsync({
     compress: 0.8,
     format: SaveFormat.WEBP,
   })
-  const file = new File(result.uri)
+  const file = new File(saved.uri)
   const data = await file.bytes()
   return {
-    data: data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength),
-    mimeType: 'image/webp',
+    result: {
+      data: data.buffer.slice(
+        data.byteOffset,
+        data.byteOffset + data.byteLength,
+      ),
+      mimeType: 'image/webp',
+    },
+    savedUri: saved.uri,
   }
 }
 
@@ -62,7 +93,34 @@ export function createMobileThumbnailAdapter(): ThumbnailAdapter {
       sourcePath: string,
       targetSize: number,
     ): Promise<ThumbnailResult> {
-      return resizeToWebP(sourcePath, targetSize as ThumbSize)
+      const { result } = await resizeToWebP(sourcePath, targetSize as ThumbSize)
+      return result
+    },
+
+    async generateImageThumbnails(
+      sourcePath: string,
+      sizes: number[],
+    ): Promise<Map<number, ThumbnailResult>> {
+      const sorted = [...sizes].sort((a, b) => b - a)
+      const results = new Map<number, ThumbnailResult>()
+
+      let inputUri = sourcePath
+      let skipDetection = false
+      for (const size of sorted) {
+        const { result, savedUri } = await resizeToWebP(
+          inputUri,
+          size,
+          skipDetection,
+        )
+        results.set(size, result)
+        // Subsequent smaller sizes resize from the larger result.
+        // That file is already correctly oriented and much smaller,
+        // so decoding it is essentially free.
+        inputUri = savedUri
+        skipDetection = true
+      }
+
+      return results
     },
 
     async generateVideoThumbnail(
@@ -73,7 +131,8 @@ export function createMobileThumbnailAdapter(): ThumbnailAdapter {
         time: 1000,
         quality: 0.8,
       })
-      return resizeToWebP(thumb.uri, targetSize as ThumbSize)
+      const { result } = await resizeToWebP(thumb.uri, targetSize as ThumbSize)
+      return result
     },
   }
 }

--- a/apps/mobile/src/managers/thumbnailScanner.test.ts
+++ b/apps/mobile/src/managers/thumbnailScanner.test.ts
@@ -376,7 +376,7 @@ describe('thumbnailScanner', () => {
     let counter = 0
     sha256FileMock.mockImplementation(async () => `thumb-hash-${++counter}`)
     const result = await runThumbnailScanner()
-    expect(result.produced).toHaveLength(10)
+    expect(result.produced).toHaveLength(20)
   })
 
   it('falls back when image size retrieval fails', async () => {

--- a/apps/mobile/src/managers/thumbnailer.ts
+++ b/apps/mobile/src/managers/thumbnailer.ts
@@ -1,7 +1,10 @@
-import { yieldToEventLoop } from '@siastorage/core/lib/yieldToEventLoop'
+import { SlotPool } from '@siastorage/core/lib/slotPool'
 import { logger } from '@siastorage/logger'
 import type { FileRecord } from '../stores/files'
 import { getThumbnailScanner } from './thumbnailScanner'
+
+// TODO: consider file-size-based concurrency (e.g., fewer slots for large images)
+const THUMBNAIL_CONCURRENCY = 5
 
 export function isFileBeingProcessed(fileId: string): boolean {
   return getThumbnailScanner().isFileBeingProcessed(fileId)
@@ -18,18 +21,22 @@ export async function generateThumbnailsForFile(
 }
 
 export async function generateThumbnails(files: FileRecord[]) {
+  const pool = new SlotPool(THUMBNAIL_CONCURRENCY)
   let produced = 0
-  for (const file of files) {
-    try {
-      await generateThumbnailsForFile(file)
-      produced++
-      await yieldToEventLoop()
-    } catch (error) {
-      logger.error('generateThumbnails', 'generation_error', {
-        fileId: file.id,
-        error: error as Error,
-      })
-    }
-  }
+  await Promise.all(
+    files.map((file) =>
+      pool.withSlot(async () => {
+        try {
+          await generateThumbnailsForFile(file)
+          produced++
+        } catch (error) {
+          logger.error('generateThumbnails', 'generation_error', {
+            fileId: file.id,
+            error: error as Error,
+          })
+        }
+      }),
+    ),
+  )
   return produced
 }

--- a/packages/core/src/adapters/thumbnail.ts
+++ b/packages/core/src/adapters/thumbnail.ts
@@ -8,6 +8,10 @@ export interface ThumbnailAdapter {
     sourcePath: string,
     targetSize: number,
   ): Promise<ThumbnailResult>
+  generateImageThumbnails(
+    sourcePath: string,
+    sizes: number[],
+  ): Promise<Map<number, ThumbnailResult>>
   generateVideoThumbnail(
     sourcePath: string,
     targetSize: number,

--- a/packages/core/src/services/thumbnailScanner.ts
+++ b/packages/core/src/services/thumbnailScanner.ts
@@ -66,7 +66,7 @@ export type EnsureResult =
     }
   | { status: 'error'; error: unknown }
 
-const MAX_THUMBS_PER_TICK = 10
+const MAX_THUMBS_PER_TICK = 20
 const ERROR_COOLDOWN_MS = 60 * 60 * 1000 // 1 hour
 
 type CandidateRow = {
@@ -193,15 +193,26 @@ export class ThumbnailScanner {
         missingSizes,
       })
 
-      for (const size of missingSizes) {
-        await this.ensureThumbnailForSize({
+      if (fileRecord.type?.startsWith('image/') && missingSizes.length > 1) {
+        await this.ensureThumbnailsBatch({
           fileId: fileRecord.id,
           fileHash: fileRecord.hash,
           fileType: fileRecord.type,
           fileLocalId: fileRecord.localId,
-          size,
+          sizes: missingSizes,
           sourceUri,
         })
+      } else {
+        for (const size of missingSizes) {
+          await this.ensureThumbnailForSize({
+            fileId: fileRecord.id,
+            fileHash: fileRecord.hash,
+            fileType: fileRecord.type,
+            fileLocalId: fileRecord.localId,
+            size,
+            sourceUri,
+          })
+        }
       }
     } finally {
       this.processingFiles.delete(fileRecord.id)
@@ -336,6 +347,89 @@ export class ThumbnailScanner {
       })
       this.markFileErrored(fileId)
       return { status: 'error', error: e }
+    }
+  }
+
+  private async ensureThumbnailsBatch(params: {
+    fileId: string
+    fileHash: string
+    fileType: string
+    fileLocalId: string | null
+    sizes: ThumbSize[]
+    sourceUri: string
+  }): Promise<void> {
+    const deps = this.getDeps()
+    const { fileId, fileHash, fileType, sizes, sourceUri } = params
+
+    const detectedType = await deps.detectMimeType(sourceUri)
+    const actualType = detectedType ?? fileType
+
+    if (
+      !actualType?.startsWith('image/') &&
+      !actualType?.startsWith('video/')
+    ) {
+      this.markFileErrored(fileId)
+      return
+    }
+
+    let thumbnails: Map<number, { data: ArrayBuffer; mimeType: string }>
+    try {
+      thumbnails = await deps.thumbnailAdapter.generateImageThumbnails(
+        sourceUri,
+        sizes,
+      )
+    } catch (e) {
+      logger.error('thumbnailer', 'batch_generate_error', {
+        fileId,
+        fileHash,
+        sizes,
+        error: e as Error,
+      })
+      this.markFileErrored(fileId)
+      return
+    }
+
+    for (const size of sizes) {
+      const result = thumbnails.get(size)
+      if (!result) continue
+      try {
+        const thumbId = uniqueId()
+        const copied = await deps.copyToFs(
+          { id: thumbId, type: result.mimeType },
+          result.data,
+        )
+        const now = Date.now()
+        await insertFileRecord(deps.db, {
+          id: thumbId,
+          name: 'thumbnail.webp',
+          type: result.mimeType,
+          kind: 'thumb',
+          size: copied.size,
+          hash: `sha256:${copied.hash}`,
+          createdAt: now,
+          updatedAt: now,
+          addedAt: now,
+          localId: null,
+          thumbForId: fileId,
+          thumbSize: size,
+          trashedAt: null,
+          deletedAt: null,
+        })
+        logger.debug('thumbnailer', 'record_created', {
+          thumbId,
+          hash: fileHash,
+          size,
+        })
+        await deps.invalidateCache?.(fileId)
+      } catch (e) {
+        logger.error('thumbnailer', 'batch_save_error', {
+          fileId,
+          fileHash,
+          size,
+          error: e as Error,
+        })
+        this.markFileErrored(fileId)
+      }
     }
   }
 


### PR DESCRIPTION
I noticed the thumbnail generation was a bit inefficient with how it allocates memory, this change makes it a bit smarter and also then bumps up the concurrency and speed which we set very low a while back to ensure it did not use too much memory.
- Add generateImageThumbnails batch method to ThumbnailAdapter that generates all sizes in a single pass using size cascading (largest first, each smaller size resizes from the previous output instead of re-decoding the source).
- This reduces native image decodes from ~4 per file to ~2.
- Add SlotPool-based concurrency (5 files) to the eager thumbnail generator so multiple files are processed in parallel during bulk imports.
