### PR TITLE
fix(core): skip scheduled ticks when scheduler is paused

### DIFF
--- a/packages/core/src/lib/serviceInterval.ts
+++ b/packages/core/src/lib/serviceInterval.ts
@@ -76,6 +76,11 @@ export class ServiceScheduler {
         const current = this.schedulerStateMap.get(name)
         if (!current || current.token !== token) return
 
+        if (this.paused) {
+          scheduleNextRun(interval)
+          return
+        }
+
         running = true
         let nextInterval = interval
         try {


### PR DESCRIPTION
- This was causing a very occasional flaky tests.
- Before this fix: pause() only set a flag. If a setTimeout was already queued before pause() was called, it still fired and the worker executed. pause() only prevented scheduling the next tick, it didn't stop the one already in the pipe.
- After this fix: When a queued tick fires and finds this.paused === true, it skips the worker and calls scheduleNextRun(interval) which sees the paused flag and defers to pausedCallbacks. When resume() is called later, the deferred callback fires and schedules the next tick normally.