### PR TITLE
fix(mobile): skip background tasks when app is in foreground

### DIFF
--- a/.changeset/skip-bg-tasks-active.md
+++ b/.changeset/skip-bg-tasks-active.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Skip heavy one-shot scanners in background tasks when the app is in the foreground.

--- a/apps/mobile/src/managers/backgroundTasks.test.ts
+++ b/apps/mobile/src/managers/backgroundTasks.test.ts
@@ -48,6 +48,7 @@ jest.mock('../stores/sdk', () => ({}))
 
 jest.mock('react-native', () => ({
   Platform: { OS: 'ios' },
+  AppState: { currentState: 'background' },
 }))
 
 jest.mock('../stores/appService', () => ({

--- a/apps/mobile/src/managers/backgroundTasks.ts
+++ b/apps/mobile/src/managers/backgroundTasks.ts
@@ -1,6 +1,6 @@
 import { minutesInMs, secondsInMs } from '@siastorage/core'
 import { logger } from '@siastorage/logger'
-import { Platform } from 'react-native'
+import { AppState, Platform } from 'react-native'
 import BackgroundFetch, {
   type BackgroundFetchConfig,
 } from 'react-native-background-fetch'
@@ -281,9 +281,13 @@ async function runBackgroundWork(config: TaskConfig, state: TaskState) {
   const isConnected = app().connection.getState().isConnected
   log('app_ready', { connected: isConnected })
 
-  await runFsOrphanScanner()
-  await runFsEvictionScanner()
-  await triggerRecentScanIfNeeded()
+  // Skip one-shot scanners if the app is foregrounded — startup already
+  // runs these. The upload polling loop below still runs regardless.
+  if (AppState.currentState !== 'active') {
+    await runFsOrphanScanner()
+    await runFsEvictionScanner()
+    await triggerRecentScanIfNeeded()
+  }
 
   const manager = getUploadManager()!
   const initialStats = await getFileStatsLocal({ localOnly: true })


### PR DESCRIPTION
Skip orphan scanner, eviction scanner, and recent scan trigger when the background task starts while the app is active. Startup already runs these. The upload polling loop still runs to benefit from the extra time.
