### PR TITLE
feat(core,mobile): sync gate overlay for initial catch-up

### DIFF
--- a/.changeset/sync-gate-overlay.md
+++ b/.changeset/sync-gate-overlay.md
@@ -1,0 +1,6 @@
+---
+mobile: minor
+core: minor
+---
+
+Show a full-screen sync progress overlay when catching up with remote changes from other devices.

--- a/apps/mobile/src/components/AppSplash.tsx
+++ b/apps/mobile/src/components/AppSplash.tsx
@@ -1,6 +1,9 @@
 import {
   useCurrentInitStep,
   useInitializationError,
+  useSyncGateGuard,
+  useSyncGateStatus,
+  useSyncState,
 } from '@siastorage/core/stores'
 import { TriangleAlertIcon } from 'lucide-react-native'
 import { Alert, StyleSheet, Text, View } from 'react-native'
@@ -11,10 +14,21 @@ import BlocksGrid from './BlocksGrid'
 import BlocksLoader from './BlocksLoader'
 import { Button } from './Button'
 
+function useSyncProgress() {
+  const { data } = useSyncState()
+  return {
+    count: data?.syncDownCount ?? 0,
+    progress: data?.syncDownProgress ?? 0,
+  }
+}
+
 export function AppSplash() {
   const currentStep = useCurrentInitStep()
   const initializationError = useInitializationError()
+  const syncGateStatus = useSyncGateStatus()
+  const { count, progress } = useSyncProgress()
   const { top, bottom } = useSafeAreaInsets()
+  useSyncGateGuard()
 
   return (
     <SafeAreaView style={styles.screen}>
@@ -68,9 +82,33 @@ export function AppSplash() {
         ) : (
           <View style={styles.waitingWrap}>
             <BlocksLoader colorStart={1} size={20} />
-            <Text style={styles.waitingText}>
-              {currentStep?.message ?? 'Getting things ready...'}
-            </Text>
+            {syncGateStatus === 'active' ? (
+              <>
+                <View style={styles.syncHeader}>
+                  <Text style={styles.syncTitle}>Syncing your library</Text>
+                  <Text style={styles.syncSubtitle}>
+                    Syncing your files from the indexer.
+                  </Text>
+                </View>
+                {count > 0 && (
+                  <Text style={styles.syncCounts}>
+                    {count.toLocaleString()} files synced
+                  </Text>
+                )}
+                <View style={styles.progressTrack}>
+                  <View
+                    style={[
+                      styles.progressFill,
+                      { width: `${Math.round(progress * 100)}%` },
+                    ]}
+                  />
+                </View>
+              </>
+            ) : (
+              <Text style={styles.waitingText}>
+                {currentStep?.message ?? 'Getting things ready...'}
+              </Text>
+            )}
           </View>
         )}
       </View>
@@ -92,11 +130,42 @@ const styles = StyleSheet.create({
   waitingWrap: {
     alignItems: 'center',
     justifyContent: 'center',
+    alignSelf: 'stretch',
     gap: 24,
   },
   waitingText: {
     color: 'white',
     fontSize: 14,
+  },
+  syncHeader: {
+    alignItems: 'center',
+    gap: 6,
+  },
+  syncTitle: {
+    color: 'white',
+    fontSize: 20,
+    fontWeight: '600',
+  },
+  syncSubtitle: {
+    color: palette.gray[400],
+    fontSize: 15,
+    textAlign: 'center',
+  },
+  syncCounts: {
+    color: palette.gray[500],
+    fontSize: 12,
+  },
+  progressTrack: {
+    width: '60%',
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: palette.gray[800],
+    overflow: 'hidden',
+  },
+  progressFill: {
+    height: '100%',
+    borderRadius: 2,
+    backgroundColor: palette.gray[400],
   },
   errorWrap: {
     alignItems: 'center',

--- a/apps/mobile/src/managers/app.ts
+++ b/apps/mobile/src/managers/app.ts
@@ -1,5 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { shutdownAllServiceIntervals } from '@siastorage/core/lib/serviceInterval'
+import { activateSyncGate } from '@siastorage/core/services/syncDownEvents'
 import { mutate } from 'swr'
 import { initializeDB, resetDb } from '../db'
 import { autoPurgeOldTrashedFiles } from '../lib/deleteFile'
@@ -18,7 +19,7 @@ import { runFsOrphanScanner } from './fsOrphanScanner'
 import { initImportScanner } from './importScanner'
 import { initLogRotation } from './logRotation'
 import { initPerfMonitor } from './perfMonitor'
-import { initSyncDownEvents } from './syncDownEvents'
+import { initSyncDownEvents, triggerSyncDownEvents } from './syncDownEvents'
 import { initSyncNewPhotos } from './syncNewPhotos'
 import { resetPhotosArchiveCursor } from './syncPhotosArchive'
 import { initSyncUpMetadata } from './syncUpMetadata'
@@ -103,8 +104,10 @@ export async function initApp(): Promise<void> {
       message: 'Launching background services...',
       runner: async () => {
         initDbOptimize()
+        await activateSyncGate(app())
         initImportScanner()
         initSyncDownEvents()
+        triggerSyncDownEvents()
         initSyncNewPhotos()
         initBackgroundTasks()
         initSyncUpMetadata()
@@ -211,12 +214,12 @@ function resetAllStores() {
   })
   app().sync.setState({
     isSyncingDown: false,
-    syncDownExisting: 0,
-    syncDownAdded: 0,
-    syncDownDeleted: 0,
+    syncDownCount: 0,
+    syncDownProgress: 0,
     isSyncingUp: false,
     syncUpProcessed: 0,
     syncUpTotal: 0,
+    syncGateStatus: 'idle',
   })
   app().uploads.clear()
   app().downloads.cancelAll()

--- a/apps/mobile/src/managers/syncDownEvents.test.ts
+++ b/apps/mobile/src/managers/syncDownEvents.test.ts
@@ -1275,6 +1275,124 @@ describe('syncDownEvents', () => {
     expect(remainingObjects[0].indexerURL).toBe('other-indexer')
   })
 
+  describe('syncGateStatus transitions', () => {
+    function makeEvents(count: number, startId = 0) {
+      return Array.from({ length: count }, (_, i) => {
+        const id = `obj-gate-${startId + i}`
+        const metadata: FileMetadata = {
+          id: `file-gate-${startId + i}`,
+          name: `gate-${startId + i}.jpg`,
+          type: 'image/jpeg',
+          kind: 'file',
+          size: 100,
+          hash: `hash-gate-${startId + i}`,
+          createdAt: NOW_BASE + startId + i,
+          updatedAt: NOW_BASE + startId + i,
+          thumbForId: undefined,
+          thumbSize: undefined,
+          trashedAt: null,
+        }
+        return makeObjectEvent({
+          id,
+          updatedAt: new Date(NOW_BASE + startId + i),
+          object: makeMockPinnedObject(metadata, id),
+        })
+      })
+    }
+
+    test('stays idle when never set to pending', async () => {
+      const events = makeEvents(20)
+      internal().setSdk({
+        objectEvents: jest.fn().mockResolvedValueOnce(events),
+        appKey: () => mockAppKey,
+      } as any)
+
+      await run(new AbortController().signal)
+      expect(app().sync.getState().syncGateStatus).toBe('idle')
+    })
+
+    test('transitions pending → active on large batch', async () => {
+      app().sync.setState({ syncGateStatus: 'pending' })
+      const events = makeEvents(20)
+      const heartbeat = makeEvents(1, 20)
+      internal().setSdk({
+        objectEvents: jest
+          .fn()
+          .mockResolvedValueOnce(events)
+          .mockResolvedValueOnce(heartbeat),
+        appKey: () => mockAppKey,
+      } as any)
+
+      await run(new AbortController().signal)
+      expect(app().sync.getState().syncGateStatus).toBe('active')
+
+      await run(new AbortController().signal)
+      expect(app().sync.getState().syncGateStatus).toBe('dismissed')
+    })
+
+    test('transitions pending → dismissed on small batch', async () => {
+      app().sync.setState({ syncGateStatus: 'pending' })
+      const events = makeEvents(5)
+      internal().setSdk({
+        objectEvents: jest.fn().mockResolvedValueOnce(events),
+        appKey: () => mockAppKey,
+      } as any)
+
+      await run(new AbortController().signal)
+      expect(app().sync.getState().syncGateStatus).toBe('dismissed')
+    })
+
+    test('transitions pending → dismissed on heartbeat', async () => {
+      app().sync.setState({ syncGateStatus: 'pending' })
+      const events = makeEvents(1)
+      internal().setSdk({
+        objectEvents: jest.fn().mockResolvedValueOnce(events),
+        appKey: () => mockAppKey,
+      } as any)
+
+      await run(new AbortController().signal)
+      expect(app().sync.getState().syncGateStatus).toBe('dismissed')
+    })
+
+    test('transitions active → dismissed when caught up', async () => {
+      app().sync.setState({ syncGateStatus: 'pending' })
+      const largeBatch = makeEvents(500)
+      const heartbeat = makeEvents(1, 500)
+
+      internal().setSdk({
+        objectEvents: jest
+          .fn()
+          .mockResolvedValueOnce(largeBatch)
+          .mockResolvedValueOnce(heartbeat),
+        appKey: () => mockAppKey,
+      } as any)
+
+      await run(new AbortController().signal)
+      expect(app().sync.getState().syncGateStatus).toBe('active')
+
+      await run(new AbortController().signal)
+      expect(app().sync.getState().syncGateStatus).toBe('dismissed')
+    })
+
+    test('unchanged when not connected', async () => {
+      app().sync.setState({ syncGateStatus: 'pending' })
+      app().connection.setState({ isConnected: false })
+
+      await run(new AbortController().signal)
+      expect(app().sync.getState().syncGateStatus).toBe('pending')
+    })
+
+    test('unchanged when auto sync disabled', async () => {
+      app().sync.setState({ syncGateStatus: 'pending' })
+      await app().settings.setAutoSyncDownEvents(false)
+
+      await run(new AbortController().signal)
+      expect(app().sync.getState().syncGateStatus).toBe('pending')
+
+      await app().settings.setAutoSyncDownEvents(true)
+    })
+  })
+
   test('delete event on already-tombstoned file preserves tombstone when no objects remain', async () => {
     const file: Omit<FileRecord, 'objects'> = {
       id: 'file-1',

--- a/apps/mobile/src/screens/OnboardingFinishedScreen.tsx
+++ b/apps/mobile/src/screens/OnboardingFinishedScreen.tsx
@@ -141,6 +141,7 @@ export default function OnboardingFinishedScreen() {
           testID="finished-upload-button"
           variant="primary"
           onPress={async () => {
+            app().init.setState({ isInitializing: true })
             await app().settings.setHasOnboarded(true)
             await initApp()
           }}

--- a/packages/core/src/app/namespaces/index.ts
+++ b/packages/core/src/app/namespaces/index.ts
@@ -76,12 +76,12 @@ export function createAppService(
   let syncState: SyncState = {
     isLeader: false,
     isSyncingDown: false,
-    syncDownExisting: 0,
-    syncDownAdded: 0,
-    syncDownDeleted: 0,
+    syncDownCount: 0,
+    syncDownProgress: 0,
     isSyncingUp: false,
     syncUpProcessed: 0,
     syncUpTotal: 0,
+    syncGateStatus: 'idle',
   }
 
   let connectionState: ConnectionState = {

--- a/packages/core/src/app/stores.ts
+++ b/packages/core/src/app/stores.ts
@@ -1,17 +1,20 @@
+/** Lifecycle stage of the sync gate overlay shown during initial catch-up. */
+export type SyncGateStatus = 'idle' | 'pending' | 'active' | 'dismissed'
+
 /** Current state of the bi-directional sync engine. */
 export type SyncState = {
   /** Whether this device is the active sync leader. */
   isLeader: boolean
   isSyncingDown: boolean
-  /** Number of existing remote objects processed during sync-down. */
-  syncDownExisting: number
-  /** Number of new objects added during sync-down. */
-  syncDownAdded: number
-  /** Number of objects deleted during sync-down. */
-  syncDownDeleted: number
+  /** Total number of objects processed during sync-down. */
+  syncDownCount: number
+  /** Estimated sync-down progress from 0 to 1, based on event timestamps. */
+  syncDownProgress: number
   isSyncingUp: boolean
   syncUpProcessed: number
   syncUpTotal: number
+  /** Gate overlay status for initial sync catch-up. Session-scoped. */
+  syncGateStatus: SyncGateStatus
 }
 
 /** Lifecycle stage of a single upload. */

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -74,6 +74,8 @@ export const TRASH_AUTO_PURGE_INTERVAL = minutesInMs(60) // 60 minutes
 export const DB_OPTIMIZE_INTERVAL = secondsInMs(60) // 60 seconds
 // Performance monitor logging interval.
 export const PERF_MONITOR_INTERVAL = secondsInMs(15)
+// Minimum events to activate the sync gate overlay during initial catch-up.
+export const SYNC_GATE_THRESHOLD = 10
 // Max concurrent pinObject calls during save phase.
 export const SAVE_BATCH_CONCURRENCY = 20
 // Delay before removing upload state after save, so cache invalidation

--- a/packages/core/src/services/syncDownEvents.ts
+++ b/packages/core/src/services/syncDownEvents.ts
@@ -1,6 +1,7 @@
 import { logger } from '@siastorage/logger'
 import type { PinnedObjectRef } from '../adapters/sdk'
 import type { AppService, AppServiceInternal } from '../app/service'
+import { SYNC_GATE_THRESHOLD } from '../config'
 import {
   decodeFileMetadata,
   hasCompleteFileMetadata,
@@ -10,12 +11,22 @@ import type { LocalObject } from '../encoding/localObject'
 import { sealPinnedObject } from '../lib/localObjects'
 import type { FileMetadata, FileRecordRow } from '../types/files'
 
+/**
+ * Activates the sync gate if auto-sync is enabled and connected.
+ * Call before starting the sync service on any platform.
+ */
+export async function activateSyncGate(app: AppService): Promise<void> {
+  const autoSync = await app.settings.getAutoSyncDownEvents()
+  const isConnected = app.connection.getState().isConnected
+  if (autoSync && isConnected) {
+    app.sync.setState({ syncGateStatus: 'pending' })
+  }
+}
+
 const batchSize = 500
 
 type Counts = {
-  existing: number
-  deleted: number
-  added: number
+  total: number
 }
 
 // A "create" means no existing file record matches this object.
@@ -69,13 +80,10 @@ export async function syncDownEventsBatch(
 
   const sdk = internal.requireSdk()
 
-  const counts: Counts = {
-    existing: 0,
-    added: 0,
-    deleted: 0,
-  }
-
+  const counts: Counts = { total: 0 }
   let totalEventsFetched = 0
+  let firstEventTime: number | undefined
+  const now = Date.now()
 
   while (true) {
     if (signal.aborted) break
@@ -92,10 +100,16 @@ export async function syncDownEventsBatch(
       if (totalEventsFetched > 1) {
         app.sync.setState({
           isSyncingDown: true,
-          syncDownExisting: counts.existing,
-          syncDownAdded: counts.added,
-          syncDownDeleted: counts.deleted,
+          syncDownCount: counts.total,
         })
+      }
+
+      const gateStatus = app.sync.getState().syncGateStatus
+      if (
+        gateStatus === 'pending' &&
+        totalEventsFetched >= SYNC_GATE_THRESHOLD
+      ) {
+        app.sync.setState({ syncGateStatus: 'active' })
       }
 
       // If the batch size is 1, we are probably synced and repeatedly polling the last event.
@@ -105,10 +119,14 @@ export async function syncDownEventsBatch(
         logger.info('syncDownEvents', 'batch', { size: events.length })
       }
 
-      const prevTotal = counts.added + counts.deleted + counts.existing
+      const prevTotal = counts.total
       await processBatch(events, counts, signal, app, internal)
-      const batchChanged =
-        counts.added + counts.deleted + counts.existing > prevTotal
+      const batchChanged = counts.total > prevTotal
+
+      // Track the first event's timestamp for progress estimation.
+      if (firstEventTime === undefined && events.length > 0) {
+        firstEventTime = events[0].updatedAt.getTime()
+      }
 
       // Update the cursor to the last event in the batch.
       const lastEvent = events[events.length - 1]
@@ -120,14 +138,21 @@ export async function syncDownEventsBatch(
         })
       }
 
+      // Estimate progress as how far through the event timeline we are.
+      const timeRange = firstEventTime !== undefined ? now - firstEventTime : 0
+      const elapsed =
+        lastEvent && firstEventTime !== undefined
+          ? lastEvent.updatedAt.getTime() - firstEventTime
+          : 0
+      const progress = timeRange > 0 ? Math.min(elapsed / timeRange, 1) : 0
+
       // Update progress after each batch. Only report isSyncing when there are
       // real events to process (>1), not on the periodic heartbeat check which
       // returns a single cursor-marker event.
       app.sync.setState({
         isSyncingDown: totalEventsFetched > 1,
-        syncDownExisting: counts.existing,
-        syncDownAdded: counts.added,
-        syncDownDeleted: counts.deleted,
+        syncDownCount: counts.total,
+        syncDownProgress: progress,
       })
       if (batchChanged) {
         app.caches.library.invalidateAll()
@@ -144,20 +169,18 @@ export async function syncDownEventsBatch(
     }
   }
 
-  logger.info('syncDownEvents', 'synced', {
-    existing: counts.existing,
-    added: counts.added,
-    deleted: counts.deleted,
-  })
+  logger.info('syncDownEvents', 'synced', { total: counts.total })
 
   await app.optimize()
 
   const willContinue = totalEventsFetched > 1 && !signal.aborted
+  const endGateStatus = app.sync.getState().syncGateStatus
+  const dismissGate =
+    endGateStatus === 'pending' || (endGateStatus === 'active' && !willContinue)
   app.sync.setState({
     isSyncingDown: willContinue,
-    syncDownExisting: counts.existing,
-    syncDownAdded: counts.added,
-    syncDownDeleted: counts.deleted,
+    syncDownCount: counts.total,
+    ...(dismissGate && { syncGateStatus: 'dismissed' }),
   })
 
   if (willContinue) {
@@ -391,9 +414,7 @@ async function processBatch(
         await app.localObjects.queryFilesWithNoObjects(deleteFileIdSet)
     }
 
-    counts.added += creates.length
-    counts.existing += updates.length
-    counts.deleted += deletedFileIds.length
+    counts.total += creates.length + updates.length + deletedFileIds.length
   })
 
   // Phase 3: Cleanup — delete local files for deleted records, clear

--- a/packages/core/src/stores/index.ts
+++ b/packages/core/src/stores/index.ts
@@ -53,7 +53,7 @@ export {
   swrCacheBy,
   swrState,
 } from './swr'
-export { useSyncState } from './sync'
+export { useSyncGateGuard, useSyncGateStatus, useSyncState } from './sync'
 export {
   useAllTags,
   useIsFavorite,

--- a/packages/core/src/stores/init.ts
+++ b/packages/core/src/stores/init.ts
@@ -1,5 +1,6 @@
 import useSWR from 'swr'
 import { useApp } from '../app/context'
+import { useSyncGateStatus } from './sync'
 
 /** Returns the full app initialization state including steps and errors. */
 export function useInitState() {
@@ -16,8 +17,14 @@ export function useIsInitializing() {
 /** Returns whether the splash screen should be shown during init or on error. */
 export function useShowSplash() {
   const { data } = useInitState()
+  const syncGateStatus = useSyncGateStatus()
   if (!data) return true
-  return data.isInitializing || !!data.initializationError
+  return (
+    data.isInitializing ||
+    !!data.initializationError ||
+    syncGateStatus === 'pending' ||
+    syncGateStatus === 'active'
+  )
 }
 
 /** Returns all initialization steps sorted by start time. */

--- a/packages/core/src/stores/sync.ts
+++ b/packages/core/src/stores/sync.ts
@@ -1,8 +1,33 @@
+import { useEffect } from 'react'
 import useSWR from 'swr'
 import { useApp } from '../app/context'
+import { useIsConnected } from './connection'
 
 /** Returns the current sync state including progress and last sync time. */
 export function useSyncState() {
   const app = useApp()
   return useSWR(app.caches.sync.key(), () => app.sync.getState())
+}
+
+/** Returns the current sync gate status for the initial catch-up overlay. */
+export function useSyncGateStatus() {
+  const { data } = useSyncState()
+  return data?.syncGateStatus ?? 'idle'
+}
+
+/**
+ * Safety-net hook that auto-dismisses the sync gate on connection drop.
+ * Without this, a disconnect while the gate is active would leave it stuck
+ * because the sync service skips runs when not connected.
+ */
+export function useSyncGateGuard() {
+  const app = useApp()
+  const syncGateStatus = useSyncGateStatus()
+  const isConnected = useIsConnected()
+
+  useEffect(() => {
+    if (syncGateStatus === 'active' && isConnected === false) {
+      app.sync.setState({ syncGateStatus: 'dismissed' })
+    }
+  }, [syncGateStatus, isConnected, app])
 }


### PR DESCRIPTION
When a returning user has thousands of indexer events to sync (new device, long absence, multi-device usage), the app currently shows files "popping in" during catch-up. This adds init step that gates the app during heavy sync, showing progress counts.