### PR TITLE
chore: ignore symlinks in .gitignore for worktree support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,11 @@ node_modules/
 # build
 dist/
 .build-cache/
+.build-cache
 
 # Expo
 .expo/
+.expo
 
 # Signing
 android-release.keystore
@@ -36,6 +38,7 @@ android/
 # Claude Code
 CLAUDE.md
 .claude/
+.claude
 
 # docs
 docs/


### PR DESCRIPTION
- Add entries without trailing slashes for .build-cache, .expo, and .claude so git ignores both directories and symlinks to them.

