### PR TITLE
feat(mobile): display available storage and handle unlimited accounts

### DIFF
--- a/.changeset/settings-remaining-storage.md
+++ b/.changeset/settings-remaining-storage.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Display remaining app storage and show 'No app limit' when the storage limit is set to the max int64 value.

--- a/apps/mobile/src/screens/SettingsIndexerScreen.tsx
+++ b/apps/mobile/src/screens/SettingsIndexerScreen.tsx
@@ -82,9 +82,18 @@ export function SettingsIndexerScreen({ navigation }: Props) {
                 value={humanSize(Number(account.data.pinnedSize))}
               />
               <LabeledValueRow
+                label="Available"
+                description="Remaining app storage"
+                value={humanSize(Number(account.data.remainingStorage))}
+              />
+              <LabeledValueRow
                 label="Storage Limit"
-                description="Maximum storage for your account"
-                value={humanSize(Number(account.data.maxPinnedData))}
+                description="Max app storage"
+                value={
+                  Number(account.data.maxPinnedData) >= 2 ** 62
+                    ? 'No app limit'
+                    : humanSize(Number(account.data.maxPinnedData))
+                }
               />
             </>
           ) : null}


### PR DESCRIPTION
- Add an Available row showing remainingStorage on the indexer settings screen.
- Show 'No limit' for the storage limit when maxPinnedData is set to the max int64 sentinel value.
