### PR TITLE
fix(mobile): retry scanners on failure instead of silently skipping

### DIFF
--- a/.changeset/scanner-error-handling.md
+++ b/.changeset/scanner-error-handling.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Surface errors from orphan and eviction scanners instead of swallowing them, and don't mark scans as successful when they fail.

--- a/apps/mobile/src/managers/fsEvictionScanner.ts
+++ b/apps/mobile/src/managers/fsEvictionScanner.ts
@@ -22,12 +22,12 @@ export async function runFsEvictionScanner(): Promise<
   }
   return flight.run(async () => {
     try {
-      return await runCacheEviction(app())
+      const result = await runCacheEviction(app())
+      await app().settings.setFsEvictionLastRun(Date.now())
+      return result
     } catch (error) {
       logger.error('fsEvictionScanner', 'scan_error', { error: error as Error })
       return undefined
-    } finally {
-      await app().settings.setFsEvictionLastRun(Date.now())
     }
   })
 }

--- a/apps/mobile/src/managers/fsOrphanScanner.ts
+++ b/apps/mobile/src/managers/fsOrphanScanner.ts
@@ -25,12 +25,11 @@ export async function runFsOrphanScanner(options?: {
     try {
       const result = await runOrphanScanner(app(), options?.onProgress)
       fsFileUriCache.invalidateAll()
+      await app().settings.setFsOrphanLastRun(Date.now())
       return result
     } catch (error) {
       logger.error('fsOrphanScanner', 'scan_error', { error: error as Error })
       return undefined
-    } finally {
-      await app().settings.setFsOrphanLastRun(Date.now())
     }
   })
 }

--- a/packages/core/src/services/cacheEviction.ts
+++ b/packages/core/src/services/cacheEviction.ts
@@ -28,54 +28,49 @@ export async function runCacheEviction(
   const minAge = config?.minAge ?? FS_EVICTABLE_MIN_AGE
   const batchSize = config?.batchSize ?? 100
 
-  try {
-    const totalSize = await app.fs.calcTotalSize()
+  const totalSize = await app.fs.calcTotalSize()
 
-    if (totalSize <= maxBytes) return undefined
+  if (totalSize <= maxBytes) return undefined
 
-    logger.info('cacheEviction', 'starting', { totalSize, limit: maxBytes })
+  logger.info('cacheEviction', 'starting', { totalSize, limit: maxBytes })
 
-    let currentSize = totalSize
-    let processedRows = 0
-    let evicted = 0
-    const evictedFileIds: string[] = []
+  let currentSize = totalSize
+  let processedRows = 0
+  let evicted = 0
+  const evictedFileIds: string[] = []
 
-    while (currentSize > maxBytes) {
-      const thresholdUsedAt = Date.now() - minAge
+  while (currentSize > maxBytes) {
+    const thresholdUsedAt = Date.now() - minAge
 
-      const candidates = await app.fs.evictionCandidates(
-        thresholdUsedAt,
-        batchSize,
-      )
+    const candidates = await app.fs.evictionCandidates(
+      thresholdUsedAt,
+      batchSize,
+    )
 
-      for (const { fileId, size, type } of candidates) {
-        if (currentSize <= maxBytes) break
-        try {
-          await app.fs.removeFile({ id: fileId, type })
-          currentSize -= size
-          evicted++
-          evictedFileIds.push(fileId)
-        } catch (e) {
-          logger.error('cacheEviction', 'remove_failed', {
-            fileId,
-            error: e as Error,
-          })
-        }
+    for (const { fileId, size, type } of candidates) {
+      if (currentSize <= maxBytes) break
+      try {
+        await app.fs.removeFile({ id: fileId, type })
+        currentSize -= size
+        evicted++
+        evictedFileIds.push(fileId)
+      } catch (e) {
+        logger.error('cacheEviction', 'remove_failed', {
+          fileId,
+          error: e as Error,
+        })
       }
-
-      processedRows += candidates.length
-
-      if (candidates.length < batchSize) break
     }
 
-    logger.info('cacheEviction', 'complete', {
-      processedRows,
-      evicted,
-      currentSize,
-    })
-    return { processedRows, evicted, evictedFileIds, currentSize }
-  } catch (e) {
-    logger.error('cacheEviction', 'failed', { error: e as Error })
-    return undefined
+    processedRows += candidates.length
+
+    if (candidates.length < batchSize) break
   }
+
+  logger.info('cacheEviction', 'complete', {
+    processedRows,
+    evicted,
+    currentSize,
+  })
+  return { processedRows, evicted, evictedFileIds, currentSize }
 }

--- a/packages/core/src/services/orphanScanner.ts
+++ b/packages/core/src/services/orphanScanner.ts
@@ -24,56 +24,49 @@ export async function runOrphanScanner(
   app: AppService,
   onProgress?: (removed: number, total: number) => void,
 ): Promise<OrphanScannerResult | undefined> {
-  try {
-    const files = await app.fs.listFiles()
-    if (files.length === 0) return undefined
+  const files = await app.fs.listFiles()
+  if (files.length === 0) return undefined
 
-    let removed = 0
+  let removed = 0
 
-    for (let i = 0; i < files.length; i += BATCH_SIZE) {
-      const batch = files.slice(i, i + BATCH_SIZE)
+  for (let i = 0; i < files.length; i += BATCH_SIZE) {
+    const batch = files.slice(i, i + BATCH_SIZE)
 
-      const entries = batch
-        .map((name) => ({ name, fileId: extractFileIdFromName(name) }))
-        .filter((e): e is { name: string; fileId: string } => e.fileId !== null)
+    const entries = batch
+      .map((name) => ({ name, fileId: extractFileIdFromName(name) }))
+      .filter((e): e is { name: string; fileId: string } => e.fileId !== null)
 
-      const orphanedIds = await app.fs.findOrphanedFileIds(
-        entries.map((e) => e.fileId),
-      )
+    const orphanedIds = await app.fs.findOrphanedFileIds(
+      entries.map((e) => e.fileId),
+    )
 
-      for (const entry of entries) {
-        if (!orphanedIds.has(entry.fileId)) continue
-        try {
-          const type =
-            getMimeTypeFromExtension(entry.name) ?? 'application/octet-stream'
-          await app.fs.removeFile({ id: entry.fileId, type })
-          removed++
-          logger.info('orphanScanner', 'file_removed', {
-            fileId: entry.fileId,
-          })
-        } catch (error) {
-          logger.error('orphanScanner', 'delete_failed', {
-            fileId: entry.fileId,
-            error: error as Error,
-          })
-        }
+    for (const entry of entries) {
+      if (!orphanedIds.has(entry.fileId)) continue
+      try {
+        const type =
+          getMimeTypeFromExtension(entry.name) ?? 'application/octet-stream'
+        await app.fs.removeFile({ id: entry.fileId, type })
+        removed++
+      } catch (error) {
+        logger.error('orphanScanner', 'delete_failed', {
+          fileId: entry.fileId,
+          error: error as Error,
+        })
       }
-
-      if (orphanedIds.size > 0) {
-        await app.fs.deleteMetaBatch([...orphanedIds])
-      }
-
-      onProgress?.(removed, files.length)
-
-      await yieldToEventLoop()
     }
 
-    if (removed > 0) {
-      logger.info('orphanScanner', 'summary', { removed })
+    if (orphanedIds.size > 0) {
+      await app.fs.deleteMetaBatch([...orphanedIds])
     }
-    return { removed }
-  } catch (e) {
-    logger.error('orphanScanner', 'failed', { error: e as Error })
-    return undefined
+
+    onProgress?.(removed, files.length)
+
+    await yieldToEventLoop()
   }
+
+  logger.info('orphanScanner', 'summary', {
+    removed,
+    total: files.length,
+  })
+  return { removed }
 }


### PR DESCRIPTION
- The orphan and eviction scanners swallowed errors internally and set lastRun, causing failed scans to silently skip for 24h/60m.
- Based on some log review it looks like an internal call may be freqently failing. This change will surface that.

