### PR TITLE
fix(mobile): update carousel cache when current file changes

### DIFF
--- a/apps/mobile/src/stores/fileCarousel.ts
+++ b/apps/mobile/src/stores/fileCarousel.ts
@@ -4,6 +4,15 @@ import type { FileRecord } from '@siastorage/core/types'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { app } from './appService'
 
+function fileRecordEqual(a: FileRecord, b: FileRecord): boolean {
+  return (
+    a.id === b.id &&
+    a.updatedAt === b.updatedAt &&
+    a.hash === b.hash &&
+    Object.keys(a.objects).length === Object.keys(b.objects).length
+  )
+}
+
 type VirtualListQueryParams = {
   sortBy: SortBy
   sortDir: SortDir
@@ -155,14 +164,7 @@ export function useFileCarousel({
       indexToFile.forEach((file, index) => {
         positionMapRef.current.set(index, file.id)
         const existing = fileCacheRef.current.get(file.id)
-        if (
-          existing &&
-          existing.updatedAt === file.updatedAt &&
-          Object.keys(existing.objects).length ===
-            Object.keys(file.objects).length
-        ) {
-          return
-        }
+        if (existing && fileRecordEqual(existing, file)) return
         fileCacheRef.current.set(file.id, file)
         changed = true
       })
@@ -313,6 +315,10 @@ export function useFileCarousel({
     populateCaches,
   ])
 
+  // The prefetch loop only queries files near the current index — it won't
+  // re-fetch a file already in cache. This listener handles the case where
+  // the current file's record changes while being viewed (e.g. import
+  // scanner finalizes hash, upload adds a sealed object).
   useOnLibraryListChange(() => {
     if (isLoading) return
     const currentFileID = currentFileIdRef.current
@@ -323,6 +329,12 @@ export function useFileCarousel({
       .then((file) => {
         if (!file) {
           onDeleted?.()
+          return
+        }
+        const existing = fileCacheRef.current.get(currentFileID)
+        if (!existing || !fileRecordEqual(existing, file)) {
+          fileCacheRef.current.set(currentFileID, file)
+          setCacheVersion((v) => v + 1)
         }
       })
       .catch(() => {})


### PR DESCRIPTION
- The library change listener only checked for file deletion. When the import scanner finalizes a file (sets hash) or an upload completes (adds sealed object), the carousel cache was stale — the viewer would keep showing "importing" status.
- Now re-fetches the current file on library changes and updates the cache if the record differs.
