### PR TITLE
feat(mobile): instant file import and background import scanner

### DIFF
--- a/.changeset/optimistic-file-import.md
+++ b/.changeset/optimistic-file-import.md
@@ -1,0 +1,5 @@
+---
+mobile: minor
+---
+
+Files now appear in the library immediately when importing, with a "Processing" indicator while copying and hashing completes in the background.

--- a/.changeset/skip-redundant-file-copy.md
+++ b/.changeset/skip-redundant-file-copy.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Eliminated a redundant file copy when importing via the document picker, halving import time for large files.

--- a/apps/mobile/src/components/AddFileActionSheet.tsx
+++ b/apps/mobile/src/components/AddFileActionSheet.tsx
@@ -4,7 +4,6 @@ import { useCallback } from 'react'
 import { useCameraCapture } from '../hooks/useCameraCapture'
 import { useDocumentPicker } from '../hooks/useDocumentPicker'
 import { useImagePicker } from '../hooks/useImagePicker'
-import { useUploader } from '../managers/uploader'
 import { closeSheet, useSheetOpen } from '../stores/sheets'
 import { ActionSheet } from './ActionSheet'
 import { ActionSheetButton } from './ActionSheetButton'
@@ -22,38 +21,36 @@ export function AddFileActionSheet({
   const pickImages = useImagePicker()
   const capture = useCameraCapture()
   const pickDocuments = useDocumentPicker()
-  const uploader = useUploader()
 
-  const pickAndUpload = useCallback(
+  const pickAndClose = useCallback(
     async (picker: () => Promise<FileRecord[]>) => {
       await closeSheet()
       const files = await picker()
       if (files.length > 0) {
         onFilesAdded?.(files)
-        await uploader(files)
       }
     },
-    [onFilesAdded, uploader],
+    [onFilesAdded],
   )
 
   return (
     <ActionSheet visible={isOpen} onRequestClose={closeSheet}>
       <ActionSheetButton
         icon={<CameraIcon size={18} />}
-        onPress={() => void pickAndUpload(capture)}
+        onPress={() => void pickAndClose(capture)}
       >
         Take Photo or Video
       </ActionSheetButton>
       <ActionSheetButton
         testID="action-choose-from-photos"
         icon={<ImageIcon size={18} />}
-        onPress={() => void pickAndUpload(pickImages)}
+        onPress={() => void pickAndClose(pickImages)}
       >
         Choose from Photos
       </ActionSheetButton>
       <ActionSheetButton
         icon={<FileIcon size={18} />}
-        onPress={() => void pickAndUpload(pickDocuments)}
+        onPress={() => void pickAndClose(pickDocuments)}
       >
         Import from Files
       </ActionSheetButton>

--- a/apps/mobile/src/components/Button.tsx
+++ b/apps/mobile/src/components/Button.tsx
@@ -59,6 +59,7 @@ const styles = StyleSheet.create({
     backgroundColor: colors.accentPrimary,
     borderRadius: 10,
     paddingVertical: 12,
+    paddingHorizontal: 24,
     alignItems: 'center',
   },
   secondaryButton: {
@@ -66,12 +67,14 @@ const styles = StyleSheet.create({
     boxShadow: `0 0 0 1px ${whiteA.a02}`,
     borderRadius: 10,
     paddingVertical: 12,
+    paddingHorizontal: 24,
     alignItems: 'center',
   },
   dangerButton: {
     backgroundColor: palette.red[500],
     borderRadius: 10,
     paddingVertical: 12,
+    paddingHorizontal: 24,
     alignItems: 'center',
   },
   primaryButtonText: { color: palette.gray[50], fontWeight: '700' },

--- a/apps/mobile/src/components/ShareIntentConsumer.tsx
+++ b/apps/mobile/src/components/ShareIntentConsumer.tsx
@@ -2,15 +2,13 @@ import { useHasOnboarded } from '@siastorage/core/stores'
 import { logger } from '@siastorage/logger'
 import { useShareIntentContext } from 'expo-share-intent'
 import { useEffect } from 'react'
-import { processAssets } from '../lib/processAssets'
+import { importFiles } from '../lib/processAssets'
 import { useToast } from '../lib/toastContext'
-import { useUploader } from '../managers/uploader'
 
 export function ShareIntentConsumer() {
   const { data: hasOnboarded } = useHasOnboarded()
   const { hasShareIntent, shareIntent, resetShareIntent } =
     useShareIntentContext()
-  const uploader = useUploader()
   const toast = useToast()
 
   useEffect(() => {
@@ -29,7 +27,7 @@ export function ShareIntentConsumer() {
           return
         }
 
-        const { files: processedFiles, warnings } = await processAssets(
+        await importFiles(
           files.map((file) => ({
             id: undefined,
             name: file.fileName ?? 'Shared File',
@@ -39,14 +37,7 @@ export function ShareIntentConsumer() {
             sourceUri: file.path,
           })),
           'file',
-          { allowDuplicates: true },
         )
-
-        if (warnings.length > 0) {
-          warnings.forEach((warning) => toast.show(warning))
-        }
-
-        await uploader(processedFiles)
       } catch (error) {
         logger.error('shareIntent', 'process_failed', { error: error as Error })
         toast.show('Failed to import shared files.')
@@ -56,14 +47,7 @@ export function ShareIntentConsumer() {
     }
 
     void handleShareIntent()
-  }, [
-    hasOnboarded,
-    hasShareIntent,
-    shareIntent,
-    resetShareIntent,
-    toast,
-    uploader,
-  ])
+  }, [hasOnboarded, hasShareIntent, shareIntent, resetShareIntent, toast])
 
   return null
 }

--- a/apps/mobile/src/hooks/useCameraCapture.ts
+++ b/apps/mobile/src/hooks/useCameraCapture.ts
@@ -3,9 +3,8 @@ import { logger } from '@siastorage/logger'
 import { useCallback, useRef } from 'react'
 import * as ImagePicker from 'react-native-image-picker'
 import { extFromMime, getMimeType } from '../lib/fileTypes'
-import { processAssets } from '../lib/processAssets'
+import { importFiles } from '../lib/processAssets'
 import { useToast } from '../lib/toastContext'
-import { useUploader } from '../managers/uploader'
 
 export function useCameraCapture() {
   const toast = useToast()
@@ -22,7 +21,9 @@ export function useCameraCapture() {
         mediaType: 'mixed',
         saveToPhotos: false,
         includeExtra: true,
-        // Docs: A mode that determines which representation to use if an asset contains more than one on iOS or disables HEIC/HEIF to JPEG conversion on Android if set to 'current'.
+        // Docs: A mode that determines which representation to use if an asset
+        // contains more than one on iOS or disables HEIC/HEIF to JPEG conversion on Android
+        // if set to 'current'.
         assetRepresentationMode: 'current',
         quality: 1,
         videoQuality: 'high',
@@ -46,7 +47,7 @@ export function useCameraCapture() {
         return []
       }
 
-      const { files, warnings } = await processAssets(
+      return importFiles(
         await Promise.all(
           (result.assets ?? []).map(async (a) => ({
             id: a.id,
@@ -65,13 +66,7 @@ export function useCameraCapture() {
           })),
         ),
         'file',
-        { allowDuplicates: true },
       )
-      if (warnings.length > 0) {
-        warnings.forEach((warning) => toast.show(warning))
-      }
-
-      return files
     } catch (e) {
       logger.error('cameraCapture', 'error', { error: e as Error })
       return []
@@ -81,19 +76,8 @@ export function useCameraCapture() {
   }, [toast])
 }
 
-export function useCameraCaptureAndUpload() {
-  const capture = useCameraCapture()
-  const uploader = useUploader()
-  return useCallback(async () => {
-    const files = await capture()
-    if (files && files.length > 0) {
-      await uploader(files)
-    }
-  }, [capture, uploader])
-}
-
 /* Build a date-based file name from a timestamp and mime type.
- * eg: Camera Capture 2025-11-03 2.36.59 PM.jpg
+ * eg: Camera Capture 2025-11-03 2.36.59 PM.jpg
  */
 function buildDateFileName(
   timestamp: string | undefined,

--- a/apps/mobile/src/hooks/useDocumentPicker.ts
+++ b/apps/mobile/src/hooks/useDocumentPicker.ts
@@ -2,12 +2,9 @@ import type { FileRecord } from '@siastorage/core/types'
 import { logger } from '@siastorage/logger'
 import * as DocumentPicker from 'expo-document-picker'
 import { useCallback, useRef } from 'react'
-import { processAssets } from '../lib/processAssets'
-import { useToast } from '../lib/toastContext'
-import { useUploader } from '../managers/uploader'
+import { importFiles } from '../lib/processAssets'
 
 export function useDocumentPicker() {
-  const toast = useToast()
   const isPickingRef = useRef<boolean>(false)
   return useCallback(async (): Promise<FileRecord[]> => {
     if (isPickingRef.current) {
@@ -20,7 +17,7 @@ export function useDocumentPicker() {
       const result = await DocumentPicker.getDocumentAsync({
         multiple: true,
         type: '*/*',
-        copyToCacheDirectory: true,
+        copyToCacheDirectory: false,
       })
 
       if (result.canceled) {
@@ -28,7 +25,7 @@ export function useDocumentPicker() {
         return []
       }
 
-      const { files, warnings } = await processAssets(
+      return importFiles(
         result.assets?.map((a) => ({
           id: undefined,
           name: a.name,
@@ -38,29 +35,12 @@ export function useDocumentPicker() {
           sourceUri: a.uri,
         })),
         'file',
-        { allowDuplicates: true },
       )
-      if (warnings.length > 0) {
-        warnings.forEach((warning) => toast.show(warning))
-      }
-
-      return files
     } catch (e) {
       logger.error('documentPicker', 'error', { error: e as Error })
       return []
     } finally {
       isPickingRef.current = false
     }
-  }, [toast.show])
-}
-
-export function useDocumentPickerAndUpload() {
-  const pickAssets = useDocumentPicker()
-  const uploader = useUploader()
-  return useCallback(async () => {
-    const files = await pickAssets()
-    if (files.length > 0) {
-      await uploader(files)
-    }
-  }, [pickAssets, uploader])
+  }, [])
 }

--- a/apps/mobile/src/hooks/useImagePicker.ts
+++ b/apps/mobile/src/hooks/useImagePicker.ts
@@ -2,12 +2,9 @@ import type { FileRecord } from '@siastorage/core/types'
 import { logger } from '@siastorage/logger'
 import { useCallback, useRef } from 'react'
 import * as ImagePicker from 'react-native-image-picker'
-import { processAssets } from '../lib/processAssets'
-import { useToast } from '../lib/toastContext'
-import { useUploader } from '../managers/uploader'
+import { importFiles } from '../lib/processAssets'
 
 export function useImagePicker() {
-  const toast = useToast()
   const isPickingRef = useRef<boolean>(false)
   return useCallback(async (): Promise<FileRecord[]> => {
     if (isPickingRef.current) {
@@ -22,7 +19,9 @@ export function useImagePicker() {
         // 0 => unlimited on iOS; Android uses picker default multi-select UI if available.
         selectionLimit: 0,
         includeExtra: true,
-        // Docs: A mode that determines which representation to use if an asset contains more than one on iOS or disables HEIC/HEIF to JPEG conversion on Android if set to 'current'.
+        // Docs: A mode that determines which representation to use if an asset
+        // contains more than one on iOS or disables HEIC/HEIF to JPEG conversion on Android
+        // if set to 'current'.
         assetRepresentationMode: 'current',
         videoQuality: 'high',
         quality: 1,
@@ -40,7 +39,7 @@ export function useImagePicker() {
         return []
       }
 
-      const { files, warnings } = await processAssets(
+      return importFiles(
         result.assets?.map((a) => ({
           id: a.id,
           name: a.fileName,
@@ -50,28 +49,12 @@ export function useImagePicker() {
           sourceUri: a.uri,
         })),
         'file',
-        { allowDuplicates: true },
       )
-      if (warnings.length > 0) {
-        warnings.forEach((warning) => toast.show(warning))
-      }
-      return files
     } catch (e) {
       logger.error('imagePicker', 'error', { error: e as Error })
       return []
     } finally {
       isPickingRef.current = false
     }
-  }, [toast.show])
-}
-
-export function useImagePickerAndUpload() {
-  const pickAssets = useImagePicker()
-  const uploader = useUploader()
-  return useCallback(async () => {
-    const files = await pickAssets()
-    if (files.length > 0) {
-      await uploader(files)
-    }
-  }, [pickAssets, uploader])
+  }, [])
 }

--- a/apps/mobile/src/lib/file.test.ts
+++ b/apps/mobile/src/lib/file.test.ts
@@ -1,0 +1,143 @@
+import type { FileRecord } from '@siastorage/core/types'
+import { computeFileStatus, fileRecordEqual } from './file'
+
+function makeFileRecord(overrides?: Partial<FileRecord>): FileRecord {
+  return {
+    id: 'file-1',
+    name: 'photo.jpg',
+    type: 'image/jpeg',
+    kind: 'file',
+    size: 1000,
+    hash: 'sha256:abc123',
+    createdAt: 1000,
+    updatedAt: 2000,
+    localId: null,
+    addedAt: 1000,
+    trashedAt: null,
+    deletedAt: null,
+    objects: {},
+    ...overrides,
+  }
+}
+
+describe('fileRecordEqual', () => {
+  it('returns true when updatedAt, hash, and objects match', () => {
+    const a = makeFileRecord()
+    const b = makeFileRecord()
+    expect(fileRecordEqual(a, b)).toBe(true)
+  })
+
+  it('returns true when both have same number of objects', () => {
+    const objects = {
+      'https://indexer.example.com': {} as any,
+    }
+    const a = makeFileRecord({ objects })
+    const b = makeFileRecord({ objects })
+    expect(fileRecordEqual(a, b)).toBe(true)
+  })
+
+  it('returns false when updatedAt differs', () => {
+    const a = makeFileRecord({ updatedAt: 2000 })
+    const b = makeFileRecord({ updatedAt: 3000 })
+    expect(fileRecordEqual(a, b)).toBe(false)
+  })
+
+  it('returns false when hash differs (processing to finalized transition)', () => {
+    const a = makeFileRecord({ hash: '' })
+    const b = makeFileRecord({ hash: 'sha256:abc123' })
+    expect(fileRecordEqual(a, b)).toBe(false)
+  })
+
+  it('returns false when objects count differs', () => {
+    const a = makeFileRecord({ objects: {} })
+    const b = makeFileRecord({
+      objects: { 'https://indexer.example.com': {} as any },
+    })
+    expect(fileRecordEqual(a, b)).toBe(false)
+  })
+
+  it('returns true when non-compared fields differ', () => {
+    const a = makeFileRecord({ name: 'old.jpg', size: 100 })
+    const b = makeFileRecord({ name: 'new.jpg', size: 200 })
+    expect(fileRecordEqual(a, b)).toBe(true)
+  })
+})
+
+describe('computeFileStatus', () => {
+  const baseArgs = {
+    uploadState: undefined,
+    downloadState: undefined,
+    fileUri: null,
+    errorText: null,
+  }
+
+  describe('isImportFailed', () => {
+    it('is false when file has no lostReason', () => {
+      const file = makeFileRecord({ hash: '', lostReason: null })
+      const status = computeFileStatus({ ...baseArgs, file })
+      expect(status.isImportFailed).toBe(false)
+    })
+
+    it('is true when file has a lostReason', () => {
+      const file = makeFileRecord({
+        hash: '',
+        lostReason: 'Source photo deleted from device',
+      })
+      const status = computeFileStatus({ ...baseArgs, file })
+      expect(status.isImportFailed).toBe(true)
+    })
+
+    it('is true even if file has a hash and lostReason', () => {
+      const file = makeFileRecord({
+        hash: 'sha256:abc',
+        lostReason: 'Failed to copy from device',
+      })
+      const status = computeFileStatus({ ...baseArgs, file })
+      expect(status.isImportFailed).toBe(true)
+    })
+  })
+
+  describe('fileIsGone', () => {
+    it('is true when file has lostReason', () => {
+      const file = makeFileRecord({
+        hash: '',
+        lostReason: 'No local file or source available',
+      })
+      const status = computeFileStatus({ ...baseArgs, file })
+      expect(status.fileIsGone).toBe(true)
+    })
+
+    it('is true when file has no local file, no sealed objects, and not processing', () => {
+      const file = makeFileRecord({ hash: 'sha256:abc', objects: {} })
+      const status = computeFileStatus({ ...baseArgs, file })
+      expect(status.fileIsGone).toBe(true)
+    })
+
+    it('is false when file is still processing (hash empty, no lostReason)', () => {
+      const file = makeFileRecord({ hash: '' })
+      const status = computeFileStatus({ ...baseArgs, file })
+      expect(status.fileIsGone).toBe(false)
+    })
+
+    it('is false when file has local URI', () => {
+      const file = makeFileRecord()
+      const status = computeFileStatus({
+        ...baseArgs,
+        file,
+        fileUri: '/local/file.jpg',
+      })
+      expect(status.fileIsGone).toBe(false)
+    })
+  })
+
+  describe('errorText', () => {
+    it('shows import failed text when lostReason is set', () => {
+      const file = makeFileRecord({
+        hash: '',
+        lostReason: 'Source photo deleted from device',
+      })
+      const status = computeFileStatus({ ...baseArgs, file })
+      expect(status.errorText).toBe('Import failed')
+    })
+  })
+})

--- a/apps/mobile/src/lib/file.ts
+++ b/apps/mobile/src/lib/file.ts
@@ -23,23 +23,32 @@ export type FileItemProps = {
   onLongPressItem?: (item: FileRecord) => void
 }
 
+export function fileRecordEqual(a: FileRecord, b: FileRecord): boolean {
+  return (
+    a.id === b.id &&
+    a.updatedAt === b.updatedAt &&
+    a.hash === b.hash &&
+    // Re-render when sealed objects change (e.g., upload completes) since
+    // updatedAt doesn't change when a local object is added.
+    Object.keys(a.objects).length === Object.keys(b.objects).length
+  )
+}
+
 export function fileItemPropsAreEqual(
   prev: FileItemProps,
   next: FileItemProps,
 ): boolean {
   return (
-    prev.file.id === next.file.id &&
-    prev.file.updatedAt === next.file.updatedAt &&
-    // Re-render when sealed objects change (e.g., upload completes) since
-    // updatedAt doesn't change when a local object is added.
-    Object.keys(prev.file.objects).length ===
-      Object.keys(next.file.objects).length &&
+    fileRecordEqual(prev.file, next.file) &&
     prev.onPressItem === next.onPressItem &&
     prev.onLongPressItem === next.onLongPressItem
   )
 }
 
 export type FileStatus = {
+  isProcessing: boolean
+  isDeferredImport: boolean
+  isImportFailed: boolean
   isUploading: boolean
   isDownloading: boolean
   isUploaded: boolean
@@ -56,7 +65,7 @@ export type FileStatus = {
   errorText: string | null
 }
 
-function computeFileStatus({
+export function computeFileStatus({
   file,
   isShared,
   uploadState,
@@ -71,6 +80,11 @@ function computeFileStatus({
   fileUri: string | null
   errorText: string | null
 }) {
+  const isProcessing = !!file && file.hash === ''
+  // Deferred import: placeholder created by archive sync with localId,
+  // waiting for the scanner to copy from the media library.
+  const isDeferredImport = isProcessing && !fileUri && !!file?.localId
+  const isImportFailed = !!file?.lostReason
   const uploadStatus = uploadState?.status
   const isUploading = ['queued', 'packing', 'packed', 'uploading'].includes(
     uploadStatus ?? '',
@@ -82,6 +96,9 @@ function computeFileStatus({
   const hasSealedObject = fileHasASealedObject(file)
   const isDownloaded = !!fileUri
   return {
+    isProcessing,
+    isDeferredImport,
+    isImportFailed,
     isUploading,
     isDownloading,
     isUploadQueued: uploadStatus === 'queued',
@@ -90,12 +107,21 @@ function computeFileStatus({
     batchFileCount: uploadState?.batchFileCount ?? 0,
     isUploaded: hasSealedObject || !!isShared,
     isDownloaded,
-    isErrored: uploadStatus === 'error' || downloadState?.status === 'error',
+    isErrored:
+      isImportFailed ||
+      uploadStatus === 'error' ||
+      downloadState?.status === 'error',
     uploadProgress: uploadState?.progress ?? 0,
     downloadProgress: downloadState?.progress ?? 0,
     fileUri,
-    fileIsGone: !isUploading && !isDownloading && !hasSealedObject && !fileUri,
-    errorText,
+    fileIsGone:
+      !!file?.lostReason ||
+      (!isProcessing &&
+        !isUploading &&
+        !isDownloading &&
+        !hasSealedObject &&
+        !fileUri),
+    errorText: isImportFailed ? 'Import failed' : errorText,
   }
 }
 

--- a/apps/mobile/src/lib/processAssets.test.ts
+++ b/apps/mobile/src/lib/processAssets.test.ts
@@ -4,7 +4,7 @@ import { copyFileToFs } from '../stores/fs'
 import { calculateContentHash } from './contentHash'
 import { getMimeType } from './fileTypes'
 import { getMediaLibraryUri } from './mediaLibrary'
-import { processAssets } from './processAssets'
+import { catalogAssets, importFiles, syncAssets } from './processAssets'
 
 jest.mock('./deleteFile', () => ({
   permanentlyDeleteFiles: jest.fn(),
@@ -17,6 +17,9 @@ jest.mock('./contentHash', () => ({
 }))
 jest.mock('../managers/thumbnailer', () => ({
   generateThumbnails: jest.fn(),
+}))
+jest.mock('../managers/importScanner', () => ({
+  triggerImportScanner: jest.fn(),
 }))
 jest.mock('./fileTypes', () => {
   const actual = jest.requireActual('./fileTypes')
@@ -35,341 +38,650 @@ afterEach(async () => {
   jest.clearAllMocks()
 })
 
-describe('processAssets', () => {
-  it('creates a new record when no duplicates exist', async () => {
+describe('importFiles — user-initiated manual import', () => {
+  describe('placeholder creation', () => {
+    it('creates records with empty hash so UI shows files before copy completes', async () => {
+      const assets = [
+        {
+          id: undefined,
+          name: 'large.zip',
+          size: 100_000_000,
+          sourceUri: 'file:///tmp/large.zip',
+          type: 'application/zip',
+          timestamp: '2024-06-01',
+        },
+      ]
+
+      const placeholders = await importFiles(assets)
+
+      expect(placeholders).toHaveLength(1)
+      expect(placeholders[0]).toMatchObject({
+        name: 'large.zip',
+        hash: '',
+        size: 100_000_000,
+        kind: 'file',
+      })
+
+      const row = await app().files.getById(placeholders[0].id)
+      expect(row).toBeTruthy()
+      expect(row!.hash).toBe('')
+    })
+
+    it('returns before copy starts so the caller is not blocked by I/O', async () => {
+      let releaseCopy!: () => void
+      const copyBlocker = new Promise<string>((resolve) => {
+        releaseCopy = () => resolve('/local/file.zip')
+      })
+      jest.mocked(copyFileToFs).mockReturnValueOnce(copyBlocker)
+
+      const assets = [
+        {
+          id: undefined,
+          name: 'big.zip',
+          size: 5_000_000_000,
+          sourceUri: 'file:///tmp/big.zip',
+          type: 'application/zip',
+          timestamp: '2024-06-01',
+        },
+      ]
+
+      const placeholders = await importFiles(assets)
+
+      expect(placeholders).toHaveLength(1)
+      const row = await app().files.getById(placeholders[0].id)
+      expect(row).toBeTruthy()
+      expect(row!.hash).toBe('')
+
+      expect(copyFileToFs).toHaveBeenCalledTimes(1)
+
+      releaseCopy()
+      await new Promise((r) => setTimeout(r, 0))
+    })
+
+    it('creates multiple placeholders in a single batch insert', async () => {
+      const assets = [
+        {
+          id: undefined,
+          name: 'file1.txt',
+          size: 10,
+          sourceUri: 'file:///tmp/file1.txt',
+          type: 'text/plain',
+          timestamp: '2024-06-01',
+        },
+        {
+          id: undefined,
+          name: 'file2.txt',
+          size: 20,
+          sourceUri: 'file:///tmp/file2.txt',
+          type: 'text/plain',
+          timestamp: '2024-06-01',
+        },
+        {
+          id: 'local-id-3',
+          name: 'photo.jpg',
+          size: 30,
+          sourceUri: 'file:///tmp/photo.jpg',
+          type: 'image/jpeg',
+          timestamp: '2024-06-01',
+        },
+      ]
+
+      const placeholders = await importFiles(assets)
+      expect(placeholders).toHaveLength(3)
+
+      expect(placeholders[2].localId).toBe('local-id-3')
+
+      await new Promise((r) => setTimeout(r, 0))
+
+      expect(copyFileToFs).toHaveBeenCalledTimes(3)
+    })
+
+    it('skips assets without sourceUri', async () => {
+      const assets = [
+        {
+          id: undefined,
+          name: 'no-uri.zip',
+          size: 500,
+          sourceUri: undefined,
+          type: 'application/zip',
+          timestamp: '2024-06-01',
+        },
+      ]
+
+      const placeholders = await importFiles(assets)
+      expect(placeholders).toHaveLength(0)
+      expect(copyFileToFs).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('background copy', () => {
+    it('fires a background copy to capture ephemeral source URIs', async () => {
+      const assets = [
+        {
+          id: undefined,
+          name: 'doc.pdf',
+          size: 500,
+          sourceUri: 'file:///tmp/doc.pdf',
+          type: 'application/pdf',
+          timestamp: '2024-06-01',
+        },
+      ]
+
+      const placeholders = await importFiles(assets)
+
+      await new Promise((r) => setTimeout(r, 0))
+
+      expect(copyFileToFs).toHaveBeenCalledTimes(1)
+      expect(copyFileToFs).toHaveBeenCalledWith(
+        expect.objectContaining({ id: placeholders[0].id }),
+        'file:///tmp/doc.pdf',
+      )
+    })
+  })
+
+  describe('scanner integration', () => {
+    it('triggers the import scanner so hashing starts promptly', async () => {
+      const { triggerImportScanner } = require('../managers/importScanner')
+      const assets = [
+        {
+          id: undefined,
+          name: 'file.txt',
+          size: 10,
+          sourceUri: 'file:///tmp/file.txt',
+          type: 'text/plain',
+          timestamp: '2024-06-01',
+        },
+      ]
+
+      await importFiles(assets)
+      expect(triggerImportScanner).toHaveBeenCalled()
+    })
+  })
+})
+
+describe('syncAssets — eager background sync for recent photos', () => {
+  describe('dedup', () => {
+    it('skips files already tracked by localId', async () => {
+      await app().files.create({
+        id: 'existing-1',
+        name: 'old.jpg',
+        size: 5,
+        createdAt: 1,
+        updatedAt: 1,
+        type: 'image/jpeg',
+        kind: 'file',
+        localId: '1',
+        hash: '',
+        addedAt: 1,
+        trashedAt: null,
+        deletedAt: null,
+      })
+
+      jest.mocked(getMediaLibraryUri).mockImplementation(async (localId) => {
+        if (localId === '1') return 'file://1'
+        return null
+      })
+      const assets = [
+        {
+          id: '1',
+          name: 'new.jpg',
+          sourceUri: 'file://1',
+          type: 'image/jpeg',
+          timestamp: '2021-01-01',
+        },
+      ]
+      const { files, updatedFiles } = await syncAssets(assets)
+
+      expect(updatedFiles).toHaveLength(1)
+      expect(files).toHaveLength(0)
+      expect(calculateContentHash).not.toHaveBeenCalled()
+      const updated = await app().files.getById('existing-1')
+      expect(updated).toMatchObject({
+        id: 'existing-1',
+        name: 'new.jpg',
+        size: 5,
+      })
+      expect(copyFileToFs).toHaveBeenCalledTimes(0)
+    })
+
+    it('blocks content-hash duplicates from another device', async () => {
+      await app().files.create({
+        id: 'existing',
+        name: 'existing.jpg',
+        size: 10,
+        createdAt: 1,
+        updatedAt: 1,
+        type: 'image/jpeg',
+        kind: 'file',
+        hash: 'sha256:existing-hash',
+        localId: null,
+        addedAt: 1,
+        trashedAt: null,
+        deletedAt: null,
+      })
+
+      jest
+        .mocked(calculateContentHash)
+        .mockImplementation(async () => 'sha256:existing-hash')
+      const assets = [
+        {
+          id: 'same-hash',
+          name: 'same-hash.jpg',
+          sourceUri: 'file://same-hash.jpg',
+          type: 'image/jpeg',
+          timestamp: '2021-01-01',
+        },
+      ]
+      const { files, updatedFiles } = await syncAssets(assets)
+
+      expect(files).toHaveLength(0)
+      expect(updatedFiles).toHaveLength(1)
+      expect(updatedFiles[0]).toMatchObject({ id: 'existing' })
+    })
+
+    it('allows same-hash files within a single batch', async () => {
+      jest.mocked(getMediaLibraryUri).mockImplementation(async () => {
+        return null
+      })
+      jest
+        .mocked(calculateContentHash)
+        .mockImplementation(async () => 'sha256:same-for-all')
+      const assets = [
+        {
+          id: undefined,
+          name: '1.jpg',
+          size: 123,
+          sourceUri: 'file://1.jpg',
+          type: 'image/jpeg',
+          timestamp: '2021-01-01',
+        },
+        {
+          id: undefined,
+          name: '2.jpg',
+          size: 123,
+          sourceUri: 'file://2.jpg',
+          type: 'image/png',
+          timestamp: '2021-01-01',
+        },
+      ]
+
+      const { files } = await syncAssets(assets)
+      expect(files).toHaveLength(2)
+    })
+  })
+
+  describe('file processing', () => {
+    it('creates finalized record with hash and size', async () => {
+      const assets = [
+        {
+          id: '1',
+          name: 'a.jpg',
+          sourceUri: 'file://1',
+          type: 'image/jpeg',
+          timestamp: '2021-01-01',
+        },
+      ]
+
+      const { files } = await syncAssets(assets)
+      expect(files).toHaveLength(1)
+      const rows = await app().files.query({ order: 'ASC' })
+      expect(rows).toHaveLength(1)
+      expect(rows[0]).toMatchObject({
+        id: files[0].id,
+        name: 'a.jpg',
+      })
+      const meta = await app().fs.readMeta(files[0].id)
+      expect(meta).toMatchObject({
+        fileId: files[0].id,
+      })
+    })
+
+    it('prefers full-quality media library URI over sourceUri', async () => {
+      jest.mocked(getMediaLibraryUri).mockImplementation(async () => {
+        return 'file:///full-quality.jpg'
+      })
+      const assets = [
+        {
+          id: 'valid',
+          name: 'no-id.jpg',
+          size: 123,
+          sourceUri: 'file:///tmp/no-id.jpg',
+          type: 'image/jpeg',
+          timestamp: '2021-01-01',
+        },
+      ]
+
+      const { files } = await syncAssets(assets)
+
+      expect(files).toHaveLength(1)
+      expect(getMediaLibraryUri).toHaveBeenCalledTimes(1)
+      expect(getMediaLibraryUri).toHaveBeenCalledWith('valid')
+
+      expect(copyFileToFs).toHaveBeenCalledTimes(1)
+      expect(copyFileToFs).toHaveBeenCalledWith(
+        expect.objectContaining({ id: files[0].id, type: 'image/jpeg' }),
+        'file:///full-quality.jpg',
+      )
+    })
+
+    it('falls back to sourceUri when media library URI is unavailable', async () => {
+      jest.mocked(getMediaLibraryUri).mockImplementation(async () => {
+        return null
+      })
+      const assets = [
+        {
+          id: 'invalid',
+          name: 'file.jpg',
+          sourceUri: 'file:///source.jpg',
+          type: 'image/jpeg',
+          timestamp: '2021-01-01',
+        },
+      ]
+
+      const { files } = await syncAssets(assets)
+
+      expect(files).toHaveLength(1)
+      expect(getMediaLibraryUri).toHaveBeenCalledTimes(1)
+      expect(getMediaLibraryUri).toHaveBeenCalledWith('invalid')
+      expect(copyFileToFs).toHaveBeenCalledTimes(1)
+      const file = await app().files.getById(files[0].id)
+      expect(file).toMatchObject({
+        id: files[0].id,
+      })
+      const meta = await app().fs.readMeta(files[0].id)
+      expect(meta).toMatchObject({
+        fileId: files[0].id,
+      })
+    })
+
+    it('retries MIME detection from local file when initial returns octet-stream', async () => {
+      jest.mocked(getMediaLibraryUri).mockImplementation(async () => {
+        return 'file:///local/photo'
+      })
+      jest
+        .mocked(getMimeType)
+        .mockResolvedValueOnce('application/octet-stream')
+        .mockResolvedValueOnce('image/jpeg')
+
+      const assets = [
+        {
+          id: '1',
+          name: 'data',
+          sourceUri: 'ph://asset-123',
+          type: undefined,
+          timestamp: '2021-01-01',
+        },
+      ]
+
+      const { files } = await syncAssets(assets)
+      expect(files).toHaveLength(1)
+      expect(files[0].type).toBe('image/jpeg')
+      expect(getMimeType).toHaveBeenCalledTimes(2)
+      expect(getMimeType).toHaveBeenNthCalledWith(1, {
+        type: undefined,
+        name: 'data',
+        uri: 'ph://asset-123',
+      })
+      expect(getMimeType).toHaveBeenNthCalledWith(2, {
+        name: 'data',
+        uri: 'file:///local/photo',
+      })
+    })
+
+    it('captures file size from the copied file', async () => {
+      const { rnfsStat } = (
+        global as unknown as { __rnfs: { rnfsStat: jest.Mock } }
+      ).__rnfs
+      rnfsStat.mockResolvedValue({ size: 333 })
+      const assets = [
+        {
+          id: undefined,
+          name: 'no-id.jpg',
+          size: undefined,
+          sourceUri: 'file:///tmp/no-id.jpg',
+          type: 'image/jpeg',
+          timestamp: '2021-01-01',
+        },
+      ]
+      const { files } = await syncAssets(assets)
+      expect(files).toHaveLength(1)
+      expect(files[0].size).toBe(333)
+    })
+  })
+
+  describe('existing records', () => {
+    it('updates existing records with new metadata by default', async () => {
+      await app().files.create({
+        id: 'existing-1',
+        name: 'old.jpg',
+        size: 5,
+        createdAt: 1,
+        updatedAt: 1,
+        type: 'image/jpeg',
+        kind: 'file',
+        localId: '1',
+        hash: '',
+        addedAt: 1,
+        trashedAt: null,
+        deletedAt: null,
+      })
+
+      jest.mocked(getMediaLibraryUri).mockImplementation(async (localId) => {
+        if (localId === '1') return 'file://1'
+        return null
+      })
+      const assets = [
+        {
+          id: '1',
+          name: 'new.jpg',
+          sourceUri: 'file://1',
+          type: 'image/jpeg',
+          timestamp: '2021-01-01',
+        },
+      ]
+      const { updatedFiles } = await syncAssets(assets)
+
+      expect(updatedFiles).toHaveLength(1)
+      const updated = await app().files.getById('existing-1')
+      expect(updated).toMatchObject({
+        id: 'existing-1',
+        name: 'new.jpg',
+      })
+    })
+
+    it('skipExistingUpdates prevents spurious updatedAt bumps', async () => {
+      await app().files.create({
+        id: 'existing-1',
+        name: 'old.jpg',
+        size: 5,
+        createdAt: 1,
+        updatedAt: 1,
+        type: 'image/jpeg',
+        kind: 'file',
+        localId: '1',
+        hash: '',
+        addedAt: 1,
+        trashedAt: null,
+        deletedAt: null,
+      })
+
+      jest.mocked(getMediaLibraryUri).mockImplementation(async (localId) => {
+        if (localId === '1') return 'file://1'
+        return null
+      })
+      const assets = [
+        {
+          id: '1',
+          name: 'new.jpg',
+          sourceUri: 'file://1',
+          type: 'image/jpeg',
+          timestamp: '2021-01-01',
+        },
+      ]
+      const { files, updatedFiles } = await syncAssets(assets, 'file', {
+        skipExistingUpdates: true,
+      })
+
+      expect(updatedFiles).toHaveLength(1)
+      expect(files).toHaveLength(0)
+      const record = await app().files.getById('existing-1')
+      expect(record).toMatchObject({
+        id: 'existing-1',
+        name: 'old.jpg',
+        updatedAt: 1,
+      })
+    })
+  })
+
+  describe('import directory', () => {
+    it('does not move files by default', async () => {
+      await app().settings.setPhotoImportDirectory('Camera Roll')
+      const assets = [
+        {
+          id: undefined,
+          name: 'photo.jpg',
+          sourceUri: 'file:///photo.jpg',
+          type: 'image/jpeg',
+          timestamp: '2021-01-01',
+        },
+      ]
+      const { files } = await syncAssets(assets)
+      expect(files).toHaveLength(1)
+      const row = await db().getFirstAsync<{ directoryId: string | null }>(
+        'SELECT directoryId FROM files WHERE id = ?',
+        files[0].id,
+      )
+      expect(row?.directoryId).toBeNull()
+      const dirs = await app().directories.getAll()
+      expect(dirs).toHaveLength(0)
+    })
+
+    it('moves media files when addToImportDirectory is set', async () => {
+      await app().settings.setPhotoImportDirectory('Camera Roll')
+      const assets = [
+        {
+          id: undefined,
+          name: 'photo.jpg',
+          sourceUri: 'file:///photo.jpg',
+          type: 'image/jpeg',
+          timestamp: '2021-01-01',
+        },
+      ]
+      const { files } = await syncAssets(assets, 'file', {
+        addToImportDirectory: true,
+      })
+      expect(files).toHaveLength(1)
+      const row = await db().getFirstAsync<{ directoryId: string | null }>(
+        'SELECT directoryId FROM files WHERE id = ?',
+        files[0].id,
+      )
+      expect(row?.directoryId).toBeTruthy()
+      const dirs = await app().directories.getAll()
+      expect(dirs).toHaveLength(1)
+      expect(dirs[0].name).toBe('Camera Roll')
+    })
+  })
+})
+
+describe('catalogAssets — deferred bulk catalog for archive sync', () => {
+  it('creates placeholders with empty hash and zero size', async () => {
     const assets = [
       {
-        id: '1',
-        name: 'a.jpg',
-        sourceUri: 'file://1',
+        id: 'local-1',
+        name: 'photo.jpg',
+        sourceUri: 'file:///photo.jpg',
         type: 'image/jpeg',
         timestamp: '2021-01-01',
       },
     ]
-
-    const fileId = 'uid-1'
-
-    const { files } = await processAssets(assets)
+    const { files } = await catalogAssets(assets)
     expect(files).toHaveLength(1)
+    expect(files[0]).toMatchObject({
+      hash: '',
+      size: 0,
+      kind: 'file',
+    })
+    const row = await app().files.getById(files[0].id)
+    expect(row).toBeTruthy()
+    expect(row!.hash).toBe('')
+    expect(row!.size).toBe(0)
+  })
+
+  it('silently skips localId duplicates via INSERT OR IGNORE', async () => {
+    await app().files.create({
+      id: 'existing-1',
+      name: 'old.jpg',
+      size: 5,
+      createdAt: 1,
+      updatedAt: 1,
+      type: 'image/jpeg',
+      kind: 'file',
+      localId: 'local-1',
+      hash: '',
+      addedAt: 1,
+      trashedAt: null,
+      deletedAt: null,
+    })
+
+    const assets = [
+      {
+        id: 'local-1',
+        name: 'same.jpg',
+        sourceUri: 'file:///same.jpg',
+        type: 'image/jpeg',
+        timestamp: '2021-01-01',
+      },
+    ]
+    const { files } = await catalogAssets(assets)
+    expect(files).toHaveLength(1)
+
     const rows = await app().files.query({ order: 'ASC' })
     expect(rows).toHaveLength(1)
-    expect(rows[0]).toMatchObject({
-      id: fileId,
-      name: 'a.jpg',
-    })
-    const meta = await app().fs.readMeta(fileId)
-    expect(meta).toMatchObject({
-      fileId,
-    })
+    expect(rows[0].id).toBe('existing-1')
   })
-  it('updates existing by localId and does not create new records', async () => {
-    await app().files.create({
-      id: 'existing-1',
-      name: 'old.jpg',
-      size: 5,
-      createdAt: 1,
-      updatedAt: 1,
-      type: 'image/jpeg',
-      kind: 'file',
-      localId: '1',
-      hash: '',
-      addedAt: 1,
-      trashedAt: null,
-      deletedAt: null,
-    })
 
-    jest.mocked(getMediaLibraryUri).mockImplementation(async (localId) => {
-      if (localId === '1') return 'file://1'
-      return null
-    })
+  it('does not copy files or compute content hashes', async () => {
     const assets = [
       {
-        id: '1',
-        name: 'new.jpg',
-        sourceUri: 'file://1',
+        id: 'local-1',
+        name: 'photo.jpg',
+        sourceUri: 'file:///photo.jpg',
         type: 'image/jpeg',
         timestamp: '2021-01-01',
       },
     ]
-    const { files, updatedFiles } = await processAssets(assets)
-
-    expect(updatedFiles).toHaveLength(1)
-    expect(files).toHaveLength(0)
-    // Should not hash when localId duplicate is detected.
+    await catalogAssets(assets)
+    expect(copyFileToFs).not.toHaveBeenCalled()
     expect(calculateContentHash).not.toHaveBeenCalled()
-    const updated = await app().files.getById('existing-1')
-    expect(updated).toMatchObject({
-      id: 'existing-1',
-      name: 'new.jpg',
-      size: 5,
-    })
-    expect(copyFileToFs).toHaveBeenCalledTimes(0)
   })
-  it('skipExistingUpdates does not update existing records', async () => {
-    await app().files.create({
-      id: 'existing-1',
-      name: 'old.jpg',
-      size: 5,
-      createdAt: 1,
-      updatedAt: 1,
-      type: 'image/jpeg',
-      kind: 'file',
-      localId: '1',
-      hash: '',
-      addedAt: 1,
-      trashedAt: null,
-      deletedAt: null,
-    })
 
-    jest.mocked(getMediaLibraryUri).mockImplementation(async (localId) => {
-      if (localId === '1') return 'file://1'
-      return null
-    })
+  it('triggers the import scanner', async () => {
+    const { triggerImportScanner } = require('../managers/importScanner')
     const assets = [
       {
-        id: '1',
-        name: 'new.jpg',
-        sourceUri: 'file://1',
-        type: 'image/jpeg',
-        timestamp: '2021-01-01',
-      },
-    ]
-    const { files, updatedFiles } = await processAssets(assets, 'file', {
-      skipExistingUpdates: true,
-    })
-
-    expect(updatedFiles).toHaveLength(1)
-    expect(files).toHaveLength(0)
-    const record = await app().files.getById('existing-1')
-    expect(record).toMatchObject({
-      id: 'existing-1',
-      name: 'old.jpg',
-      updatedAt: 1,
-    })
-  })
-  it('allowDuplicates bypasses localId dedup', async () => {
-    await app().files.create({
-      id: 'existing-1',
-      name: 'old.jpg',
-      size: 5,
-      createdAt: 1,
-      updatedAt: 1,
-      type: 'image/jpeg',
-      kind: 'file',
-      localId: '1',
-      hash: '',
-      addedAt: 1,
-      trashedAt: null,
-      deletedAt: null,
-    })
-
-    jest.mocked(getMediaLibraryUri).mockImplementation(async (localId) => {
-      if (localId === '1') return 'file://1'
-      return null
-    })
-    const assets = [
-      {
-        id: '1',
-        name: 'new.jpg',
-        sourceUri: 'file://1',
-        type: 'image/jpeg',
-        timestamp: '2021-01-01',
-      },
-    ]
-    const { files } = await processAssets(assets, 'file', {
-      allowDuplicates: true,
-    })
-
-    expect(files).toHaveLength(1)
-  })
-  it('blocks content hash duplicates during auto-sync', async () => {
-    await app().files.create({
-      id: 'existing',
-      name: 'existing.jpg',
-      size: 10,
-      createdAt: 1,
-      updatedAt: 1,
-      type: 'image/jpeg',
-      kind: 'file',
-      hash: 'sha256:existing-hash',
-      localId: null,
-      addedAt: 1,
-      trashedAt: null,
-      deletedAt: null,
-    })
-
-    jest
-      .mocked(calculateContentHash)
-      .mockImplementation(async () => 'sha256:existing-hash')
-    const assets = [
-      {
-        id: 'same-hash',
-        name: 'same-hash.jpg',
-        sourceUri: 'file://same-hash.jpg',
-        type: 'image/jpeg',
-        timestamp: '2021-01-01',
-      },
-    ]
-    const { files, updatedFiles } = await processAssets(assets)
-
-    expect(files).toHaveLength(0)
-    expect(updatedFiles).toHaveLength(1)
-    expect(updatedFiles[0]).toMatchObject({ id: 'existing' })
-  })
-  it('allowDuplicates bypasses content hash dedup', async () => {
-    await app().files.create({
-      id: 'existing',
-      name: 'existing.jpg',
-      size: 10,
-      createdAt: 1,
-      updatedAt: 1,
-      type: 'image/jpeg',
-      kind: 'file',
-      hash: 'sha256:existing-hash',
-      localId: null,
-      addedAt: 1,
-      trashedAt: null,
-      deletedAt: null,
-    })
-
-    jest
-      .mocked(calculateContentHash)
-      .mockImplementation(async () => 'sha256:existing-hash')
-    const assets = [
-      {
-        id: undefined,
-        name: 'same-hash.jpg',
-        sourceUri: 'file://same-hash.jpg',
-        type: 'image/jpeg',
-        timestamp: '2021-01-01',
-      },
-    ]
-    const { files, warnings } = await processAssets(assets, 'file', {
-      allowDuplicates: true,
-    })
-
-    expect(files).toHaveLength(1)
-    expect(warnings).toHaveLength(1)
-    expect(warnings[0]).toMatch(/already exist/)
-  })
-  it('allows importing multiple files with same hash', async () => {
-    jest.mocked(getMediaLibraryUri).mockImplementation(async () => {
-      return null
-    })
-    jest
-      .mocked(calculateContentHash)
-      .mockImplementation(async () => 'sha256:same-for-all')
-    const assets = [
-      {
-        id: undefined,
-        name: '1.jpg',
-        size: 123,
-        sourceUri: 'file://1.jpg',
-        type: 'image/jpeg',
-        timestamp: '2021-01-01',
-      },
-      {
-        id: undefined,
-        name: '2.jpg',
-        size: 123,
-        sourceUri: 'file://2.jpg',
-        type: 'image/png',
-        timestamp: '2021-01-01',
-      },
-    ]
-
-    const { files } = await processAssets(assets)
-    expect(files).toHaveLength(2)
-  })
-  it('grabs the highest quality file when localId is valid', async () => {
-    jest.mocked(getMediaLibraryUri).mockImplementation(async () => {
-      return 'file:///full-quality.jpg'
-    })
-    const assets = [
-      {
-        id: 'valid',
-        name: 'no-id.jpg',
-        size: 123,
-        sourceUri: 'file:///tmp/no-id.jpg',
-        type: 'image/jpeg',
-        timestamp: '2021-01-01',
-      },
-    ]
-
-    const { files } = await processAssets(assets)
-
-    expect(files).toHaveLength(1)
-    expect(getMediaLibraryUri).toHaveBeenCalledTimes(1)
-    expect(getMediaLibraryUri).toHaveBeenCalledWith('valid')
-
-    expect(copyFileToFs).toHaveBeenCalledTimes(1)
-    expect(copyFileToFs).toHaveBeenCalledWith(
-      expect.objectContaining({ id: files[0].id, type: 'image/jpeg' }),
-      'file:///full-quality.jpg',
-    )
-  })
-  it('uses sourceUri when localId is not valid', async () => {
-    jest.mocked(getMediaLibraryUri).mockImplementation(async () => {
-      return null
-    })
-    const assets = [
-      {
-        id: 'invalid',
-        name: 'file.jpg',
-        sourceUri: 'file:///source.jpg',
-        type: 'image/jpeg',
-        timestamp: '2021-01-01',
-      },
-    ]
-
-    const { files } = await processAssets(assets)
-
-    expect(files).toHaveLength(1)
-    expect(getMediaLibraryUri).toHaveBeenCalledTimes(1)
-    expect(getMediaLibraryUri).toHaveBeenCalledWith('invalid')
-    expect(copyFileToFs).toHaveBeenCalledTimes(1)
-    const file = await app().files.getById(files[0].id)
-    expect(file).toMatchObject({
-      id: files[0].id,
-    })
-    const meta = await app().fs.readMeta(files[0].id)
-    expect(meta).toMatchObject({
-      fileId: files[0].id,
-    })
-  })
-  it('does not auto-move files by default', async () => {
-    await app().settings.setPhotoImportDirectory('Camera Roll')
-    const assets = [
-      {
-        id: undefined,
+        id: 'local-1',
         name: 'photo.jpg',
         sourceUri: 'file:///photo.jpg',
         type: 'image/jpeg',
         timestamp: '2021-01-01',
       },
     ]
-    const { files } = await processAssets(assets)
-    expect(files).toHaveLength(1)
-    const row = await db().getFirstAsync<{ directoryId: string | null }>(
-      'SELECT directoryId FROM files WHERE id = ?',
-      files[0].id,
-    )
-    expect(row?.directoryId).toBeNull()
-    const dirs = await app().directories.getAll()
-    expect(dirs).toHaveLength(0)
+    await catalogAssets(assets)
+    expect(triggerImportScanner).toHaveBeenCalled()
   })
-  it('addToImportDirectory moves media files to photo import directory', async () => {
+
+  it('moves media files when addToImportDirectory is set', async () => {
     await app().settings.setPhotoImportDirectory('Camera Roll')
     const assets = [
       {
-        id: undefined,
+        id: 'local-1',
         name: 'photo.jpg',
         sourceUri: 'file:///photo.jpg',
         type: 'image/jpeg',
         timestamp: '2021-01-01',
       },
     ]
-    const { files } = await processAssets(assets, 'file', {
+    const { files } = await catalogAssets(assets, 'file', {
       addToImportDirectory: true,
     })
     expect(files).toHaveLength(1)
@@ -381,57 +693,5 @@ describe('processAssets', () => {
     const dirs = await app().directories.getAll()
     expect(dirs).toHaveLength(1)
     expect(dirs[0].name).toBe('Camera Roll')
-  })
-  it('re-detects MIME type from local file when initial detection returns octet-stream', async () => {
-    jest.mocked(getMediaLibraryUri).mockImplementation(async () => {
-      return 'file:///local/photo'
-    })
-    jest
-      .mocked(getMimeType)
-      .mockResolvedValueOnce('application/octet-stream')
-      .mockResolvedValueOnce('image/jpeg')
-
-    const assets = [
-      {
-        id: '1',
-        name: 'data',
-        sourceUri: 'ph://asset-123',
-        type: undefined,
-        timestamp: '2021-01-01',
-      },
-    ]
-
-    const { files } = await processAssets(assets)
-    expect(files).toHaveLength(1)
-    expect(files[0].type).toBe('image/jpeg')
-    expect(getMimeType).toHaveBeenCalledTimes(2)
-    expect(getMimeType).toHaveBeenNthCalledWith(1, {
-      type: undefined,
-      name: 'data',
-      uri: 'ph://asset-123',
-    })
-    expect(getMimeType).toHaveBeenNthCalledWith(2, {
-      name: 'data',
-      uri: 'file:///local/photo',
-    })
-  })
-  it('adds file size to new files', async () => {
-    const { rnfsStat } = (
-      global as unknown as { __rnfs: { rnfsStat: jest.Mock } }
-    ).__rnfs
-    rnfsStat.mockResolvedValue({ size: 333 })
-    const assets = [
-      {
-        id: undefined,
-        name: 'no-id.jpg',
-        size: undefined,
-        sourceUri: 'file:///tmp/no-id.jpg',
-        type: 'image/jpeg',
-        timestamp: '2021-01-01',
-      },
-    ]
-    const { files } = await processAssets(assets)
-    expect(files).toHaveLength(1)
-    expect(files[0].size).toBe(333)
   })
 })

--- a/apps/mobile/src/lib/processAssets.ts
+++ b/apps/mobile/src/lib/processAssets.ts
@@ -1,8 +1,27 @@
+// Three import paths for getting files into the database:
+//
+// importFiles — User-initiated (picker, camera, share intent). Creates
+//   placeholder records instantly so the UI updates, then copies files
+//   in the background. The import scanner finalizes each file once the
+//   local copy lands on disk. No dedup — manual imports always create
+//   new records.
+//
+// syncAssets — Background recent photo sync (syncNewPhotos). Copies
+//   files and computes content hashes inline so duplicates (by localId
+//   or content hash) are detected immediately, preventing re-importing
+//   files already tracked locally or synced from another device.
+//
+// catalogAssets — Archive library walk (syncPhotosArchive). Creates
+//   placeholder records in bulk via INSERT OR IGNORE (no copy, no hash).
+//   The import scanner finalizes these in the background with
+//   backpressure based on the upload backlog.
+
 import { uniqueId } from '@siastorage/core/lib/uniqueId'
 import { yieldToEventLoop } from '@siastorage/core/lib/yieldToEventLoop'
 import type { FileRecord } from '@siastorage/core/types'
 import { logger } from '@siastorage/logger'
 import RNFS from 'react-native-fs'
+import { triggerImportScanner } from '../managers/importScanner'
 import { generateThumbnails } from '../managers/thumbnailer'
 import { app } from '../stores/appService'
 import { copyFileToFs } from '../stores/fs'
@@ -24,12 +43,80 @@ async function processInBatches<T>(
   }
 }
 
-type Asset = {
+export type Asset = {
   id: string | undefined
   sourceUri: string | undefined
   type: string | undefined
   name: string | undefined
+  size?: number | undefined
   timestamp: string | undefined
+}
+
+type FileContentResult = {
+  type: string
+  hash: string
+  size: number
+}
+
+/**
+ * Shared file processing pipeline: MIME re-detection, copy to app cache,
+ * SHA-256 content hash, and file size.
+ */
+async function processFileContent(
+  file: { id: string; name: string; type: string },
+  sourceUri: string,
+): Promise<FileContentResult | null> {
+  let type = file.type
+  if (type === 'application/octet-stream') {
+    type = await getMimeType({ name: file.name, uri: sourceUri })
+  }
+
+  const fileUri = await copyFileToFs(file, sourceUri)
+  if (!fileUri) return null
+
+  const hash = await calculateContentHash(fileUri)
+  if (!hash) return null
+
+  const size = await getFileSize(fileUri)
+  if (!size) return null
+
+  return { type, hash, size }
+}
+
+type ParsedAssetMetadata = {
+  name: string
+  createdAt: number
+  updatedAt: number
+  type: MimeType
+}
+
+async function parseAssetMetadata(
+  asset: Asset,
+  defaultFileName: string,
+): Promise<ParsedAssetMetadata> {
+  const ts = new Date(asset.timestamp ?? Date.now()).getTime()
+  return {
+    name: asset.name ?? defaultFileName,
+    createdAt: ts,
+    updatedAt: ts,
+    type: await getMimeType({
+      type: asset.type,
+      name: asset.name,
+      uri: asset.sourceUri,
+    }),
+  }
+}
+
+async function moveMediaToImportDirectory(files: FileRecord[]): Promise<void> {
+  const photoImportDir = await app().settings.getPhotoImportDirectory()
+  if (!photoImportDir) return
+  const mediaFileIds = files
+    .filter((f) => f.type.startsWith('image/') || f.type.startsWith('video/'))
+    .map((f) => f.id)
+  if (mediaFileIds.length > 0) {
+    const dir = await app().directories.getOrCreate(photoImportDir)
+    await app().directories.moveFiles(mediaFileIds, dir.id)
+  }
 }
 
 type CandidateFileRecord = {
@@ -47,34 +134,13 @@ type CandidateFileRecord = {
     | 'foundByLocalId'
     | 'foundByContentHash'
     | 'noUri'
-    | 'invalidUri'
-    | 'noFileSize'
-    | 'noContentHash'
+    | 'processingFailed'
     | null
 }
 
-/**
- * processAssets imports a list of assets from any source.
- * This function will:
- * - Check for duplicates by localId and hash.
- * - Copy every asset to the app's file cache.
- * - Add content hashes to files that are new.
- * - Create new file records for the assets.
- * - Update the metadata of any existing files.
- * - Generate thumbnails for new image and video files.
- * - Return the resulting files and warnings.
- * @param assets - The assets to process.
- * @param defaultFileName - The default file name to use for assets that do not have a file name.
- * @returns The resulting files and warnings.
- * @throws If the assets cannot be processed.
- */
-type ProcessAssetsOptions = {
-  /** Allow importing files that already exist by content hash. When true,
-   * localId is nulled out and dedup checks are skipped so every import
-   * creates a new file record. Used for manual imports (camera, picker). */
-  allowDuplicates?: boolean
+type SyncAssetsOptions = {
   /** Move newly imported media files into the configured photo import
-   * directory. Used by auto-sync and archive sync. */
+   * directory. Used by auto-sync. */
   addToImportDirectory?: boolean
   /** Skip updating DB records for files that already exist. Prevents
    * spurious updatedAt bumps when the same assets are re-encountered
@@ -82,44 +148,40 @@ type ProcessAssetsOptions = {
   skipExistingUpdates?: boolean
 }
 
-export async function processAssets(
+/**
+ * Background recent photo sync (syncNewPhotos). Copies files and computes
+ * content hashes inline so duplicates are detected immediately — by
+ * localId (same device) or content hash (synced from another device).
+ * This eager processing prevents re-importing files the system already
+ * knows about.
+ */
+export async function syncAssets(
   assets: Asset[] | undefined,
   defaultFileName: string = 'file',
   {
-    allowDuplicates = false,
     addToImportDirectory = false,
     skipExistingUpdates = false,
-  }: ProcessAssetsOptions = {},
+  }: SyncAssetsOptions = {},
 ) {
   const candidateFiles: CandidateFileRecord[] = await Promise.all(
-    (assets ?? []).map(async (a) => ({
-      id: uniqueId(),
-      // Null out localId for manual imports so duplicates don't hit the
-      // UNIQUE constraint and auto-sync never dedupes against them.
-      localId: allowDuplicates ? null : (a.id ?? null),
-      sourceUri: a.sourceUri ?? null,
-      name: a.name ?? defaultFileName,
-      size: null,
-      createdAt: new Date(a.timestamp ?? Date.now()).getTime(),
-      updatedAt: new Date(a.timestamp ?? Date.now()).getTime(),
-      type: await getMimeType({
-        type: a.type,
-        name: a.name,
-        uri: a.sourceUri,
-      }),
-      hash: null,
-      status: 'new',
-      statusDetails: null,
-    })),
+    (assets ?? []).map(async (a) => {
+      const meta = await parseAssetMetadata(a, defaultFileName)
+      return {
+        id: uniqueId(),
+        localId: a.id ?? null,
+        sourceUri: a.sourceUri ?? null,
+        ...meta,
+        hash: null,
+        size: null,
+        status: 'new' as const,
+        statusDetails: null,
+      }
+    }),
   )
 
-  // Update the status of the files that are found by localId.
-  // This is quick but will only detect duplicates from the same device.
-  const existingLocalIds = allowDuplicates
-    ? []
-    : await app().files.getByLocalIds(
-        candidateFiles.filter((a) => !!a.localId).map((a) => a.localId!),
-      )
+  const existingLocalIds = await app().files.getByLocalIds(
+    candidateFiles.filter((a) => !!a.localId).map((a) => a.localId!),
+  )
   for (const f of existingLocalIds) {
     const validFile = candidateFiles.find((v) => v.localId === f.localId)
     if (validFile) {
@@ -129,20 +191,15 @@ export async function processAssets(
     }
   }
 
-  // Copy files to the app's file cache.
-  // Add content hash and file size to files that are still new.
-  // Process in batches to limit memory pressure from large files.
   await processInBatches(
     candidateFiles.filter((f) => f.status === 'new'),
     BATCH_SIZE,
     async (f) => {
-      // Verify that the localId is a valid Media Library or MediaStore ID.
       const localUri = await getMediaLibraryUri(f.localId)
       if (!localUri) {
         f.localId = null
       }
 
-      // Verify we have a URI.
       const bestUri = localUri ?? f.sourceUri
       if (!bestUri) {
         f.status = 'incomplete'
@@ -150,42 +207,19 @@ export async function processAssets(
         return
       }
 
-      // The initial MIME detection may have returned octet-stream because the
-      // source URI was a ph:// or content:// asset reference that can't be read
-      // directly. Now that we have a local file:// URI, retry with byte detection.
-      if (f.type === 'application/octet-stream') {
-        f.type = await getMimeType({ name: f.name, uri: bestUri })
-      }
-
-      // Copy the file to the app's file cache.
-      const fileUri = await copyFileToFs(f, bestUri)
-      if (!fileUri) {
+      const result = await processFileContent(f, bestUri)
+      if (!result) {
         f.status = 'incomplete'
-        f.statusDetails = 'invalidUri'
+        f.statusDetails = 'processingFailed'
         return
       }
 
-      const hash = await calculateContentHash(fileUri)
-      if (!hash) {
-        f.status = 'incomplete'
-        f.statusDetails = 'noContentHash'
-        return
-      }
-      f.hash = hash
-
-      const size = await getFileSize(fileUri)
-      if (!size) {
-        f.status = 'incomplete'
-        f.statusDetails = 'noFileSize'
-        return
-      }
-      f.size = size
+      f.type = result.type as MimeType
+      f.hash = result.hash
+      f.size = result.size
     },
   )
 
-  // Check for content hash duplicates. Auto-sync blocks them to prevent
-  // re-importing files already synced from another device. Manual imports
-  // warn but allow.
   const existingContentHashes = await app().files.getByContentHashes(
     candidateFiles
       .filter((f) => f.status === 'new' && f.hash !== null)
@@ -193,19 +227,16 @@ export async function processAssets(
   )
   const contentHashDuplicateCount = existingContentHashes.length
 
-  if (!allowDuplicates) {
-    for (const f of existingContentHashes) {
-      const validFile = candidateFiles.find((v) => v.hash === f.hash)
-      if (validFile) {
-        validFile.id = f.id
-        validFile.status = 'existing'
-        validFile.statusDetails = 'foundByContentHash'
-      }
+  for (const f of existingContentHashes) {
+    const validFile = candidateFiles.find((v) => v.hash === f.hash)
+    if (validFile) {
+      validFile.id = f.id
+      validFile.status = 'existing'
+      validFile.statusDetails = 'foundByContentHash'
     }
   }
 
-  // Assert that the files are new and have a content hash and size.
-  const newFiles: FileRecord[] = candidateFiles
+  const newFiles = candidateFiles
     .filter((f) => f.status === 'new' && f.hash !== null && f.size !== null)
     .map((f) => ({
       id: f.id,
@@ -222,13 +253,14 @@ export async function processAssets(
       deletedAt: null,
       objects: {},
     }))
+
   const incompleteFiles = candidateFiles.filter(
     (f) => f.status === 'incomplete',
   )
   const existingFiles = candidateFiles.filter((f) => f.status === 'existing')
 
   const warnings: string[] = []
-  logger.debug('processAssets', 'result', {
+  logger.debug('syncAssets', 'result', {
     picked: candidateFiles.length,
     new: newFiles.length,
     incomplete: incompleteFiles.length,
@@ -253,25 +285,13 @@ export async function processAssets(
   }
   await app().files.createMany(newFiles)
 
-  // Move media files to the configured photo import directory.
-  // Skipped when importing from a directory or tag context.
-  const photoImportDir = await app().settings.getPhotoImportDirectory()
-  if (photoImportDir && addToImportDirectory) {
-    const mediaFileIds = newFiles
-      .filter((f) => f.type.startsWith('image/') || f.type.startsWith('video/'))
-      .map((f) => f.id)
-    if (mediaFileIds.length > 0) {
-      const dir = await app().directories.getOrCreate(photoImportDir)
-      await app().directories.moveFiles(mediaFileIds, dir.id)
-    }
+  if (addToImportDirectory) {
+    await moveMediaToImportDirectory(newFiles)
   }
 
-  // Generate thumbnails for new image and video files.
-  logger.debug('processAssets', 'generating_thumbnails', {
+  logger.debug('syncAssets', 'generating_thumbnails', {
     count: newFiles.length,
   })
-
-  // Generate thumbnails for new files, this will run in the background.
   generateThumbnails(newFiles)
 
   return {
@@ -279,6 +299,137 @@ export async function processAssets(
     updatedFiles: existingFiles,
     warnings,
   }
+}
+
+type CatalogAssetsOptions = {
+  /** Move newly imported media files into the configured photo import
+   * directory. Used by archive sync. */
+  addToImportDirectory?: boolean
+}
+
+/**
+ * Archive library walk (syncPhotosArchive). Creates placeholder records
+ * with hash: '' and size: 0, using INSERT OR IGNORE to silently skip
+ * localId duplicates without a pre-check query. No copy, no hash — the
+ * import scanner handles those with backpressure based on the upload backlog.
+ */
+export async function catalogAssets(
+  assets: Asset[] | undefined,
+  defaultFileName: string = 'file',
+  { addToImportDirectory = false }: CatalogAssetsOptions = {},
+) {
+  const newFiles: FileRecord[] = await Promise.all(
+    (assets ?? []).map(async (a) => {
+      const meta = await parseAssetMetadata(a, defaultFileName)
+      return {
+        id: uniqueId(),
+        localId: a.id ?? null,
+        ...meta,
+        addedAt: Date.now(),
+        kind: 'file' as const,
+        size: 0,
+        hash: '',
+        trashedAt: null,
+        deletedAt: null,
+        objects: {},
+      }
+    }),
+  )
+
+  logger.debug('catalogAssets', 'result', {
+    count: newFiles.length,
+  })
+
+  await app().files.createMany(newFiles, { conflictClause: 'OR IGNORE' })
+
+  if (addToImportDirectory) {
+    await moveMediaToImportDirectory(newFiles)
+  }
+
+  triggerImportScanner()
+
+  return { files: newFiles }
+}
+
+/**
+ * Import for manual flows (document picker, camera, share intent, etc.).
+ *
+ * Creates placeholder FileRecords with hash: '' immediately so the UI
+ * updates, then fires a background copy for each file. The import scanner
+ * finalizes each file by hashing once the local copy lands on disk.
+ *
+ * Files with a localId (photos) can be recovered by the scanner via
+ * resolveLocalId even if the background copy is interrupted.
+ */
+export async function importFiles(
+  assets: Asset[] | undefined,
+  defaultFileName: string = 'file',
+): Promise<FileRecord[]> {
+  const now = Date.now()
+
+  type PendingCopy = { id: string; type: string; sourceUri: string }
+  const pendingCopies: PendingCopy[] = []
+
+  const placeholders: FileRecord[] = await Promise.all(
+    (assets ?? [])
+      .filter((a) => !!a.sourceUri)
+      .map(async (a) => {
+        const id = uniqueId()
+        const type = await getMimeType({
+          type: a.type,
+          name: a.name,
+          uri: a.sourceUri,
+        })
+        const name = a.name ?? defaultFileName
+        const ts = new Date(a.timestamp ?? now).getTime()
+        pendingCopies.push({ id, type, sourceUri: a.sourceUri! })
+        return {
+          id,
+          localId: a.id ?? null,
+          name,
+          createdAt: ts,
+          updatedAt: ts,
+          addedAt: now,
+          type,
+          kind: 'file' as const,
+          size: a.size ?? 0,
+          hash: '',
+          trashedAt: null,
+          deletedAt: null,
+          objects: {},
+        }
+      }),
+  )
+
+  if (placeholders.length > 0) {
+    await app().files.createMany(placeholders)
+  }
+
+  // Fire-and-forget: sourceURIs are ephemeral (document picker content://
+  // URIs, share intent file:// paths) and must be copied promptly. The
+  // copy runs without blocking the caller so the UI shows placeholders
+  // immediately. If interrupted, files with localId are recovered by the
+  // scanner via media library.
+  void copyImportedFiles(pendingCopies)
+
+  triggerImportScanner()
+  return placeholders
+}
+
+async function copyImportedFiles(
+  copies: { id: string; type: string; sourceUri: string }[],
+): Promise<void> {
+  for (const { id, type, sourceUri } of copies) {
+    try {
+      await copyFileToFs({ id, type }, sourceUri)
+    } catch (e) {
+      logger.warn('importFiles', 'copy_failed', {
+        fileId: id,
+        error: e as Error,
+      })
+    }
+  }
+  triggerImportScanner()
 }
 
 async function getFileSize(fileUri: string) {

--- a/apps/mobile/src/managers/app.ts
+++ b/apps/mobile/src/managers/app.ts
@@ -14,6 +14,7 @@ import { resetViewSettings } from '../stores/viewSettings'
 import { initBackgroundTasks } from './backgroundTasks'
 import { runFsEvictionScanner } from './fsEvictionScanner'
 import { runFsOrphanScanner } from './fsOrphanScanner'
+import { initImportScanner } from './importScanner'
 import { initLogRotation } from './logRotation'
 import { initPerfMonitor } from './perfMonitor'
 import { initSyncDownEvents } from './syncDownEvents'
@@ -89,6 +90,7 @@ export async function initApp(): Promise<void> {
       label: 'Starting background services',
       message: 'Launching background services...',
       runner: async () => {
+        initImportScanner()
         initSyncDownEvents()
         initSyncNewPhotos()
         initSyncPhotosArchive()

--- a/apps/mobile/src/managers/importScanner.ts
+++ b/apps/mobile/src/managers/importScanner.ts
@@ -1,0 +1,56 @@
+import {
+  IMPORT_SCANNER_BACKLOG_LIMIT,
+  IMPORT_SCANNER_INTERVAL,
+} from '@siastorage/core/config'
+import { createServiceInterval } from '@siastorage/core/lib/serviceInterval'
+import {
+  ImportScanner,
+  type ImportScannerResult,
+} from '@siastorage/core/services/importScanner'
+import { calculateContentHash } from '../lib/contentHash'
+import { getMimeType } from '../lib/fileTypes'
+import { getMediaLibraryUri } from '../lib/mediaLibrary'
+import { app } from '../stores/appService'
+
+const scanner = new ImportScanner()
+
+function ensureInitialized(): void {
+  if (scanner.isInitialized()) return
+  scanner.initialize(app(), calculateContentHash, getMimeType)
+}
+
+/**
+ * Computes how many placeholder files (from catalogAssets) the scanner
+ * should finalize this tick. When the upload backlog is full, returns 0
+ * so the scanner stops copying new photos and avoids filling device
+ * storage.
+ */
+async function computeMaxDeferred(): Promise<number> {
+  const indexerURL = await app().settings.getIndexerURL()
+  const pendingUpload = await app().files.queryCount({
+    order: 'ASC',
+    pinned: { indexerURL, isPinned: false },
+    fileExistsLocally: true,
+    activeOnly: true,
+    hashNotEmpty: true,
+  })
+  if (pendingUpload >= IMPORT_SCANNER_BACKLOG_LIMIT) return 0
+  return IMPORT_SCANNER_BACKLOG_LIMIT - pendingUpload
+}
+
+export async function runImportScanner(
+  signal?: AbortSignal,
+): Promise<ImportScannerResult> {
+  ensureInitialized()
+  const maxDeferred = await computeMaxDeferred()
+  return scanner.runScan(signal, getMediaLibraryUri, maxDeferred)
+}
+
+export const { init: initImportScanner, triggerNow: triggerImportScanner } =
+  createServiceInterval({
+    name: 'importScanner',
+    worker: async (signal) => {
+      await runImportScanner(signal)
+    },
+    interval: IMPORT_SCANNER_INTERVAL,
+  })

--- a/apps/mobile/src/managers/syncNewPhotos.test.ts
+++ b/apps/mobile/src/managers/syncNewPhotos.test.ts
@@ -1,7 +1,7 @@
 import { SYNC_NEW_PHOTOS_INTERVAL } from '@siastorage/core/config'
 import { shutdownAllServiceIntervals } from '@siastorage/core/lib/serviceInterval'
 import * as MediaLibrary from 'expo-media-library'
-import { processAssets } from '../lib/processAssets'
+import { syncAssets } from '../lib/processAssets'
 import { app } from '../stores/appService'
 import {
   initSyncNewPhotos,
@@ -30,11 +30,11 @@ jest.mock('../lib/mediaLibraryPermissions', () => ({
   },
 }))
 jest.mock('../lib/processAssets', () => ({
-  processAssets: jest.fn(),
+  syncAssets: jest.fn(),
 }))
 
 const getAssetsAsyncMock = jest.mocked(MediaLibrary.getAssetsAsync)
-const processAssetsMock = jest.mocked(processAssets)
+const syncAssetsMock = jest.mocked(syncAssets)
 
 function asset(
   id: string,
@@ -67,7 +67,7 @@ function page(
 }
 
 function mockProcessAssetsSuccess() {
-  processAssetsMock.mockResolvedValue({
+  syncAssetsMock.mockResolvedValue({
     files: [{ id: '1' }] as never,
     updatedFiles: [],
     warnings: [],
@@ -116,7 +116,7 @@ describe('syncNewPhotos', () => {
       ]),
     )
     await run()
-    expect(processAssetsMock).toHaveBeenCalledWith(
+    expect(syncAssetsMock).toHaveBeenCalledWith(
       [
         expect.objectContaining({ id: 'a1', name: 'new1.jpg' }),
         expect.objectContaining({ id: 'a2', name: 'new2.jpg' }),
@@ -136,13 +136,13 @@ describe('syncNewPhotos', () => {
       ]),
     )
     await run()
-    expect(processAssetsMock).not.toHaveBeenCalled()
+    expect(syncAssetsMock).not.toHaveBeenCalled()
   })
 
   it('no photos returns early without processing', async () => {
     getAssetsAsyncMock.mockResolvedValueOnce(page([]))
     await run()
-    expect(processAssetsMock).not.toHaveBeenCalled()
+    expect(syncAssetsMock).not.toHaveBeenCalled()
   })
 
   it('does not paginate even when page is full', async () => {
@@ -152,8 +152,8 @@ describe('syncNewPhotos', () => {
     getAssetsAsyncMock.mockResolvedValueOnce(page(fullPage, 'cursor-page-1'))
     await run()
     expect(getAssetsAsyncMock).toHaveBeenCalledTimes(1)
-    expect(processAssetsMock).toHaveBeenCalledTimes(1)
-    expect(processAssetsMock.mock.calls[0][0]).toHaveLength(50)
+    expect(syncAssetsMock).toHaveBeenCalledTimes(1)
+    expect(syncAssetsMock.mock.calls[0][0]).toHaveLength(50)
   })
 
   it('excludes old photo with AI-bumped modificationTime', async () => {
@@ -167,7 +167,7 @@ describe('syncNewPhotos', () => {
       ]),
     )
     await run()
-    expect(processAssetsMock).not.toHaveBeenCalled()
+    expect(syncAssetsMock).not.toHaveBeenCalled()
   })
 
   it('setAutoSyncNewPhotos saves enablement timestamp', async () => {
@@ -181,7 +181,7 @@ describe('syncNewPhotos', () => {
 
   it('aborts before processAssets when shutdown is called mid-tick', async () => {
     const getAssetsAsyncMock = jest.mocked(MediaLibrary.getAssetsAsync)
-    const processAssetsMock = jest.mocked(processAssets)
+    const syncAssetsMock = jest.mocked(syncAssets)
 
     await setAutoSyncNewPhotos(true)
 
@@ -203,6 +203,6 @@ describe('syncNewPhotos', () => {
     await jest.advanceTimersByTimeAsync(0)
     await shutdownPromise
 
-    expect(processAssetsMock).not.toHaveBeenCalled()
+    expect(syncAssetsMock).not.toHaveBeenCalled()
   })
 })

--- a/apps/mobile/src/managers/syncNewPhotos.ts
+++ b/apps/mobile/src/managers/syncNewPhotos.ts
@@ -32,7 +32,7 @@ import {
   getMediaLibraryPermissions,
   mediaLibraryPermissionsCache,
 } from '../lib/mediaLibraryPermissions'
-import { processAssets } from '../lib/processAssets'
+import { syncAssets } from '../lib/processAssets'
 import { app } from '../stores/appService'
 
 const PAGE_SIZE = 50
@@ -67,7 +67,7 @@ export async function run(signal?: AbortSignal): Promise<void> {
       totalOnPage: page.assets.length,
     })
     if (signal?.aborted) return
-    const { files } = await processAssets(
+    const { files } = await syncAssets(
       assets.map((asset) => ({
         id: asset.id,
         sourceUri: asset.uri,

--- a/apps/mobile/src/managers/syncPhotosArchive.test.ts
+++ b/apps/mobile/src/managers/syncPhotosArchive.test.ts
@@ -3,7 +3,7 @@ import {
   SYNC_ARCHIVE_RECENT_SCAN_LOOKBACK,
 } from '@siastorage/core/config'
 import * as MediaLibrary from 'expo-media-library'
-import { processAssets } from '../lib/processAssets'
+import { catalogAssets } from '../lib/processAssets'
 import {
   getLastRecentScanAt,
   getPhotosArchiveCursor,
@@ -36,14 +36,14 @@ jest.mock('../lib/mediaLibraryPermissions', () => ({
   },
 }))
 jest.mock('../lib/processAssets', () => ({
-  processAssets: jest.fn(),
+  catalogAssets: jest.fn(),
 }))
 jest.mock('../stores/files', () => ({
   getFileStatsLocal: jest.fn().mockResolvedValue({ count: 0, totalBytes: 0 }),
 }))
 
 const getAssetsAsyncMock = jest.mocked(MediaLibrary.getAssetsAsync)
-const processAssetsMock = jest.mocked(processAssets)
+const catalogAssetsMock = jest.mocked(catalogAssets)
 
 function asset(
   id: string,
@@ -76,10 +76,8 @@ function page(
 }
 
 function mockProcessAssetsSuccess() {
-  processAssetsMock.mockResolvedValue({
+  catalogAssetsMock.mockResolvedValue({
     files: [{ id: '1' }] as never,
-    updatedFiles: [],
-    warnings: [],
   })
 }
 
@@ -164,7 +162,7 @@ describe('syncPhotosArchive', () => {
     getAssetsAsyncMock.mockResolvedValueOnce(page([]))
     await run()
     expect(await getPhotosArchiveCursor()).toBe('done')
-    expect(processAssetsMock).not.toHaveBeenCalled()
+    expect(catalogAssetsMock).not.toHaveBeenCalled()
   })
 
   it('stores displayDate from oldest modificationTime in batch', async () => {
@@ -204,7 +202,7 @@ describe('syncPhotosArchive', () => {
       ),
     )
     await run()
-    expect(processAssetsMock).toHaveBeenCalledWith(
+    expect(catalogAssetsMock).toHaveBeenCalledWith(
       [
         expect.objectContaining({
           timestamp: new Date(50_000).toISOString(),
@@ -228,7 +226,7 @@ describe('syncPhotosArchive', () => {
       ),
     )
     await run()
-    expect(processAssetsMock).toHaveBeenCalledWith(
+    expect(catalogAssetsMock).toHaveBeenCalledWith(
       [
         expect.objectContaining({ id: 'a1' }),
         expect.objectContaining({ id: 'a2' }),
@@ -241,7 +239,7 @@ describe('syncPhotosArchive', () => {
 
   it('aborts before processAssets when signal is aborted during getAssetsAsync', async () => {
     const getAssetsAsyncMock = jest.mocked(MediaLibrary.getAssetsAsync)
-    const processAssetsMock = jest.mocked(processAssets)
+    const catalogAssetsMock = jest.mocked(catalogAssets)
 
     const ac = new AbortController()
     getAssetsAsyncMock.mockImplementation(async () => {
@@ -252,7 +250,7 @@ describe('syncPhotosArchive', () => {
     await restartPhotosArchiveCursor()
     await run(ac.signal)
 
-    expect(processAssetsMock).not.toHaveBeenCalled()
+    expect(catalogAssetsMock).not.toHaveBeenCalled()
   })
 
   describe('triggerRecentScanIfNeeded', () => {
@@ -300,7 +298,7 @@ describe('syncPhotosArchive', () => {
       )
       await run()
 
-      expect(processAssetsMock).toHaveBeenCalledTimes(1)
+      expect(catalogAssetsMock).toHaveBeenCalledTimes(1)
       expect(await getPhotosArchiveCursor()).toBe('done')
       expect(await getPhotosArchiveDisplayDate()).toBe(0)
       expect(await getLastRecentScanAt()).toBe(NOW)
@@ -342,7 +340,7 @@ describe('syncPhotosArchive', () => {
       )
       await run()
 
-      expect(processAssetsMock).toHaveBeenCalledWith(
+      expect(catalogAssetsMock).toHaveBeenCalledWith(
         [
           expect.objectContaining({ id: 'a1' }),
           expect.objectContaining({ id: 'a2' }),

--- a/apps/mobile/src/managers/syncPhotosArchive.ts
+++ b/apps/mobile/src/managers/syncPhotosArchive.ts
@@ -44,7 +44,7 @@ import {
   getMediaLibraryPermissions,
   mediaLibraryPermissionsCache,
 } from '../lib/mediaLibraryPermissions'
-import { processAssets } from '../lib/processAssets'
+import { catalogAssets } from '../lib/processAssets'
 import { app } from '../stores/appService'
 import { getFileStatsLocal } from '../stores/files'
 
@@ -115,7 +115,7 @@ export async function run(signal?: AbortSignal) {
       nextCursor: page.endCursor,
     })
     if (signal?.aborted) return
-    const { files } = await processAssets(
+    const { files } = await catalogAssets(
       assets.map((asset) => ({
         id: asset.id,
         sourceUri: asset.uri,

--- a/apps/mobile/src/managers/uploader.test.ts
+++ b/apps/mobile/src/managers/uploader.test.ts
@@ -1168,6 +1168,62 @@ describe('UploadManager', () => {
       expect(mockPacker.add).not.toHaveBeenCalled()
     })
 
+    it('skips files with empty hash (placeholder files still processing)', async () => {
+      enablePolling()
+      const filesWithEmptyHash = [
+        {
+          id: 'empty-hash-1',
+          name: 'empty-hash-1.bin',
+          size: 400,
+          type: 'application/octet-stream',
+          hash: '',
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+          localId: null,
+          addedAt: Date.now(),
+          objects: {},
+        },
+        {
+          id: 'has-hash-1',
+          name: 'has-hash-1.bin',
+          size: 400,
+          type: 'application/octet-stream',
+          hash: 'sha256:abc123',
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+          localId: null,
+          addedAt: Date.now(),
+          objects: {},
+        },
+        {
+          id: 'empty-hash-2',
+          name: 'empty-hash-2.bin',
+          size: 400,
+          type: 'application/octet-stream',
+          hash: '',
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+          localId: null,
+          addedAt: Date.now(),
+          objects: {},
+        },
+      ]
+      queryFilesSpy
+        .mockResolvedValueOnce(filesWithEmptyHash)
+        .mockResolvedValue([] as any)
+
+      manager.initialize(app(), internal(), defaultAdapters())
+      await jest.advanceTimersByTimeAsync(0)
+
+      // Only the file with a hash should be added to the packer
+      expect(mockPacker.add).toHaveBeenCalledTimes(1)
+
+      // Only has-hash-1 should be registered in the upload store
+      expect(app().uploads.getEntry('has-hash-1')).toBeDefined()
+      expect(app().uploads.getEntry('empty-hash-1')).toBeUndefined()
+      expect(app().uploads.getEntry('empty-hash-2')).toBeUndefined()
+    })
+
     it('excludeIds allows polling past the 200-file query limit', async () => {
       // Without excludeIds, a second poll would return the same 200 files
       // (still local-only until pin), JS filter removes them all, and idle

--- a/apps/mobile/src/stores/fileCarousel.ts
+++ b/apps/mobile/src/stores/fileCarousel.ts
@@ -2,16 +2,8 @@ import type { Category, SortBy, SortDir } from '@siastorage/core/db/operations'
 import { useOnLibraryListChange } from '@siastorage/core/stores'
 import type { FileRecord } from '@siastorage/core/types'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { fileRecordEqual } from '../lib/file'
 import { app } from './appService'
-
-function fileRecordEqual(a: FileRecord, b: FileRecord): boolean {
-  return (
-    a.id === b.id &&
-    a.updatedAt === b.updatedAt &&
-    a.hash === b.hash &&
-    Object.keys(a.objects).length === Object.keys(b.objects).length
-  )
-}
 
 type VirtualListQueryParams = {
   sortBy: SortBy

--- a/apps/mobile/src/stores/files.test.ts
+++ b/apps/mobile/src/stores/files.test.ts
@@ -88,6 +88,31 @@ describe('files store (core functions with appService)', () => {
     expect(verSpy).not.toHaveBeenCalled()
   })
 
+  test('updateMany invalidates fileById cache for each updated record', async () => {
+    await app().files.create(makeFileRecord('f1'))
+    await app().files.create(makeFileRecord('f2'))
+    await app().files.create(makeFileRecord('f3'))
+    const fileSpy = jest.spyOn(app().caches.fileById, 'invalidate')
+    const verSpy = jest.spyOn(app().caches.libraryVersion, 'invalidate')
+    await app().files.updateMany([
+      { id: 'f1', name: 'a.jpg' },
+      { id: 'f2', name: 'b.jpg' },
+    ])
+    expect(fileSpy).toHaveBeenCalledWith('f1')
+    expect(fileSpy).toHaveBeenCalledWith('f2')
+    expect(fileSpy).not.toHaveBeenCalledWith('f3')
+    expect(fileSpy).toHaveBeenCalledTimes(2)
+    expect(verSpy).toHaveBeenCalled()
+  })
+
+  test('updateMany with empty array does not invalidate', async () => {
+    const fileSpy = jest.spyOn(app().caches.fileById, 'invalidate')
+    const verSpy = jest.spyOn(app().caches.libraryVersion, 'invalidate')
+    await app().files.updateMany([])
+    expect(fileSpy).not.toHaveBeenCalled()
+    expect(verSpy).not.toHaveBeenCalled()
+  })
+
   test('deleteFileRecord removes record', async () => {
     await app().files.create(makeFileRecord('f1'))
     const libSpy = jest.spyOn(app().caches.library, 'invalidateAll')

--- a/apps/mobile/src/stores/files.ts
+++ b/apps/mobile/src/stores/files.ts
@@ -43,15 +43,7 @@ export function useFilesLocalOnly(params: {
 
 async function getFileCountLost() {
   const currentIndexerURL = await app().settings.getIndexerURL()
-  return app().files.queryCount({
-    order: 'ASC',
-    pinned: {
-      indexerURL: currentIndexerURL,
-      isPinned: false,
-    },
-    fileExistsLocally: false,
-    activeOnly: true,
-  })
+  return app().files.getLostCount(currentIndexerURL)
 }
 
 export function useFileCountLost(config?: SWRConfiguration) {
@@ -61,15 +53,7 @@ export function useFileCountLost(config?: SWRConfiguration) {
 
 async function getFileStatsLost() {
   const currentIndexerURL = await app().settings.getIndexerURL()
-  return app().files.queryStats({
-    order: 'ASC',
-    pinned: {
-      indexerURL: currentIndexerURL,
-      isPinned: false,
-    },
-    fileExistsLocally: false,
-    activeOnly: true,
-  })
+  return app().files.getLostStats(currentIndexerURL)
 }
 
 export function useFileStatsLost(config?: SWRConfiguration) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,6 +36,7 @@
     "./services/syncUpMetadata": "./src/services/syncUpMetadata.ts",
     "./services/thumbnailScanner": "./src/services/thumbnailScanner.ts",
     "./services/cacheEviction": "./src/services/cacheEviction.ts",
+    "./services/importScanner": "./src/services/importScanner.ts",
     "./services/uploader": "./src/services/uploader.ts",
     "./services/fsFileUri": "./src/services/fsFileUri.ts",
     "./app": "./src/app/index.ts",

--- a/packages/core/src/app/namespaces/db.ts
+++ b/packages/core/src/app/namespaces/db.ts
@@ -194,8 +194,14 @@ export function buildDbNamespaces(
           invalidateLibrary()
         }
       },
-      createMany: async (records) => {
-        await ops.insertManyFileRecords(db, records)
+      createMany: async (records, opts) => {
+        await ops.insertManyFileRecords(
+          db,
+          records,
+          opts?.conflictClause
+            ? { conflictClause: opts.conflictClause }
+            : undefined,
+        )
         if (records.length > 0) {
           invalidateLibrary()
         }
@@ -210,6 +216,9 @@ export function buildDbNamespaces(
       updateMany: async (updates, opts) => {
         await ops.updateManyFileRecordFields(db, updates, opts)
         if (updates.length > 0) {
+          for (const u of updates) {
+            caches.fileById.invalidate(u.id)
+          }
           caches.libraryVersion.invalidate()
         }
       },
@@ -259,6 +268,8 @@ export function buildDbNamespaces(
         await ops.restoreFiles(db, ids)
         invalidateLibrary()
       },
+      getLostCount: (indexerURL) => ops.queryLostFileCount(db, indexerURL),
+      getLostStats: (indexerURL) => ops.queryLostFileStats(db, indexerURL),
       getUnuploadedCount: () => ops.queryUnuploadedFileCount(db),
       getUnuploaded: () => ops.queryUnuploadedFiles(db),
       getActiveSummaries: () => ops.queryActiveFileSummaries(db),

--- a/packages/core/src/app/service.ts
+++ b/packages/core/src/app/service.ts
@@ -143,8 +143,12 @@ export interface AppService {
       localObject?: LocalObject,
       opts?: { skipInvalidation?: boolean },
     ): Promise<void>
-    /** Creates multiple file records in a single transaction. */
-    createMany(records: Omit<FileRecord, 'objects'>[]): Promise<void>
+    /** Creates multiple file records via bulk insert. Pass conflictClause
+     * 'OR IGNORE' to silently skip duplicates (e.g. localId conflicts). */
+    createMany(
+      records: Omit<FileRecord, 'objects'>[],
+      opts?: { conflictClause?: 'OR IGNORE' },
+    ): Promise<void>
     /** Partially updates a file record by ID. */
     update(
       update: Partial<FileRecordRow> & { id: string },
@@ -199,6 +203,12 @@ export interface AppService {
     ): Promise<void>
     /** Runs auto-purge and cleans up local files and uploads for purged files. */
     autoPurgeWithCleanup(): Promise<void>
+    /** Returns the count of lost files for the given indexer. */
+    getLostCount(indexerURL: string): Promise<number>
+    /** Returns count and total byte size of lost files for the given indexer. */
+    getLostStats(
+      indexerURL: string,
+    ): Promise<{ count: number; totalBytes: number }>
   }
   /** Directory operations: create, rename, delete, and organize files into directories. */
   directories: {

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -37,13 +37,17 @@ export const SYNC_EVENTS_INTERVAL = secondsInMs(10) // 10 seconds
 // Sync new photos interval.
 export const SYNC_NEW_PHOTOS_INTERVAL = secondsInMs(10) // 10 seconds
 // Sync archive photos interval.
-export const SYNC_PHOTOS_ARCHIVE_INTERVAL = secondsInMs(5) // 5 seconds
+export const SYNC_PHOTOS_ARCHIVE_INTERVAL = secondsInMs(1) // 1 second
 // Resume fetching archive photos when pending local-only bytes drop below this threshold.
 export const SYNC_ARCHIVE_RESUME_THRESHOLD = 4 * SLAB_SIZE
 // Minimum interval between bounded recent re-scans of the archive.
 export const SYNC_ARCHIVE_RECENT_SCAN_INTERVAL = minutesInMs(180) // 3 hours
 // How far back the bounded recent re-scan walks.
 export const SYNC_ARCHIVE_RECENT_SCAN_LOOKBACK = daysInMs(14) // 14 days
+// Import scanner interval.
+export const IMPORT_SCANNER_INTERVAL = secondsInMs(3) // 3 seconds
+// Max files requiring copy and hash allowed in the upload backlog before throttling.
+export const IMPORT_SCANNER_BACKLOG_LIMIT = 50
 // Thumbnail scanner interval.
 export const THUMBNAIL_SCANNER_INTERVAL = secondsInMs(5) // 5 seconds
 // Maximum number of bytes to retain in the local file system before evicting.

--- a/packages/core/src/db/migrations/0001_init_schema.ts
+++ b/packages/core/src/db/migrations/0001_init_schema.ts
@@ -60,7 +60,6 @@ async function up(db: DatabaseAdapter): Promise<void> {
   await db.execAsync(
     `CREATE INDEX IF NOT EXISTS idx_files_deletedAt ON files(deletedAt);`,
   )
-
   await db.execAsync(
     `CREATE TABLE IF NOT EXISTS objects (
     fileId TEXT NOT NULL,

--- a/packages/core/src/db/migrations/0002_add_lost_reason.ts
+++ b/packages/core/src/db/migrations/0002_add_lost_reason.ts
@@ -1,0 +1,15 @@
+import type { DatabaseAdapter } from '../../adapters/db'
+import type { Migration } from '../types'
+
+async function up(db: DatabaseAdapter): Promise<void> {
+  await db.execAsync(`ALTER TABLE files ADD COLUMN lostReason TEXT;`)
+  await db.execAsync(
+    `CREATE INDEX IF NOT EXISTS idx_files_addedAt_id ON files(addedAt, id);`,
+  )
+}
+
+export const migration_0002_add_lost_reason: Migration = {
+  id: '0002_add_lost_reason',
+  description: 'Add lostReason column to files table.',
+  up,
+}

--- a/packages/core/src/db/migrations/index.ts
+++ b/packages/core/src/db/migrations/index.ts
@@ -1,7 +1,11 @@
 import type { Migration } from '../types'
 import { migration_0001_init_schema } from './0001_init_schema'
+import { migration_0002_add_lost_reason } from './0002_add_lost_reason'
 
-export const coreMigrations: Migration[] = [migration_0001_init_schema]
+export const coreMigrations: Migration[] = [
+  migration_0001_init_schema,
+  migration_0002_add_lost_reason,
+]
 
 export function sortMigrations(migrations: Migration[]): Migration[] {
   return [...migrations].sort((a, b) => a.id.localeCompare(b.id))

--- a/packages/core/src/db/operations/files.ts
+++ b/packages/core/src/db/operations/files.ts
@@ -29,6 +29,7 @@ export function transformRow(
     thumbSize: row.thumbSize ?? undefined,
     trashedAt: row.trashedAt ?? null,
     deletedAt: row.deletedAt ?? null,
+    lostReason: row.lostReason ?? null,
     objects: objectsMap,
   }
 }
@@ -52,6 +53,7 @@ export async function insertFileRecord(
     thumbSize,
     trashedAt,
     deletedAt,
+    lostReason,
   } = fileRecord
   await sql.insert(db, 'files', {
     id,
@@ -68,10 +70,11 @@ export async function insertFileRecord(
     thumbSize,
     trashedAt,
     deletedAt,
+    lostReason,
   })
 }
 
-type FileRecordCursorColumn = 'createdAt' | 'updatedAt'
+type FileRecordCursorColumn = 'createdAt' | 'updatedAt' | 'addedAt'
 
 export type FileRecordsQueryOpts = {
   limit?: number
@@ -85,6 +88,8 @@ export type FileRecordsQueryOpts = {
   fileExistsLocally?: boolean
   excludeIds?: string[]
   activeOnly?: boolean
+  hashEmpty?: boolean
+  hashNotEmpty?: boolean
 }
 
 function buildFileRecordsQuery(
@@ -105,6 +110,8 @@ function buildFileRecordsQuery(
     fileExistsLocally,
     excludeIds,
     activeOnly,
+    hashEmpty,
+    hashNotEmpty,
   } = opts
   const sortColumn: FileRecordCursorColumn = orderBy ?? 'createdAt'
 
@@ -115,6 +122,14 @@ function buildFileRecordsQuery(
   if (activeOnly) {
     whereClauses.push(`${tableAlias}.trashedAt IS NULL`)
     whereClauses.push(`${tableAlias}.deletedAt IS NULL`)
+  }
+
+  if (hashEmpty) {
+    whereClauses.push(`${tableAlias}.hash = ''`)
+  }
+
+  if (hashNotEmpty) {
+    whereClauses.push(`${tableAlias}.hash != ''`)
   }
 
   if (after) {
@@ -212,7 +227,7 @@ export async function queryFileRecords(
         objectUpdatedAt: number
       }
   >(
-    `SELECT f.id, f.name, f.size, f.createdAt, f.updatedAt, f.type, f.kind, f.localId, f.hash, f.addedAt, f.thumbForId, f.thumbSize, f.trashedAt, f.deletedAt,
+    `SELECT f.id, f.name, f.size, f.createdAt, f.updatedAt, f.type, f.kind, f.localId, f.hash, f.addedAt, f.thumbForId, f.thumbSize, f.trashedAt, f.deletedAt, f.lostReason,
             o.fileId as fileId, o.indexerURL as indexerURL, o.id as objectId, o.slabs as slabs,
             o.encryptedDataKey as encryptedDataKey, o.encryptedMetadataKey as encryptedMetadataKey,
             o.encryptedMetadata as encryptedMetadata, o.dataSignature as dataSignature,
@@ -256,7 +271,7 @@ export async function queryFileRecordByObjectId(
   indexerURL: string,
 ): Promise<FileRecordRow | null> {
   return db.getFirstAsync<FileRecordRow>(
-    `SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize, trashedAt, deletedAt FROM files WHERE id IN (SELECT fileId FROM objects WHERE id = ? AND indexerURL = ?) LIMIT 1`,
+    `SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize, trashedAt, deletedAt, lostReason FROM files WHERE id IN (SELECT fileId FROM objects WHERE id = ? AND indexerURL = ?) LIMIT 1`,
     objectId,
     indexerURL,
   )
@@ -267,7 +282,7 @@ export async function queryFileRecordsByLocalIds(
   localIds: string[],
 ): Promise<FileRecordRow[]> {
   return db.getAllAsync<FileRecordRow>(
-    `SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize, trashedAt, deletedAt FROM files WHERE deletedAt IS NULL AND trashedAt IS NULL AND localId IN (${localIds
+    `SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize, trashedAt, deletedAt, lostReason FROM files WHERE deletedAt IS NULL AND trashedAt IS NULL AND localId IN (${localIds
       .map((_) => `?`)
       .join(',')})`,
     ...localIds,
@@ -279,7 +294,7 @@ export async function queryFileRecordsByContentHashes(
   contentHashes: string[],
 ): Promise<FileRecordRow[]> {
   return db.getAllAsync<FileRecordRow>(
-    `SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize, trashedAt, deletedAt FROM files WHERE deletedAt IS NULL AND trashedAt IS NULL AND hash IN (${contentHashes
+    `SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize, trashedAt, deletedAt, lostReason FROM files WHERE deletedAt IS NULL AND trashedAt IS NULL AND hash IN (${contentHashes
       .map((_) => `?`)
       .join(',')})`,
     ...contentHashes,
@@ -291,7 +306,7 @@ export async function queryFileRecordByContentHash(
   hash: string,
 ): Promise<FileRecordRow | null> {
   const row = await db.getFirstAsync<FileRecordRow>(
-    'SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize, trashedAt, deletedAt FROM files WHERE deletedAt IS NULL AND trashedAt IS NULL AND hash = ?',
+    'SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize, trashedAt, deletedAt, lostReason FROM files WHERE deletedAt IS NULL AND trashedAt IS NULL AND hash = ?',
     hash,
   )
   if (!row) {
@@ -305,7 +320,7 @@ export async function queryFileRecordById(
   id: string,
 ): Promise<FileRecordRow | null> {
   const row = await db.getFirstAsync<FileRecordRow>(
-    'SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize, trashedAt, deletedAt FROM files WHERE id = ?',
+    'SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize, trashedAt, deletedAt, lostReason FROM files WHERE id = ?',
     id,
   )
   if (!row) {
@@ -333,6 +348,7 @@ export async function updateFileRecordFields(
     'localId',
     'trashedAt',
     'deletedAt',
+    'lostReason',
   ]
   if (options.includeUpdatedAt) {
     updatableFields.push('updatedAt')
@@ -508,24 +524,36 @@ export async function queryLostFileCount(
   db: DatabaseAdapter,
   indexerURL: string,
 ): Promise<number> {
-  return queryFileRecordsCount(db, {
-    order: 'ASC',
-    pinned: { indexerURL, isPinned: false },
-    fileExistsLocally: false,
-    activeOnly: true,
-  })
+  const row = await db.getFirstAsync<{ count: number }>(
+    `SELECT COUNT(*) as count FROM files f
+     WHERE f.trashedAt IS NULL AND f.deletedAt IS NULL
+     AND (
+       (NOT EXISTS (SELECT 1 FROM objects s WHERE s.fileId = f.id AND s.indexerURL = ?)
+        AND NOT EXISTS (SELECT 1 FROM fs fsMeta WHERE fsMeta.fileId = f.id)
+        AND f.hash != '')
+       OR f.lostReason IS NOT NULL
+     )`,
+    indexerURL,
+  )
+  return row?.count ?? 0
 }
 
 export async function queryLostFileStats(
   db: DatabaseAdapter,
   indexerURL: string,
 ): Promise<{ count: number; totalBytes: number }> {
-  return queryFileRecordsStats(db, {
-    order: 'ASC',
-    pinned: { indexerURL, isPinned: false },
-    fileExistsLocally: false,
-    activeOnly: true,
-  })
+  const row = await db.getFirstAsync<{ count: number; totalBytes: number }>(
+    `SELECT COUNT(*) as count, COALESCE(SUM(size), 0) as totalBytes FROM files f
+     WHERE f.trashedAt IS NULL AND f.deletedAt IS NULL
+     AND (
+       (NOT EXISTS (SELECT 1 FROM objects s WHERE s.fileId = f.id AND s.indexerURL = ?)
+        AND NOT EXISTS (SELECT 1 FROM fs fsMeta WHERE fsMeta.fileId = f.id)
+        AND f.hash != '')
+       OR f.lostReason IS NOT NULL
+     )`,
+    indexerURL,
+  )
+  return { count: row?.count ?? 0, totalBytes: row?.totalBytes ?? 0 }
 }
 
 export async function queryLocalFileCount(
@@ -568,7 +596,7 @@ export async function readFileRecordsByIds(
         objectUpdatedAt: number
       }
   >(
-    `SELECT f.id, f.name, f.size, f.createdAt, f.updatedAt, f.type, f.kind, f.localId, f.hash, f.addedAt, f.thumbForId, f.thumbSize, f.trashedAt, f.deletedAt,
+    `SELECT f.id, f.name, f.size, f.createdAt, f.updatedAt, f.type, f.kind, f.localId, f.hash, f.addedAt, f.thumbForId, f.thumbSize, f.trashedAt, f.deletedAt, f.lostReason,
             o.fileId as fileId, o.indexerURL as indexerURL, o.id as objectId, o.slabs as slabs,
             o.encryptedDataKey as encryptedDataKey, o.encryptedMetadataKey as encryptedMetadataKey,
             o.encryptedMetadata as encryptedMetadata, o.dataSignature as dataSignature,
@@ -608,13 +636,31 @@ export async function readFileRecordsByIds(
 export async function insertManyFileRecords(
   db: DatabaseAdapter,
   records: Omit<FileRecord, 'objects'>[],
+  options?: sql.InsertOptions,
 ): Promise<void> {
   if (records.length === 0) return
-  await db.withTransactionAsync(async () => {
-    for (const record of records) {
-      await insertFileRecord(db, record)
-    }
-  })
+  await sql.insertMany(
+    db,
+    'files',
+    records.map((r) => ({
+      id: r.id,
+      name: r.name,
+      size: r.size,
+      createdAt: r.createdAt,
+      updatedAt: r.updatedAt,
+      type: r.type,
+      kind: r.kind,
+      localId: r.localId,
+      hash: r.hash,
+      addedAt: r.addedAt,
+      thumbForId: r.thumbForId,
+      thumbSize: r.thumbSize,
+      trashedAt: r.trashedAt,
+      deletedAt: r.deletedAt,
+      lostReason: r.lostReason,
+    })),
+    options,
+  )
 }
 
 export async function updateManyFileRecordFields(
@@ -647,7 +693,7 @@ export async function queryFileRecordByName(
   name: string,
 ): Promise<FileRecordRow | null> {
   return db.getFirstAsync<FileRecordRow>(
-    `SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize, trashedAt, deletedAt
+    `SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize, trashedAt, deletedAt, lostReason
      FROM files WHERE name = ? AND kind = 'file' AND trashedAt IS NULL AND deletedAt IS NULL`,
     name,
   )
@@ -720,16 +766,19 @@ export async function deleteLostFiles(
   db: DatabaseAdapter,
   indexerURL: string,
 ): Promise<string[]> {
-  const lost = await queryFileRecords(db, {
-    order: 'ASC',
-    pinned: { indexerURL, isPinned: false },
-    fileExistsLocally: false,
-    activeOnly: true,
-  })
-  if (lost.length === 0) return []
-  await deleteFileRecordsAndThumbnails(
-    db,
-    lost.map((f) => f.id),
+  const lost = await db.getAllAsync<{ id: string }>(
+    `SELECT f.id FROM files f
+     WHERE f.trashedAt IS NULL AND f.deletedAt IS NULL
+     AND (
+       (NOT EXISTS (SELECT 1 FROM objects s WHERE s.fileId = f.id AND s.indexerURL = ?)
+        AND NOT EXISTS (SELECT 1 FROM fs fsMeta WHERE fsMeta.fileId = f.id)
+        AND f.hash != '')
+       OR f.lostReason IS NOT NULL
+     )`,
+    indexerURL,
   )
-  return lost.map((f) => f.id)
+  if (lost.length === 0) return []
+  const ids = lost.map((f) => f.id)
+  await deleteFileRecordsAndThumbnails(db, ids)
+  return ids
 }

--- a/packages/core/src/db/sql.ts
+++ b/packages/core/src/db/sql.ts
@@ -49,6 +49,51 @@ export async function insert<
   return await run(db, sql, params)
 }
 
+// SQLite limits the number of ? placeholders per statement
+// (SQLITE_MAX_VARIABLE_NUMBER, default 999). Each row contributes one
+// placeholder per non-null column, so the chunk size is computed from the
+// column count to stay safely under the limit.
+const MAX_VARIABLES = 999
+
+export async function insertMany<
+  T extends Record<string, string | number | boolean | null | undefined>,
+>(
+  db: DatabaseAdapter,
+  table: string,
+  rows: T[],
+  options?: InsertOptions,
+): Promise<void> {
+  if (rows.length === 0) return
+  const columns = Object.keys(rows[0])
+  const chunkSize = Math.max(1, Math.floor(MAX_VARIABLES / columns.length))
+  const verb = options?.conflictClause
+    ? `INSERT ${options.conflictClause}`
+    : 'INSERT'
+
+  for (let i = 0; i < rows.length; i += chunkSize) {
+    const chunk = rows.slice(i, i + chunkSize)
+    const allValuesSql: string[] = []
+    const params: SqlBindable[] = []
+
+    for (const row of chunk) {
+      const rowValues: string[] = []
+      for (const key of columns) {
+        const value = row[key]
+        if (value === null || value === undefined) {
+          rowValues.push('NULL')
+        } else {
+          rowValues.push('?')
+          params.push(value)
+        }
+      }
+      allValuesSql.push(`(${rowValues.join(', ')})`)
+    }
+
+    const sql = `${verb} INTO ${table} (${columns.join(', ')}) VALUES ${allValuesSql.join(', ')}`
+    await run(db, sql, params)
+  }
+}
+
 function normalizeSqlValue(value: SqlValue): string | number {
   if (value === null || value === undefined) {
     throw new Error(

--- a/packages/core/src/services/importScanner.test.ts
+++ b/packages/core/src/services/importScanner.test.ts
@@ -1,0 +1,452 @@
+import { ImportScanner } from './importScanner'
+
+type MockHelper = {
+  app: any
+  fileRecords: Map<string, any>
+  fsFiles: Map<string, string>
+  fsMeta: Map<string, any>
+  caches: any
+  addFile: (id: string, overrides?: any) => void
+  addLocalFile: (fileId: string, uri: string) => void
+}
+
+function createMockApp(): MockHelper {
+  const fileRecords = new Map<string, any>()
+  const fsFiles = new Map<string, string>()
+  const fsMeta = new Map<string, any>()
+
+  const caches = {
+    library: { invalidateAll: jest.fn() },
+    libraryVersion: { invalidate: jest.fn() },
+    fileById: { invalidate: jest.fn() },
+  }
+
+  const app: any = {
+    files: {
+      query: jest.fn(async (opts: any) => {
+        const results: any[] = []
+        for (const [, file] of fileRecords) {
+          if (opts.activeOnly && (file.trashedAt || file.deletedAt)) continue
+          if (opts.hashEmpty && file.hash !== '') continue
+          results.push({ ...file, objects: {} })
+        }
+        results.sort((a: any, b: any) =>
+          opts.order === 'DESC' ? b.addedAt - a.addedAt : a.addedAt - b.addedAt,
+        )
+        if (opts.limit) return results.slice(0, opts.limit)
+        return results
+      }),
+      updateMany: jest.fn(async (updates: any[]) => {
+        for (const u of updates) {
+          const existing = fileRecords.get(u.id)
+          if (existing) {
+            fileRecords.set(u.id, { ...existing, ...u, updatedAt: Date.now() })
+          }
+        }
+      }),
+    },
+    fs: {
+      getFileUri: jest.fn(async (file: any) => fsFiles.get(file.id) ?? null),
+      copyFile: jest.fn(async (file: any, _sourceUri: string) => {
+        const uri = `/local/${file.id}.${file.type.split('/')[1]}`
+        fsFiles.set(file.id, uri)
+        fsMeta.set(file.id, {
+          fileId: file.id,
+          size: 1234,
+          addedAt: Date.now(),
+          usedAt: Date.now(),
+        })
+        return uri
+      }),
+      readMeta: jest.fn(async (fileId: string) => fsMeta.get(fileId) ?? null),
+    },
+    caches,
+  }
+
+  return {
+    app,
+    fileRecords,
+    fsFiles,
+    fsMeta,
+    caches,
+    addFile: (id: string, overrides: any = {}) => {
+      fileRecords.set(id, {
+        id,
+        name: `${id}.jpg`,
+        type: 'image/jpeg',
+        kind: 'file',
+        size: 0,
+        hash: '',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        addedAt: Date.now(),
+        localId: null,
+        trashedAt: null,
+        deletedAt: null,
+        lostReason: null,
+        ...overrides,
+      })
+    },
+    addLocalFile: (fileId: string, uri: string) => {
+      fsFiles.set(fileId, uri)
+      fsMeta.set(fileId, {
+        fileId,
+        size: 1234,
+        addedAt: Date.now(),
+        usedAt: Date.now(),
+      })
+    },
+  }
+}
+
+describe('ImportScanner', () => {
+  let scanner: ImportScanner
+  let mock: MockHelper
+  const mockHash: jest.Mock<Promise<string | null>, [string]> = jest.fn(
+    async (uri: string) => `sha256:hash-of-${uri}`,
+  )
+  const mockMimeType = jest.fn(async () => 'image/jpeg')
+
+  beforeEach(() => {
+    scanner = new ImportScanner()
+    mock = createMockApp()
+    scanner.initialize(mock.app, mockHash, mockMimeType)
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    scanner.reset()
+  })
+
+  describe('initialization', () => {
+    it('starts uninitialized', () => {
+      const s = new ImportScanner()
+      expect(s.isInitialized()).toBe(false)
+    })
+
+    it('is initialized after initialize()', () => {
+      expect(scanner.isInitialized()).toBe(true)
+    })
+
+    it('throws when running scan without initialization', async () => {
+      const s = new ImportScanner()
+      await expect(s.runScan()).rejects.toThrow('not initialized')
+    })
+  })
+
+  describe('requires hash (local file exists)', () => {
+    it('hashes local file and updates record', async () => {
+      mock.addFile('f1')
+      mock.addLocalFile('f1', '/local/f1.jpg')
+
+      const result = await scanner.runScan()
+
+      expect(result.finalized).toBe(1)
+      expect(result.failed).toBe(0)
+      expect(result.lost).toBe(0)
+      expect(mock.app.files.updateMany).toHaveBeenCalledWith([
+        expect.objectContaining({
+          id: 'f1',
+          hash: 'sha256:hash-of-/local/f1.jpg',
+        }),
+      ])
+    })
+
+    it('processes regardless of maxDeferred=0', async () => {
+      mock.addFile('f1')
+      mock.addLocalFile('f1', '/local/f1.jpg')
+
+      const result = await scanner.runScan(undefined, undefined, 0)
+
+      expect(result.finalized).toBe(1)
+    })
+  })
+
+  describe('requires copy and hash (photo library placeholder)', () => {
+    it('resolves localId and copies', async () => {
+      mock.addFile('f4', { localId: 'ph://asset-123' })
+      const resolveLocalId = jest.fn(async () => 'file:///photo.jpg')
+
+      const result = await scanner.runScan(undefined, resolveLocalId)
+
+      expect(result.finalized).toBe(1)
+      expect(resolveLocalId).toHaveBeenCalledWith('ph://asset-123')
+      expect(mock.app.fs.copyFile).toHaveBeenCalledWith(
+        { id: 'f4', type: 'image/jpeg' },
+        'file:///photo.jpg',
+      )
+    })
+
+    it('throttles when maxDeferred is reached', async () => {
+      mock.addFile('f1', { localId: 'ph://1', addedAt: 3000 })
+      mock.addFile('f2', { localId: 'ph://2', addedAt: 2000 })
+      mock.addFile('f3', { localId: 'ph://3', addedAt: 1000 })
+      const resolveLocalId = jest.fn(async () => 'file:///photo.jpg')
+
+      const result = await scanner.runScan(undefined, resolveLocalId, 1)
+
+      expect(result.finalized).toBe(1)
+      expect(result.skipped).toBe(2)
+      expect(resolveLocalId).toHaveBeenCalledTimes(1)
+    })
+
+    it('skips entirely when maxDeferred=0', async () => {
+      mock.addFile('f1', { localId: 'ph://1' })
+      const resolveLocalId = jest.fn(async () => 'file:///photo.jpg')
+
+      const result = await scanner.runScan(undefined, resolveLocalId, 0)
+
+      expect(result.finalized).toBe(0)
+      expect(result.skipped).toBe(1)
+      expect(resolveLocalId).not.toHaveBeenCalled()
+    })
+
+    it('skips files with localId when no resolver is provided', async () => {
+      mock.addFile('f1', { localId: 'ph://1' })
+
+      const result = await scanner.runScan()
+
+      expect(result.skipped).toBe(1)
+      expect(result.lost).toBe(0)
+    })
+  })
+
+  describe('lostReason marking', () => {
+    it('marks file lost when localId does not resolve', async () => {
+      mock.addFile('f5', { localId: 'ph://deleted-asset' })
+      const resolveLocalId = jest.fn(async () => null)
+
+      const result = await scanner.runScan(undefined, resolveLocalId)
+
+      expect(result.lost).toBe(1)
+      expect(mock.app.files.updateMany).toHaveBeenCalledWith([
+        expect.objectContaining({
+          id: 'f5',
+          lostReason: 'Source photo deleted from device',
+        }),
+      ])
+    })
+
+    it('marks file lost when copy from localId fails', async () => {
+      mock.addFile('f6', { localId: 'ph://asset' })
+      const resolveLocalId = jest.fn(async () => 'file:///photo.jpg')
+      mock.app.fs.copyFile.mockRejectedValueOnce(new Error('Copy failed'))
+
+      const result = await scanner.runScan(undefined, resolveLocalId)
+
+      expect(result.lost).toBe(1)
+      expect(mock.app.files.updateMany).toHaveBeenCalledWith([
+        expect.objectContaining({
+          id: 'f6',
+          lostReason: 'Failed to copy from device',
+        }),
+      ])
+    })
+
+    it('marks orphan file (no local file, no localId) as lost', async () => {
+      mock.addFile('f7')
+
+      const result = await scanner.runScan()
+
+      expect(result.lost).toBe(1)
+      expect(mock.app.files.updateMany).toHaveBeenCalledWith([
+        expect.objectContaining({
+          id: 'f7',
+          lostReason: 'No local file or source available',
+        }),
+      ])
+    })
+  })
+
+  describe('skip in-progress files', () => {
+    it('skips files currently being processed', async () => {
+      mock.addFile('f7')
+      mock.addLocalFile('f7', '/local/f7.jpg')
+      ;(scanner as any).processingFiles.add('f7')
+
+      const result = await scanner.runScan()
+
+      expect(result.skipped).toBe(1)
+      expect(result.finalized).toBe(0)
+    })
+  })
+
+  describe('error cooldown', () => {
+    it('skips files that recently errored', async () => {
+      mock.addFile('f8')
+      ;(scanner as any).erroredFiles.set('f8', Date.now())
+
+      const result = await scanner.runScan()
+
+      expect(result.skipped).toBe(1)
+      expect(result.finalized).toBe(0)
+    })
+
+    it('retries files after cooldown expires', async () => {
+      mock.addFile('f9')
+      mock.addLocalFile('f9', '/local/f9.jpg')
+      ;(scanner as any).erroredFiles.set('f9', Date.now() - 10 * 60 * 1000)
+
+      const result = await scanner.runScan()
+
+      expect(result.finalized).toBe(1)
+    })
+  })
+
+  describe('abort signal', () => {
+    it('respects aborted signal', async () => {
+      mock.addFile('f10')
+      mock.addFile('f11')
+      mock.addLocalFile('f10', '/local/f10.jpg')
+      mock.addLocalFile('f11', '/local/f11.jpg')
+
+      const controller = new AbortController()
+      controller.abort()
+
+      const result = await scanner.runScan(controller.signal)
+
+      expect(result.finalized).toBe(0)
+    })
+  })
+
+  describe('batch limit', () => {
+    it('processes at most MAX_PER_TICK files', async () => {
+      for (let i = 0; i < 25; i++) {
+        mock.addFile(`batch-${i}`, { addedAt: Date.now() - i })
+        mock.addLocalFile(`batch-${i}`, `/local/batch-${i}.jpg`)
+      }
+
+      const result = await scanner.runScan()
+
+      expect(result.finalized).toBe(20)
+    })
+  })
+
+  describe('priority ordering', () => {
+    it('processes newest addedAt first (DESC order)', async () => {
+      mock.addFile('old', { addedAt: 1000 })
+      mock.addFile('new', { addedAt: 2000 })
+      mock.addLocalFile('old', '/local/old.jpg')
+      mock.addLocalFile('new', '/local/new.jpg')
+
+      await scanner.runScan()
+
+      expect(mock.app.files.query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          order: 'DESC',
+          orderBy: 'addedAt',
+          hashEmpty: true,
+        }),
+      )
+    })
+  })
+
+  describe('MIME re-detection', () => {
+    it('re-detects MIME when type is application/octet-stream', async () => {
+      mock.addFile('f12', { type: 'application/octet-stream' })
+      mock.addLocalFile('f12', '/local/f12.bin')
+      mockMimeType.mockResolvedValueOnce('image/png')
+
+      const result = await scanner.runScan()
+
+      expect(result.finalized).toBe(1)
+      expect(mockMimeType).toHaveBeenCalledWith({
+        name: 'f12.jpg',
+        uri: '/local/f12.bin',
+      })
+      expect(mock.app.files.updateMany).toHaveBeenCalledWith([
+        expect.objectContaining({ id: 'f12', type: 'image/png' }),
+      ])
+    })
+  })
+
+  describe('cache invalidation', () => {
+    it('invalidates caches after finalization', async () => {
+      mock.addFile('f13')
+      mock.addLocalFile('f13', '/local/f13.jpg')
+
+      await scanner.runScan()
+
+      expect(mock.caches.library.invalidateAll).toHaveBeenCalled()
+      expect(mock.caches.libraryVersion.invalidate).toHaveBeenCalled()
+    })
+
+    it('invalidates caches after marking files lost', async () => {
+      mock.addFile('f14')
+
+      await scanner.runScan()
+
+      expect(mock.caches.library.invalidateAll).toHaveBeenCalled()
+      expect(mock.caches.libraryVersion.invalidate).toHaveBeenCalled()
+    })
+
+    it('does not invalidate when no files processed', async () => {
+      const result = await scanner.runScan()
+
+      expect(result.finalized).toBe(0)
+      expect(mock.caches.library.invalidateAll).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('files with real hash are skipped', () => {
+    it('only queries files with hash = empty string', async () => {
+      mock.addFile('has-hash', { hash: 'sha256:real-hash' })
+
+      const result = await scanner.runScan()
+
+      expect(result.finalized).toBe(0)
+      expect(mock.app.files.query).toHaveBeenCalledWith(
+        expect.objectContaining({ hashEmpty: true }),
+      )
+    })
+  })
+
+  describe('multiple files in one tick', () => {
+    it('processes mix of local files and localIds', async () => {
+      mock.addFile('local-file', { addedAt: 3000 })
+      mock.addLocalFile('local-file', '/local/local-file.jpg')
+
+      mock.addFile('photo-file', { localId: 'ph://123', addedAt: 1000 })
+
+      const resolveLocalId = jest.fn(async () => 'file:///photo.jpg')
+
+      const result = await scanner.runScan(undefined, resolveLocalId)
+
+      expect(result.finalized).toBe(2)
+      expect(result.lost).toBe(0)
+    })
+  })
+
+  describe('hash failure', () => {
+    it('marks file as failed when hash returns null', async () => {
+      mock.addFile('hash-fail')
+      mock.addLocalFile('hash-fail', '/local/hash-fail.jpg')
+      mockHash.mockResolvedValueOnce(null)
+
+      const result = await scanner.runScan()
+
+      expect(result.failed).toBe(1)
+      expect(result.finalized).toBe(0)
+    })
+  })
+
+  describe('requires hash + requires copy and hash mixed with maxDeferred', () => {
+    it('always hashes local files but limits copy and hash files', async () => {
+      mock.addFile('local1', { addedAt: 5000 })
+      mock.addLocalFile('local1', '/local/local1.jpg')
+
+      mock.addFile('local2', { addedAt: 4000 })
+      mock.addLocalFile('local2', '/local/local2.jpg')
+
+      mock.addFile('deferred1', { localId: 'ph://1', addedAt: 3000 })
+      mock.addFile('deferred2', { localId: 'ph://2', addedAt: 2000 })
+
+      const resolveLocalId = jest.fn(async () => 'file:///photo.jpg')
+
+      const result = await scanner.runScan(undefined, resolveLocalId, 1)
+
+      expect(result.finalized).toBe(3) // 2 local + 1 deferred
+      expect(result.skipped).toBe(1) // 1 deferred throttled
+    })
+  })
+})

--- a/packages/core/src/services/importScanner.ts
+++ b/packages/core/src/services/importScanner.ts
@@ -1,0 +1,336 @@
+import { logger } from '@siastorage/logger'
+import type { AppService } from '../app/service'
+
+const MAX_PER_TICK = 20
+const ERROR_COOLDOWN_MS = 5 * 60 * 1000 // 5 minutes
+
+export type ImportScannerResult = {
+  finalized: number
+  failed: number
+  lost: number
+  skipped: number
+}
+
+export type ResolveLocalId = (localId: string) => Promise<string | null>
+export type CalculateContentHash = (uri: string) => Promise<string | null>
+export type GetMimeType = (opts: {
+  name?: string
+  uri?: string
+}) => Promise<string>
+
+export class ImportScanner {
+  private app: AppService | null = null
+  private processingFiles = new Set<string>()
+  private erroredFiles = new Map<string, number>()
+  private _calculateContentHash: CalculateContentHash | null = null
+  private _getMimeType: GetMimeType | null = null
+
+  initialize(
+    app: AppService,
+    calculateContentHash: CalculateContentHash,
+    getMimeType: GetMimeType,
+  ): void {
+    this.app = app
+    this._calculateContentHash = calculateContentHash
+    this._getMimeType = getMimeType
+  }
+
+  reset(): void {
+    this.app = null
+    this._calculateContentHash = null
+    this._getMimeType = null
+    this.processingFiles.clear()
+    this.erroredFiles.clear()
+  }
+
+  isInitialized(): boolean {
+    return this.app !== null
+  }
+
+  isFileBeingProcessed(fileId: string): boolean {
+    return this.processingFiles.has(fileId)
+  }
+
+  isFileInErrorCooldown(fileId: string): boolean {
+    const lastError = this.erroredFiles.get(fileId)
+    if (!lastError) return false
+    const elapsed = Date.now() - lastError
+    if (elapsed >= ERROR_COOLDOWN_MS) {
+      this.erroredFiles.delete(fileId)
+      return false
+    }
+    return true
+  }
+
+  private markFileErrored(fileId: string): void {
+    this.erroredFiles.set(fileId, Date.now())
+  }
+
+  private getApp(): AppService {
+    if (!this.app) throw new Error('ImportScanner not initialized')
+    return this.app
+  }
+
+  /**
+   * Finalizes placeholder files (hash: '') in two passes:
+   *
+   * 1. File already on disk (importFiles background copy landed, or
+   *    manually added): hash the local file and update the record.
+   *    Always processed — no I/O pressure since the file is local.
+   *
+   * 2. File has localId but no local copy (catalogAssets placeholder):
+   *    copy from the media library, then hash. Throttled by maxDeferred
+   *    to avoid filling device storage faster than uploads drain it.
+   *
+   * Files that cannot be recovered (localId doesn't resolve, no local
+   * file and no localId) are marked with lostReason so the UI can
+   * surface them to the user.
+   */
+  async runScan(
+    signal?: AbortSignal,
+    resolveLocalId?: ResolveLocalId,
+    maxDeferred?: number,
+  ): Promise<ImportScannerResult> {
+    const app = this.getApp()
+    const result: ImportScannerResult = {
+      finalized: 0,
+      failed: 0,
+      lost: 0,
+      skipped: 0,
+    }
+
+    try {
+      const candidates = await app.files.query({
+        hashEmpty: true,
+        activeOnly: true,
+        limit: MAX_PER_TICK,
+        order: 'DESC',
+        orderBy: 'addedAt',
+      })
+
+      if (candidates.length === 0) return result
+
+      logger.debug('importScanner', 'tick', { candidates: candidates.length })
+
+      const effectiveMaxDeferred = maxDeferred ?? Infinity
+      let deferredProcessed = 0
+
+      const updates: Array<{
+        id: string
+        hash: string
+        size: number
+        type: string
+      }> = []
+      const lostUpdates: Array<{
+        id: string
+        lostReason: string
+      }> = []
+
+      for (const file of candidates) {
+        if (signal?.aborted) break
+
+        if (this.processingFiles.has(file.id)) {
+          result.skipped++
+          continue
+        }
+
+        if (this.isFileInErrorCooldown(file.id)) {
+          result.skipped++
+          continue
+        }
+
+        this.processingFiles.add(file.id)
+        try {
+          const localFileUri = await app.fs.getFileUri({
+            id: file.id,
+            type: file.type,
+          })
+
+          // Pass 1: local file on disk — hash and finalize.
+          if (localFileUri) {
+            const outcome = await this.hashExistingFile(file, localFileUri)
+            if (outcome.action === 'finalized') {
+              updates.push({
+                id: file.id,
+                hash: outcome.hash,
+                size: outcome.size,
+                type: outcome.type,
+              })
+              result.finalized++
+            } else {
+              this.markFileErrored(file.id)
+              result.failed++
+            }
+            continue
+          }
+
+          // Pass 2: has localId, no local file — copy from media library
+          // then hash. Throttled by maxDeferred to limit storage pressure.
+          if (file.localId && resolveLocalId) {
+            if (deferredProcessed >= effectiveMaxDeferred) {
+              result.skipped++
+              continue
+            }
+            deferredProcessed++
+
+            const resolvedUri = await resolveLocalId(file.localId)
+            if (!resolvedUri) {
+              logger.debug('importScanner', 'localId_not_resolved', {
+                fileId: file.id,
+                localId: file.localId,
+              })
+              lostUpdates.push({
+                id: file.id,
+                lostReason: 'Source photo deleted from device',
+              })
+              result.lost++
+              continue
+            }
+
+            try {
+              const uri = await app.fs.copyFile(
+                { id: file.id, type: file.type },
+                resolvedUri,
+              )
+              const outcome = await this.hashExistingFile(file, uri)
+              if (outcome.action === 'finalized') {
+                updates.push({
+                  id: file.id,
+                  hash: outcome.hash,
+                  size: outcome.size,
+                  type: outcome.type,
+                })
+                result.finalized++
+              } else {
+                this.markFileErrored(file.id)
+                result.failed++
+              }
+            } catch (e) {
+              logger.error('importScanner', 'copy_from_localId_failed', {
+                fileId: file.id,
+                error: e as Error,
+              })
+              lostUpdates.push({
+                id: file.id,
+                lostReason: 'Failed to copy from device',
+              })
+              result.lost++
+            }
+            continue
+          }
+
+          // Has localId but no resolver available — skip, don't mark lost.
+          if (file.localId) {
+            result.skipped++
+            continue
+          }
+
+          // No local file, no localId — orphan.
+          logger.debug('importScanner', 'orphan', { fileId: file.id })
+          lostUpdates.push({
+            id: file.id,
+            lostReason: 'No local file or source available',
+          })
+          result.lost++
+        } catch (e) {
+          logger.error('importScanner', 'process_error', {
+            fileId: file.id,
+            error: e as Error,
+          })
+          this.markFileErrored(file.id)
+          result.failed++
+        } finally {
+          this.processingFiles.delete(file.id)
+        }
+      }
+
+      if (updates.length > 0) {
+        await app.files.updateMany(
+          updates.map((u) => ({
+            id: u.id,
+            hash: u.hash,
+            size: u.size,
+            type: u.type,
+          })),
+        )
+      }
+
+      if (lostUpdates.length > 0) {
+        await app.files.updateMany(
+          lostUpdates.map((u) => ({
+            id: u.id,
+            lostReason: u.lostReason,
+          })),
+        )
+      }
+
+      if (updates.length > 0 || lostUpdates.length > 0) {
+        await app.caches.library.invalidateAll()
+        app.caches.libraryVersion.invalidate()
+      }
+
+      logger.debug('importScanner', 'tick_complete', {
+        finalized: result.finalized,
+        failed: result.failed,
+        lost: result.lost,
+        skipped: result.skipped,
+      })
+    } catch (e) {
+      logger.error('importScanner', 'scan_error', { error: e as Error })
+    }
+
+    return result
+  }
+
+  private async hashExistingFile(
+    file: { id: string; name: string; type: string },
+    fileUri: string,
+  ): Promise<
+    | {
+        action: 'finalized'
+        hash: string
+        size: number
+        type: string
+      }
+    | { action: 'failed' }
+  > {
+    const app = this.getApp()
+
+    let type = file.type
+    if (type === 'application/octet-stream' && this._getMimeType) {
+      const detected = await this._getMimeType({
+        name: file.name,
+        uri: fileUri,
+      })
+      if (detected && detected !== 'application/octet-stream') {
+        type = detected
+      }
+    }
+
+    if (!this._calculateContentHash) {
+      return { action: 'failed' }
+    }
+
+    const hash = await this._calculateContentHash(fileUri)
+    if (!hash) {
+      logger.warn('importScanner', 'hash_failed', { fileId: file.id })
+      return { action: 'failed' }
+    }
+
+    let size: number
+    try {
+      const meta = await app.fs.readMeta(file.id)
+      size = meta?.size ?? 0
+    } catch {
+      size = 0
+    }
+
+    logger.debug('importScanner', 'file_complete', {
+      fileId: file.id,
+      hash,
+      size,
+    })
+
+    return { action: 'finalized', hash, size, type }
+  }
+}

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -8,6 +8,13 @@ export {
   type FsIOAdapter,
   getFsFileUri,
 } from './fsFileUri'
+export {
+  type CalculateContentHash,
+  type GetMimeType,
+  ImportScanner,
+  type ImportScannerResult,
+  type ResolveLocalId,
+} from './importScanner'
 export { LOG_ROTATION_INTERVAL, runLogRotation } from './logRotation'
 export { type OrphanScannerResult, runOrphanScanner } from './orphanScanner'
 export { syncDownEventsBatch } from './syncDownEvents'

--- a/packages/core/src/services/uploader.ts
+++ b/packages/core/src/services/uploader.ts
@@ -785,6 +785,7 @@ export class UploadManager {
 
       const newEntries: FileEntry[] = []
       for (const file of candidateFiles) {
+        if (!file.hash) continue
         const fileUri = await this.app.fs.getFileUri(file)
         if (!fileUri) continue
         newEntries.push({ fileId: file.id, fileUri, file, size: file.size })

--- a/packages/core/src/types/files.ts
+++ b/packages/core/src/types/files.ts
@@ -47,12 +47,14 @@ export type FileLocalMetadata = {
   localId: string | null
   addedAt: number
   deletedAt: number | null
+  lostReason?: string | null
 }
 
 export const fileLocalMetadataKeys = keysOf<FileLocalMetadata>()([
   'localId',
   'addedAt',
   'deletedAt',
+  'lostReason',
 ])
 
 export type FileRecordRow = Omit<FileMetadata, 'tags' | 'directory'> &


### PR DESCRIPTION
Instant file import: Files from the photo picker, camera, document picker, and share intent now appear in the library immediately. Previously the UI blocked while copying and hashing each file. Now a placeholder is inserted into the DB instantly, the copy runs in the background, and the file transitions from "Importing" to uploadable once finalized.

Background import scanner: A new service polls for placeholder files (hash = '') and finalizes them — copies from source if needed, computes the content hash, resolves MIME type. Processes newest files first (addedAt DESC) so user-initiated imports are prioritized. Deferred imports from the archive sync are throttled against the upload backlog to avoid filling device storage.

Other changes:
- Three import paths are now clearly separated: importFiles (user-initiated, instant placeholders), syncAssets (recent photo sync, inline copy+hash), catalogAssets (archive walk, bulk placeholders)
- Document picker skips the redundant cache copy (copyToCacheDirectory: false), halving import time for large files
- New lostReason field tracks permanent import failures (source deleted, copy failed)
- fileRecordEqual compares hash so the UI re-renders when a placeholder is finalized
- computeFileStatus distinguishes deferred imports (queued) from active imports (processing)
