### PR TITLE
fix(mobile): replace two remaining sync fs calls and add lint rule

### DIFF
--- a/.changeset/sync-fs-calls.md
+++ b/.changeset/sync-fs-calls.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Removed synchronous file system calls used for log export.

--- a/apps/mobile/mocks/fs.ts
+++ b/apps/mobile/mocks/fs.ts
@@ -1,3 +1,4 @@
+// biome-ignore lint/style/noRestrictedImports: File constructor for mock URI refs only
 import { File } from 'expo-file-system'
 import { extFromMime } from '../src/lib/fileTypes'
 import type { FsFileInfo } from '../src/stores/fs'

--- a/apps/mobile/src/adapters/fsIO.ts
+++ b/apps/mobile/src/adapters/fsIO.ts
@@ -1,6 +1,7 @@
 import { extFromMime } from '@siastorage/core/lib/fileTypes'
 import type { FsIOAdapter } from '@siastorage/core/services/fsFileUri'
 import { Buffer } from 'buffer'
+// biome-ignore lint/style/noRestrictedImports: Paths.document.uri constant only
 import { Paths } from 'expo-file-system'
 import RNFS from 'react-native-fs'
 

--- a/apps/mobile/src/adapters/thumbnail.ts
+++ b/apps/mobile/src/adapters/thumbnail.ts
@@ -3,6 +3,7 @@ import type {
   ThumbnailResult,
 } from '@siastorage/core/adapters'
 import type { ThumbSize } from '@siastorage/core/types'
+// biome-ignore lint/style/noRestrictedImports: File constructor + .bytes() (async)
 import { File } from 'expo-file-system'
 import { ImageManipulator, SaveFormat } from 'expo-image-manipulator'
 import * as VideoThumbnails from 'expo-video-thumbnails'

--- a/apps/mobile/src/components/SettingsLogsControlBar.tsx
+++ b/apps/mobile/src/components/SettingsLogsControlBar.tsx
@@ -1,6 +1,5 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack'
 import { type LogLevel, logger } from '@siastorage/logger'
-import { File, Paths } from 'expo-file-system'
 import {
   ChevronDownIcon,
   DownloadIcon,
@@ -17,6 +16,7 @@ import {
   Text,
   View,
 } from 'react-native'
+import RNFS from 'react-native-fs'
 import Share from 'react-native-share'
 import { logsCache } from '../hooks/useLogs'
 import { exportLogs } from '../lib/exportLogs'
@@ -151,17 +151,11 @@ export function SettingsLogsControlBar({ navigation }: Props) {
         .join('\n')
       const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
       const fileName = `logs-${timestamp}.jsonl`
-      const tempFile = new File(Paths.cache, fileName)
-      tempFile.create({ intermediates: true })
-      const writer = tempFile.writableStream().getWriter()
-      try {
-        await writer.write(new TextEncoder().encode(content))
-      } finally {
-        await writer.close()
-      }
+      const tempFilePath = `${RNFS.CachesDirectoryPath}/${fileName}`
+      await RNFS.writeFile(tempFilePath, content, 'utf8')
       try {
         await Share.open({
-          url: `file://${tempFile.uri}`,
+          url: `file://${tempFilePath}`,
           type: 'application/x-ndjson',
           filename: fileName,
         })
@@ -170,7 +164,7 @@ export function SettingsLogsControlBar({ navigation }: Props) {
           return
         throw e
       } finally {
-        tempFile.delete()
+        await RNFS.unlink(tempFilePath)
       }
     } catch (error) {
       logger.error('logs', 'share_failed', { error: error as Error })

--- a/apps/mobile/src/lib/exportLogs.ts
+++ b/apps/mobile/src/lib/exportLogs.ts
@@ -1,6 +1,6 @@
 import { uniqueId } from '@siastorage/core/lib/uniqueId'
 import { logger } from '@siastorage/logger'
-import { File, Paths } from 'expo-file-system'
+import RNFS from 'react-native-fs'
 import { queueUploadForFileId } from '../managers/uploader'
 import { app } from '../stores/appService'
 import { copyFileToFs } from '../stores/fs'
@@ -30,33 +30,22 @@ export async function exportLogs(): Promise<string | null> {
 
     // Write to temporary file.
     const tempFileName = `logs-export-${Date.now()}.jsonl`
-    const tempFile = new File(Paths.document, tempFileName)
-    const contentBytes = new TextEncoder().encode(content)
-
-    // Create empty file first.
-    tempFile.create({ intermediates: true })
-
-    // Write content.
-    const writer = tempFile.writableStream().getWriter()
-    try {
-      await writer.write(contentBytes)
-    } finally {
-      await writer.close()
-    }
+    const tempFilePath = `${RNFS.DocumentDirectoryPath}/${tempFileName}`
+    await RNFS.writeFile(tempFilePath, content, 'utf8')
 
     const fileId = uniqueId()
-    const size = contentBytes.length
+    const size = new TextEncoder().encode(content).length
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
     const fileName = `logs-${timestamp}.jsonl`
 
     // Copy temp file to FS storage.
     const fsFileUri = await copyFileToFs(
       { id: fileId, type: 'application/x-ndjson' },
-      tempFile.uri,
+      tempFilePath,
     )
 
     // Clean up temp file.
-    tempFile.delete()
+    await RNFS.unlink(tempFilePath)
 
     // Calculate hash.
     const hash = await calculateContentHash(fsFileUri)

--- a/apps/mobile/src/lib/fileReader.ts
+++ b/apps/mobile/src/lib/fileReader.ts
@@ -1,3 +1,4 @@
+// biome-ignore lint/style/noRestrictedImports: File constructor + .stream() (async)
 import { File } from 'expo-file-system'
 import type { Reader } from 'react-native-sia'
 

--- a/apps/mobile/src/lib/readFileBytes.ts
+++ b/apps/mobile/src/lib/readFileBytes.ts
@@ -1,4 +1,5 @@
 import { logger } from '@siastorage/logger'
+// biome-ignore lint/style/noRestrictedImports: File constructor + .readableStream() (async)
 import { File } from 'expo-file-system'
 
 function isFileUri(uri: string): boolean {

--- a/apps/mobile/src/lib/streamToCache.ts
+++ b/apps/mobile/src/lib/streamToCache.ts
@@ -1,4 +1,5 @@
 import { logger } from '@siastorage/logger'
+// biome-ignore lint/style/noRestrictedImports: type-only import for .writableStream() (async)
 import type { File } from 'expo-file-system'
 import type { Writer } from 'react-native-sia'
 import { getOrCreateTempDownloadFile } from '../stores/tempFs'

--- a/apps/mobile/src/stores/tempFs.ts
+++ b/apps/mobile/src/stores/tempFs.ts
@@ -1,3 +1,4 @@
+// biome-ignore lint/style/noRestrictedImports: constructors for URI refs only, all ops use RNFS
 import { Directory, File, Paths } from 'expo-file-system'
 import RNFS from 'react-native-fs'
 

--- a/biome.json
+++ b/biome.json
@@ -28,7 +28,17 @@
         "useImportType": "error",
         "noUnusedTemplateLiteral": "off",
         "noNonNullAssertion": "off",
-        "useNodejsImportProtocol": "off"
+        "useNodejsImportProtocol": "off",
+        "noRestrictedImports": {
+          "level": "error",
+          "options": {
+            "paths": {
+              "expo-file-system": {
+                "message": "expo-file-system has sync JSI methods (.info(), .delete(), .create(), .list()) that block the JS thread. Use react-native-fs (RNFS) instead. If you need expo-file-system streaming APIs, add a biome-ignore comment."
+              }
+            }
+          }
+        }
       },
       "suspicious": {
         "noExplicitAny": "off",


### PR DESCRIPTION
- Removed synchronous file system calls used for log export.
- Add lint rule to require case by case exceptions for expo-file-system.