### PR TITLE
feat(core): add natural sorting for file and directory name lists

### DIFF
--- a/.changeset/natural-sort-order.md
+++ b/.changeset/natural-sort-order.md
@@ -1,0 +1,5 @@
+---
+mobile: minor
+---
+
+File and folder lists now sort names naturally, so "file2" comes before "file10".

--- a/apps/benchmark/src/dataset.ts
+++ b/apps/benchmark/src/dataset.ts
@@ -1,5 +1,6 @@
 import type { DatabaseAdapter } from '@siastorage/core/adapters'
 import * as sql from '@siastorage/core/db/sql'
+import { naturalSortKey } from '@siastorage/core/lib/naturalSortKey'
 import type { DatasetConfig, DatasetInfo } from './types'
 
 const TYPES = [
@@ -61,10 +62,11 @@ export async function generateDataset(
     const name = `folder-${String(i).padStart(4, '0')}`
     dirIds.push(id)
     await db.runAsync(
-      'INSERT INTO directories (id, name, createdAt) VALUES (?, ?, ?)',
+      'INSERT INTO directories (id, name, createdAt, nameSortKey) VALUES (?, ?, ?, ?)',
       id,
       name,
       Date.now(),
+      naturalSortKey(name),
     )
   }
 
@@ -135,6 +137,7 @@ export async function generateDataset(
         batchBuffer.push({
           id,
           name: groupName,
+          nameSortKey: naturalSortKey(groupName),
           size,
           createdAt,
           updatedAt,

--- a/apps/integration/test/sync-down.test.ts
+++ b/apps/integration/test/sync-down.test.ts
@@ -349,4 +349,27 @@ describe('Sync Down', () => {
     const objects = await app.readLocalObjectsForFile('obj-test-file')
     expect(objects).toHaveLength(2)
   })
+
+  it('synced files sort correctly by name (natural sort)', async () => {
+    app.sdk.injectObject({
+      metadata: generateMockFileMetadata(1, { name: 'file10.jpg' }),
+    })
+    app.sdk.injectObject({
+      metadata: generateMockFileMetadata(2, { name: 'file2.jpg' }),
+    })
+    app.sdk.injectObject({
+      metadata: generateMockFileMetadata(3, { name: 'file1.jpg' }),
+    })
+
+    await app.waitForFileCount(3)
+
+    const ids = await app.app.library.sortedFileIds(
+      { sortBy: 'NAME', sortDir: 'ASC', tags: [] },
+      10,
+      0,
+    )
+    const files = await app.app.files.getByIds(ids)
+    const names = ids.map((id) => files.find((f) => f.id === id)?.name)
+    expect(names).toEqual(['file1.jpg', 'file2.jpg', 'file10.jpg'])
+  })
 })

--- a/packages/core/src/db/migrations/0004_add_name_sort_key.ts
+++ b/packages/core/src/db/migrations/0004_add_name_sort_key.ts
@@ -1,0 +1,26 @@
+import type { DatabaseAdapter } from '../../adapters/db'
+import type { Migration } from '../types'
+
+async function up(db: DatabaseAdapter): Promise<void> {
+  await db.execAsync(`ALTER TABLE files ADD COLUMN nameSortKey TEXT`)
+  await db.execAsync(`ALTER TABLE directories ADD COLUMN nameSortKey TEXT`)
+
+  await db.execAsync(
+    `CREATE INDEX IF NOT EXISTS idx_files_nameSortKey_id ON files(nameSortKey, id)`,
+  )
+  await db.execAsync(
+    `CREATE INDEX IF NOT EXISTS idx_files_current_nameSortKey
+     ON files(nameSortKey, id)
+     WHERE current = 1 AND kind = 'file' AND trashedAt IS NULL AND deletedAt IS NULL`,
+  )
+  await db.execAsync(
+    `CREATE INDEX IF NOT EXISTS idx_directories_nameSortKey ON directories(nameSortKey)`,
+  )
+  await db.execAsync(`DROP INDEX IF EXISTS idx_files_fileName_nocase_id`)
+}
+
+export const migration_0004_add_name_sort_key: Migration = {
+  id: '0004_add_name_sort_key',
+  description: 'Add nameSortKey column for natural sorting.',
+  up,
+}

--- a/packages/core/src/db/migrations/index.ts
+++ b/packages/core/src/db/migrations/index.ts
@@ -2,11 +2,13 @@ import type { Migration } from '../types'
 import { migration_0001_init_schema } from './0001_init_schema'
 import { migration_0002_add_lost_reason } from './0002_add_lost_reason'
 import { migration_0003_version_indexes } from './0003_version_indexes'
+import { migration_0004_add_name_sort_key } from './0004_add_name_sort_key'
 
 export const coreMigrations: Migration[] = [
   migration_0001_init_schema,
   migration_0002_add_lost_reason,
   migration_0003_version_indexes,
+  migration_0004_add_name_sort_key,
 ]
 
 export function sortMigrations(migrations: Migration[]): Migration[] {

--- a/packages/core/src/db/operations/directories.test.ts
+++ b/packages/core/src/db/operations/directories.test.ts
@@ -407,3 +407,23 @@ describe('queryDirectoryNameForFile', () => {
     expect(name).toBeUndefined()
   })
 })
+
+describe('natural sort order', () => {
+  it('sorts directories in natural numeric order', async () => {
+    await insertDirectory(db(), 'Folder 10')
+    await insertDirectory(db(), 'Folder 2')
+    await insertDirectory(db(), 'Folder 1')
+    await insertDirectory(db(), 'Folder 20')
+    await insertDirectory(db(), 'Folder 3')
+
+    const dirs = await queryAllDirectoriesWithCounts(db())
+    const names = dirs.map((d) => d.name)
+    expect(names).toEqual([
+      'Folder 1',
+      'Folder 2',
+      'Folder 3',
+      'Folder 10',
+      'Folder 20',
+    ])
+  })
+})

--- a/packages/core/src/db/operations/directories.ts
+++ b/packages/core/src/db/operations/directories.ts
@@ -1,4 +1,5 @@
 import type { DatabaseAdapter } from '../../adapters/db'
+import { naturalSortKey } from '../../lib/naturalSortKey'
 import { uniqueId } from '../../lib/uniqueId'
 import type { FileRecordRow } from '../../types/files'
 import * as sql from '../sql'
@@ -55,7 +56,10 @@ export async function insertDirectory(
     createdAt: now,
   }
 
-  await sql.insert(db, 'directories', dir)
+  await sql.insert(db, 'directories', {
+    ...dir,
+    nameSortKey: naturalSortKey(trimmed),
+  })
   return dir
 }
 
@@ -71,10 +75,11 @@ export async function getOrCreateDirectory(
   const now = Date.now()
   const id = uniqueId()
   await db.runAsync(
-    `INSERT OR IGNORE INTO directories (id, name, createdAt) VALUES (?, ?, ?)`,
+    `INSERT OR IGNORE INTO directories (id, name, createdAt, nameSortKey) VALUES (?, ?, ?, ?)`,
     id,
     trimmed,
     now,
+    naturalSortKey(trimmed),
   )
 
   const dir = await db.getFirstAsync<Directory>(
@@ -98,7 +103,7 @@ export async function queryAllDirectoriesWithCounts(
      LEFT JOIN files f ON f.directoryId = d.id AND f.kind = 'file' AND f.trashedAt IS NULL AND f.deletedAt IS NULL
        AND ${buildLatestVersionFilter('f')}
      GROUP BY d.id
-     ORDER BY d.name COLLATE NOCASE`,
+     ORDER BY d.nameSortKey`,
   )
 }
 
@@ -327,7 +332,7 @@ export async function queryFilesByDirectoryName(
      WHERE d.name = ? AND f.kind = 'file'
        AND f.trashedAt IS NULL AND f.deletedAt IS NULL
        AND ${buildLatestVersionFilter('f')}
-     ORDER BY f.name`,
+     ORDER BY f.nameSortKey`,
     directoryName,
   )
 }
@@ -351,7 +356,12 @@ export async function renameDirectory(
     throw new Error(`Folder "${trimmed}" already exists`)
   }
 
-  await sql.update(db, 'directories', { name: trimmed }, { id: dirId })
+  await sql.update(
+    db,
+    'directories',
+    { name: trimmed, nameSortKey: naturalSortKey(trimmed) },
+    { id: dirId },
+  )
   const now = Date.now()
   await db.runAsync(
     'UPDATE files SET updatedAt = ? WHERE directoryId = ?',

--- a/packages/core/src/db/operations/files.ts
+++ b/packages/core/src/db/operations/files.ts
@@ -2,6 +2,7 @@ import { logger } from '@siastorage/logger'
 import type { DatabaseAdapter } from '../../adapters/db'
 import type { LocalObject, LocalObjectRow } from '../../encoding/localObject'
 import { localObjectFromStorageRow } from '../../encoding/localObject'
+import { naturalSortKey } from '../../lib/naturalSortKey'
 import type { FileRecord, FileRecordRow } from '../../types/files'
 import * as sql from '../sql'
 import { buildLatestVersionFilter } from './library'
@@ -191,6 +192,7 @@ export async function insertFileRecord(
   await sql.insert(db, 'files', {
     id,
     name,
+    nameSortKey: naturalSortKey(name),
     size,
     createdAt,
     updatedAt,
@@ -502,6 +504,10 @@ export async function updateFileRecordFields(
       continue
     }
     assignments[field] = value
+  }
+
+  if (update.name !== undefined) {
+    assignments.nameSortKey = naturalSortKey(update.name)
   }
 
   if (!options.includeUpdatedAt) {
@@ -856,6 +862,7 @@ export async function insertManyFileRecords(
     records.map((r) => ({
       id: r.id,
       name: r.name,
+      nameSortKey: naturalSortKey(r.name),
       size: r.size,
       createdAt: r.createdAt,
       updatedAt: r.updatedAt,
@@ -889,6 +896,7 @@ export async function insertManyFileRecords(
 
 const FILE_UPSERT_UPDATE_COLUMNS = [
   'name',
+  'nameSortKey',
   'size',
   'type',
   'kind',
@@ -912,6 +920,7 @@ export async function upsertManyFileRecords(
     records.map((r) => ({
       id: r.id,
       name: r.name,
+      nameSortKey: naturalSortKey(r.name),
       size: r.size,
       type: r.type,
       kind: r.kind,
@@ -1128,8 +1137,9 @@ export async function renameAllFileVersions(
   await db.withTransactionAsync(async () => {
     for (let i = 0; i < versions.length; i++) {
       await db.runAsync(
-        'UPDATE files SET name = ?, updatedAt = ? WHERE id = ?',
+        'UPDATE files SET name = ?, nameSortKey = ?, updatedAt = ? WHERE id = ?',
         newName,
+        naturalSortKey(newName),
         now - i,
         versions[i].id,
       )

--- a/packages/core/src/db/operations/library.test.ts
+++ b/packages/core/src/db/operations/library.test.ts
@@ -227,7 +227,7 @@ describe('library count queries', () => {
     await createTestFile('f1')
     await createTestFile('f2')
     await db().runAsync(
-      "INSERT INTO directories (id, name, createdAt) VALUES ('dir1', 'Folder', 1000)",
+      "INSERT INTO directories (id, name, createdAt, nameSortKey) VALUES ('dir1', 'Folder', 1000, 'folder')",
     )
     await db().runAsync("UPDATE files SET directoryId = 'dir1' WHERE id = 'f1'")
     const count = await queryUnfiledFileCount(db())
@@ -238,7 +238,7 @@ describe('library count queries', () => {
     await createTestFile('f1')
     await createTestFile('f2')
     await db().runAsync(
-      "INSERT INTO directories (id, name, createdAt) VALUES ('dir1', 'Folder', 1000)",
+      "INSERT INTO directories (id, name, createdAt, nameSortKey) VALUES ('dir1', 'Folder', 1000, 'folder')",
     )
     await db().runAsync("UPDATE files SET directoryId = 'dir1' WHERE id = 'f1'")
     const count = await queryDirectoryFileCount(db(), 'dir1')
@@ -249,7 +249,7 @@ describe('library count queries', () => {
     await createTestFile('f1')
     await createTestFile('f2')
     await db().runAsync(
-      "INSERT INTO directories (id, name, createdAt) VALUES ('dir1', 'Folder', 1000)",
+      "INSERT INTO directories (id, name, createdAt, nameSortKey) VALUES ('dir1', 'Folder', 1000, 'folder')",
     )
     await db().runAsync("UPDATE files SET directoryId = 'dir1' WHERE id = 'f1'")
     const count = await queryDirectoryFileCount(db(), UNFILED_DIRECTORY_ID)
@@ -656,5 +656,37 @@ describe('querySortedFileIds', () => {
       0,
     )
     expect(ids).toEqual(['file-e', 'file-c', 'file-a', 'file-b', 'file-d'])
+  })
+
+  test('returns IDs in natural NAME sort order', async () => {
+    await createTestFile('f1', { name: 'file1.jpg', createdAt: base })
+    await createTestFile('f10', { name: 'file10.jpg', createdAt: base + 10 })
+    await createTestFile('f2', { name: 'file2.jpg', createdAt: base + 20 })
+    await createTestFile('f20', { name: 'file20.jpg', createdAt: base + 30 })
+    await createTestFile('f3', { name: 'file3.jpg', createdAt: base + 40 })
+
+    const ids = await querySortedFileIds(
+      db(),
+      { sortBy: 'NAME', sortDir: 'ASC' },
+      5,
+      0,
+    )
+    expect(ids).toEqual(['f1', 'f2', 'f3', 'f10', 'f20'])
+  })
+
+  test('returns IDs in natural NAME sort order (DESC)', async () => {
+    await createTestFile('f1', { name: 'file1.jpg', createdAt: base })
+    await createTestFile('f10', { name: 'file10.jpg', createdAt: base + 10 })
+    await createTestFile('f2', { name: 'file2.jpg', createdAt: base + 20 })
+    await createTestFile('f20', { name: 'file20.jpg', createdAt: base + 30 })
+    await createTestFile('f3', { name: 'file3.jpg', createdAt: base + 40 })
+
+    const ids = await querySortedFileIds(
+      db(),
+      { sortBy: 'NAME', sortDir: 'DESC' },
+      5,
+      0,
+    )
+    expect(ids).toEqual(['f20', 'f10', 'f3', 'f2', 'f1'])
   })
 })

--- a/packages/core/src/db/operations/library.ts
+++ b/packages/core/src/db/operations/library.ts
@@ -116,7 +116,7 @@ export function buildLibraryQueryParts(
   let orderExpr: string
   switch (sortBy) {
     case 'NAME':
-      orderExpr = `(${tableAlias}.name IS NULL) ASC, ${tableAlias}.name COLLATE NOCASE ${dir}, ${tableAlias}.id ${dir}`
+      orderExpr = `(${tableAlias}.nameSortKey IS NULL) ASC, ${tableAlias}.nameSortKey ${dir}, ${tableAlias}.id ${dir}`
       break
     case 'ADDED':
       orderExpr = `${tableAlias}.addedAt ${dir}, ${tableAlias}.id ${dir}`
@@ -233,12 +233,12 @@ export async function queryFilePositionInSortedList(
 
   const anchorRow = await db.getFirstAsync<{
     id: string
-    name: string | null
+    nameSortKey: string | null
     size: number
     createdAt: number
     addedAt: number
   }>(
-    `SELECT f.id, f.name, f.size, f.createdAt, f.addedAt FROM files f ${
+    `SELECT f.id, f.nameSortKey, f.size, f.createdAt, f.addedAt FROM files f ${
       where ? `${where} AND f.id = ?` : 'WHERE f.id = ?'
     } LIMIT 1`,
     ...queryParams,
@@ -255,7 +255,7 @@ export async function queryFilePositionInSortedList(
     beforeCursor = buildNameBeforeCursor(
       opts.sortDir,
       'f',
-      anchorRow.name ?? null,
+      anchorRow.nameSortKey ?? null,
       anchorRow.id,
     )
   } else {
@@ -369,24 +369,23 @@ function buildDateBeforeCursor(
 function buildNameBeforeCursor(
   dir: SortDir,
   alias: string,
-  anchorName: string | null,
+  anchorSortKey: string | null,
   anchorId: string,
 ): { clause: string; params: (string | number)[] } {
-  const nullExpr = `${alias}.name IS NULL`
-  const nameExpr = `${alias}.name COLLATE NOCASE`
-  const anchorNull = anchorName === null ? 1 : 0
-  const nameOp = dir === 'ASC' ? '<' : '>'
-  const idOp = dir === 'ASC' ? '<' : '>'
+  const nullExpr = `${alias}.nameSortKey IS NULL`
+  const sortKeyExpr = `${alias}.nameSortKey`
+  const anchorNull = anchorSortKey === null ? 1 : 0
+  const op = dir === 'ASC' ? '<' : '>'
 
-  if (anchorName === null) {
+  if (anchorSortKey === null) {
     return {
-      clause: `(${nullExpr} < ?) OR (${nullExpr} = ? AND ${alias}.id ${idOp} ?)`,
+      clause: `(${nullExpr} < ?) OR (${nullExpr} = ? AND ${alias}.id ${op} ?)`,
       params: [anchorNull, anchorNull, anchorId],
     }
   }
 
   return {
-    clause: `(${nullExpr} < ?) OR (${nullExpr} = ? AND (${nameExpr} ${nameOp} ? OR (${nameExpr} = ? AND ${alias}.id ${idOp} ?)))`,
-    params: [anchorNull, anchorNull, anchorName, anchorName, anchorId],
+    clause: `(${nullExpr} < ?) OR (${nullExpr} = ? AND (${sortKeyExpr} ${op} ? OR (${sortKeyExpr} = ? AND ${alias}.id ${op} ?)))`,
+    params: [anchorNull, anchorNull, anchorSortKey, anchorSortKey, anchorId],
   }
 }

--- a/packages/core/src/db/operations/versions.test.ts
+++ b/packages/core/src/db/operations/versions.test.ts
@@ -16,6 +16,7 @@ import {
   queryFileCountWithFilters,
   queryLibraryFileCount,
   queryMediaFileCount,
+  querySortedFileIds,
   queryTagFileCount,
   queryUnfiledFileCount,
 } from './library'
@@ -69,10 +70,11 @@ async function createFile(
 
 async function createDirectory(id: string, name: string) {
   await db().runAsync(
-    'INSERT INTO directories (id, name, createdAt) VALUES (?, ?, ?)',
+    'INSERT INTO directories (id, name, createdAt, nameSortKey) VALUES (?, ?, ?, ?)',
     id,
     name,
     base,
+    name.toLowerCase(),
   )
 }
 
@@ -757,5 +759,23 @@ describe('trash file trashes all versions', () => {
     await restoreFiles(db(), ids)
     expect(await queryLibraryFileCount(db())).toBe(1)
     expect((await queryFileRecordByName(db(), 'doc.txt'))?.id).toBe('v3')
+  })
+})
+
+describe('rename updates nameSortKey for natural sort', () => {
+  test('renamed files sort correctly by name', async () => {
+    await createFile('f1', { name: 'a1.txt', updatedAt: base })
+    await createFile('f2', { name: 'b2.txt', updatedAt: base + 100 })
+
+    await renameAllFileVersions(db(), 'a1.txt', null, 'b10.txt')
+
+    const ids = await querySortedFileIds(
+      db(),
+      { sortBy: 'NAME', sortDir: 'ASC' },
+      10,
+      0,
+    )
+    // b2 should come before b10 in natural sort
+    expect(ids).toEqual(['f2', 'f1'])
   })
 })

--- a/packages/core/src/lib/naturalSortKey.test.ts
+++ b/packages/core/src/lib/naturalSortKey.test.ts
@@ -1,0 +1,88 @@
+import { naturalSortKey } from './naturalSortKey'
+
+describe('naturalSortKey', () => {
+  it('returns null for null input', () => {
+    expect(naturalSortKey(null)).toBeNull()
+  })
+
+  it('returns empty string for empty input', () => {
+    expect(naturalSortKey('')).toBe('')
+  })
+
+  it('lowercases alphabetic strings', () => {
+    expect(naturalSortKey('ABC')).toBe('abc')
+    expect(naturalSortKey('Hello World')).toBe('hello world')
+  })
+
+  it('pads single numeric sequences', () => {
+    expect(naturalSortKey('file2')).toBe('file' + '2'.padStart(20, '0'))
+    expect(naturalSortKey('file10')).toBe('file' + '10'.padStart(20, '0'))
+  })
+
+  it('pads multiple numeric sequences independently', () => {
+    const key = naturalSortKey('v1.2.10')
+    expect(key).toBe(
+      'v' +
+        '1'.padStart(20, '0') +
+        '.' +
+        '2'.padStart(20, '0') +
+        '.' +
+        '10'.padStart(20, '0'),
+    )
+  })
+
+  it('produces correct natural sort order', () => {
+    const names = ['file10', 'file2', 'file1', 'file20', 'file3']
+    const sorted = [...names].sort((a, b) =>
+      naturalSortKey(a)!.localeCompare(naturalSortKey(b)!),
+    )
+    expect(sorted).toEqual(['file1', 'file2', 'file3', 'file10', 'file20'])
+  })
+
+  it('handles case-insensitive natural sorting', () => {
+    const names = ['File10', 'FILE2', 'file1']
+    const sorted = [...names].sort((a, b) =>
+      naturalSortKey(a)!.localeCompare(naturalSortKey(b)!),
+    )
+    expect(sorted).toEqual(['file1', 'FILE2', 'File10'])
+  })
+
+  it('handles leading zeros in original name', () => {
+    const key7 = naturalSortKey('file007')!
+    const key7plain = naturalSortKey('file7')!
+    expect(key7).toBe(key7plain)
+  })
+
+  it('preserves numbers longer than 20 digits', () => {
+    const longNum = '1'.repeat(25)
+    const key = naturalSortKey('file' + longNum)
+    expect(key).toBe('file' + longNum)
+  })
+
+  it('handles path-style names with slashes', () => {
+    const names = ['photos/2', 'photos/10', 'photos/1']
+    const sorted = [...names].sort((a, b) =>
+      naturalSortKey(a)!.localeCompare(naturalSortKey(b)!),
+    )
+    expect(sorted).toEqual(['photos/1', 'photos/2', 'photos/10'])
+  })
+
+  it('handles names with dots, underscores, hyphens, spaces', () => {
+    const key = naturalSortKey('IMG_2024-01-15 (3).jpg')
+    expect(key).toBe(
+      'img_' +
+        '2024'.padStart(20, '0') +
+        '-' +
+        '01'.padStart(20, '0') +
+        '-' +
+        '15'.padStart(20, '0') +
+        ' (' +
+        '3'.padStart(20, '0') +
+        ').jpg',
+    )
+  })
+
+  it('handles purely numeric string', () => {
+    expect(naturalSortKey('42')).toBe('42'.padStart(20, '0'))
+  })
+})

--- a/packages/core/src/lib/naturalSortKey.ts
+++ b/packages/core/src/lib/naturalSortKey.ts
@@ -1,0 +1,4 @@
+export function naturalSortKey(name: string | null): string | null {
+  if (name == null) return null
+  return name.toLowerCase().replace(/\d+/g, (m) => m.padStart(20, '0'))
+}


### PR DESCRIPTION
- Add a precomputed nameSortKey column so "file2" sorts before "file10".
- Uses zero-padded numeric sequences in a lowercased sort key.
