### PR TITLE
fix(mobile): sort syncNewPhotos by creationTime to prevent false positives

### DIFF
--- a/.changeset/fix-sync-new-photos-ai-bump.md
+++ b/.changeset/fix-sync-new-photos-ai-bump.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Fixed old photos appearing in recent sync after iOS background processing.

--- a/apps/mobile/src/managers/syncNewPhotos.test.ts
+++ b/apps/mobile/src/managers/syncNewPhotos.test.ts
@@ -83,21 +83,21 @@ describe('syncNewPhotos', () => {
     mockProcessAssetsSuccess()
   })
 
-  it('sorts by modificationTime DESC', async () => {
+  it('sorts by creationTime DESC', async () => {
     getAssetsAsyncMock.mockResolvedValueOnce(
-      page([asset('a1', '1.jpg', { modificationTime: 5_000 })]),
+      page([asset('a1', '1.jpg', { creationTime: 5_000 })]),
     )
     await run()
     expect(getAssetsAsyncMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        sortBy: [['modificationTime', false]],
+        sortBy: [['creationTime', false]],
       }),
     )
   })
 
   it('does not pass createdBefore or createdAfter', async () => {
     getAssetsAsyncMock.mockResolvedValueOnce(
-      page([asset('a1', '1.jpg', { modificationTime: 5_000 })]),
+      page([asset('a1', '1.jpg', { creationTime: 5_000 })]),
     )
     await run()
     const opts = getAssetsAsyncMock.mock.calls[0][0]
@@ -105,14 +105,14 @@ describe('syncNewPhotos', () => {
     expect(opts).not.toHaveProperty('createdBefore')
   })
 
-  it('only processes assets with modificationTime >= enabledAt', async () => {
+  it('only processes assets with creationTime >= enabledAt', async () => {
     await setSyncNewPhotosEnabledAt(3_000)
     getAssetsAsyncMock.mockResolvedValueOnce(
       page([
-        asset('a1', 'new1.jpg', { modificationTime: 5_000 }),
-        asset('a2', 'new2.jpg', { modificationTime: 4_000 }),
-        asset('a3', 'exact.jpg', { modificationTime: 3_000 }),
-        asset('a4', 'old.jpg', { modificationTime: 2_000 }),
+        asset('a1', 'new1.jpg', { creationTime: 5_000 }),
+        asset('a2', 'new2.jpg', { creationTime: 4_000 }),
+        asset('a3', 'exact.jpg', { creationTime: 3_000 }),
+        asset('a4', 'old.jpg', { creationTime: 2_000 }),
       ]),
     )
     await run()
@@ -131,8 +131,8 @@ describe('syncNewPhotos', () => {
     await setSyncNewPhotosEnabledAt(10_000)
     getAssetsAsyncMock.mockResolvedValueOnce(
       page([
-        asset('a1', '1.jpg', { modificationTime: 5_000 }),
-        asset('a2', '2.jpg', { modificationTime: 3_000 }),
+        asset('a1', '1.jpg', { creationTime: 5_000 }),
+        asset('a2', '2.jpg', { creationTime: 3_000 }),
       ]),
     )
     await run()
@@ -147,7 +147,7 @@ describe('syncNewPhotos', () => {
 
   it('does not paginate even when page is full', async () => {
     const fullPage = Array.from({ length: 50 }, (_, i) =>
-      asset(`a${i}`, `${i}.jpg`, { modificationTime: 10_000 - i }),
+      asset(`a${i}`, `${i}.jpg`, { creationTime: 10_000 - i }),
     )
     getAssetsAsyncMock.mockResolvedValueOnce(page(fullPage, 'cursor-page-1'))
     await run()
@@ -156,25 +156,18 @@ describe('syncNewPhotos', () => {
     expect(processAssetsMock.mock.calls[0][0]).toHaveLength(50)
   })
 
-  it('falls back to modificationTime for timestamp when creationTime is 0', async () => {
+  it('excludes old photo with AI-bumped modificationTime', async () => {
+    await setSyncNewPhotosEnabledAt(10_000)
     getAssetsAsyncMock.mockResolvedValueOnce(
       page([
-        asset('a1', 'downloaded.jpg', {
-          creationTime: 0,
-          modificationTime: 5_000,
+        asset('a1', 'ai-bumped.jpg', {
+          creationTime: 1_000,
+          modificationTime: 20_000,
         }),
       ]),
     )
     await run()
-    expect(processAssetsMock).toHaveBeenCalledWith(
-      [
-        expect.objectContaining({
-          timestamp: new Date(5_000).toISOString(),
-        }),
-      ],
-      'file',
-      { addToImportDirectory: true, skipExistingUpdates: true },
-    )
+    expect(processAssetsMock).not.toHaveBeenCalled()
   })
 
   it('setAutoSyncNewPhotos saves enablement timestamp', async () => {

--- a/apps/mobile/src/managers/syncNewPhotos.ts
+++ b/apps/mobile/src/managers/syncNewPhotos.ts
@@ -3,22 +3,22 @@
  *
  * Runs in the foreground while the user is active. Kept lightweight
  * (small page, longer interval) to minimize jank. Only processes
- * photos with modificationTime >= enabledAt so that historic photos
+ * photos with creationTime >= enabledAt so that historic photos
  * don't appear unexpectedly — the archive handles the backfill.
  * As time passes, the enabledAt floor stays fixed so the window of
  * "new" photos grows naturally.
  *
- * Catches: newly taken photos and recently modified photos near the
- * top of the sorted list. The deep historical tail and periodic
- * re-scans for cross-device synced photos are handled by
- * syncPhotosArchive (which runs its bounded re-scan during background
- * tasks where heavier DB work is free).
+ * Catches newly taken photos near the top of the sorted list. The
+ * deep historical tail is handled by the archive sync.
  *
- * Sorts by modificationTime DESC because:
- * - Android: DATE_TAKEN can be NULL for imported/downloaded photos,
- *   silently excluding them from createdAfter/createdBefore queries.
- * - iOS: creationDate can be an old EXIF date; modificationDate is the
- *   iCloud-synced metadata timestamp (not local arrival time).
+ * Sorts by creationTime DESC rather than modificationTime because
+ * iOS background processing (face recognition, scene detection, Live
+ * Photo adjustments) bumps modificationTime on old photos, causing
+ * them to appear "new". creationTime is always populated on iOS. On
+ * Android, DATE_TAKEN can be NULL (creationTime=0) for imported or
+ * downloaded files — these sort to the end and may be caught by
+ * archive, otherwise the user can manually import them.
+ *
  */
 
 import { useApp } from '@siastorage/core/app'
@@ -52,11 +52,11 @@ export async function run(signal?: AbortSignal): Promise<void> {
   try {
     const page = await MediaLibrary.getAssetsAsync({
       first: PAGE_SIZE,
-      sortBy: [[MediaLibrary.SortBy.modificationTime, false]],
+      sortBy: [[MediaLibrary.SortBy.creationTime, false]],
       mediaType: [MediaLibrary.MediaType.photo, MediaLibrary.MediaType.video],
     })
     if (signal?.aborted) return
-    const assets = page.assets.filter((a) => a.modificationTime >= enabledAt)
+    const assets = page.assets.filter((a) => a.creationTime >= enabledAt)
     if (assets.length === 0) {
       logger.debug('syncNewPhotos', 'no_new_photos')
       return
@@ -74,9 +74,7 @@ export async function run(signal?: AbortSignal): Promise<void> {
         name: asset.filename,
         type: undefined,
         size: undefined,
-        timestamp: new Date(
-          asset.creationTime || asset.modificationTime,
-        ).toISOString(),
+        timestamp: new Date(asset.creationTime).toISOString(),
       })),
       'file',
       { addToImportDirectory: true, skipExistingUpdates: true },


### PR DESCRIPTION
- iOS background processing (face recognition, scene detection) updates modificationTime on old photos, causing them to pass the enabledAt filter.
- Switch back to creationTime DESC sort, photos without EXIF will be skipped at least on android, thats ok this is a Photos feature. Archive sync will pick them up, otherwise its up to the user to import.