### PR TITLE
fix(mobile): prevent concurrent orphan and eviction scans

### DIFF
--- a/.changeset/singleflight-scanners.md
+++ b/.changeset/singleflight-scanners.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Fixed concurrent orphan and eviction scans when multiple background tasks resume simultaneously.

--- a/apps/mobile/src/managers/fsEvictionScanner.ts
+++ b/apps/mobile/src/managers/fsEvictionScanner.ts
@@ -1,8 +1,11 @@
 import { FS_EVICTION_FREQUENCY } from '@siastorage/core/config'
+import { SingleInit } from '@siastorage/core/lib/singleflight'
 import type { CacheEvictionResult } from '@siastorage/core/services'
 import { runCacheEviction } from '@siastorage/core/services'
 import { logger } from '@siastorage/logger'
 import { app } from '../stores/appService'
+
+const flight = new SingleInit()
 
 /**
  * fsEvictionScanner evicts stale files from the file system under the following rules:
@@ -17,11 +20,14 @@ export async function runFsEvictionScanner(): Promise<
   if (Date.now() - lastRun < FS_EVICTION_FREQUENCY) {
     return
   }
-  try {
-    return await runCacheEviction(app())
-  } catch (error) {
-    logger.error('fsEvictionScanner', 'scan_error', { error: error as Error })
-  } finally {
-    await app().settings.setFsEvictionLastRun(Date.now())
-  }
+  return flight.run(async () => {
+    try {
+      return await runCacheEviction(app())
+    } catch (error) {
+      logger.error('fsEvictionScanner', 'scan_error', { error: error as Error })
+      return undefined
+    } finally {
+      await app().settings.setFsEvictionLastRun(Date.now())
+    }
+  })
 }

--- a/apps/mobile/src/managers/fsOrphanScanner.test.ts
+++ b/apps/mobile/src/managers/fsOrphanScanner.test.ts
@@ -206,4 +206,24 @@ describe('fsOrphanScanner', () => {
 
     expect(result).toEqual({ removed: 60 })
   })
+
+  it('coalesces concurrent calls into a single scan', async () => {
+    let resolveList!: (value: string[]) => void
+    listFilesSpy.mockReturnValue(
+      new Promise<string[]>((r) => {
+        resolveList = r
+      }),
+    )
+
+    const call1 = runFsOrphanScanner()
+    const call2 = runFsOrphanScanner()
+
+    resolveList(['orphan.jpg'])
+
+    const [result1, result2] = await Promise.all([call1, call2])
+
+    expect(listFilesSpy).toHaveBeenCalledTimes(1)
+    expect(result1).toEqual({ removed: 1 })
+    expect(result2).toEqual({ removed: 1 })
+  })
 })

--- a/apps/mobile/src/managers/fsOrphanScanner.ts
+++ b/apps/mobile/src/managers/fsOrphanScanner.ts
@@ -1,9 +1,12 @@
 import { FS_ORPHAN_FREQUENCY } from '@siastorage/core/config'
+import { SingleInit } from '@siastorage/core/lib/singleflight'
 import type { OrphanScannerResult } from '@siastorage/core/services'
 import { runOrphanScanner } from '@siastorage/core/services'
 import { logger } from '@siastorage/logger'
 import { app } from '../stores/appService'
 import { fsFileUriCache } from '../stores/fs'
+
+const flight = new SingleInit()
 
 /**
  * fsOrphanScanner scans the file system for files that are not indexed in the database.
@@ -18,13 +21,16 @@ export async function runFsOrphanScanner(options?: {
   if (Date.now() - lastRun < FS_ORPHAN_FREQUENCY) {
     return
   }
-  try {
-    const result = await runOrphanScanner(app(), options?.onProgress)
-    fsFileUriCache.invalidateAll()
-    return result
-  } catch (error) {
-    logger.error('fsOrphanScanner', 'scan_error', { error: error as Error })
-  } finally {
-    await app().settings.setFsOrphanLastRun(Date.now())
-  }
+  return flight.run(async () => {
+    try {
+      const result = await runOrphanScanner(app(), options?.onProgress)
+      fsFileUriCache.invalidateAll()
+      return result
+    } catch (error) {
+      logger.error('fsOrphanScanner', 'scan_error', { error: error as Error })
+      return undefined
+    } finally {
+      await app().settings.setFsOrphanLastRun(Date.now())
+    }
+  })
 }


### PR DESCRIPTION
- The orphan and eviction scanners can be called from both app startup and background tasks. If multiple callers overlap before the frequency gate is written, they race past the check and run concurrently.
- Wrap both scanners with SingleInit to coalesce concurrent calls into a single in-flight execution.
