### PR TITLE
feat(mobile): import status UI and library status sheet improvements

### DIFF
--- a/.changeset/import-status-ui.md
+++ b/.changeset/import-status-ui.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Import status icons distinguish queued, active, and failed imports. Library status sheet shows pending import count and active upload progress.

--- a/apps/mobile/src/components/FileDetails/FileMeta.tsx
+++ b/apps/mobile/src/components/FileDetails/FileMeta.tsx
@@ -36,6 +36,7 @@ export function FileMeta({
 }) {
   const showAdvanced = useShowAdvanced()
   const fileSize = useMemo(() => {
+    if (file.size === 0) return null
     return humanSize(file.size)
   }, [file.size])
 

--- a/apps/mobile/src/components/FileListItem.tsx
+++ b/apps/mobile/src/components/FileListItem.tsx
@@ -53,8 +53,12 @@ function FileListItemComponent({ file, onPressItem, onLongPressItem }: Props) {
                 <DotIcon size={16} color="grey" />
               </>
             ) : null}
-            <Text style={styles.fileText}>{humanSize(file.size)}</Text>
-            <DotIcon size={16} color="grey" />
+            {file.size > 0 ? (
+              <>
+                <Text style={styles.fileText}>{humanSize(file.size)}</Text>
+                <DotIcon size={16} color="grey" />
+              </>
+            ) : null}
             <Text style={styles.fileText}>{file.type}</Text>
             {isFavorite.data ? (
               <>

--- a/apps/mobile/src/components/LibraryStatusSheet.tsx
+++ b/apps/mobile/src/components/LibraryStatusSheet.tsx
@@ -26,6 +26,7 @@ import {
 import { useIsConnected } from '../stores/sdk'
 import { useStatusDisplayMode } from '../stores/settings'
 import { closeSheet, useSheetOpen } from '../stores/sheets'
+import { getActiveUploads } from '../stores/uploads'
 import { palette, whiteA } from '../styles/colors'
 import { Button } from './Button'
 import { RowGroup, RowSubGroup } from './Group'
@@ -86,12 +87,36 @@ export function LibraryStatusSheet() {
       refreshInterval,
     },
   )
+  const importing = useSWR(
+    ['importing-stats', isOpen ?? null],
+    async () =>
+      app().files.queryStats({
+        hashEmpty: true,
+        activeOnly: true,
+        order: 'ASC',
+      }),
+    { refreshInterval },
+  )
   const onDevice = useFileStatsLocal({ localOnly: false }, { refreshInterval })
   const pendingBackup = useFileStatsLocal(
     { localOnly: true },
     { refreshInterval },
   )
   const lost = useFileStatsLost({ refreshInterval })
+  const batch = useSWR(
+    ['active-batch', isOpen ?? null],
+    () => {
+      const uploads = getActiveUploads()
+      const count = uploads.length
+      const totalBytes = uploads.reduce((s, u) => s + u.size, 0)
+      const uploadedBytes = uploads.reduce((s, u) => s + u.progress * u.size, 0)
+      const percent = totalBytes
+        ? `${((uploadedBytes / totalBytes) * 100).toFixed(1)}%`
+        : ''
+      return { count, totalBytes, percent }
+    },
+    { refreshInterval },
+  )
 
   const handleClose = useCallback(() => {
     closeSheet()
@@ -210,7 +235,89 @@ export function LibraryStatusSheet() {
         </RowGroup>
 
         <RowGroup title="Files" indicator={toggle} style={styles.groupSpacing}>
-          <RowSubGroup title="Network" style={styles.subGroupSpacing}>
+          <RowSubGroup title="Library" style={styles.subGroupSpacing}>
+            <Text style={styles.sectionDesc}>
+              All files tracked in the library. Pending imports are waiting to
+              be copied from your device's photo library.
+            </Text>
+            <InfoCard>
+              <LabeledValueRow
+                label="Device and network"
+                labelWidth={180}
+                value={
+                  <View style={styles.valueRight}>
+                    <Text style={styles.valueText}>
+                      {`${(stats.data?.files.total ?? 0).toLocaleString()} files`}
+                    </Text>
+                  </View>
+                }
+                align="right"
+                canCopy={false}
+              />
+              {(importing.data?.count ?? 0) > 0 && (
+                <LabeledValueRow
+                  label="Pending import"
+                  labelWidth={120}
+                  value={
+                    <View style={styles.valueRight}>
+                      <Text style={styles.valueText}>
+                        {`${(importing.data?.count ?? 0).toLocaleString()} files`}
+                      </Text>
+                      <View style={styles.dotSyncing} />
+                    </View>
+                  }
+                  align="right"
+                  canCopy={false}
+                  showDividerTop
+                />
+              )}
+              <LabeledValueRow
+                label="Total"
+                labelWidth={120}
+                value={
+                  <View style={styles.valueRight}>
+                    <Text style={styles.valueText}>
+                      {`${((stats.data?.files.total ?? 0) + (importing.data?.count ?? 0)).toLocaleString()} files`}
+                    </Text>
+                  </View>
+                }
+                align="right"
+                canCopy={false}
+                showDividerTop
+              />
+            </InfoCard>
+          </RowSubGroup>
+          <RowSubGroup title="Sync" style={styles.subGroupSpacing}>
+            <Text style={styles.sectionDesc}>
+              Upload progress across all files ready to be synced to the
+              network.
+            </Text>
+            {(batch.data?.count ?? 0) > 0 && (
+              <InfoCard>
+                <LabeledValueRow
+                  label="Active uploads"
+                  labelWidth={120}
+                  value={
+                    <View style={styles.valueRight}>
+                      <Text style={styles.valueText}>
+                        {displayMode === 'size'
+                          ? (humanSize(batch.data?.totalBytes ?? 0) ?? '0 B')
+                          : `${(batch.data?.count ?? 0).toLocaleString()} files`}
+                      </Text>
+                      <Text style={styles.valuePercent}>
+                        {batch.data?.percent}
+                      </Text>
+                      <View style={styles.dotSyncing} />
+                    </View>
+                  }
+                  align="right"
+                  canCopy={false}
+                />
+              </InfoCard>
+            )}
+            {(batch.data?.count ?? 0) > 0 && (
+              <View style={styles.networkGroupGap} />
+            )}
             <InfoCard>
               <LabeledValueRow
                 label="Files"
@@ -371,6 +478,7 @@ export function LibraryStatusSheet() {
             </InfoCard>
           </RowSubGroup>
           <RowSubGroup title="Device" style={styles.subGroupSpacing}>
+            <Text style={styles.sectionDesc}>Files cached on this device.</Text>
             <InfoCard>
               <LabeledValueRow
                 label="On device"
@@ -380,13 +488,13 @@ export function LibraryStatusSheet() {
                     <Text style={styles.valueText}>
                       {formatDeviceValue(
                         onDevice.data,
-                        stats.data?.overall,
+                        stats.data?.files,
                         displayMode,
                       )}
                     </Text>
                     <Text style={styles.valuePercent}>
                       {humanUploadPercent(
-                        devicePercent(onDevice.data, stats.data?.overall),
+                        devicePercent(onDevice.data, stats.data?.files),
                       )}
                     </Text>
                   </View>
@@ -402,13 +510,13 @@ export function LibraryStatusSheet() {
                     <Text style={styles.valueText}>
                       {formatDeviceValue(
                         pendingBackup.data,
-                        stats.data?.overall,
+                        stats.data?.files,
                         displayMode,
                       )}
                     </Text>
                     <Text style={styles.valuePercent}>
                       {humanUploadPercent(
-                        devicePercent(pendingBackup.data, stats.data?.overall),
+                        devicePercent(pendingBackup.data, stats.data?.files),
                       )}
                     </Text>
                   </View>
@@ -425,13 +533,13 @@ export function LibraryStatusSheet() {
                     <Text style={styles.valueText}>
                       {formatDeviceValue(
                         lost.data,
-                        stats.data?.overall,
+                        stats.data?.files,
                         displayMode,
                       )}
                     </Text>
                     <Text style={styles.valuePercent}>
                       {humanUploadPercent(
-                        devicePercent(lost.data, stats.data?.overall),
+                        devicePercent(lost.data, stats.data?.files),
                       )}
                     </Text>
                   </View>
@@ -495,6 +603,11 @@ const styles = StyleSheet.create({
   },
   groupSpacing: { marginTop: 8 },
   subGroupSpacing: { marginTop: 12 },
+  sectionDesc: {
+    color: palette.gray[400],
+    fontSize: 12,
+    marginBottom: 8,
+  },
   networkGroupGap: { height: 8 },
   boldLabel: { fontWeight: '700' },
   toggleTrack: {

--- a/apps/mobile/src/components/UploadStatusIcon.tsx
+++ b/apps/mobile/src/components/UploadStatusIcon.tsx
@@ -1,4 +1,6 @@
 import {
+  ClockArrowUpIcon,
+  ClockIcon,
   CloudAlertIcon,
   CloudCheckIcon,
   CloudDownloadIcon,
@@ -22,10 +24,14 @@ export function UploadStatusIcon({
   variant?: 'badge' | 'icon'
   color?: string
 }) {
-  const pillColor = status.isErrored ? palette.red[500] : overlay.pill
+  const pillColor =
+    status.isErrored || status.fileIsGone ? palette.red[500] : overlay.pill
   const iconColor = color ?? palette.gray[50]
 
   const label = useMemo(() => {
+    if (status.isImportFailed) return 'Import failed'
+    if (status.isDeferredImport) return 'Import queued'
+    if (status.isProcessing) return 'Importing'
     if (status.isErrored) return status.errorText || 'Error'
     if (status.isUploadQueued) return 'Queued'
     if (status.isDownloadQueued) return 'Download queued'
@@ -35,10 +41,15 @@ export function UploadStatusIcon({
       return 'File on network and device'
     if (status.isUploaded && !status.isDownloaded) return 'File only on network'
     if (!status.isUploaded && status.isDownloaded) return 'File only on device'
+    if (status.fileIsGone) return 'File unavailable'
     return ''
   }, [status])
 
-  const iconEL = status.isErrored ? (
+  const iconEL = status.isDeferredImport ? (
+    <ClockIcon color={iconColor} size={size} />
+  ) : status.isProcessing ? (
+    <ClockArrowUpIcon color={iconColor} size={size} />
+  ) : status.isErrored ? (
     <CloudAlertIcon color={iconColor} size={size} />
   ) : status.isUploadQueued ? (
     <SpinnerIcon color={iconColor} size={size} />
@@ -53,6 +64,8 @@ export function UploadStatusIcon({
     ) : (
       <SpinnerIcon color={iconColor} size={size} />
     )
+  ) : status.fileIsGone ? (
+    <CloudAlertIcon color={iconColor} size={size} />
   ) : status.isUploaded ? (
     status.isDownloaded ? (
       <CloudCheckIcon color={iconColor} size={size} />
@@ -77,17 +90,19 @@ export function UploadStatusIcon({
       textColor={palette.gray[50]}
       accessibilityLabel={`Status: ${label}`}
       testID={`upload-status-${
-        status.isErrored
-          ? 'error'
-          : status.isUploadQueued
-            ? 'queued'
-            : status.isPacking
-              ? 'packing'
-              : status.isUploading
-                ? 'uploading'
-                : status.isUploaded
-                  ? 'uploaded'
-                  : 'local'
+        status.isProcessing
+          ? 'processing'
+          : status.isErrored
+            ? 'error'
+            : status.isUploadQueued
+              ? 'queued'
+              : status.isPacking
+                ? 'packing'
+                : status.isUploading
+                  ? 'uploading'
+                  : status.isUploaded
+                    ? 'uploaded'
+                    : 'local'
       }`}
     >
       {iconEL}

--- a/apps/mobile/src/hooks/useBestThumbnail.ts
+++ b/apps/mobile/src/hooks/useBestThumbnail.ts
@@ -22,9 +22,12 @@ export function useBestThumbnailUri(
   file?: FileRecord,
   thumbSize: ThumbSize = 512,
 ) {
-  // Fetch the best thumbnail record.
+  // Skip thumbnail lookup for files still being imported (no hash yet).
+  const isImported = !!file && file.hash !== ''
   const thumbRecord = useSWR(
-    file ? app().caches.thumbnails.best.key(file.id, String(thumbSize)) : null,
+    isImported
+      ? app().caches.thumbnails.best.key(file.id, String(thumbSize))
+      : null,
     () => (file ? app().thumbnails.getBest(file.id, thumbSize) : null),
   )
 

--- a/packages/core/src/db/operations/fileStats.ts
+++ b/packages/core/src/db/operations/fileStats.ts
@@ -87,7 +87,9 @@ export async function queryUploadStats(
   db: DatabaseAdapter,
   indexerURL: string,
 ): Promise<UploadStats> {
-  const active = `f.trashedAt IS NULL AND f.deletedAt IS NULL`
+  // Exclude pending imports (hash = '') — they have no size yet and are
+  // shown separately in the "Pending import" row.
+  const active = `f.trashedAt IS NULL AND f.deletedAt IS NULL AND f.hash != ''`
   const q = (where: string) => queryStatsForWhere(db, where, indexerURL)
 
   const [photos, videos, audio, docs, other, thumbnails] = await Promise.all([

--- a/packages/core/src/db/operations/thumbnails.ts
+++ b/packages/core/src/db/operations/thumbnails.ts
@@ -127,6 +127,7 @@ export async function queryThumbnailCandidatePage(
      WHERE (f.type LIKE 'image/%' OR f.type LIKE 'video/%')
        AND f.type != 'image/tiff'
        AND f.kind = 'file'
+       AND f.hash != ''
        AND f.trashedAt IS NULL AND f.deletedAt IS NULL
        ${cursorClause}
      GROUP BY f.id


### PR DESCRIPTION
UI improvements for how placeholder files and file states display throughout the app.

- Import status icons: UploadStatusIcon distinguishes three pre-upload states — "Import queued" (deferred archive placeholder, ClockIcon), "Importing" (copy done awaiting hash, ClockArrowUpIcon), and "Import failed" (lostReason set, CloudAlertIcon red)
- Gone state: Files that are unrecoverable (no local file, no sealed object, not processing) now show "File unavailable" with CloudAlertIcon and red error styling, instead of silently falling through to the upload icon
- Library status sheet: New "Library" section shows current file count, pending imports, and total.  New "Sync" section shows active upload count and progress percentage
- Placeholder handling: File list and details hide size when it's 0 (placeholders have no size yet).  Upload stats and thumbnail candidate queries exclude hash = '' files. useBestThumbnail skips thumbnail lookup for unfinalized files
