### PR TITLE
perf(mobile): defer sync-down cache invalidation and fix batch upload progress

### DIFF
--- a/.changeset/defer-batch-invalidation.md
+++ b/.changeset/defer-batch-invalidation.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Deferred cache invalidation during sync-down batch processing to avoid React re-render depth limits with large batches.

--- a/.changeset/fix-batch-upload-progress.md
+++ b/.changeset/fix-batch-upload-progress.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Fixed batch upload progress not updating until after file data finished streaming to the network.

--- a/apps/mobile/src/managers/uploader.test.ts
+++ b/apps/mobile/src/managers/uploader.test.ts
@@ -277,6 +277,32 @@ describe('UploadManager', () => {
       expect(upload?.status).toBe('error')
       expect(upload?.error).toBe('Add failed')
     })
+
+    it('rolls back batch state when add fails, subsequent files flush correctly', async () => {
+      const entry1 = await createTestFile('file1')
+      const entry2 = await createTestFile('file2')
+      manager.initialize(app(), internal(), defaultAdapters())
+
+      // First add fails
+      mockPacker.add.mockRejectedValueOnce(new Error('Add failed'))
+      // Second add succeeds (default mock)
+
+      await manager.__testProcessFiles([entry1, entry2])
+
+      // Flush should finalize with only file2
+      const obj2 = createMockPinnedObject()
+      mockPacker.finalize.mockResolvedValueOnce([obj2])
+      await manager.flush()
+
+      // file1 errored, file2 completed
+      const u1 = app().uploads.getEntry('file1')
+      expect(u1?.status).toBe('error')
+      const u2 = app().uploads.getEntry('file2')
+      expect(u2).toBeUndefined()
+
+      // Finalize was called with batch containing only file2
+      expect(mockPacker.finalize).toHaveBeenCalled()
+    })
   })
 
   describe('flush', () => {

--- a/packages/core/src/app/namespaces/db.ts
+++ b/packages/core/src/app/namespaces/db.ts
@@ -161,11 +161,13 @@ export function buildDbNamespaces(
         return tag
       },
       ensureSystemTags: () => ops.ensureSystemTags(db),
-      syncFromMetadata: async (fileId, tagNames) => {
+      syncFromMetadata: async (fileId, tagNames, opts) => {
         if (tagNames === undefined) return
         await ops.syncTagsFromMetadata(db, fileId, tagNames)
-        caches.tags.invalidateAll()
-        caches.libraryVersion.invalidate()
+        if (!opts?.skipInvalidation) {
+          caches.tags.invalidateAll()
+          caches.libraryVersion.invalidate()
+        }
       },
     },
     files: {
@@ -333,12 +335,14 @@ export function buildDbNamespaces(
       },
       countFilesWithDirectories: (fileIds) =>
         ops.queryCountFilesWithDirectories(db, fileIds),
-      syncFromMetadata: async (fileId, dirName) => {
+      syncFromMetadata: async (fileId, dirName, opts) => {
         if (dirName === undefined) return
         await ops.syncDirectoryFromMetadata(db, fileId, dirName)
-        caches.directories.invalidate('all')
-        caches.directories.invalidate(`file/${fileId}`)
-        caches.libraryVersion.invalidate()
+        if (!opts?.skipInvalidation) {
+          caches.directories.invalidate('all')
+          caches.directories.invalidate(`file/${fileId}`)
+          caches.libraryVersion.invalidate()
+        }
       },
     },
     thumbnails: {

--- a/packages/core/src/app/service.ts
+++ b/packages/core/src/app/service.ts
@@ -103,6 +103,7 @@ export interface AppService {
     syncFromMetadata(
       fileId: string,
       tagNames: string[] | undefined,
+      opts?: { skipInvalidation?: boolean },
     ): Promise<void>
   }
   /** File record CRUD, queries, trash, and purge operations. */
@@ -224,7 +225,11 @@ export interface AppService {
     /** Returns how many of the given files belong to a directory. */
     countFilesWithDirectories(fileIds: string[]): Promise<number>
     /** Reconciles a file's directory assignment with metadata. */
-    syncFromMetadata(fileId: string, dirName: string | undefined): Promise<void>
+    syncFromMetadata(
+      fileId: string,
+      dirName: string | undefined,
+      opts?: { skipInvalidation?: boolean },
+    ): Promise<void>
   }
   /** Thumbnail queries and generation. */
   thumbnails: {

--- a/packages/core/src/services/syncDownEvents.ts
+++ b/packages/core/src/services/syncDownEvents.ts
@@ -285,7 +285,11 @@ async function processBatch(
   })
 
   // Phase 3: Cleanup — delete local files for deleted records, clear
-  // upload state for updated records, sync tags. Errors here are non-fatal.
+  // upload state for updated records, sync tags/directories. Errors
+  // here are non-fatal. Cache invalidation is deferred to the end of
+  // the batch to avoid triggering React re-render depth limits when
+  // processing large batches (e.g. 500 files from archive sync).
+  let needsLibraryInvalidation = false
   for (const event of prepared) {
     if (event.kind === 'delete' && deletedFileIds.has(event.fileId)) {
       try {
@@ -300,16 +304,17 @@ async function processBatch(
       }
     } else if (event.kind === 'update') {
       app.caches.fileById.invalidate(event.fileId)
-      app.caches.libraryVersion.invalidate()
+      needsLibraryInvalidation = true
     }
-    // Sync tags and directories from remote metadata for file records.
     if (event.kind !== 'delete' && event.isFile) {
       const shouldSync =
         event.kind === 'create' ||
         (event.kind === 'update' && event.isRemoteNewer)
       if (shouldSync) {
         try {
-          await app.tags.syncFromMetadata(event.fileRecord.id, event.tags)
+          await app.tags.syncFromMetadata(event.fileRecord.id, event.tags, {
+            skipInvalidation: true,
+          })
         } catch (e) {
           logger.error('syncDownEvents', 'tag_sync_error', {
             fileId: event.fileRecord.id,
@@ -320,6 +325,7 @@ async function processBatch(
           await app.directories.syncFromMetadata(
             event.fileRecord.id,
             event.directory,
+            { skipInvalidation: true },
           )
         } catch (e) {
           logger.error('syncDownEvents', 'directory_sync_error', {
@@ -327,8 +333,14 @@ async function processBatch(
             error: e as Error,
           })
         }
+        needsLibraryInvalidation = true
       }
     }
+  }
+  if (needsLibraryInvalidation) {
+    app.caches.tags.invalidateAll()
+    app.caches.directories.invalidateAll()
+    app.caches.libraryVersion.invalidate()
   }
 }
 

--- a/packages/core/src/services/uploader.ts
+++ b/packages/core/src/services/uploader.ts
@@ -505,6 +505,7 @@ export class UploadManager {
    * After adding, if slabsFilled >= PACKER_MAX_SLABS, flush immediately.
    */
   private async processEntry(entry: FileEntry): Promise<void> {
+    let needsRollback = false
     try {
       if (this.batch && this.shouldFlushBeforeAdding(entry.size)) {
         await this.flush('slab_threshold')
@@ -556,10 +557,17 @@ export class UploadManager {
         batchId: this.batch!.batchId,
       })
 
+      // Add to batch state BEFORE packer.add() so onProgress can
+      // distribute progress to this file while data streams to the network.
+      this.batch!.files.push(entry)
+      this.batch!.totalSize += entry.size
+      needsRollback = true
+
       const t0 = Date.now()
       const reader = this.adapters.createFileReader(entry.fileUri)
       const t1 = Date.now()
       await this.packer.add(reader)
+      needsRollback = false
       const t2 = Date.now()
       const addMs = t2 - t1
       const slabsBefore = this.batch!.slabsFilled
@@ -578,6 +586,13 @@ export class UploadManager {
         await this.flush('max_slabs')
       }
     } catch (e) {
+      if (needsRollback && this.batch) {
+        const idx = this.batch.files.indexOf(entry)
+        if (idx !== -1) {
+          this.batch.files.splice(idx, 1)
+          this.batch.totalSize -= entry.size
+        }
+      }
       const message = e instanceof Error ? e.message : String(e)
       logger.error('uploadManager', 'file_process_error', {
         fileId: entry.fileId,
@@ -644,6 +659,10 @@ export class UploadManager {
         size: entry.size,
         batchId: this.batch!.batchId,
       })
+      // Add to batch state before packer.add() so onProgress can
+      // distribute progress while data streams to the network.
+      this.batch!.files.push(entry)
+      this.batch!.totalSize += entry.size
       const t0 = Date.now()
       const reader = this.adapters.createFileReader(entry.fileUri)
       inflight.push({
@@ -680,6 +699,13 @@ export class UploadManager {
         }
       } catch (e) {
         if (!this.active) break
+        if (this.batch) {
+          const idx = this.batch.files.indexOf(entry)
+          if (idx !== -1) {
+            this.batch.files.splice(idx, 1)
+            this.batch.totalSize -= entry.size
+          }
+        }
         const message = e instanceof Error ? e.message : String(e)
         logger.error('uploadManager', 'file_process_error', {
           fileId: entry.fileId,
@@ -807,8 +833,6 @@ export class UploadManager {
   /** Update batch state after a successful packer.add(). */
   private recordAdd(entry: FileEntry, addMs: number): void {
     this.batch!.lastProcessedAt = Date.now()
-    this.batch!.files.push(entry)
-    this.batch!.totalSize += entry.size
     this._packedCount++
     this._packedBytes += entry.size
     this.app.uploads.setStatus(entry.fileId, 'packed')


### PR DESCRIPTION
- Track batch state before packer.add() so onProgress can distribute progress to each file while data streams to the network.
- Defer tag, directory, and library cache invalidation to the end of each sync-down batch instead of per-event.
