### PR TITLE
feat(mobile): add storage details with descriptions to indexer settings

### DIFF
--- a/.changeset/add-pinned-size-to-indexer-settings.md
+++ b/.changeset/add-pinned-size-to-indexer-settings.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Added library size, usage, and storage details with descriptions to the indexer settings screen.

--- a/apps/mobile/src/screens/SettingsIndexerScreen.tsx
+++ b/apps/mobile/src/screens/SettingsIndexerScreen.tsx
@@ -59,19 +59,31 @@ export function SettingsIndexerScreen({ navigation }: Props) {
         }
       >
         <InfoCard>
-          <LabeledValueRow label="URL" value={currentIndexerURL.data} />
+          <LabeledValueRow
+            label="URL"
+            description="Indexer service pinning your data"
+            value={currentIndexerURL.data}
+          />
           {account.data ? (
             <>
               <LabeledValueRow
                 label="Account Key"
+                description="Derived from your recovery phrase"
                 value={account.data.accountKey}
               />
               <LabeledValueRow
-                label="Used Storage"
+                label="Library Size"
+                description="Total size of files in your library"
                 value={humanSize(Number(account.data.pinnedData))}
               />
               <LabeledValueRow
+                label="Usage"
+                description="Data is stored at 3x redundancy"
+                value={humanSize(Number(account.data.pinnedSize))}
+              />
+              <LabeledValueRow
                 label="Storage Limit"
+                description="Maximum storage for your account"
                 value={humanSize(Number(account.data.maxPinnedData))}
               />
             </>

--- a/packages/core/src/adapters/sdk.ts
+++ b/packages/core/src/adapters/sdk.ts
@@ -110,6 +110,7 @@ export interface Account {
   accountKey: string
   maxPinnedData: bigint
   pinnedData: bigint
+  pinnedSize: bigint
   app: AccountApp
   lastUsed: Date
 }

--- a/packages/sdk-mock/src/index.ts
+++ b/packages/sdk-mock/src/index.ts
@@ -342,6 +342,7 @@ export class MockSdk implements SdkAdapter {
       accountKey: '0'.repeat(64),
       maxPinnedData: 1000000000n,
       pinnedData: 0n,
+      pinnedSize: 0n,
       app: {
         id: 'mock-app',
         description: 'Mock App',


### PR DESCRIPTION
- Rename "Used Storage" to "Library Size" and add a new "Usage With Redundancy" row showing the actual usage after erasure encoding.
