### PR TITLE
feat(mobile): one-shot archive sync and import status UI

### DIFF
--- a/.changeset/archive-sync-oneshot.md
+++ b/.changeset/archive-sync-oneshot.md
@@ -1,0 +1,5 @@
+---
+mobile: minor
+---
+
+One-shot archive sync walks the photo library as a tight async loop with a modal showing scan progress. Import status icons distinguish queued vs active imports, and the library status sheet shows totals and sync progress.

--- a/.changeset/file-viewer-localid-fallback.md
+++ b/.changeset/file-viewer-localid-fallback.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+File viewer shows photos and videos from the media library for archive placeholders that haven't been imported yet.

--- a/apps/mobile/src/components/ArchiveSyncModal.tsx
+++ b/apps/mobile/src/components/ArchiveSyncModal.tsx
@@ -1,0 +1,372 @@
+import * as MediaLibrary from 'expo-media-library'
+import {
+  CheckCircle2Icon,
+  ImageIcon,
+  LoaderCircleIcon,
+} from 'lucide-react-native'
+import { useCallback, useEffect, useReducer } from 'react'
+import { Pressable, StyleSheet, Text, View } from 'react-native'
+import {
+  startArchiveSync,
+  stopArchiveSync,
+  usePhotosAddedCount,
+  usePhotosArchiveCursor,
+  usePhotosArchiveDisplayDate,
+  usePhotosExistingCount,
+} from '../managers/syncPhotosArchive'
+import { colors, palette } from '../styles/colors'
+import { Button } from './Button'
+import { ModalSheet } from './ModalSheet'
+
+type LibraryStats = {
+  totalCount: number
+  oldestDate: number
+  newestDate: number
+}
+
+async function fetchLibraryStats(): Promise<LibraryStats | null> {
+  try {
+    const mediaTypes = [
+      MediaLibrary.MediaType.photo,
+      MediaLibrary.MediaType.video,
+    ]
+    const oldest = await MediaLibrary.getAssetsAsync({
+      first: 1,
+      sortBy: [[MediaLibrary.SortBy.modificationTime, true]],
+      mediaType: mediaTypes,
+    })
+    if (oldest.totalCount === 0) return null
+    const newest = await MediaLibrary.getAssetsAsync({
+      first: 1,
+      sortBy: [[MediaLibrary.SortBy.modificationTime, false]],
+      mediaType: mediaTypes,
+    })
+    return {
+      totalCount: oldest.totalCount,
+      oldestDate: oldest.assets[0]?.modificationTime ?? 0,
+      newestDate: newest.assets[0]?.modificationTime ?? 0,
+    }
+  } catch {
+    return null
+  }
+}
+
+type Phase = 'loading' | 'preview' | 'running' | 'complete'
+
+type State = {
+  phase: Phase
+  stats: LibraryStats | null
+}
+
+type Action =
+  | { type: 'open' }
+  | { type: 'close' }
+  | { type: 'stats_loaded'; stats: LibraryStats | null }
+  | { type: 'start' }
+  | { type: 'done' }
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'open':
+      return { phase: 'loading', stats: null }
+    case 'close':
+      return { phase: 'loading', stats: null }
+    case 'stats_loaded':
+      return { ...state, phase: 'preview', stats: action.stats }
+    case 'start':
+      return state.phase === 'preview' ? { ...state, phase: 'running' } : state
+    case 'done':
+      return state.phase === 'running' ? { ...state, phase: 'complete' } : state
+  }
+}
+
+type Props = {
+  visible: boolean
+  onRequestClose: () => void
+}
+
+export function ArchiveSyncModal({ visible, onRequestClose }: Props) {
+  const photosArchiveCursor = usePhotosArchiveCursor()
+  const photosArchiveDisplayDate = usePhotosArchiveDisplayDate()
+  const photosAddedCount = usePhotosAddedCount()
+  const photosExistingCount = usePhotosExistingCount()
+  const cursorValue = photosArchiveCursor.data ?? 'done'
+  const displayDate = photosArchiveDisplayDate.data ?? 0
+  const addedCount = photosAddedCount.data ?? 0
+  const existingCount = photosExistingCount.data ?? 0
+  const newCount = addedCount - existingCount
+
+  const [{ phase, stats }, dispatch] = useReducer(reducer, {
+    phase: 'loading',
+    stats: null,
+  })
+
+  useEffect(() => {
+    if (visible) {
+      dispatch({ type: 'open' })
+      fetchLibraryStats().then((s) =>
+        dispatch({ type: 'stats_loaded', stats: s }),
+      )
+    } else {
+      dispatch({ type: 'close' })
+    }
+  }, [visible])
+
+  useEffect(() => {
+    if (cursorValue === 'done') {
+      dispatch({ type: 'done' })
+    }
+  }, [cursorValue])
+
+  const handleStart = useCallback(() => {
+    dispatch({ type: 'start' })
+    void startArchiveSync()
+  }, [])
+
+  const progress =
+    phase === 'running' && stats && stats.totalCount > 0
+      ? Math.min(addedCount / stats.totalCount, 1)
+      : 0
+
+  const canClose = phase !== 'running'
+  const showContent = phase !== 'loading'
+
+  const titleText =
+    phase === 'preview'
+      ? stats
+        ? `${stats.totalCount.toLocaleString()} photos and videos`
+        : 'No photos or videos found'
+      : phase === 'running'
+        ? displayDate > 0
+          ? `Scanning: ${formatDisplayDate(displayDate)}`
+          : 'Starting import...'
+        : phase === 'complete'
+          ? 'Import complete'
+          : ''
+
+  const line1Text =
+    phase === 'preview' && stats
+      ? `${formatDisplayDate(stats.oldestDate)} — ${formatDisplayDate(stats.newestDate)}`
+      : (phase === 'running' || phase === 'complete') && addedCount > 0
+        ? `${addedCount.toLocaleString()}${stats ? ` / ${stats.totalCount.toLocaleString()}` : ''} photos scanned`
+        : ''
+
+  const line2Text =
+    (phase === 'running' || phase === 'complete') && addedCount > 0
+      ? `${newCount.toLocaleString()} new${existingCount > 0 ? ` · ${existingCount.toLocaleString()} already imported` : ''}`
+      : ''
+
+  return (
+    <ModalSheet
+      visible={visible}
+      onRequestClose={canClose ? onRequestClose : () => {}}
+      title="Import Photo Library"
+      headerRight={
+        canClose ? (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Done"
+            onPress={onRequestClose}
+            hitSlop={8}
+          >
+            <Text style={styles.doneText}>Done</Text>
+          </Pressable>
+        ) : (
+          <View />
+        )
+      }
+    >
+      <View style={styles.root}>
+        <View style={styles.slots}>
+          <View style={styles.iconRow}>
+            {phase === 'running' ? (
+              <LoaderCircleIcon
+                color={palette.blue[400]}
+                size={48}
+                strokeWidth={1.5}
+              />
+            ) : phase === 'complete' ? (
+              <CheckCircle2Icon
+                color={palette.green[500]}
+                size={48}
+                strokeWidth={1.5}
+              />
+            ) : (
+              <ImageIcon
+                color={palette.gray[400]}
+                size={48}
+                strokeWidth={1.5}
+              />
+            )}
+          </View>
+          <View style={styles.titleRow}>
+            <Text style={styles.titleText}>{showContent ? titleText : ''}</Text>
+          </View>
+          <View style={styles.lineRow}>
+            <Text style={styles.lineText}>{showContent ? line1Text : ''}</Text>
+          </View>
+          <View style={styles.lineRow}>
+            <Text style={styles.lineText}>{showContent ? line2Text : ''}</Text>
+          </View>
+          <View style={styles.progressRow}>
+            <View
+              style={[
+                styles.progressTrack,
+                phase !== 'running' && styles.invisible,
+              ]}
+            >
+              <View
+                style={[
+                  styles.progressFill,
+                  {
+                    width: `${(progress * 100).toFixed(1)}%` as `${number}%`,
+                  },
+                ]}
+              />
+            </View>
+          </View>
+          <View style={styles.descriptionRow}>
+            <Text
+              style={[
+                styles.descriptionText,
+                (phase === 'running' || phase === 'loading') &&
+                  styles.invisible,
+              ]}
+            >
+              Your system photo library will be imported into Sia Storage. The
+              import process immediately adds files to your library's processing
+              queue. Photos in the processing queue are then gradually copied
+              and uploaded in the background. Sia Storage will lose access to
+              files that are deleted from your system library during this
+              window.
+            </Text>
+          </View>
+        </View>
+        <View style={styles.actionRow}>
+          <View
+            style={
+              phase !== 'preview' && phase !== 'running'
+                ? styles.invisible
+                : undefined
+            }
+          >
+            <Button
+              variant={phase === 'running' ? 'secondary' : 'primary'}
+              onPress={
+                phase === 'running'
+                  ? () => {
+                      void stopArchiveSync()
+                    }
+                  : handleStart
+              }
+              disabled={
+                phase === 'preview' && (!stats || stats.totalCount === 0)
+              }
+            >
+              {phase === 'running' ? 'Stop import' : 'Start import'}
+            </Button>
+          </View>
+        </View>
+      </View>
+    </ModalSheet>
+  )
+}
+
+const ICON_SIZE = 48
+const TITLE_HEIGHT = 24
+const LINE_HEIGHT = 20
+const PROGRESS_HEIGHT = 4
+const DESCRIPTION_MIN_HEIGHT = 80
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    paddingHorizontal: 24,
+  },
+  slots: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  iconRow: {
+    height: ICON_SIZE,
+    marginBottom: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  titleRow: {
+    height: TITLE_HEIGHT,
+    marginBottom: 8,
+    justifyContent: 'center',
+  },
+  lineRow: {
+    height: LINE_HEIGHT,
+    marginBottom: 4,
+    justifyContent: 'center',
+  },
+  progressRow: {
+    height: PROGRESS_HEIGHT,
+    width: '60%',
+    marginTop: 16,
+    marginBottom: 20,
+  },
+  descriptionRow: {
+    minHeight: DESCRIPTION_MIN_HEIGHT,
+  },
+  titleText: {
+    color: colors.textPrimary,
+    fontSize: 17,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  lineText: {
+    color: colors.textSecondary,
+    fontSize: 14,
+    textAlign: 'center',
+  },
+  descriptionText: {
+    color: colors.textSecondary,
+    fontSize: 14,
+    textAlign: 'center',
+    lineHeight: 20,
+    maxWidth: 300,
+  },
+  doneText: {
+    color: palette.blue[400],
+    fontSize: 17,
+    fontWeight: '600',
+  },
+  progressTrack: {
+    height: PROGRESS_HEIGHT,
+    borderRadius: 2,
+    backgroundColor: palette.gray[800],
+    overflow: 'hidden',
+  },
+  progressFill: {
+    height: '100%',
+    borderRadius: 2,
+    backgroundColor: palette.blue[400],
+  },
+  actionRow: {
+    height: 100,
+    justifyContent: 'flex-start',
+    paddingTop: 8,
+  },
+  invisible: {
+    opacity: 0,
+  },
+})
+
+function formatDisplayDate(displayDate: number): string {
+  const d = new Date(displayDate)
+  if (Number.isNaN(d.getTime())) return ''
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    }).format(d)
+  } catch {
+    return d.toDateString()
+  }
+}

--- a/apps/mobile/src/components/FileViewer/index.tsx
+++ b/apps/mobile/src/components/FileViewer/index.tsx
@@ -1,10 +1,23 @@
 import { useDownloadEntry } from '@siastorage/core/stores'
 import type { FileRecord } from '@siastorage/core/types'
-import { CloudDownloadIcon, FileIcon } from 'lucide-react-native'
+import {
+  ClockArrowUpIcon,
+  ClockIcon,
+  CloudDownloadIcon,
+  FileIcon,
+} from 'lucide-react-native'
 import { useCallback, useMemo } from 'react'
-import { StyleSheet, Text, TouchableHighlight, View } from 'react-native'
+import {
+  ActivityIndicator,
+  StyleSheet,
+  Text,
+  TouchableHighlight,
+  View,
+} from 'react-native'
+import useSWR from 'swr'
 import { useFileStatus } from '../../lib/file'
 import { humanSize } from '../../lib/humanSize'
+import { getMediaLibraryUri } from '../../lib/mediaLibrary'
 import { useDownload } from '../../managers/downloader'
 import { colors } from '../../styles/colors'
 import { AudioPlayer } from '../MediaConsumers/AudioPlayer'
@@ -38,9 +51,25 @@ export function FileViewer({
 }: FileViewerProps) {
   const { type, name } = file
   const status = useFileStatus(file, isShared)
-  const { fileUri, isDownloaded, isDownloading } = status.data ?? {}
+  const {
+    fileUri,
+    isDownloaded,
+    isDownloading,
+    isProcessing,
+    isDeferredImport,
+  } = status.data ?? {}
   const fileDownload = useDownload(file)
   const { data: fileDownloadState } = useDownloadEntry(file.id)
+
+  const localId = file.hash === '' && file.localId ? file.localId : null
+  const mediaLibrarySwr = useSWR(
+    localId ? ['mediaLibraryUri', localId] : null,
+    () => getMediaLibraryUri(localId),
+  )
+  const mediaLibraryUri = mediaLibrarySwr.data
+  const mediaLibraryLoading = localId
+    ? !mediaLibrarySwr.data && !mediaLibrarySwr.error
+    : false
 
   const baseMediaStyle = styles.media
   const textMediaStyle = textTopInset
@@ -98,13 +127,76 @@ export function FileViewer({
     file.size,
   ])
 
+  const ImportingPanel = useMemo(() => {
+    return (
+      <View
+        style={[
+          baseMediaStyle,
+          {
+            justifyContent: 'center',
+            alignItems: 'center',
+            gap: 12,
+            paddingHorizontal: 32,
+          },
+        ]}
+      >
+        {isDeferredImport ? (
+          <ClockIcon color={colors.textSecondary} size={40} />
+        ) : (
+          <ClockArrowUpIcon color={colors.textSecondary} size={40} />
+        )}
+        <Text
+          style={{
+            color: colors.textPrimary,
+            fontSize: 17,
+            fontWeight: '600',
+            textAlign: 'center',
+          }}
+        >
+          {isDeferredImport ? 'Import queued' : 'Importing...'}
+        </Text>
+        {isDeferredImport ? (
+          <Text
+            style={{
+              color: colors.textSecondary,
+              fontSize: 14,
+              textAlign: 'center',
+              maxWidth: 280,
+            }}
+          >
+            Files imported from the Photos library are queued for import and
+            uploaded in order
+          </Text>
+        ) : null}
+      </View>
+    )
+  }, [isDeferredImport])
+
+  const displayUri = fileUri || mediaLibraryUri || null
+  const canDisplay = isDownloaded || !!mediaLibraryUri
+
+  const LoadingPanel = useMemo(() => {
+    return (
+      <View
+        style={[
+          baseMediaStyle,
+          { justifyContent: 'center', alignItems: 'center' },
+        ]}
+      >
+        <ActivityIndicator color={colors.textSecondary} />
+      </View>
+    )
+  }, [])
+
   const mediaContent = useMemo(() => {
-    if (!isDownloaded || !fileUri) return DownloadPanel
+    if (isProcessing && mediaLibraryLoading) return LoadingPanel
+    if (isProcessing && !mediaLibraryUri) return ImportingPanel
+    if (!canDisplay || !displayUri) return DownloadPanel
 
     if (type?.includes('image'))
       return (
         <ImageViewer
-          uri={fileUri}
+          uri={displayUri}
           style={baseMediaStyle}
           onZoomChange={onImageZoomChange}
         />
@@ -112,7 +204,7 @@ export function FileViewer({
     if (type?.includes('video'))
       return (
         <VideoPlayer
-          source={fileUri}
+          source={displayUri}
           style={baseMediaStyle}
           onViewerControlPress={onViewerControlPress}
         />
@@ -120,7 +212,7 @@ export function FileViewer({
     if (type?.includes('audio')) {
       return (
         <AudioPlayer
-          source={fileUri}
+          source={displayUri}
           filename={name}
           style={baseMediaStyle}
           onViewerControlPress={onViewerControlPress}
@@ -130,7 +222,7 @@ export function FileViewer({
     if (type?.includes('pdf') || lowerCasedFileName.endsWith('.pdf')) {
       return (
         <PDFViewer
-          source={fileUri}
+          source={displayUri}
           style={baseMediaStyle}
           onSwipeLeft={onSwipeLeft}
           onSwipeRight={onSwipeRight}
@@ -144,7 +236,7 @@ export function FileViewer({
     ) {
       return (
         <JSONViewer
-          uri={fileUri}
+          uri={displayUri}
           fileSize={file.size}
           style={baseMediaStyle}
           topInset={textInsetValue}
@@ -158,7 +250,7 @@ export function FileViewer({
     ) {
       return (
         <MarkdownViewer
-          uri={fileUri}
+          uri={displayUri}
           style={textMediaStyle}
           onViewerControlPress={onViewerControlPress}
         />
@@ -167,7 +259,7 @@ export function FileViewer({
     if (type?.includes('text/plain') || lowerCasedFileName.endsWith('.txt')) {
       return (
         <TextViewer
-          uri={fileUri}
+          uri={displayUri}
           fileSize={file.size}
           style={baseMediaStyle}
           topInset={textInsetValue}
@@ -187,9 +279,14 @@ export function FileViewer({
       </View>
     )
   }, [
+    LoadingPanel,
+    ImportingPanel,
+    isProcessing,
+    mediaLibraryLoading,
+    mediaLibraryUri,
     DownloadPanel,
-    fileUri,
-    isDownloaded,
+    displayUri,
+    canDisplay,
     lowerCasedFileName,
     name,
     textInsetValue,

--- a/apps/mobile/src/components/SettingsSyncPhotos.tsx
+++ b/apps/mobile/src/components/SettingsSyncPhotos.tsx
@@ -1,24 +1,16 @@
-import { SYNC_ARCHIVE_RESUME_THRESHOLD } from '@siastorage/core/config'
 import { usePhotoImportDirectory } from '@siastorage/core/stores'
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 import { Linking, Pressable, StyleSheet, Switch, Text } from 'react-native'
-import { humanSize } from '../lib/humanSize'
 import { useMediaLibraryPermissions } from '../lib/mediaLibraryPermissions'
 import {
   toggleAutoSyncNewPhotos,
   useAutoSyncNewPhotos,
 } from '../managers/syncNewPhotos'
-import {
-  restartPhotosArchiveCursor,
-  toggleAutoSyncPhotosArchive,
-  useAutoSyncPhotosArchive,
-  usePhotosArchiveCursor,
-  usePhotosArchiveDisplayDate,
-} from '../managers/syncPhotosArchive'
+import { useArchiveSyncCompletedAt } from '../managers/syncPhotosArchive'
 import { app } from '../stores/appService'
-import { useFileStatsLocal } from '../stores/files'
 import { openSheet } from '../stores/sheets'
 import { colors } from '../styles/colors'
+import { ArchiveSyncModal } from './ArchiveSyncModal'
 import { Button } from './Button'
 import { RowGroup } from './Group'
 import { InfoCard } from './InfoCard'
@@ -27,19 +19,12 @@ import { SelectDirectorySheet } from './SelectDirectorySheet'
 
 export function SettingsSyncPhotos() {
   const autoSyncNew = useAutoSyncNewPhotos()
-  const autoSyncPhotosArchive = useAutoSyncPhotosArchive()
-  const photosArchiveCursor = usePhotosArchiveCursor()
-  const photosArchiveDisplayDate = usePhotosArchiveDisplayDate()
-  const localOnlyStats = useFileStatsLocal({ localOnly: true })
-  const cursorValue = photosArchiveCursor.data ?? 'done'
-  const photosArchiveInProgress = cursorValue !== 'done'
+  const archiveCompletedAt = useArchiveSyncCompletedAt()
   const { isSomeAccess, accessLabel, color } = useMediaLibraryPermissions()
   const photoImportDir = usePhotoImportDirectory()
+  const [modalVisible, setModalVisible] = useState(false)
 
-  const isPhotosAccessDisabled = !isSomeAccess
-  const archiveDateLabel = formatDisplayDate(photosArchiveDisplayDate.data ?? 0)
-  const syncPhotosArchiveControlsDisabled =
-    isPhotosAccessDisabled || !autoSyncPhotosArchive.data
+  const completedDateLabel = formatDisplayDate(archiveCompletedAt.data ?? 0)
 
   const handleOpenDirectoryPicker = useCallback(() => {
     openSheet('selectPhotoImportDirectory')
@@ -96,53 +81,20 @@ export function SettingsSyncPhotos() {
           }
         />
       </InfoCard>
-      <InfoCard style={{ marginTop: 10 }}>
-        <LabeledValueRow
-          label="Import archive"
-          labelWidth={250}
-          value={
-            <Switch
-              value={autoSyncPhotosArchive.data ?? false}
-              onValueChange={toggleAutoSyncPhotosArchive}
-            />
-          }
-        />
-      </InfoCard>
-      {photosArchiveInProgress ? (
-        <Text
-          style={[
-            styles.info,
-            syncPhotosArchiveControlsDisabled ? styles.infoDisabled : undefined,
-          ]}
-        >
-          {archiveDateLabel
-            ? `Currently synced back to: ${archiveDateLabel} ${
-                !autoSyncPhotosArchive.data ? '(paused)' : '(in progress)'
-              }`
-            : `Archive sync ${
-                !autoSyncPhotosArchive.data ? '(paused)' : '(in progress)'
-              }`}
-        </Text>
-      ) : null}
-      {autoSyncPhotosArchive.data &&
-      photosArchiveInProgress &&
-      (localOnlyStats.data?.totalBytes ?? 0) >=
-        SYNC_ARCHIVE_RESUME_THRESHOLD ? (
-        <Text
-          style={styles.info}
-        >{`Waiting for ${humanSize(localOnlyStats.data?.totalBytes ?? 0) ?? '0 B'} to upload before continuing archive sync`}</Text>
-      ) : null}
       <Button
         style={{ marginTop: 10 }}
-        disabled={syncPhotosArchiveControlsDisabled}
-        onPress={() => {
-          void restartPhotosArchiveCursor()
-        }}
+        disabled={!isSomeAccess}
+        onPress={() => setModalVisible(true)}
       >
-        {photosArchiveInProgress
-          ? 'Restart archive sync'
-          : 'Start archive sync'}
+        Import photo library
       </Button>
+      {completedDateLabel ? (
+        <Text style={styles.info}>Last completed: {completedDateLabel}</Text>
+      ) : null}
+      <ArchiveSyncModal
+        visible={modalVisible}
+        onRequestClose={() => setModalVisible(false)}
+      />
     </RowGroup>
   )
 }
@@ -154,9 +106,6 @@ const styles = StyleSheet.create({
   info: {
     color: colors.textSecondary,
     marginTop: 10,
-  },
-  infoDisabled: {
-    color: colors.textMuted,
   },
 })
 

--- a/apps/mobile/src/lib/processAssets.test.ts
+++ b/apps/mobile/src/lib/processAssets.test.ts
@@ -594,17 +594,16 @@ describe('catalogAssets — deferred bulk catalog for archive sync', () => {
         timestamp: '2021-01-01',
       },
     ]
-    const { files } = await catalogAssets(assets)
-    expect(files).toHaveLength(1)
-    expect(files[0]).toMatchObject({
+    const { newCount, existingCount } = await catalogAssets(assets)
+    expect(newCount).toBe(1)
+    expect(existingCount).toBe(0)
+    const rows = await app().files.query({ order: 'ASC' })
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
       hash: '',
       size: 0,
       kind: 'file',
     })
-    const row = await app().files.getById(files[0].id)
-    expect(row).toBeTruthy()
-    expect(row!.hash).toBe('')
-    expect(row!.size).toBe(0)
   })
 
   it('silently skips localId duplicates via INSERT OR IGNORE', async () => {
@@ -632,8 +631,9 @@ describe('catalogAssets — deferred bulk catalog for archive sync', () => {
         timestamp: '2021-01-01',
       },
     ]
-    const { files } = await catalogAssets(assets)
-    expect(files).toHaveLength(1)
+    const { newCount, existingCount } = await catalogAssets(assets)
+    expect(newCount).toBe(0)
+    expect(existingCount).toBe(1)
 
     const rows = await app().files.query({ order: 'ASC' })
     expect(rows).toHaveLength(1)
@@ -681,13 +681,15 @@ describe('catalogAssets — deferred bulk catalog for archive sync', () => {
         timestamp: '2021-01-01',
       },
     ]
-    const { files } = await catalogAssets(assets, 'file', {
+    const { newCount } = await catalogAssets(assets, 'file', {
       addToImportDirectory: true,
     })
-    expect(files).toHaveLength(1)
+    expect(newCount).toBe(1)
+    const rows = await app().files.query({ order: 'ASC' })
+    expect(rows).toHaveLength(1)
     const row = await db().getFirstAsync<{ directoryId: string | null }>(
       'SELECT directoryId FROM files WHERE id = ?',
-      files[0].id,
+      rows[0].id,
     )
     expect(row?.directoryId).toBeTruthy()
     const dirs = await app().directories.getAll()

--- a/apps/mobile/src/lib/processAssets.ts
+++ b/apps/mobile/src/lib/processAssets.ts
@@ -310,7 +310,8 @@ type CatalogAssetsOptions = {
 /**
  * Archive library walk (syncPhotosArchive). Creates placeholder records
  * with hash: '' and size: 0, using INSERT OR IGNORE to silently skip
- * localId duplicates without a pre-check query. No copy, no hash — the
+ * localId duplicates. Queries existing localIds first so callers get
+ * an accurate new-vs-existing breakdown. No copy, no hash — the
  * import scanner handles those with backpressure based on the upload backlog.
  */
 export async function catalogAssets(
@@ -318,7 +319,7 @@ export async function catalogAssets(
   defaultFileName: string = 'file',
   { addToImportDirectory = false }: CatalogAssetsOptions = {},
 ) {
-  const newFiles: FileRecord[] = await Promise.all(
+  const candidates: FileRecord[] = await Promise.all(
     (assets ?? []).map(async (a) => {
       const meta = await parseAssetMetadata(a, defaultFileName)
       return {
@@ -336,19 +337,31 @@ export async function catalogAssets(
     }),
   )
 
+  const localIds = candidates.filter((f) => f.localId).map((f) => f.localId!)
+  const existingFiles =
+    localIds.length > 0 ? await app().files.getByLocalIds(localIds) : []
+  const existingLocalIds = new Set(existingFiles.map((f) => f.localId))
+  const existingCount = existingLocalIds.size
+  const newCount = candidates.length - existingCount
+
   logger.debug('catalogAssets', 'result', {
-    count: newFiles.length,
+    count: candidates.length,
+    newCount,
+    existingCount,
   })
 
-  await app().files.createMany(newFiles, { conflictClause: 'OR IGNORE' })
+  await app().files.createMany(candidates, { conflictClause: 'OR IGNORE' })
 
   if (addToImportDirectory) {
+    const newFiles = candidates.filter(
+      (f) => !f.localId || !existingLocalIds.has(f.localId),
+    )
     await moveMediaToImportDirectory(newFiles)
   }
 
   triggerImportScanner()
 
-  return { files: newFiles }
+  return { newCount, existingCount }
 }
 
 /**

--- a/apps/mobile/src/managers/app.ts
+++ b/apps/mobile/src/managers/app.ts
@@ -19,10 +19,7 @@ import { initLogRotation } from './logRotation'
 import { initPerfMonitor } from './perfMonitor'
 import { initSyncDownEvents } from './syncDownEvents'
 import { initSyncNewPhotos } from './syncNewPhotos'
-import {
-  initSyncPhotosArchive,
-  resetPhotosArchiveCursor,
-} from './syncPhotosArchive'
+import { resetPhotosArchiveCursor } from './syncPhotosArchive'
 import { initSyncUpMetadata } from './syncUpMetadata'
 import { initThumbnailScanner } from './thumbnailScanner'
 import { getUploadManager } from './uploader'
@@ -93,7 +90,6 @@ export async function initApp(): Promise<void> {
         initImportScanner()
         initSyncDownEvents()
         initSyncNewPhotos()
-        initSyncPhotosArchive()
         initBackgroundTasks()
         initSyncUpMetadata()
         initThumbnailScanner()

--- a/apps/mobile/src/managers/syncPhotosArchive.test.ts
+++ b/apps/mobile/src/managers/syncPhotosArchive.test.ts
@@ -5,12 +5,13 @@ import {
 import * as MediaLibrary from 'expo-media-library'
 import { catalogAssets } from '../lib/processAssets'
 import {
+  getArchiveSyncCompletedAt,
   getLastRecentScanAt,
   getPhotosArchiveCursor,
   getPhotosArchiveDisplayDate,
   restartPhotosArchiveCursor,
   run,
-  setAutoSyncPhotosArchive,
+  setArchiveSyncCompletedAt,
   setLastRecentScanAt,
   setPhotosArchiveCursor,
   triggerRecentScanIfNeeded,
@@ -38,8 +39,9 @@ jest.mock('../lib/mediaLibraryPermissions', () => ({
 jest.mock('../lib/processAssets', () => ({
   catalogAssets: jest.fn(),
 }))
-jest.mock('../stores/files', () => ({
-  getFileStatsLocal: jest.fn().mockResolvedValue({ count: 0, totalBytes: 0 }),
+jest.mock('../stores/files', () => ({}))
+jest.mock('@siastorage/core/lib/yieldToEventLoop', () => ({
+  yieldToEventLoop: jest.fn().mockResolvedValue(undefined),
 }))
 
 const getAssetsAsyncMock = jest.mocked(MediaLibrary.getAssetsAsync)
@@ -77,7 +79,8 @@ function page(
 
 function mockProcessAssetsSuccess() {
   catalogAssetsMock.mockResolvedValue({
-    files: [{ id: '1' }] as never,
+    newCount: 1,
+    existingCount: 0,
   })
 }
 
@@ -88,8 +91,8 @@ describe('syncPhotosArchive', () => {
     jest.clearAllMocks()
     jest.setSystemTime(new Date(NOW))
     getAssetsAsyncMock.mockReset()
-    await setAutoSyncPhotosArchive(true)
     await setLastRecentScanAt(0)
+    await setArchiveSyncCompletedAt(0)
     await restartPhotosArchiveCursor()
     mockProcessAssetsSuccess()
   })
@@ -157,11 +160,12 @@ describe('syncPhotosArchive', () => {
     expect(getAssetsAsyncMock).not.toHaveBeenCalled()
   })
 
-  it('sets cursor to "done" when no assets remain', async () => {
+  it('sets cursor to "done" and records completion time when no assets remain', async () => {
     await setPhotosArchiveCursor('some-ref')
     getAssetsAsyncMock.mockResolvedValueOnce(page([]))
     await run()
     expect(await getPhotosArchiveCursor()).toBe('done')
+    expect(await getArchiveSyncCompletedAt()).toBe(NOW)
     expect(catalogAssetsMock).not.toHaveBeenCalled()
   })
 
@@ -237,33 +241,28 @@ describe('syncPhotosArchive', () => {
     )
   })
 
-  it('aborts before processAssets when signal is aborted during getAssetsAsync', async () => {
-    const getAssetsAsyncMock = jest.mocked(MediaLibrary.getAssetsAsync)
-    const catalogAssetsMock = jest.mocked(catalogAssets)
-
-    const ac = new AbortController()
-    getAssetsAsyncMock.mockImplementation(async () => {
-      ac.abort()
-      return page([asset('b1', 'one.jpg', { modificationTime: 10_000 })])
-    })
-
-    await restartPhotosArchiveCursor()
-    await run(ac.signal)
-
-    expect(catalogAssetsMock).not.toHaveBeenCalled()
-  })
-
   describe('triggerRecentScanIfNeeded', () => {
-    it('triggers when archive is done and interval elapsed', async () => {
+    it('triggers when archive is done, previously completed, and interval elapsed', async () => {
       await setPhotosArchiveCursor('done')
+      await setArchiveSyncCompletedAt(NOW - 1_000_000)
       await setLastRecentScanAt(0)
       const triggered = await triggerRecentScanIfNeeded()
       expect(triggered).toBe(true)
       expect(await getPhotosArchiveCursor()).toBe('start')
     })
 
+    it('skips when archive has never completed', async () => {
+      await setPhotosArchiveCursor('done')
+      await setArchiveSyncCompletedAt(0)
+      await setLastRecentScanAt(0)
+      const triggered = await triggerRecentScanIfNeeded()
+      expect(triggered).toBe(false)
+      expect(await getPhotosArchiveCursor()).toBe('done')
+    })
+
     it('skips when archive is mid-walk', async () => {
       await setPhotosArchiveCursor('some-ref')
+      await setArchiveSyncCompletedAt(NOW - 1_000_000)
       await setLastRecentScanAt(0)
       const triggered = await triggerRecentScanIfNeeded()
       expect(triggered).toBe(false)
@@ -272,6 +271,7 @@ describe('syncPhotosArchive', () => {
 
     it('skips when last scan was recent', async () => {
       await setPhotosArchiveCursor('done')
+      await setArchiveSyncCompletedAt(NOW - 1_000_000)
       await setLastRecentScanAt(NOW - SYNC_ARCHIVE_RECENT_SCAN_INTERVAL + 1_000)
       const triggered = await triggerRecentScanIfNeeded()
       expect(triggered).toBe(false)
@@ -282,6 +282,7 @@ describe('syncPhotosArchive', () => {
   describe('bounded recent scan', () => {
     it('stops at boundary during recent scan', async () => {
       await setPhotosArchiveCursor('done')
+      await setArchiveSyncCompletedAt(NOW - 1_000_000)
       await setLastRecentScanAt(0)
       await triggerRecentScanIfNeeded()
 
@@ -324,6 +325,7 @@ describe('syncPhotosArchive', () => {
 
     it('processes the boundary-crossing batch before stopping', async () => {
       await setPhotosArchiveCursor('done')
+      await setArchiveSyncCompletedAt(NOW - 1_000_000)
       await setLastRecentScanAt(0)
       await triggerRecentScanIfNeeded()
 

--- a/apps/mobile/src/managers/syncPhotosArchive.ts
+++ b/apps/mobile/src/managers/syncPhotosArchive.ts
@@ -1,12 +1,12 @@
 /*
- * syncPhotosArchive — polls every 5s, fetches 1 page of 50 photos.
+ * syncPhotosArchive — one-shot walk of the photo library.
  *
  * Two modes of operation:
  *
  * 1. Initial walk: walks the entire photo library from newest to oldest
  *    by endCursor, stopping when all photos have been visited
- *    (cursor = 'done'). Pauses when pending local-only bytes exceed
- *    4 slabs to avoid overwhelming the upload pipeline.
+ *    (cursor = 'done'). Runs back-to-back with only a yieldToEventLoop()
+ *    between pages.
  *
  * 2. Bounded recent re-scan: after the initial walk completes, a
  *    periodic re-scan is triggered during background tasks (every ~3h)
@@ -32,45 +32,58 @@ import { useApp } from '@siastorage/core/app'
 import {
   SYNC_ARCHIVE_RECENT_SCAN_INTERVAL,
   SYNC_ARCHIVE_RECENT_SCAN_LOOKBACK,
-  SYNC_ARCHIVE_RESUME_THRESHOLD,
-  SYNC_PHOTOS_ARCHIVE_INTERVAL,
 } from '@siastorage/core/config'
-import { createServiceInterval } from '@siastorage/core/lib/serviceInterval'
+import { yieldToEventLoop } from '@siastorage/core/lib/yieldToEventLoop'
 import { logger } from '@siastorage/logger'
 import * as MediaLibrary from 'expo-media-library'
 import useSWR from 'swr'
-import {
-  ensureMediaLibraryPermission,
-  getMediaLibraryPermissions,
-  mediaLibraryPermissionsCache,
-} from '../lib/mediaLibraryPermissions'
+import { getMediaLibraryPermissions } from '../lib/mediaLibraryPermissions'
 import { catalogAssets } from '../lib/processAssets'
 import { app } from '../stores/appService'
-import { getFileStatsLocal } from '../stores/files'
 
-const PAGE_SIZE = 50
+const PAGE_SIZE = 500
 const CURSOR_DONE = 'done'
 const CURSOR_START = 'start'
 
 let recentScanBoundary = 0
+let activeWalk: Promise<void> | null = null
+let walkAbortController: AbortController | null = null
+let photosAddedCount = 0
+let photosExistingCount = 0
 
-export async function run(signal?: AbortSignal) {
-  if (!(await getAutoSyncPhotosArchive())) {
-    logger.debug('syncPhotosArchive', 'skipped', { reason: 'disabled' })
-    return
+export async function startArchiveSync(): Promise<void> {
+  if (activeWalk) return
+  photosAddedCount = 0
+  photosExistingCount = 0
+  await setPhotosAddedCount(0)
+  await setPhotosExistingCount(0)
+  await restartPhotosArchiveCursor()
+  walkAbortController = new AbortController()
+  activeWalk = runArchiveWalk(walkAbortController.signal)
+  activeWalk.finally(() => {
+    activeWalk = null
+    walkAbortController = null
+  })
+}
+
+export async function stopArchiveSync(): Promise<void> {
+  walkAbortController?.abort()
+  await setPhotosArchiveCursor(CURSOR_DONE)
+}
+
+async function runArchiveWalk(signal: AbortSignal): Promise<void> {
+  while (!signal.aborted) {
+    const cursor = await getPhotosArchiveCursor()
+    if (cursor === CURSOR_DONE) break
+    await run()
+    await yieldToEventLoop()
   }
+}
+
+export async function run() {
+  logger.debug('syncPhotosArchive', 'tick')
   if (!(await getMediaLibraryPermissions())) {
     logger.debug('syncPhotosArchive', 'skipped', { reason: 'no_permission' })
-    return
-  }
-  if (signal?.aborted) return
-  const { count, totalBytes } = await getFileStatsLocal({ localOnly: true })
-  if (totalBytes >= SYNC_ARCHIVE_RESUME_THRESHOLD) {
-    logger.info('syncPhotosArchive', 'skipped', {
-      reason: 'local_only_pending',
-      count,
-      totalBytes,
-    })
     return
   }
   const cursor = await getPhotosArchiveCursor()
@@ -90,7 +103,6 @@ export async function run(signal?: AbortSignal) {
       sortBy: [[MediaLibrary.SortBy.modificationTime, false]],
       mediaType: [MediaLibrary.MediaType.photo, MediaLibrary.MediaType.video],
     })
-    if (signal?.aborted) return
     if (page.assets.length === 0) {
       if (cursor !== CURSOR_START) {
         logger.info('syncPhotosArchive', 'cursor_reached_end', {
@@ -99,6 +111,7 @@ export async function run(signal?: AbortSignal) {
       }
       logger.info('syncPhotosArchive', 'fully_synced')
       await setPhotosArchiveCursor(CURSOR_DONE)
+      await setArchiveSyncCompletedAt(Date.now())
       return
     }
     const assets = page.assets
@@ -114,8 +127,7 @@ export async function run(signal?: AbortSignal) {
       prevCursor: prevCursor === CURSOR_START ? 'start' : prevCursor,
       nextCursor: page.endCursor,
     })
-    if (signal?.aborted) return
-    const { files } = await catalogAssets(
+    const { newCount, existingCount } = await catalogAssets(
       assets.map((asset) => ({
         id: asset.id,
         sourceUri: asset.uri,
@@ -129,9 +141,14 @@ export async function run(signal?: AbortSignal) {
       'file',
       { addToImportDirectory: true },
     )
-    if (files.length > 0) {
+    photosAddedCount += assets.length
+    photosExistingCount += existingCount
+    await setPhotosAddedCount(photosAddedCount)
+    await setPhotosExistingCount(photosExistingCount)
+    if (newCount > 0) {
       logger.info('syncPhotosArchive', 'batch_processed', {
-        newFiles: files.length,
+        newCount,
+        existingCount,
         totalAssets: assets.length,
       })
       await app().caches.library.invalidateAll()
@@ -151,6 +168,7 @@ export async function run(signal?: AbortSignal) {
       await setPhotosArchiveCursor(CURSOR_DONE)
       await setPhotosArchiveDisplayDate(0)
       await setLastRecentScanAt(Date.now())
+      await setArchiveSyncCompletedAt(Date.now())
     }
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e)
@@ -167,39 +185,6 @@ export async function run(signal?: AbortSignal) {
       cursor,
     })
   }
-}
-
-export const { init: initSyncPhotosArchive } = createServiceInterval({
-  name: 'syncPhotosArchive',
-  worker: run,
-  interval: SYNC_PHOTOS_ARCHIVE_INTERVAL,
-})
-
-export async function getAutoSyncPhotosArchive(): Promise<boolean> {
-  const raw = await app().storage.getItem('autoSyncPhotosArchive')
-  return raw === null ? false : raw === 'true'
-}
-
-export function useAutoSyncPhotosArchive() {
-  const app = useApp()
-  return useSWR(app.caches.settings.key('autoSyncPhotosArchive'), () =>
-    getAutoSyncPhotosArchive(),
-  )
-}
-
-export async function setAutoSyncPhotosArchive(value: boolean) {
-  await app().storage.setItem('autoSyncPhotosArchive', String(value))
-  app().caches.settings.invalidate('autoSyncPhotosArchive')
-  if (value) {
-    ensureMediaLibraryPermission()
-  }
-  mediaLibraryPermissionsCache.invalidate()
-}
-
-export async function toggleAutoSyncPhotosArchive() {
-  const current = await getAutoSyncPhotosArchive()
-  const next = !current
-  await setAutoSyncPhotosArchive(next)
 }
 
 export async function getPhotosArchiveCursor(): Promise<string> {
@@ -250,6 +235,24 @@ export async function setPhotosArchiveDisplayDate(value: number) {
   app().caches.settings.invalidate('photosArchiveDisplayDate')
 }
 
+export async function getArchiveSyncCompletedAt(): Promise<number> {
+  const raw = await app().storage.getItem('archiveSyncCompletedAt')
+  const n = raw ? Number(raw) : 0
+  return Number.isFinite(n) ? n : 0
+}
+
+export async function setArchiveSyncCompletedAt(value: number) {
+  await app().storage.setItem('archiveSyncCompletedAt', String(value))
+  app().caches.settings.invalidate('archiveSyncCompletedAt')
+}
+
+export function useArchiveSyncCompletedAt() {
+  const app = useApp()
+  return useSWR(app.caches.settings.key('archiveSyncCompletedAt'), () =>
+    getArchiveSyncCompletedAt(),
+  )
+}
+
 export async function getLastRecentScanAt(): Promise<number> {
   const raw = await app().storage.getItem('lastRecentScanAt')
   const n = raw ? Number(raw) : 0
@@ -261,9 +264,49 @@ export async function setLastRecentScanAt(value: number) {
   app().caches.settings.invalidate('lastRecentScanAt')
 }
 
+export async function getPhotosAddedCount(): Promise<number> {
+  const raw = await app().storage.getItem('photosAddedCount')
+  const n = raw ? Number(raw) : 0
+  return Number.isFinite(n) ? n : 0
+}
+
+export function usePhotosAddedCount() {
+  const app = useApp()
+  return useSWR(app.caches.settings.key('photosAddedCount'), () =>
+    getPhotosAddedCount(),
+  )
+}
+
+export async function setPhotosAddedCount(value: number) {
+  await app().storage.setItem('photosAddedCount', String(value))
+  app().caches.settings.invalidate('photosAddedCount')
+}
+
+export async function getPhotosExistingCount(): Promise<number> {
+  const raw = await app().storage.getItem('photosExistingCount')
+  const n = raw ? Number(raw) : 0
+  return Number.isFinite(n) ? n : 0
+}
+
+export function usePhotosExistingCount() {
+  const app = useApp()
+  return useSWR(app.caches.settings.key('photosExistingCount'), () =>
+    getPhotosExistingCount(),
+  )
+}
+
+export async function setPhotosExistingCount(value: number) {
+  await app().storage.setItem('photosExistingCount', String(value))
+  app().caches.settings.invalidate('photosExistingCount')
+}
+
 export async function triggerRecentScanIfNeeded(): Promise<boolean> {
   const cursor = await getPhotosArchiveCursor()
   if (cursor !== CURSOR_DONE) return false
+
+  // Only re-scan if the user has completed at least one full archive sync.
+  const completedAt = await getArchiveSyncCompletedAt()
+  if (completedAt === 0) return false
 
   const lastScan = await getLastRecentScanAt()
   if (Date.now() - lastScan < SYNC_ARCHIVE_RECENT_SCAN_INTERVAL) return false

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -36,8 +36,6 @@ export const PACKER_POLL_INTERVAL = secondsInMs(5) // 5 seconds
 export const SYNC_EVENTS_INTERVAL = secondsInMs(10) // 10 seconds
 // Sync new photos interval.
 export const SYNC_NEW_PHOTOS_INTERVAL = secondsInMs(10) // 10 seconds
-// Sync archive photos interval.
-export const SYNC_PHOTOS_ARCHIVE_INTERVAL = secondsInMs(1) // 1 second
 // Resume fetching archive photos when pending local-only bytes drop below this threshold.
 export const SYNC_ARCHIVE_RESUME_THRESHOLD = 4 * SLAB_SIZE
 // Minimum interval between bounded recent re-scans of the archive.


### PR DESCRIPTION
One-shot archive sync: Archive sync now runs as a single continuous walk completing the full library scan as fast as the media library can page through it.

Import modal: Tapping "Import photo library" opens a modal that shows a spinner with the current scan date progressing backward through the library. The modal locks out dismissal while running and shows a completion state with a Done button when finished.

File viewer localId fallback: Files with hash = '' and a localId (archive placeholders not yet imported) resolve their display URI from the media library so the user can view the photo/video before it's been copied and uploaded.