### PR TITLE
chore(mobile): bump react-native-sia to 0.13.14

### DIFF
--- a/apps/integration/test/app.ts
+++ b/apps/integration/test/app.ts
@@ -210,7 +210,7 @@ export function createTestApp(
     },
     uploader: createTestUploaderAdapters(),
     sdkAuth: {
-      createBuilder: async () => {},
+      createBuilder: async (_indexerUrl: string, _appMeta: string) => {},
       requestConnection: async () => '',
       waitForApproval: async () => {},
       connectWithKey: async () => false,

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -85,7 +85,7 @@
     "react-native-safe-area-context": "5.6.2",
     "react-native-screens": "4.23.0",
     "react-native-share": "12.2.5",
-    "react-native-sia": "0.13.13",
+    "react-native-sia": "0.13.14",
     "react-native-svg": "15.15.3",
     "react-native-webview": "13.16.0",
     "react-native-worklets": "0.7.2",

--- a/apps/mobile/src/adapters/auth.ts
+++ b/apps/mobile/src/adapters/auth.ts
@@ -32,12 +32,7 @@ export class MobileSdkAuthAdapter implements SdkAuthAdapters {
     return this.lastSdk
   }
 
-  createBuilder(indexerUrl: string): void {
-    this.builder = new Builder(indexerUrl)
-  }
-
-  async requestConnection(appMetaJson: string): Promise<string> {
-    if (!this.builder) throw new Error('No builder instance')
+  createBuilder(indexerUrl: string, appMetaJson: string): void {
     const meta = JSON.parse(appMetaJson) as {
       appID: string
       name: string
@@ -46,7 +41,7 @@ export class MobileSdkAuthAdapter implements SdkAuthAdapters {
       callbackUrl?: string
       logoUrl?: string
     }
-    await this.builder.requestConnection({
+    this.builder = new Builder(indexerUrl, {
       id: hexToUint8(meta.appID).buffer as ArrayBuffer,
       name: meta.name,
       description: meta.description,
@@ -54,6 +49,11 @@ export class MobileSdkAuthAdapter implements SdkAuthAdapters {
       callbackUrl: meta.callbackUrl,
       logoUrl: meta.logoUrl,
     })
+  }
+
+  async requestConnection(): Promise<string> {
+    if (!this.builder) throw new Error('No builder instance')
+    await this.builder.requestConnection()
     return this.builder.responseUrl()
   }
 

--- a/apps/mobile/src/stores/sdk.ts
+++ b/apps/mobile/src/stores/sdk.ts
@@ -91,7 +91,7 @@ export async function connectSdk(): Promise<SdkInterface | null> {
     }
 
     const keyHex = uint8ToHex(keyBytes)
-    await app().auth.builder.create(indexerURL)
+    await app().auth.builder.create(indexerURL, APP_META_JSON)
 
     const connected = await withTimeout(
       app().auth.builder.connectWithKey(keyHex),
@@ -197,7 +197,7 @@ export async function authenticateIndexer(
     app().connection.setState({ isAuthing: true })
     const keyHex = uint8ToHex(keyBytes)
     try {
-      await app().auth.builder.create(indexerURL)
+      await app().auth.builder.create(indexerURL, APP_META_JSON)
       const connected = await withTimeout(
         app().auth.builder.connectWithKey(keyHex),
         CONNECTION_TIMEOUT_MS,
@@ -441,10 +441,10 @@ async function runBrowserAuthFlow(
   indexerURL: string,
 ): Promise<Result<void, AuthError>> {
   try {
-    await app().auth.builder.create(indexerURL)
+    await app().auth.builder.create(indexerURL, APP_META_JSON)
     logger.debug('sdk', 'connection_request')
     const responseUrl = await withTimeout(
-      app().auth.builder.requestConnection(APP_META_JSON),
+      app().auth.builder.requestConnection(),
       CONNECTION_TIMEOUT_MS,
     )
 

--- a/bun.lock
+++ b/bun.lock
@@ -82,7 +82,7 @@
         "react-native-safe-area-context": "5.6.2",
         "react-native-screens": "4.23.0",
         "react-native-share": "12.2.5",
-        "react-native-sia": "0.13.13",
+        "react-native-sia": "0.13.14",
         "react-native-svg": "15.15.3",
         "react-native-webview": "13.16.0",
         "react-native-worklets": "0.7.2",
@@ -1592,7 +1592,7 @@
 
     "react-native-share": ["react-native-share@12.2.5", "", {}, "sha512-2uwd/PdlUyvpsSBfL7OMiL4sD0Ja51wu5m62JSIXjrtlF+uSTUOGsMrE49ncIRYziqAfYUeI195WwhpvqXB0ww=="],
 
-    "react-native-sia": ["react-native-sia@0.13.13", "", { "dependencies": { "uniffi-bindgen-react-native": "^0.29.3-1" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-p7sg4FdJ1YhnfETD84gF9lv7RpGYiaalHGuWHT9v0tcdQOZI3yB1mpnIbV1dx8BEj15sPwZD84zt5yCXJ9HRPg=="],
+    "react-native-sia": ["react-native-sia@0.13.14", "", { "dependencies": { "uniffi-bindgen-react-native": "^0.29.3-1" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-iBOWc06iUsL5I/1X9Qi09q1/L2Ufr4T6KjgPdp4A3L4nbs3EqSVr1MTpO0f/B6YJBM8FFstklYJN4pDC4NRF7w=="],
 
     "react-native-svg": ["react-native-svg@15.15.3", "", { "dependencies": { "css-select": "^5.1.0", "css-tree": "^1.1.3", "warn-once": "0.1.1" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-/k4KYwPBLGcx2f5d4FjE+vCScK7QOX14cl2lIASJ28u4slHHtIhL0SZKU7u9qmRBHxTCKPoPBtN6haT1NENJNA=="],
 

--- a/packages/core/src/adapters/auth.ts
+++ b/packages/core/src/adapters/auth.ts
@@ -1,6 +1,6 @@
 export interface SdkAuthAdapters {
-  createBuilder(indexerUrl: string): void | Promise<void>
-  requestConnection(appMeta: string): Promise<string>
+  createBuilder(indexerUrl: string, appMeta: string): void | Promise<void>
+  requestConnection(): Promise<string>
   setConnectionResponse?(appKey: string, response: string): void | Promise<void>
   waitForApproval(): Promise<void>
   connectWithKey(keyHex: string): Promise<boolean>

--- a/packages/core/src/app/namespaces/auth.ts
+++ b/packages/core/src/app/namespaces/auth.ts
@@ -75,11 +75,11 @@ export function buildAuthNamespace(
       await secrets.deleteItem(APP_KEYS_KEY)
     },
     builder: {
-      async create(indexerUrl: string) {
-        await sdkAuth.createBuilder(indexerUrl)
+      async create(indexerUrl: string, appMeta: string) {
+        await sdkAuth.createBuilder(indexerUrl, appMeta)
       },
-      async requestConnection(appMeta: string) {
-        return sdkAuth.requestConnection(appMeta)
+      async requestConnection() {
+        return sdkAuth.requestConnection()
       },
       async setConnectionResponse(appKey: string, response: string) {
         if (sdkAuth.setConnectionResponse) {

--- a/packages/core/src/app/service.ts
+++ b/packages/core/src/app/service.ts
@@ -502,10 +502,10 @@ export interface AppService {
     clearAppKeys(): Promise<void>
     /** Step-by-step connection builder for pairing with an indexer. */
     builder: {
-      /** Initializes a new connection flow for the given indexer URL. */
-      create(indexerUrl: string): Promise<void>
-      /** Sends a connection request with app metadata; returns the request ID. */
-      requestConnection(appMeta: string): Promise<string>
+      /** Initializes a new connection flow for the given indexer URL with app metadata. */
+      create(indexerUrl: string, appMeta: string): Promise<void>
+      /** Sends a connection request; returns the response URL. */
+      requestConnection(): Promise<string>
       /** Submits the approval response received from the indexer. */
       setConnectionResponse(appKey: string, response: string): Promise<void>
       /** Blocks until the connection is approved or rejected. */


### PR DESCRIPTION
- Bump react-native-sia to 0.13.14.
- SDK changes the Builder constructor to accept app metadata upfront.
- Update the adapter interface and call sites to match.
