### PR TITLE
fix(core): remove COLLATE NOCASE from directories table

### DIFF
--- a/.changeset/directories-case-sensitive.md
+++ b/.changeset/directories-case-sensitive.md
@@ -1,0 +1,6 @@
+---
+core: patch
+mobile: patch
+---
+
+Directory names, tag names, and file versioning are now case-sensitive. Search remains case-insensitive.

--- a/packages/core/src/db/migrations/0005_directories_case_sensitive.ts
+++ b/packages/core/src/db/migrations/0005_directories_case_sensitive.ts
@@ -1,0 +1,72 @@
+import type { DatabaseAdapter } from '../../adapters/db'
+import type { Migration } from '../types'
+
+async function up(db: DatabaseAdapter): Promise<void> {
+  // Save file→directory mappings before DROP triggers ON DELETE SET NULL
+  await db.execAsync(
+    `CREATE TEMP TABLE _dir_file_map AS
+     SELECT id, directoryId FROM files WHERE directoryId IS NOT NULL`,
+  )
+
+  // Recreate directories table without COLLATE NOCASE, with nameSortKey
+  await db.execAsync(
+    `CREATE TABLE directories_new (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL UNIQUE,
+      createdAt INTEGER NOT NULL,
+      nameSortKey TEXT
+    )`,
+  )
+  await db.execAsync(
+    `INSERT INTO directories_new (id, name, createdAt, nameSortKey)
+     SELECT id, name, createdAt, nameSortKey FROM directories`,
+  )
+  await db.execAsync(`DROP TABLE directories`)
+  await db.execAsync(`ALTER TABLE directories_new RENAME TO directories`)
+
+  // Restore file→directory mappings
+  await db.execAsync(
+    `UPDATE files SET directoryId = (
+       SELECT directoryId FROM _dir_file_map WHERE _dir_file_map.id = files.id
+     )
+     WHERE id IN (SELECT id FROM _dir_file_map)`,
+  )
+  await db.execAsync(`DROP TABLE _dir_file_map`)
+
+  // Recreate directory indexes
+  await db.execAsync(
+    `CREATE INDEX IF NOT EXISTS idx_directories_nameSortKey ON directories(nameSortKey)`,
+  )
+
+  // Recreate tags table without COLLATE NOCASE
+  await db.execAsync(
+    `CREATE TABLE tags_new (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL UNIQUE,
+      createdAt INTEGER NOT NULL,
+      usedAt INTEGER NOT NULL,
+      system INTEGER NOT NULL DEFAULT 0
+    )`,
+  )
+  await db.execAsync(`INSERT INTO tags_new SELECT * FROM tags`)
+  await db.execAsync(`DROP TABLE tags`)
+  await db.execAsync(`ALTER TABLE tags_new RENAME TO tags`)
+  await db.execAsync(
+    `CREATE INDEX IF NOT EXISTS idx_tags_usedAt ON tags(usedAt)`,
+  )
+
+  // Recreate version group index without COLLATE NOCASE
+  await db.execAsync(`DROP INDEX IF EXISTS idx_files_version_group`)
+  await db.execAsync(
+    `CREATE INDEX IF NOT EXISTS idx_files_version_group
+     ON files(name, directoryId, updatedAt DESC, id DESC)
+     WHERE kind = 'file' AND trashedAt IS NULL AND deletedAt IS NULL`,
+  )
+}
+
+export const migration_0005_directories_case_sensitive: Migration = {
+  id: '0005_directories_case_sensitive',
+  description:
+    'Remove COLLATE NOCASE from directories, tags, and file version index.',
+  up,
+}

--- a/packages/core/src/db/migrations/index.ts
+++ b/packages/core/src/db/migrations/index.ts
@@ -3,12 +3,14 @@ import { migration_0001_init_schema } from './0001_init_schema'
 import { migration_0002_add_lost_reason } from './0002_add_lost_reason'
 import { migration_0003_version_indexes } from './0003_version_indexes'
 import { migration_0004_add_name_sort_key } from './0004_add_name_sort_key'
+import { migration_0005_directories_case_sensitive } from './0005_directories_case_sensitive'
 
 export const coreMigrations: Migration[] = [
   migration_0001_init_schema,
   migration_0002_add_lost_reason,
   migration_0003_version_indexes,
   migration_0004_add_name_sort_key,
+  migration_0005_directories_case_sensitive,
 ]
 
 export function sortMigrations(migrations: Migration[]): Migration[] {

--- a/packages/core/src/db/operations/directories.test.ts
+++ b/packages/core/src/db/operations/directories.test.ts
@@ -105,11 +105,12 @@ describe('insertDirectory', () => {
     )
   })
 
-  it('throws on duplicate name (case-insensitive)', async () => {
-    await insertDirectory(db(), 'Photos')
-    await expect(insertDirectory(db(), 'photos')).rejects.toThrow(
-      'already exists',
-    )
+  it('allows directories with different casing', async () => {
+    const dir1 = await insertDirectory(db(), 'Photos')
+    const dir2 = await insertDirectory(db(), 'photos')
+    expect(dir1.id).not.toBe(dir2.id)
+    expect(dir1.name).toBe('Photos')
+    expect(dir2.name).toBe('photos')
   })
 
   it('sanitizes slashes from the name', async () => {
@@ -119,11 +120,12 @@ describe('insertDirectory', () => {
 })
 
 describe('getOrCreateDirectory', () => {
-  it('returns existing directory (case-insensitive)', async () => {
+  it('creates separate directory for different casing', async () => {
     const dir1 = await getOrCreateDirectory(db(), 'Photos')
     const dir2 = await getOrCreateDirectory(db(), 'photos')
-    expect(dir2.id).toBe(dir1.id)
-    expect(dir2.name).toBe('Photos')
+    expect(dir1.id).not.toBe(dir2.id)
+    expect(dir1.name).toBe('Photos')
+    expect(dir2.name).toBe('photos')
   })
 
   it('creates a new directory if not found', async () => {
@@ -377,7 +379,7 @@ describe('syncDirectoryFromMetadata', () => {
     expect(name).toBe('Photos')
   })
 
-  it('reuses existing directory (case-insensitive)', async () => {
+  it('creates separate directories for different casing', async () => {
     await insertDirectory(db(), 'Photos')
     await createTestFile('f1')
     await createTestFile('f2')
@@ -386,8 +388,9 @@ describe('syncDirectoryFromMetadata', () => {
     await syncDirectoryFromMetadata(db(), 'f2', 'photos')
 
     const dirs = await queryAllDirectoriesWithCounts(db())
-    expect(dirs).toHaveLength(1)
-    expect(dirs[0].fileCount).toBe(2)
+    expect(dirs).toHaveLength(2)
+    expect(dirs[0].fileCount).toBe(1)
+    expect(dirs[1].fileCount).toBe(1)
   })
 })
 

--- a/packages/core/src/db/operations/directories.ts
+++ b/packages/core/src/db/operations/directories.ts
@@ -42,7 +42,7 @@ export async function insertDirectory(
   }
 
   const existing = await db.getFirstAsync<{ id: string }>(
-    'SELECT id FROM directories WHERE name = ? COLLATE NOCASE',
+    'SELECT id FROM directories WHERE name = ?',
     trimmed,
   )
   if (existing) {
@@ -83,7 +83,7 @@ export async function getOrCreateDirectory(
   )
 
   const dir = await db.getFirstAsync<Directory>(
-    'SELECT id, name, createdAt FROM directories WHERE name = ? COLLATE NOCASE',
+    'SELECT id, name, createdAt FROM directories WHERE name = ?',
     trimmed,
   )
 
@@ -293,7 +293,7 @@ export async function queryDirectoryByName(
   name: string,
 ): Promise<Directory | null> {
   return db.getFirstAsync<Directory>(
-    'SELECT id, name, createdAt FROM directories WHERE name = ? COLLATE NOCASE LIMIT 1',
+    'SELECT id, name, createdAt FROM directories WHERE name = ? LIMIT 1',
     name,
   )
 }
@@ -348,7 +348,7 @@ export async function renameDirectory(
   }
 
   const existing = await db.getFirstAsync<{ id: string }>(
-    'SELECT id FROM directories WHERE name = ? COLLATE NOCASE AND id != ?',
+    'SELECT id FROM directories WHERE name = ? AND id != ?',
     trimmed,
     dirId,
   )

--- a/packages/core/src/db/operations/library.test.ts
+++ b/packages/core/src/db/operations/library.test.ts
@@ -177,6 +177,23 @@ describe('buildLibraryQueryParts', () => {
       expect(rows.map((r) => r.id)).toEqual(['abc'])
     })
 
+    test('search is case-insensitive', async () => {
+      await createTestFile('PhotoAlbum')
+
+      const { where, params } = buildLibraryQueryParts({
+        tags: [],
+        query: 'photoalbum',
+        tableAlias: 'files',
+      })
+
+      const rows = await db().getAllAsync<{ id: string }>(
+        `SELECT id FROM files ${where}`,
+        ...params,
+      )
+
+      expect(rows.map((r) => r.id)).toEqual(['PhotoAlbum'])
+    })
+
     test('returns all files when no tags selected', async () => {
       await createTestFile('file-1')
       await createTestFile('file-2')

--- a/packages/core/src/db/operations/tags.test.ts
+++ b/packages/core/src/db/operations/tags.test.ts
@@ -79,18 +79,24 @@ describe('insertTag', () => {
     )
   })
 
-  it('throws on duplicate name (case-insensitive)', async () => {
+  it('allows same name with different case', async () => {
     await insertTag(db(), 'Travel')
-    await expect(insertTag(db(), 'travel')).rejects.toThrow('already exists')
+    const tag = await insertTag(db(), 'travel')
+    expect(tag.name).toBe('travel')
+  })
+
+  it('throws on exact duplicate name', async () => {
+    await insertTag(db(), 'Travel')
+    await expect(insertTag(db(), 'Travel')).rejects.toThrow('already exists')
   })
 })
 
 describe('getOrCreateTag', () => {
-  it('returns existing tag (case-insensitive) with updated usedAt', async () => {
+  it('creates separate tag for different case', async () => {
     const original = await insertTag(db(), 'Travel')
     const result = await getOrCreateTag(db(), 'travel')
-    expect(result.id).toBe(original.id)
-    expect(result.usedAt).toBeGreaterThanOrEqual(original.usedAt)
+    expect(result.id).not.toBe(original.id)
+    expect(result.name).toBe('travel')
   })
 
   it('creates new tag if not found', async () => {
@@ -351,14 +357,16 @@ describe('addTagToFile', () => {
     expect(tags).toHaveLength(1)
   })
 
-  it('reuses existing tag case-insensitively across files', async () => {
+  it('treats different case as separate tags', async () => {
     await createTestFile('f1')
     await createTestFile('f2')
     await addTagToFile(db(), 'f1', 'Work')
     await addTagToFile(db(), 'f2', 'work')
     const tags = await queryAllTagsWithCounts(db())
-    const work = tags.find((t) => t.name === 'Work')
-    expect(work!.fileCount).toBe(2)
+    const upper = tags.find((t) => t.name === 'Work')
+    const lower = tags.find((t) => t.name === 'work')
+    expect(upper!.fileCount).toBe(1)
+    expect(lower!.fileCount).toBe(1)
   })
 })
 

--- a/packages/core/src/db/operations/tags.ts
+++ b/packages/core/src/db/operations/tags.ts
@@ -41,7 +41,7 @@ export async function insertTag(
   }
 
   const existing = await db.getFirstAsync<{ id: string }>(
-    'SELECT id FROM tags WHERE name = ? COLLATE NOCASE',
+    'SELECT id FROM tags WHERE name = ?',
     trimmed,
   )
   if (existing) {
@@ -81,7 +81,7 @@ export async function getOrCreateTag(
   )
 
   const tag = await db.getFirstAsync<Tag>(
-    'SELECT id, name, createdAt, usedAt, system FROM tags WHERE name = ? COLLATE NOCASE',
+    'SELECT id, name, createdAt, usedAt, system FROM tags WHERE name = ?',
     trimmed,
   )
 
@@ -102,7 +102,7 @@ export async function queryTagsForFile(
      FROM tags t
      INNER JOIN file_tags ft ON ft.tagId = t.id
      WHERE ft.fileId = ?
-     ORDER BY t.name COLLATE NOCASE`,
+     ORDER BY t.name`,
     fileId,
   )
 }
@@ -124,7 +124,7 @@ export async function queryAllTagsWithCounts(
      LEFT JOIN file_tags ft ON ft.tagId = t.id
      LEFT JOIN files f ON f.id = ft.fileId AND f.kind = 'file' AND f.trashedAt IS NULL AND f.deletedAt IS NULL
      GROUP BY t.id
-     ORDER BY t.system DESC, t.name COLLATE NOCASE`,
+     ORDER BY t.system DESC, t.name`,
   )
 }
 
@@ -295,7 +295,7 @@ export async function renameTag(
   }
 
   const existing = await db.getFirstAsync<{ id: string }>(
-    'SELECT id FROM tags WHERE name = ? COLLATE NOCASE AND id != ?',
+    'SELECT id FROM tags WHERE name = ? AND id != ?',
     trimmed,
     tagId,
   )


### PR DESCRIPTION
- Directory, tags, and file names are now case-sensitive so "Photos" and "photos" are treated as distinct folders, matching natural filesystem behavior.