### PR TITLE
fix(mobile): adjust cache eviction thresholds

### DIFF
--- a/.changeset/update-eviction-thresholds.md
+++ b/.changeset/update-eviction-thresholds.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Raised cache eviction threshold from 1 GB to 4 GB and reduced minimum file age from 7 days to 1 day.

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -49,13 +49,13 @@ export const IMPORT_SCANNER_BACKLOG_LIMIT = 50
 // Thumbnail scanner interval.
 export const THUMBNAIL_SCANNER_INTERVAL = secondsInMs(5) // 5 seconds
 // Maximum number of bytes to retain in the local file system before evicting.
-export const FS_MAX_BYTES = 1_000_000_000 // 1 GB
+export const FS_MAX_BYTES = 4_000_000_000 // 4 GB
 // File system orphaned file cleanup frequency.
 export const FS_ORPHAN_FREQUENCY = daysInMs(1) // 1 day
 // File system file eviction frequency.
 export const FS_EVICTION_FREQUENCY = minutesInMs(60) // 60 minutes
 // Age threshold for considering files evictable.
-export const FS_EVICTABLE_MIN_AGE = daysInMs(7) // 7 days
+export const FS_EVICTABLE_MIN_AGE = daysInMs(1) // 1 day
 // Sync up metadata interval.
 export const SYNC_UP_METADATA_INTERVAL = secondsInMs(10) // 10 seconds
 // Sync up metadata batch size.


### PR DESCRIPTION
Raise FS_MAX_BYTES from 1 GB to 4 GB and reduce FS_EVICTABLE_MIN_AGE from 7 days to 1 day so eviction kicks in sooner.