### PR TITLE
fix(mobile): add confirmation prompt before --rebuild

### DIFF
--- a/apps/mobile/scripts/dev.ts
+++ b/apps/mobile/scripts/dev.ts
@@ -42,6 +42,7 @@ import {
   needsRebuild,
   PROJECT_ROOT,
 } from './buildCache'
+import { confirmRebuild } from './lib/confirm'
 import {
   type Device,
   installAndroidApp,
@@ -115,8 +116,9 @@ console.log('')
 
 $.cwd(PROJECT_ROOT)
 
-// Full rebuild: wipe everything and start fresh
+// Full rebuild: confirm, then wipe everything and start fresh
 if (forceRebuild) {
+  confirmRebuild(platform)
   console.log('🔨 Full rebuild requested')
   console.log(`   Removing ${platform}/...`)
   rmSync(join(PROJECT_ROOT, platform), { recursive: true, force: true })

--- a/apps/mobile/scripts/e2e.ts
+++ b/apps/mobile/scripts/e2e.ts
@@ -34,6 +34,7 @@ import {
   needsRebuild,
   PROJECT_ROOT,
 } from './buildCache'
+import { confirmRebuild } from './lib/confirm'
 
 const E2E_DIR = join(PROJECT_ROOT, 'e2e')
 const FLOWS_DIR = join(E2E_DIR, 'flows')
@@ -500,6 +501,10 @@ async function main() {
     `   Flags: ${[forceRebuild && '--rebuild', skipInstall && '--skip-install', headless && '--headless'].filter(Boolean).join(' ') || 'none'}`,
   )
   console.log('')
+
+  if (forceRebuild) {
+    confirmRebuild(platform)
+  }
 
   try {
     // 1. Boot device and get device ID

--- a/apps/mobile/scripts/lib/confirm.ts
+++ b/apps/mobile/scripts/lib/confirm.ts
@@ -1,0 +1,15 @@
+import type { Platform } from './devices'
+
+/**
+ * Prompts the user to confirm a full rebuild. Exits if they decline.
+ */
+export function confirmRebuild(platform: Platform): void {
+  const answer = prompt(
+    `⚠️  Full rebuild will delete ${platform}/ and rebuild from scratch. Continue? [y/N]`,
+  )
+  const normalized = answer?.trim().toLowerCase() ?? ''
+  if (normalized !== 'y' && normalized !== 'yes') {
+    console.log('Aborted.')
+    process.exit(0)
+  }
+}


### PR DESCRIPTION
- Prevents accidental full rebuilds when re-running commands from terminal history.
