### PR TITLE
fix(mobile): rename inner SwitchIndexer screen to avoid duplicate name warning

### DIFF
--- a/.changeset/fix-duplicate-switch-indexer-screen.md
+++ b/.changeset/fix-duplicate-switch-indexer-screen.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Fixed duplicate SwitchIndexer screen name warning in navigation.

--- a/apps/mobile/src/screens/SwitchIndexerScreen.tsx
+++ b/apps/mobile/src/screens/SwitchIndexerScreen.tsx
@@ -11,7 +11,7 @@ import { palette } from '../styles/colors'
 
 type Props = NativeStackScreenProps<
   SwitchIndexerStackParamList,
-  'SwitchIndexer'
+  'SwitchIndexerHome'
 >
 
 export function SwitchIndexerScreen({ navigation }: Props) {

--- a/apps/mobile/src/stacks/SwitchIndexerStack.tsx
+++ b/apps/mobile/src/stacks/SwitchIndexerStack.tsx
@@ -35,7 +35,7 @@ export function SwitchIndexerStack() {
       }}
     >
       <Stack.Screen
-        name="SwitchIndexer"
+        name="SwitchIndexerHome"
         component={SwitchIndexerScreen}
         options={{
           title: 'Switch Indexer',

--- a/apps/mobile/src/stacks/types.ts
+++ b/apps/mobile/src/stacks/types.ts
@@ -8,7 +8,7 @@ export type MainStackParamList = {
 }
 
 export type SwitchIndexerStackParamList = {
-  SwitchIndexer: undefined
+  SwitchIndexerHome: undefined
   SwitchRecoveryPhrase: { indexerURL: string }
   SwitchFinished: { indexerURL: string }
 }


### PR DESCRIPTION
- Fixes a naming conflict between screens.
