### PR TITLE
refactor(mobile): standardize service skip conditions and gate on sync-down

### DIFF
--- a/.changeset/defer-thumbnailer-during-sync-down.md
+++ b/.changeset/defer-thumbnailer-during-sync-down.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Skip thumbnail scanning during sync-down since we don't yet know which thumbnails already exist.

--- a/.changeset/standardize-service-skip-conditions.md
+++ b/.changeset/standardize-service-skip-conditions.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Standardized skip conditions with debug logging across all periodic services.

--- a/apps/integration/test/app.ts
+++ b/apps/integration/test/app.ts
@@ -14,7 +14,7 @@ import { detectMimeType } from '@siastorage/core/lib/detectMimeType'
 import { ServiceScheduler } from '@siastorage/core/lib/serviceInterval'
 import type { FsIOAdapter } from '@siastorage/core/services/fsFileUri'
 import { syncDownEventsBatch } from '@siastorage/core/services/syncDownEvents'
-import { runSyncUpMetadataBatch } from '@siastorage/core/services/syncUpMetadata'
+import { syncUpMetadataBatch } from '@siastorage/core/services/syncUpMetadata'
 import { ThumbnailScanner } from '@siastorage/core/services/thumbnailScanner'
 import type { UploadManager } from '@siastorage/core/services/uploader'
 import type { FileRecord, FileRecordRow } from '@siastorage/core/types'
@@ -223,27 +223,35 @@ export function createTestApp(
     thumbnail: thumbnailAdapter,
     detectMimeType: detectMimeTypeFn,
   })
+  function runSyncDown(signal: AbortSignal) {
+    if (!connected) return
+    return syncDownEventsBatch(signal, appService, internal)
+  }
+
+  function runSyncUp(signal: AbortSignal) {
+    if (!connected) return
+    return syncUpMetadataBatch(100, 5, signal, appService, internal)
+  }
+
+  async function runThumbScan(signal: AbortSignal) {
+    await thumbnailScanner.runScan(signal)
+  }
+
   const syncDown = scheduler.createInterval({
     name: 'syncDownEvents',
-    worker: (signal) => syncDownEventsBatch(signal, appService, internal),
-    getState: async () => connected,
+    worker: runSyncDown,
     interval: SYNC_INTERVAL,
   })
 
   const syncUp = scheduler.createInterval({
     name: 'syncUpMetadata',
-    worker: (signal) =>
-      runSyncUpMetadataBatch(100, 5, signal, appService, internal),
-    getState: async () => connected,
+    worker: runSyncUp,
     interval: SYNC_INTERVAL,
   })
 
   const thumbScan = scheduler.createInterval({
     name: 'thumbnailScanner',
-    worker: async (signal) => {
-      await thumbnailScanner.runScan(signal)
-    },
-    getState: async () => true,
+    worker: runThumbScan,
     interval: THUMBNAIL_SCAN_INTERVAL,
   })
 

--- a/apps/mobile/src/lib/serviceInterval.test.ts
+++ b/apps/mobile/src/lib/serviceInterval.test.ts
@@ -32,7 +32,6 @@ test('shutdown waits for in-flight worker with abort signal loop', async () => {
         })
       }
     },
-    getState: async () => true,
     interval: 1000,
   })
 
@@ -81,7 +80,7 @@ test('shutdown waits for multiple services concurrently', async () => {
     worker: async () => {
       fastDone = true
     },
-    getState: async () => true,
+
     interval: 100,
   })
 
@@ -92,7 +91,7 @@ test('shutdown waits for multiple services concurrently', async () => {
         slowResolve = r
       })
     },
-    getState: async () => true,
+
     interval: 100,
   })
 
@@ -133,7 +132,7 @@ test('triggerNow is a noop while worker is running', async () => {
         resolveWork = r
       })
     },
-    getState: async () => true,
+
     interval: 5000,
   })
 

--- a/apps/mobile/src/managers/fsEvictionScanner.ts
+++ b/apps/mobile/src/managers/fsEvictionScanner.ts
@@ -18,6 +18,7 @@ export async function runFsEvictionScanner(): Promise<
 > {
   const lastRun = await app().settings.getFsEvictionLastRun()
   if (Date.now() - lastRun < FS_EVICTION_FREQUENCY) {
+    logger.debug('fsEvictionScanner', 'skipped', { reason: 'too_recent' })
     return
   }
   return flight.run(async () => {

--- a/apps/mobile/src/managers/fsOrphanScanner.ts
+++ b/apps/mobile/src/managers/fsOrphanScanner.ts
@@ -19,6 +19,7 @@ export async function runFsOrphanScanner(options?: {
 }): Promise<OrphanScannerResult | undefined> {
   const lastRun = await app().settings.getFsOrphanLastRun()
   if (Date.now() - lastRun < FS_ORPHAN_FREQUENCY) {
+    logger.debug('fsOrphanScanner', 'skipped', { reason: 'too_recent' })
     return
   }
   return flight.run(async () => {

--- a/apps/mobile/src/managers/logRotation.ts
+++ b/apps/mobile/src/managers/logRotation.ts
@@ -10,11 +10,12 @@ export async function initLogRotation(): Promise<void> {
   initLogRotationInterval()
 }
 
+async function run(): Promise<void> {
+  await runLogRotation(app())
+}
+
 const { init: initLogRotationInterval } = createServiceInterval({
   name: 'logRotation',
-  worker: async () => {
-    await runLogRotation(app())
-  },
-  getState: async () => true,
+  worker: run,
   interval: LOG_ROTATION_INTERVAL,
 })

--- a/apps/mobile/src/managers/perfMonitor.ts
+++ b/apps/mobile/src/managers/perfMonitor.ts
@@ -8,15 +8,16 @@ import {
   getUiFps,
 } from 'react-native-performance-toolkit'
 
+function run(): void {
+  const cpu = getCpuUsage()
+  const mem = getMemoryUsage()
+  const jsFps = getJsFps()
+  const uiFps = getUiFps()
+  logger.info('perfMonitor', 'tick', { cpu, mem, jsFps, uiFps })
+}
+
 export const { init: initPerfMonitor } = createServiceInterval({
   name: 'perfMonitor',
-  worker: () => {
-    const cpu = getCpuUsage()
-    const mem = getMemoryUsage()
-    const jsFps = getJsFps()
-    const uiFps = getUiFps()
-    logger.info('perfMonitor', 'tick', { cpu, mem, jsFps, uiFps })
-  },
-  getState: async () => true,
+  worker: run,
   interval: PERF_MONITOR_INTERVAL,
 })

--- a/apps/mobile/src/managers/syncDownEvents.test.ts
+++ b/apps/mobile/src/managers/syncDownEvents.test.ts
@@ -4,7 +4,7 @@ import type { FileMetadata, FileRecord } from '@siastorage/core/types'
 import type { ObjectEvent, PinnedObjectInterface } from 'react-native-sia'
 import { initializeDB, resetDb } from '../db'
 import { app, internal } from '../stores/appService'
-import { syncDownEvents } from './syncDownEvents'
+import { run } from './syncDownEvents'
 
 function makeLocalObject(params: {
   fileId: string
@@ -98,13 +98,13 @@ describe('syncDownEvents', () => {
 
   test('early exit when not connected', async () => {
     app().connection.setState({ isConnected: false })
-    await syncDownEvents(new AbortController().signal)
+    await run(new AbortController().signal)
   })
 
   test('early exit when no sdk', async () => {
     app().connection.setState({ isConnected: true })
     internal().setSdk(null)
-    await syncDownEvents(new AbortController().signal)
+    await run(new AbortController().signal)
     const cur = await app().sync.getSyncDownCursor()
     expect(cur).toBeUndefined()
   })
@@ -156,7 +156,7 @@ describe('syncDownEvents', () => {
       appKey: () => mockAppKey,
     } as any)
 
-    await syncDownEvents(new AbortController().signal)
+    await run(new AbortController().signal)
 
     const cursor = await app().sync.getSyncDownCursor()
     expect(cursor).toEqual({
@@ -203,7 +203,7 @@ describe('syncDownEvents', () => {
       appKey: () => mockAppKey,
     } as any)
 
-    await syncDownEvents(new AbortController().signal)
+    await run(new AbortController().signal)
 
     const cursor = await app().sync.getSyncDownCursor()
     expect(cursor).toEqual({
@@ -253,7 +253,7 @@ describe('syncDownEvents', () => {
       appKey: () => mockAppKey,
     } as any)
 
-    await syncDownEvents(new AbortController().signal)
+    await run(new AbortController().signal)
 
     expect(removeFileSpy).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'file-1' }),
@@ -318,7 +318,7 @@ describe('syncDownEvents', () => {
       appKey: () => mockAppKey,
     } as any)
 
-    await syncDownEvents(new AbortController().signal)
+    await run(new AbortController().signal)
 
     const updatedFile = await app().files.getByObjectId('obj-1', INDEXER_URL)
     expect(updatedFile).not.toBeNull()
@@ -352,7 +352,7 @@ describe('syncDownEvents', () => {
       appKey: () => mockAppKey,
     } as any)
 
-    await syncDownEvents(new AbortController().signal)
+    await run(new AbortController().signal)
 
     const newFile = await app().files.getByObjectId('obj-1', INDEXER_URL)
     expect(newFile).not.toBeNull()
@@ -413,7 +413,7 @@ describe('syncDownEvents', () => {
       appKey: () => mockAppKey,
     } as any)
 
-    await syncDownEvents(new AbortController().signal)
+    await run(new AbortController().signal)
 
     const updatedFile = await app().files.getByObjectId('obj-1', INDEXER_URL)
     expect(updatedFile).not.toBeNull()
@@ -495,7 +495,7 @@ describe('syncDownEvents', () => {
       appKey: () => mockAppKey,
     } as any)
 
-    await syncDownEvents(new AbortController().signal)
+    await run(new AbortController().signal)
 
     const file2 = await app().files.getByObjectId('obj-1', INDEXER_URL)
     expect(file2).not.toBeNull()
@@ -538,7 +538,7 @@ describe('syncDownEvents', () => {
       appKey: () => mockAppKey,
     } as any)
 
-    await syncDownEvents(new AbortController().signal)
+    await run(new AbortController().signal)
 
     const file = await app().files.getByObjectId('obj-1', INDEXER_URL)
     expect(file).toBeNull()
@@ -592,7 +592,7 @@ describe('syncDownEvents', () => {
 
     removeFileSpy.mockRejectedValueOnce(new Error('FS error'))
 
-    await syncDownEvents(new AbortController().signal)
+    await run(new AbortController().signal)
 
     const cursor = await app().sync.getSyncDownCursor()
     expect(cursor).toEqual({
@@ -658,7 +658,7 @@ describe('syncDownEvents', () => {
 
     mockSdk.objectEvents.mockResolvedValueOnce(events)
 
-    await syncDownEvents(new AbortController().signal)
+    await run(new AbortController().signal)
 
     const cursor = await app().sync.getSyncDownCursor()
     expect(cursor).toBeUndefined()
@@ -695,7 +695,7 @@ describe('syncDownEvents', () => {
       appKey: () => mockAppKey,
     } as any)
 
-    await syncDownEvents(new AbortController().signal)
+    await run(new AbortController().signal)
 
     const thumb = await app().files.getByObjectId('obj-thumb', INDEXER_URL)
     expect(thumb).not.toBeNull()
@@ -752,14 +752,14 @@ describe('syncDownEvents', () => {
       appKey: () => mockAppKey,
     } as any)
 
-    await syncDownEvents(new AbortController().signal)
+    await run(new AbortController().signal)
     const cursor1 = await app().sync.getSyncDownCursor()
     expect(cursor1).toEqual({
       id: 'obj-1',
       after: new Date(NOW_BASE + cursorIncrement),
     })
 
-    await syncDownEvents(new AbortController().signal)
+    await run(new AbortController().signal)
     const cursor2 = await app().sync.getSyncDownCursor()
     expect(cursor2).toEqual({
       id: 'obj-2',
@@ -829,7 +829,7 @@ describe('syncDownEvents', () => {
       appKey: () => mockAppKey,
     } as any)
 
-    const result = await syncDownEvents(new AbortController().signal)
+    const result = await run(new AbortController().signal)
     expect(result).toBe(0)
   })
 
@@ -861,7 +861,7 @@ describe('syncDownEvents', () => {
       appKey: () => mockAppKey,
     } as any)
 
-    const result = await syncDownEvents(new AbortController().signal)
+    const result = await run(new AbortController().signal)
     expect(result).toBeUndefined()
   })
 
@@ -871,7 +871,7 @@ describe('syncDownEvents', () => {
       appKey: () => mockAppKey,
     } as any)
 
-    const result = await syncDownEvents(new AbortController().signal)
+    const result = await run(new AbortController().signal)
     expect(result).toBeUndefined()
   })
 
@@ -918,7 +918,7 @@ describe('syncDownEvents', () => {
       appKey: () => mockAppKey,
     } as any)
 
-    await syncDownEvents(new AbortController().signal)
+    await run(new AbortController().signal)
 
     const file1 = await app().files.getByObjectId('obj-1', INDEXER_URL)
     const file2 = await app().files.getByObjectId('obj-2', INDEXER_URL)
@@ -979,7 +979,7 @@ describe('syncDownEvents', () => {
       appKey: () => mockAppKey,
     } as any)
 
-    await syncDownEvents(new AbortController().signal)
+    await run(new AbortController().signal)
 
     const file1 = await app().files.getByObjectId('obj-1', INDEXER_URL)
     const file2 = await app().files.getByObjectId('obj-2', INDEXER_URL)
@@ -1037,7 +1037,7 @@ describe('syncDownEvents', () => {
       appKey: () => mockAppKey,
     } as any)
 
-    await syncDownEvents(new AbortController().signal)
+    await run(new AbortController().signal)
 
     const t1 = await app().files.getByObjectId('obj-t1', INDEXER_URL)
     const t2 = await app().files.getByObjectId('obj-t2', INDEXER_URL)
@@ -1078,7 +1078,7 @@ describe('syncDownEvents', () => {
       appKey: () => mockAppKey,
     } as any)
 
-    await syncDownEvents(new AbortController().signal)
+    await run(new AbortController().signal)
 
     const fromObj1 = await app().files.getByObjectId('obj-1', INDEXER_URL)
     const fromObj2 = await app().files.getByObjectId('obj-2', INDEXER_URL)
@@ -1141,7 +1141,7 @@ describe('syncDownEvents', () => {
       appKey: () => mockAppKey,
     } as any)
 
-    await syncDownEvents(new AbortController().signal)
+    await run(new AbortController().signal)
 
     const fileRecord = await app().files.getById('file-1')
     expect(fileRecord).not.toBeNull()
@@ -1205,7 +1205,7 @@ describe('syncDownEvents', () => {
       appKey: () => mockAppKey,
     } as any)
 
-    await syncDownEvents(new AbortController().signal)
+    await run(new AbortController().signal)
 
     const fileRecord = await app().files.getById('file-1')
     expect(fileRecord).not.toBeNull()
@@ -1263,7 +1263,7 @@ describe('syncDownEvents', () => {
       appKey: () => mockAppKey,
     } as any)
 
-    await syncDownEvents(new AbortController().signal)
+    await run(new AbortController().signal)
 
     const fileRecord = await app().files.getById('file-1')
     expect(fileRecord).not.toBeNull()
@@ -1317,7 +1317,7 @@ describe('syncDownEvents', () => {
       appKey: () => mockAppKey,
     } as any)
 
-    await syncDownEvents(new AbortController().signal)
+    await run(new AbortController().signal)
 
     const deletedFile = await app().files.getByObjectId('obj-1', INDEXER_URL)
     expect(deletedFile).toBeNull()
@@ -1384,7 +1384,7 @@ describe('syncDownEvents', () => {
       appKey: () => mockAppKey,
     } as any)
 
-    await syncDownEvents(new AbortController().signal)
+    await run(new AbortController().signal)
 
     const fileRecord = await app().files.getById('file-1')
     expect(fileRecord).not.toBeNull()

--- a/apps/mobile/src/managers/syncDownEvents.ts
+++ b/apps/mobile/src/managers/syncDownEvents.ts
@@ -4,9 +4,11 @@ import { syncDownEventsBatch } from '@siastorage/core/services/syncDownEvents'
 import { logger } from '@siastorage/logger'
 import { app, internal } from '../stores/appService'
 
-export async function syncDownEvents(
-  signal: AbortSignal,
-): Promise<number | void> {
+export async function run(signal: AbortSignal): Promise<number | void> {
+  if (!(await app().settings.getAutoSyncDownEvents())) {
+    logger.debug('syncDownEvents', 'skipped', { reason: 'disabled' })
+    return
+  }
   if (!app().connection.getState().isConnected) {
     logger.debug('syncDownEvents', 'skipped', { reason: 'not_connected' })
     return
@@ -23,7 +25,6 @@ export async function syncDownEvents(
 export const { init: initSyncDownEvents, triggerNow: triggerSyncDownEvents } =
   createServiceInterval({
     name: 'syncDownEvents',
-    worker: syncDownEvents,
-    getState: () => app().settings.getAutoSyncDownEvents(),
+    worker: run,
     interval: SYNC_EVENTS_INTERVAL,
   })

--- a/apps/mobile/src/managers/syncNewPhotos.test.ts
+++ b/apps/mobile/src/managers/syncNewPhotos.test.ts
@@ -5,9 +5,9 @@ import { processAssets } from '../lib/processAssets'
 import { app } from '../stores/appService'
 import {
   initSyncNewPhotos,
+  run,
   setAutoSyncNewPhotos,
   setSyncNewPhotosEnabledAt,
-  workNew,
 } from './syncNewPhotos'
 
 jest.useFakeTimers()
@@ -78,6 +78,7 @@ describe('syncNewPhotos', () => {
   beforeEach(async () => {
     jest.clearAllMocks()
     getAssetsAsyncMock.mockReset()
+    await setAutoSyncNewPhotos(true)
     await setSyncNewPhotosEnabledAt(0)
     mockProcessAssetsSuccess()
   })
@@ -86,7 +87,7 @@ describe('syncNewPhotos', () => {
     getAssetsAsyncMock.mockResolvedValueOnce(
       page([asset('a1', '1.jpg', { modificationTime: 5_000 })]),
     )
-    await workNew()
+    await run()
     expect(getAssetsAsyncMock).toHaveBeenCalledWith(
       expect.objectContaining({
         sortBy: [['modificationTime', false]],
@@ -98,7 +99,7 @@ describe('syncNewPhotos', () => {
     getAssetsAsyncMock.mockResolvedValueOnce(
       page([asset('a1', '1.jpg', { modificationTime: 5_000 })]),
     )
-    await workNew()
+    await run()
     const opts = getAssetsAsyncMock.mock.calls[0][0]
     expect(opts).not.toHaveProperty('createdAfter')
     expect(opts).not.toHaveProperty('createdBefore')
@@ -114,7 +115,7 @@ describe('syncNewPhotos', () => {
         asset('a4', 'old.jpg', { modificationTime: 2_000 }),
       ]),
     )
-    await workNew()
+    await run()
     expect(processAssetsMock).toHaveBeenCalledWith(
       [
         expect.objectContaining({ id: 'a1', name: 'new1.jpg' }),
@@ -134,13 +135,13 @@ describe('syncNewPhotos', () => {
         asset('a2', '2.jpg', { modificationTime: 3_000 }),
       ]),
     )
-    await workNew()
+    await run()
     expect(processAssetsMock).not.toHaveBeenCalled()
   })
 
   it('no photos returns early without processing', async () => {
     getAssetsAsyncMock.mockResolvedValueOnce(page([]))
-    await workNew()
+    await run()
     expect(processAssetsMock).not.toHaveBeenCalled()
   })
 
@@ -149,7 +150,7 @@ describe('syncNewPhotos', () => {
       asset(`a${i}`, `${i}.jpg`, { modificationTime: 10_000 - i }),
     )
     getAssetsAsyncMock.mockResolvedValueOnce(page(fullPage, 'cursor-page-1'))
-    await workNew()
+    await run()
     expect(getAssetsAsyncMock).toHaveBeenCalledTimes(1)
     expect(processAssetsMock).toHaveBeenCalledTimes(1)
     expect(processAssetsMock.mock.calls[0][0]).toHaveLength(50)
@@ -164,7 +165,7 @@ describe('syncNewPhotos', () => {
         }),
       ]),
     )
-    await workNew()
+    await run()
     expect(processAssetsMock).toHaveBeenCalledWith(
       [
         expect.objectContaining({

--- a/apps/mobile/src/managers/syncNewPhotos.ts
+++ b/apps/mobile/src/managers/syncNewPhotos.ts
@@ -37,9 +37,15 @@ import { app } from '../stores/appService'
 
 const PAGE_SIZE = 50
 
-export async function workNew(signal?: AbortSignal): Promise<void> {
-  logger.debug('syncNewPhotos', 'tick')
-  if (!(await getMediaLibraryPermissions())) return
+export async function run(signal?: AbortSignal): Promise<void> {
+  if (!(await getAutoSyncNewPhotos())) {
+    logger.debug('syncNewPhotos', 'skipped', { reason: 'disabled' })
+    return
+  }
+  if (!(await getMediaLibraryPermissions())) {
+    logger.debug('syncNewPhotos', 'skipped', { reason: 'no_permission' })
+    return
+  }
   if (signal?.aborted) return
   const enabledAt = await getSyncNewPhotosEnabledAt()
 
@@ -88,8 +94,7 @@ export async function workNew(signal?: AbortSignal): Promise<void> {
 
 export const { init: initSyncNewPhotos } = createServiceInterval({
   name: 'syncNewPhotos',
-  worker: workNew,
-  getState: () => getAutoSyncNewPhotos(),
+  worker: run,
   interval: SYNC_NEW_PHOTOS_INTERVAL,
 })
 

--- a/apps/mobile/src/managers/syncPhotosArchive.test.ts
+++ b/apps/mobile/src/managers/syncPhotosArchive.test.ts
@@ -9,11 +9,11 @@ import {
   getPhotosArchiveCursor,
   getPhotosArchiveDisplayDate,
   restartPhotosArchiveCursor,
+  run,
   setAutoSyncPhotosArchive,
   setLastRecentScanAt,
   setPhotosArchiveCursor,
   triggerRecentScanIfNeeded,
-  workBackward,
 } from './syncPhotosArchive'
 
 jest.useFakeTimers()
@@ -101,7 +101,7 @@ describe('syncPhotosArchive', () => {
     getAssetsAsyncMock.mockResolvedValueOnce(
       page([asset('a1', '1.jpg', { modificationTime: 50_000 })], 'ref1'),
     )
-    await workBackward()
+    await run()
     expect(getAssetsAsyncMock).toHaveBeenCalledWith(
       expect.objectContaining({
         sortBy: [['modificationTime', false]],
@@ -114,7 +114,7 @@ describe('syncPhotosArchive', () => {
     getAssetsAsyncMock.mockResolvedValueOnce(
       page([asset('a1', '1.jpg', { modificationTime: 50_000 })], 'ref1'),
     )
-    await workBackward()
+    await run()
     const opts = getAssetsAsyncMock.mock.calls[0][0]
     expect(opts).not.toHaveProperty('createdBefore')
     expect(opts).not.toHaveProperty('createdAfter')
@@ -125,7 +125,7 @@ describe('syncPhotosArchive', () => {
     getAssetsAsyncMock.mockResolvedValueOnce(
       page([asset('a1', '1.jpg', { modificationTime: 50_000 })], 'ref1'),
     )
-    await workBackward()
+    await run()
     expect(getAssetsAsyncMock.mock.calls[0][0]?.after).toBeUndefined()
   })
 
@@ -134,7 +134,7 @@ describe('syncPhotosArchive', () => {
     getAssetsAsyncMock.mockResolvedValueOnce(
       page([asset('a1', '1.jpg', { modificationTime: 30_000 })], 'next-ref'),
     )
-    await workBackward()
+    await run()
     expect(getAssetsAsyncMock.mock.calls[0][0]?.after).toBe('some-asset-ref')
   })
 
@@ -149,20 +149,20 @@ describe('syncPhotosArchive', () => {
         'page-end-ref',
       ),
     )
-    await workBackward()
+    await run()
     expect(await getPhotosArchiveCursor()).toBe('page-end-ref')
   })
 
   it('cursor "done" means fully synced — returns early', async () => {
     await setPhotosArchiveCursor('done')
-    await workBackward()
+    await run()
     expect(getAssetsAsyncMock).not.toHaveBeenCalled()
   })
 
   it('sets cursor to "done" when no assets remain', async () => {
     await setPhotosArchiveCursor('some-ref')
     getAssetsAsyncMock.mockResolvedValueOnce(page([]))
-    await workBackward()
+    await run()
     expect(await getPhotosArchiveCursor()).toBe('done')
     expect(processAssetsMock).not.toHaveBeenCalled()
   })
@@ -179,7 +179,7 @@ describe('syncPhotosArchive', () => {
         'ref3',
       ),
     )
-    await workBackward()
+    await run()
     expect(await getPhotosArchiveDisplayDate()).toBe(40_000)
   })
 
@@ -203,7 +203,7 @@ describe('syncPhotosArchive', () => {
         'ref1',
       ),
     )
-    await workBackward()
+    await run()
     expect(processAssetsMock).toHaveBeenCalledWith(
       [
         expect.objectContaining({
@@ -227,7 +227,7 @@ describe('syncPhotosArchive', () => {
         'ref3',
       ),
     )
-    await workBackward()
+    await run()
     expect(processAssetsMock).toHaveBeenCalledWith(
       [
         expect.objectContaining({ id: 'a1' }),
@@ -250,7 +250,7 @@ describe('syncPhotosArchive', () => {
     })
 
     await restartPhotosArchiveCursor()
-    await workBackward(ac.signal)
+    await run(ac.signal)
 
     expect(processAssetsMock).not.toHaveBeenCalled()
   })
@@ -298,7 +298,7 @@ describe('syncPhotosArchive', () => {
           'ref1',
         ),
       )
-      await workBackward()
+      await run()
 
       expect(processAssetsMock).toHaveBeenCalledTimes(1)
       expect(await getPhotosArchiveCursor()).toBe('done')
@@ -318,7 +318,7 @@ describe('syncPhotosArchive', () => {
           'ref2',
         ),
       )
-      await workBackward()
+      await run()
 
       expect(await getPhotosArchiveCursor()).toBe('ref2')
       expect(await getPhotosArchiveDisplayDate()).toBe(1_000)
@@ -340,7 +340,7 @@ describe('syncPhotosArchive', () => {
           'ref1',
         ),
       )
-      await workBackward()
+      await run()
 
       expect(processAssetsMock).toHaveBeenCalledWith(
         [

--- a/apps/mobile/src/managers/syncPhotosArchive.ts
+++ b/apps/mobile/src/managers/syncPhotosArchive.ts
@@ -54,9 +54,15 @@ const CURSOR_START = 'start'
 
 let recentScanBoundary = 0
 
-export async function workBackward(signal?: AbortSignal) {
-  logger.debug('syncPhotosArchive', 'tick')
-  if (!(await getMediaLibraryPermissions())) return
+export async function run(signal?: AbortSignal) {
+  if (!(await getAutoSyncPhotosArchive())) {
+    logger.debug('syncPhotosArchive', 'skipped', { reason: 'disabled' })
+    return
+  }
+  if (!(await getMediaLibraryPermissions())) {
+    logger.debug('syncPhotosArchive', 'skipped', { reason: 'no_permission' })
+    return
+  }
   if (signal?.aborted) return
   const { count, totalBytes } = await getFileStatsLocal({ localOnly: true })
   if (totalBytes >= SYNC_ARCHIVE_RESUME_THRESHOLD) {
@@ -68,7 +74,10 @@ export async function workBackward(signal?: AbortSignal) {
     return
   }
   const cursor = await getPhotosArchiveCursor()
-  if (cursor === CURSOR_DONE) return
+  if (cursor === CURSOR_DONE) {
+    logger.debug('syncPhotosArchive', 'skipped', { reason: 'fully_synced' })
+    return
+  }
 
   logger.info('syncPhotosArchive', 'query', {
     cursor: cursor === CURSOR_START ? 'start' : cursor,
@@ -162,8 +171,7 @@ export async function workBackward(signal?: AbortSignal) {
 
 export const { init: initSyncPhotosArchive } = createServiceInterval({
   name: 'syncPhotosArchive',
-  worker: workBackward,
-  getState: async () => getAutoSyncPhotosArchive(),
+  worker: run,
   interval: SYNC_PHOTOS_ARCHIVE_INTERVAL,
 })
 

--- a/apps/mobile/src/managers/syncUpMetadata.ts
+++ b/apps/mobile/src/managers/syncUpMetadata.ts
@@ -4,7 +4,8 @@ import {
   SYNC_UP_METADATA_INTERVAL,
 } from '@siastorage/core/config'
 import { createServiceInterval } from '@siastorage/core/lib/serviceInterval'
-import { runSyncUpMetadataBatch } from '@siastorage/core/services/syncUpMetadata'
+import { syncUpMetadataBatch } from '@siastorage/core/services/syncUpMetadata'
+import { logger } from '@siastorage/logger'
 import { app, internal } from '../stores/appService'
 
 export async function runSyncUpMetadata(
@@ -12,7 +13,7 @@ export async function runSyncUpMetadata(
   signal?: AbortSignal,
 ): Promise<void> {
   const effectiveSignal = signal ?? new AbortController().signal
-  return runSyncUpMetadataBatch(
+  return syncUpMetadataBatch(
     batchSize,
     SYNC_UP_METADATA_CONCURRENCY,
     effectiveSignal,
@@ -21,11 +22,16 @@ export async function runSyncUpMetadata(
   )
 }
 
+async function run(signal: AbortSignal): Promise<void> {
+  if (app().sync.getState().isSyncingDown) {
+    logger.debug('syncUpMetadata', 'skipped', { reason: 'syncing_down' })
+    return
+  }
+  return runSyncUpMetadata(SYNC_UP_METADATA_BATCH_SIZE, signal)
+}
+
 export const { init: initSyncUpMetadata } = createServiceInterval({
   name: 'syncUpMetadata',
-  worker: async (signal) => {
-    return runSyncUpMetadata(SYNC_UP_METADATA_BATCH_SIZE, signal)
-  },
-  getState: async () => true,
+  worker: run,
   interval: SYNC_UP_METADATA_INTERVAL,
 })

--- a/apps/mobile/src/managers/thumbnailScanner.ts
+++ b/apps/mobile/src/managers/thumbnailScanner.ts
@@ -4,6 +4,7 @@ import {
   ThumbnailScanner,
   type ThumbnailScannerResult,
 } from '@siastorage/core/services/thumbnailScanner'
+import { logger } from '@siastorage/logger'
 import { app } from '../stores/appService'
 
 const scanner = new ThumbnailScanner()
@@ -30,11 +31,16 @@ export async function runThumbnailScanner(
   return result
 }
 
+async function run(signal: AbortSignal): Promise<void> {
+  if (app().sync.getState().isSyncingDown) {
+    logger.debug('thumbnailScanner', 'skipped', { reason: 'syncing_down' })
+    return
+  }
+  await runThumbnailScanner(signal)
+}
+
 export const { init: initThumbnailScanner } = createServiceInterval({
   name: 'thumbnailScanner',
-  worker: async (signal) => {
-    await runThumbnailScanner(signal)
-  },
-  getState: async () => true,
+  worker: run,
   interval: THUMBNAIL_SCANNER_INTERVAL,
 })

--- a/packages/core/src/lib/serviceInterval.ts
+++ b/packages/core/src/lib/serviceInterval.ts
@@ -11,7 +11,6 @@ type ServiceIntervalOptions = {
   worker: (
     signal: AbortSignal,
   ) => void | undefined | number | Promise<void | undefined | number>
-  getState: () => Promise<boolean>
   interval: number
 }
 
@@ -40,12 +39,10 @@ export class ServiceScheduler {
     return this.paused
   }
 
-  createInterval({
-    name,
-    worker,
-    getState,
-    interval,
-  }: ServiceIntervalOptions): { init: () => void; triggerNow: () => void } {
+  createInterval({ name, worker, interval }: ServiceIntervalOptions): {
+    init: () => void
+    triggerNow: () => void
+  } {
     let running = false
     let runTick: (() => void) | null = null
 
@@ -78,18 +75,6 @@ export class ServiceScheduler {
         // Guard against stale ticks created before the latest init.
         const current = this.schedulerStateMap.get(name)
         if (!current || current.token !== token) return
-
-        const enabled = await getState()
-
-        // Re-check after awaiting, in case another init occurred while waiting.
-        const stillCurrent = this.schedulerStateMap.get(name)
-        if (!stillCurrent || stillCurrent.token !== token) return
-
-        if (!enabled) {
-          // Service disabled: skip work but still schedule the next check.
-          scheduleNextRun(interval)
-          return
-        }
 
         running = true
         let nextInterval = interval

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -13,8 +13,8 @@ export { type OrphanScannerResult, runOrphanScanner } from './orphanScanner'
 export { syncDownEventsBatch } from './syncDownEvents'
 export {
   diffFileMetadata,
-  runSyncUpMetadataBatch,
   type SyncUpCursor,
+  syncUpMetadataBatch,
 } from './syncUpMetadata'
 export {
   computeTargetDimensions,

--- a/packages/core/src/services/logRotation.ts
+++ b/packages/core/src/services/logRotation.ts
@@ -14,6 +14,7 @@ export async function runLogRotation(app: AppService): Promise<void> {
   try {
     const count = await app.logs.count()
     if (count <= MAX_LOGS) {
+      logger.debug('logRotation', 'skipped', { reason: 'under_limit', count })
       return
     }
     const deleted = await app.logs.rotate(MAX_LOGS)

--- a/packages/core/src/services/syncDownEvents.ts
+++ b/packages/core/src/services/syncDownEvents.ts
@@ -150,14 +150,15 @@ export async function syncDownEventsBatch(
     deleted: counts.deleted,
   })
 
+  const willContinue = totalEventsFetched > 1 && !signal.aborted
   app.sync.setState({
-    isSyncingDown: false,
+    isSyncingDown: willContinue,
     syncDownExisting: counts.existing,
     syncDownAdded: counts.added,
     syncDownDeleted: counts.deleted,
   })
 
-  if (totalEventsFetched > 1) {
+  if (willContinue) {
     return 0 // Zero interval — poll again immediately.
   }
 }

--- a/packages/core/src/services/syncUpMetadata.ts
+++ b/packages/core/src/services/syncUpMetadata.ts
@@ -66,7 +66,7 @@ async function tryWithLog<T>(
  * rows on non-current indexers. Alternatively, the cursor could be reset
  * or stored per-indexer when multi-indexer support is added.
  */
-export async function runSyncUpMetadataBatch(
+export async function syncUpMetadataBatch(
   batchSize: number,
   concurrency: number,
   signal: AbortSignal,


### PR DESCRIPTION
- Remove getState from ServiceScheduler, standardize all workers to named work functions with structured skip logging.
- Thumbnail scanner defers during sync-down since we don't yet know which thumbnails already exist.
- Fix isSyncingDown briefly dropping to false between re-polls.
