### PR TITLE
chore: enforce minimum 3-day release age for dependencies

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,3 @@
+[install]
+minimumReleaseAge = 259200
+minimumReleaseAgeExcludes = ["@siafoundation/*", "react-native-sia"]


### PR DESCRIPTION
- Prevents installing packages published less than 3 days ago, with exceptions for @siafoundation/* and react-native-sia.
