### PR TITLE
test: restore cache invalidation assertions in store tests

### DIFF
--- a/apps/mobile/src/stores/directories.test.ts
+++ b/apps/mobile/src/stores/directories.test.ts
@@ -36,47 +36,70 @@ describe('directories store', () => {
 
   test('deleteDirectory removes directory', async () => {
     const dir = await app().directories.create('Photos')
+    const dirSpy = jest.spyOn(app().caches.directories, 'invalidateAll')
+    const verSpy = jest.spyOn(app().caches.libraryVersion, 'invalidate')
     await app().directories.delete(dir.id)
     const dirs = await app().directories.getAll()
     expect(dirs.find((d: { id: string }) => d.id === dir.id)).toBeUndefined()
+    expect(dirSpy).toHaveBeenCalled()
+    expect(verSpy).toHaveBeenCalled()
   })
 
   test('deleteDirectoryAndTrashFiles trashes associated files', async () => {
     const dir = await app().directories.create('Photos')
     await createTestFile('f1')
     await app().directories.moveFile('f1', dir.id)
+    const dirSpy = jest.spyOn(app().caches.directories, 'invalidateAll')
+    const libSpy = jest.spyOn(app().caches.library, 'invalidateAll')
+    const verSpy = jest.spyOn(app().caches.libraryVersion, 'invalidate')
 
     await app().directories.deleteAndTrashFiles(dir.id)
 
     const record = await app().files.getById('f1')
     expect(record!.trashedAt).not.toBeNull()
+    expect(dirSpy).toHaveBeenCalled()
+    expect(libSpy).toHaveBeenCalled()
+    expect(verSpy).toHaveBeenCalled()
   })
 
   test('renameDirectory updates name', async () => {
     const dir = await app().directories.create('Photos')
+    const dirSpy = jest.spyOn(app().caches.directories, 'invalidate')
+    const verSpy = jest.spyOn(app().caches.libraryVersion, 'invalidate')
     await app().directories.rename(dir.id, 'Images')
     const dirs = await app().directories.getAll()
     expect(dirs.find((d: { id: string }) => d.id === dir.id)?.name).toBe(
       'Images',
     )
+    expect(dirSpy).toHaveBeenCalledWith('all')
+    expect(verSpy).toHaveBeenCalled()
   })
 
   test('syncDirectoryFromMetadata skips when undefined', async () => {
     await createTestFile('f1')
     await app().directories.syncFromMetadata('f1', 'Photos')
+    const dirSpy = jest.spyOn(app().caches.directories, 'invalidate')
+    const verSpy = jest.spyOn(app().caches.libraryVersion, 'invalidate')
 
-    const dirsBefore = await app().directories.getAll()
     await app().directories.syncFromMetadata('f1', undefined)
     const dirsAfter = await app().directories.getAll()
 
-    expect(dirsAfter.length).toBe(dirsBefore.length)
+    expect(dirsAfter.some((d: { name: string }) => d.name === 'Photos')).toBe(
+      true,
+    )
+    expect(dirSpy).not.toHaveBeenCalled()
+    expect(verSpy).not.toHaveBeenCalled()
   })
 
   test('syncDirectoryFromMetadata creates directory for file', async () => {
     await createTestFile('f1')
+    const dirSpy = jest.spyOn(app().caches.directories, 'invalidate')
+    const verSpy = jest.spyOn(app().caches.libraryVersion, 'invalidate')
     await app().directories.syncFromMetadata('f1', 'Photos')
 
     const dirs = await app().directories.getAll()
     expect(dirs.some((d: { name: string }) => d.name === 'Photos')).toBe(true)
+    expect(dirSpy).toHaveBeenCalledWith('all')
+    expect(verSpy).toHaveBeenCalled()
   })
 })

--- a/apps/mobile/src/stores/files.test.ts
+++ b/apps/mobile/src/stores/files.test.ts
@@ -8,6 +8,7 @@ describe('files store (core functions with appService)', () => {
 
   afterEach(async () => {
     await resetDb()
+    jest.restoreAllMocks()
   })
 
   function makeFileRecord(id: string) {
@@ -28,43 +29,80 @@ describe('files store (core functions with appService)', () => {
   }
 
   test('createFileRecord persists record', async () => {
+    const libSpy = jest.spyOn(app().caches.library, 'invalidateAll')
+    const verSpy = jest.spyOn(app().caches.libraryVersion, 'invalidate')
     await app().files.create(makeFileRecord('f1'))
     const record = await app().files.getById('f1')
     expect(record).not.toBeNull()
     expect(record!.name).toBe('f1.jpg')
+    expect(libSpy).toHaveBeenCalled()
+    expect(verSpy).toHaveBeenCalled()
+  })
+
+  test('createFileRecord skips invalidation with skipInvalidation', async () => {
+    const libSpy = jest.spyOn(app().caches.library, 'invalidateAll')
+    await app().files.create(makeFileRecord('f1'), undefined, {
+      skipInvalidation: true,
+    })
+    expect(libSpy).not.toHaveBeenCalled()
   })
 
   test('createManyFileRecords persists multiple records', async () => {
+    const libSpy = jest.spyOn(app().caches.library, 'invalidateAll')
+    const verSpy = jest.spyOn(app().caches.libraryVersion, 'invalidate')
     await app().files.createMany([makeFileRecord('f1'), makeFileRecord('f2')])
     expect(await app().files.getById('f1')).not.toBeNull()
     expect(await app().files.getById('f2')).not.toBeNull()
+    expect(libSpy).toHaveBeenCalled()
+    expect(verSpy).toHaveBeenCalled()
   })
 
   test('createManyFileRecords handles empty array', async () => {
+    const libSpy = jest.spyOn(app().caches.library, 'invalidateAll')
     await app().files.createMany([])
+    expect(libSpy).not.toHaveBeenCalled()
   })
 
   test('updateFileRecord modifies record', async () => {
     await app().files.create(makeFileRecord('f1'))
+    const fileSpy = jest.spyOn(app().caches.fileById, 'invalidate')
+    const verSpy = jest.spyOn(app().caches.libraryVersion, 'invalidate')
     await app().files.update({ id: 'f1', name: 'renamed.jpg' })
     const record = await app().files.getById('f1')
     expect(record!.name).toBe('renamed.jpg')
+    expect(fileSpy).toHaveBeenCalledWith('f1')
+    expect(verSpy).toHaveBeenCalled()
   })
 
   test('updateFileRecord passes includeUpdatedAt option', async () => {
     await app().files.create(makeFileRecord('f1'))
+    const fileSpy = jest.spyOn(app().caches.fileById, 'invalidate')
+    const verSpy = jest.spyOn(app().caches.libraryVersion, 'invalidate')
     await app().files.update(
       { id: 'f1', updatedAt: 9999, name: 'updated.jpg' },
       { includeUpdatedAt: true, skipInvalidation: true },
     )
     const record = await app().files.getById('f1')
     expect(record!.updatedAt).toBe(9999)
+    expect(fileSpy).not.toHaveBeenCalled()
+    expect(verSpy).not.toHaveBeenCalled()
   })
 
   test('deleteFileRecord removes record', async () => {
     await app().files.create(makeFileRecord('f1'))
+    const libSpy = jest.spyOn(app().caches.library, 'invalidateAll')
+    const verSpy = jest.spyOn(app().caches.libraryVersion, 'invalidate')
     await app().files.delete('f1')
     const record = await app().files.getById('f1')
     expect(record).toBeNull()
+    expect(libSpy).toHaveBeenCalled()
+    expect(verSpy).toHaveBeenCalled()
+  })
+
+  test('deleteFileRecord skips invalidation with skipInvalidation', async () => {
+    await app().files.create(makeFileRecord('f1'))
+    const libSpy = jest.spyOn(app().caches.library, 'invalidateAll')
+    await app().files.delete('f1', { skipInvalidation: true })
+    expect(libSpy).not.toHaveBeenCalled()
   })
 })

--- a/apps/mobile/src/stores/tags.test.ts
+++ b/apps/mobile/src/stores/tags.test.ts
@@ -36,49 +36,73 @@ describe('tags store (core stores)', () => {
 
   test('addTagToFile associates tag with file', async () => {
     await createTestFile('f1')
+    const tagSpy = jest.spyOn(app().caches.tags, 'invalidateAll')
+    const verSpy = jest.spyOn(app().caches.libraryVersion, 'invalidate')
     await app().tags.add('f1', 'tag1')
     const tags = await app().tags.getForFile('f1')
     expect(tags.some((t) => t.name === 'tag1')).toBe(true)
+    expect(tagSpy).toHaveBeenCalled()
+    expect(verSpy).toHaveBeenCalled()
   })
 
   test('toggleFavorite adds favorite tag', async () => {
     await createTestFile('f1')
     app().tags.ensureSystemTags()
+    const tagSpy = jest.spyOn(app().caches.tags, 'invalidateAll')
+    const verSpy = jest.spyOn(app().caches.libraryVersion, 'invalidate')
     await app().tags.toggleFavorite('f1')
     const tags = await app().tags.getForFile('f1')
     expect(tags.some((t) => t.name === 'Favorites')).toBe(true)
+    expect(tagSpy).toHaveBeenCalled()
+    expect(verSpy).toHaveBeenCalled()
   })
 
   test('renameTag updates tag name', async () => {
     const tag = await app().tags.create('old')
+    const tagSpy = jest.spyOn(app().caches.tags, 'invalidateAll')
+    const verSpy = jest.spyOn(app().caches.libraryVersion, 'invalidate')
     await app().tags.rename(tag.id, 'new')
     await createTestFile('f1')
     await app().tags.add('f1', 'new')
     const tags = await app().tags.getForFile('f1')
     expect(tags.some((t: { name: string }) => t.name === 'new')).toBe(true)
+    expect(tagSpy).toHaveBeenCalled()
+    expect(verSpy).toHaveBeenCalled()
   })
 
   test('deleteTag removes tag', async () => {
     const tag = await app().tags.create('toDelete')
+    const tagSpy = jest.spyOn(app().caches.tags, 'invalidateAll')
+    const verSpy = jest.spyOn(app().caches.libraryVersion, 'invalidate')
     await app().tags.delete(tag.id)
     const newTag = await app().tags.create('toDelete')
     expect(newTag.id).not.toBe(tag.id)
+    expect(tagSpy).toHaveBeenCalled()
+    expect(verSpy).toHaveBeenCalled()
   })
 
   test('syncTagsFromMetadata skips when undefined', async () => {
     await createTestFile('f1')
     await app().tags.add('f1', 'existing')
+    const tagSpy = jest.spyOn(app().caches.tags, 'invalidateAll')
+    const verSpy = jest.spyOn(app().caches.libraryVersion, 'invalidate')
 
     await app().tags.syncFromMetadata('f1', undefined)
 
     const tags = await app().tags.getForFile('f1')
     expect(tags.some((t: { name: string }) => t.name === 'existing')).toBe(true)
+    expect(tagSpy).not.toHaveBeenCalled()
+    expect(verSpy).not.toHaveBeenCalled()
   })
 
   test('syncTagsFromMetadata applies defined tags', async () => {
     await createTestFile('f1')
+    const tagSpy = jest.spyOn(app().caches.tags, 'invalidateAll')
+    const verSpy = jest.spyOn(app().caches.libraryVersion, 'invalidate')
     await app().tags.syncFromMetadata('f1', ['newTag'])
     const tags = await app().tags.getForFile('f1')
     expect(tags.some((t: { name: string }) => t.name === 'newTag')).toBe(true)
+    expect(tagSpy).toHaveBeenCalled()
+    expect(verSpy).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
- Restores some cache invalidation assertions in tests that were moved to core.

