### PR TITLE
fix(mobile): auto reset Metro cache after killing stale processes

### DIFF
--- a/apps/mobile/scripts/start.ts
+++ b/apps/mobile/scripts/start.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env bun
 /**
  * Start the Expo dev server, killing any existing Metro process first.
+ * If stale processes were found, automatically adds --reset-cache to
+ * clear ghost connections that cause the "multiple hosts" DevTools error.
  *
  * Uses stdio: 'inherit' so the interactive Expo menu works properly.
  */
@@ -11,13 +13,21 @@ import { $ } from 'bun'
 const killResult = await $`lsof -ti:8081`.quiet().nothrow()
 const pids = killResult.stdout.toString().trim()
 
+let resetCache = false
 if (pids) {
   await $`kill -9 ${pids}`.quiet().nothrow()
-  console.log('Killed existing Metro process')
+  resetCache = true
+  console.log('Killed existing Metro process, starting with --reset-cache')
+}
+
+const extraArgs = process.argv.slice(2)
+const args = ['bunx', 'expo', 'start', '--dev-client', ...extraArgs]
+if (resetCache && !extraArgs.includes('--reset-cache')) {
+  args.push('--reset-cache')
 }
 
 // Start Expo dev server with inherited stdio for interactive menu
-const proc = Bun.spawn(['bunx', 'expo', 'start', '--dev-client'], {
+const proc = Bun.spawn(args, {
   cwd: `${import.meta.dir}/..`,
   stdio: ['inherit', 'inherit', 'inherit'],
   env: process.env,


### PR DESCRIPTION
When a stale Metro process is found on port 8081, automatically add --reset-cache to clear ghost connections that cause the DevTools "multiple hosts" error.