### PR TITLE
perf: reduce native bridge calls in getFsFileUri

### DIFF
--- a/.changeset/fix-gallery-tab-switch-delay.md
+++ b/.changeset/fix-gallery-tab-switch-delay.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Reduced native bridge calls when resolving file URIs.

--- a/apps/integration/test/adapters/fs.ts
+++ b/apps/integration/test/adapters/fs.ts
@@ -12,17 +12,17 @@ export function createFsAdapter(params: { tempDir: string }) {
   }
 
   const fsIO: FsIOAdapter = {
-    async exists(fileId, type) {
-      return nodeFs.existsSync(fsFilePath(fileId, type))
-    },
     uri(fileId, type) {
       return `file://${fsFilePath(fileId, type)}`
     },
     async size(fileId, type) {
       try {
-        return nodeFs.statSync(fsFilePath(fileId, type)).size
-      } catch {
-        return null
+        return { value: nodeFs.statSync(fsFilePath(fileId, type)).size }
+      } catch (e: any) {
+        if (e?.code === 'ENOENT') {
+          return { value: null, error: 'not_found' as const }
+        }
+        return { value: null, error: 'stat_error' as const }
       }
     },
     async remove(fileId, type) {

--- a/apps/integration/test/adapters/fsIO.ts
+++ b/apps/integration/test/adapters/fsIO.ts
@@ -2,9 +2,8 @@ import type { FsIOAdapter } from '@siastorage/core/services/fsFileUri'
 
 export function createMockFsIO(overrides?: Partial<FsIOAdapter>): FsIOAdapter {
   return {
-    exists: async () => true,
     uri: () => 'file://source.jpg',
-    size: async () => null,
+    size: async () => ({ value: 1000 }),
     remove: async () => {},
     copy: async () => ({ uri: '', size: 0 }),
     writeFile: async (_file, data) => ({

--- a/apps/integration/test/thumbnail-scanner.test.ts
+++ b/apps/integration/test/thumbnail-scanner.test.ts
@@ -30,7 +30,9 @@ describe('ThumbnailScanner', () => {
   it('skips files without source URI', async () => {
     const now = Date.now()
     const noSourceApp = createTestApp(undefined, {
-      fsIO: { exists: async () => false },
+      fsIO: {
+        size: async () => ({ value: null, error: 'not_found' as const }),
+      },
       thumbnail: {},
       crypto: { sha256: async () => `thumb-hash-${++hashCounter}` },
       detectMimeType: async () => 'image/jpeg',
@@ -135,7 +137,12 @@ describe('ThumbnailScanner', () => {
     }
 
     const customApp = createTestApp(undefined, {
-      fsIO: { exists: async (fileId) => !noSourceIds.has(fileId) },
+      fsIO: {
+        size: async (fileId) =>
+          noSourceIds.has(fileId)
+            ? { value: null, error: 'not_found' as const }
+            : { value: 1000 },
+      },
       thumbnail: {},
       crypto: { sha256: async () => `thumb-hash-${++hashCounter}` },
       detectMimeType: async () => 'image/jpeg',

--- a/apps/mobile/src/adapters/fsIO.ts
+++ b/apps/mobile/src/adapters/fsIO.ts
@@ -12,18 +12,19 @@ function fsFileUri(fileId: string, type: string): string {
 
 export function createFsIOAdapter(): FsIOAdapter {
   return {
-    async exists(fileId, type) {
-      return RNFS.exists(fsFileUri(fileId, type))
-    },
     uri(fileId, type) {
       return fsFileUri(fileId, type)
     },
     async size(fileId, type) {
       try {
         const stat = await RNFS.stat(fsFileUri(fileId, type))
-        return stat.size
-      } catch {
-        return null
+        return { value: stat.size }
+      } catch (e: any) {
+        const msg = e?.message ?? ''
+        if (msg.includes('does not exist') || msg.includes('ENOENT')) {
+          return { value: null, error: 'not_found' as const }
+        }
+        return { value: null, error: 'stat_error' as const }
       }
     },
     async remove(fileId, type) {

--- a/packages/core/src/app/namespaces/downloads.ts
+++ b/packages/core/src/app/namespaces/downloads.ts
@@ -74,8 +74,8 @@ export function buildDownloadsNamespace(
     const file = await ops.readFileRecord(db, fileId)
     if (!file) throw new Error('File record not found')
 
-    const exists = await fsIO.exists(fileId, file.type).catch(() => false)
-    if (exists) return
+    const { value: size } = await fsIO.size(fileId, file.type)
+    if (size !== null) return
 
     const sdk = getSdk()
     if (!sdk) throw new Error('SDK not initialized')

--- a/packages/core/src/services/fsFileUri.ts
+++ b/packages/core/src/services/fsFileUri.ts
@@ -8,10 +8,13 @@ import {
 
 const USED_AT_UPDATE_INTERVAL_MS = 60 * 60 * 1000 // 1 hour
 
+export type SizeResult =
+  | { value: number; error?: undefined }
+  | { value: null; error: 'not_found' | 'stat_error' }
+
 export type FsFileUriAdapter = {
-  exists(fileId: string, type: string): Promise<boolean>
   uri(fileId: string, type: string): string
-  size(fileId: string, type: string): Promise<number | null>
+  size(fileId: string, type: string): Promise<SizeResult>
 }
 
 export type FsIOAdapter = FsFileUriAdapter & {
@@ -35,17 +38,16 @@ export async function getFsFileUri(
   opts?: { usedAtUpdateInterval?: number },
 ): Promise<string | null> {
   const existingMeta = await readFsFileMetadata(db, file.id)
-  const fileExists = await adapter.exists(file.id, file.type)
+  const { value: size, error } = await adapter.size(file.id, file.type)
 
-  if (!fileExists) {
-    if (existingMeta) {
+  if (size === null) {
+    if (error === 'not_found' && existingMeta) {
       await deleteFsFileMetadata(db, file.id)
     }
+    // On stat_error, preserve existing metadata so we don't lose
+    // track of files that haven't been uploaded yet.
     return null
   }
-
-  const size =
-    (await adapter.size(file.id, file.type)) ?? existingMeta?.size ?? 0
   const now = Date.now()
 
   if (!existingMeta) {


### PR DESCRIPTION
- Minor consistency/efficiency improvement found during the other more significant file system optimizations.
- Replace sequential exists() + size() adapter calls with a single size() call that returns null for missing files.
- Remove exists from FsFileUriAdapter interface and all implementations.
