### PR TITLE
fix(mobile): center icons in action sheet buttons

### DIFF
--- a/.changeset/fix-action-sheet-icon-alignment.md
+++ b/.changeset/fix-action-sheet-icon-alignment.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Fixed action sheet icons appearing vertically off-center relative to their text labels.

--- a/apps/mobile/src/components/ActionSheetButton.tsx
+++ b/apps/mobile/src/components/ActionSheetButton.tsx
@@ -5,6 +5,7 @@ import {
   StyleSheet,
   Text,
   type TextStyle,
+  View,
 } from 'react-native'
 import { palette } from '../styles/colors'
 
@@ -46,7 +47,7 @@ export function ActionSheetButton({
       onPress={onPress}
       testID={testID}
     >
-      <Text style={iconStyle}>{renderedIcon}</Text>
+      <View>{renderedIcon}</View>
       <Text style={textStyle}>{children}</Text>
     </Pressable>
   )


### PR DESCRIPTION
- Fixed action sheet icons appearing vertically off-center relative to their text labels.
