### PR TITLE
feat(mobile): pause uploads when account storage is full

### DIFF
--- a/.changeset/gate-uploads-storage-full.md
+++ b/.changeset/gate-uploads-storage-full.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Pause uploads when account storage is full and automatically resume when space becomes available.

--- a/apps/mobile/src/managers/uploader.test.ts
+++ b/apps/mobile/src/managers/uploader.test.ts
@@ -14,6 +14,7 @@ jest.mock('@siastorage/core/config', () => ({
   PACKER_MAX_SLABS: 10,
   SLAB_FILL_THRESHOLD: 0.9,
   PACKER_POLL_INTERVAL: 5000,
+  STORAGE_FULL_POLL_INTERVAL: 30000,
   SAVE_BATCH_CONCURRENCY: 50,
   SAVE_REMOVAL_DELAY_MS: 0,
 }))
@@ -23,6 +24,7 @@ import {
   SECTOR_SIZE,
   SLAB_FILL_THRESHOLD,
   SLAB_SIZE,
+  STORAGE_FULL_POLL_INTERVAL,
   UPLOAD_DATA_SHARDS,
   UPLOAD_MAX_INFLIGHT,
   UPLOAD_PARITY_SHARDS,
@@ -144,6 +146,7 @@ function createMockSdk(
     uploadPacked: jest.fn().mockResolvedValue(packer),
     pinObject: jest.fn().mockResolvedValue(undefined),
     appKey: jest.fn().mockReturnValue(mockAppKey),
+    account: jest.fn().mockResolvedValue({ remainingStorage: 1000000000n }),
   } as unknown as jest.Mocked<SdkInterface>
 }
 
@@ -1248,6 +1251,56 @@ describe('UploadManager', () => {
         0,
       )
       expect(totalFiles).toBe(300)
+    })
+  })
+
+  describe('storage full gate', () => {
+    function enablePolling() {
+      app().connection.setState({ isConnected: true })
+      void app().settings.setAutoScanUploads(true)
+    }
+
+    it('does not poll for files when remainingStorage is 0', async () => {
+      enablePolling()
+      mockSdk.account.mockResolvedValue({ remainingStorage: 0n } as any)
+
+      const querySpy = jest
+        .spyOn(app().files, 'query')
+        .mockResolvedValue([] as any)
+
+      manager.initialize(app(), internal(), defaultAdapters())
+      await jest.advanceTimersByTimeAsync(0)
+
+      expect(querySpy).not.toHaveBeenCalled()
+      querySpy.mockRestore()
+    })
+
+    it('resumes polling after storage becomes available', async () => {
+      enablePolling()
+      mockSdk.account
+        .mockResolvedValueOnce({ remainingStorage: 0n } as any)
+        .mockResolvedValueOnce({ remainingStorage: 0n } as any)
+        .mockResolvedValue({ remainingStorage: 1000000000n } as any)
+
+      const querySpy = jest
+        .spyOn(app().files, 'query')
+        .mockResolvedValue([] as any)
+
+      manager.initialize(app(), internal(), defaultAdapters())
+
+      // First iteration: storage full, waits
+      await jest.advanceTimersByTimeAsync(0)
+      expect(querySpy).not.toHaveBeenCalled()
+
+      // Advance past one poll interval — still full
+      await jest.advanceTimersByTimeAsync(STORAGE_FULL_POLL_INTERVAL)
+      expect(querySpy).not.toHaveBeenCalled()
+
+      // Advance past another poll interval — now has space, resumes
+      await jest.advanceTimersByTimeAsync(STORAGE_FULL_POLL_INTERVAL)
+      expect(querySpy).toHaveBeenCalled()
+
+      querySpy.mockRestore()
     })
   })
 

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -32,6 +32,8 @@ export const PACKER_MAX_SLABS = 10
 export const SLAB_FILL_THRESHOLD = 0.9
 // Packer DB poll interval.
 export const PACKER_POLL_INTERVAL = secondsInMs(5) // 5 seconds
+// How often to re-check account when storage is full.
+export const STORAGE_FULL_POLL_INTERVAL = secondsInMs(30)
 // Sync events interval.
 export const SYNC_EVENTS_INTERVAL = secondsInMs(10) // 10 seconds
 // Sync new photos interval.

--- a/packages/core/src/services/uploader.ts
+++ b/packages/core/src/services/uploader.ts
@@ -12,6 +12,7 @@ import {
   SECTOR_SIZE,
   SLAB_FILL_THRESHOLD,
   SLAB_SIZE,
+  STORAGE_FULL_POLL_INTERVAL,
   UPLOAD_DATA_SHARDS,
   UPLOAD_MAX_INFLIGHT,
   UPLOAD_PARITY_SHARDS,
@@ -471,6 +472,11 @@ export class UploadManager {
         this.app.caches.libraryVersion.invalidate()
       }
 
+      if (await this.isStorageFull()) {
+        await this.waitForWorkOrTimeout(STORAGE_FULL_POLL_INTERVAL)
+        continue
+      }
+
       const newFiles = await this.pollDB()
       if (newFiles > 0) {
         continue
@@ -765,6 +771,20 @@ export class UploadManager {
    *
    * @returns Number of new files added to the polledFiles queue.
    */
+  private async isStorageFull(): Promise<boolean> {
+    if (!this.app.connection.getState().isConnected) return false
+    try {
+      const account = await this.app.account()
+      if (account.remainingStorage === 0n) {
+        logger.warn('uploadManager', 'storage_full')
+        return true
+      }
+      return false
+    } catch {
+      return false
+    }
+  }
+
   private async pollDB(): Promise<number> {
     if (!this.app.connection.getState().isConnected) return 0
 


### PR DESCRIPTION
Check remainingStorage before polling for new files to upload. When storage is full the upload loop waits on a 30-second interval and resumes automatically once space becomes available.
