### PR TITLE
fix(mobile): close database properly before deletion during app reset

### DIFF
--- a/apps/mobile/src/db/index.ts
+++ b/apps/mobile/src/db/index.ts
@@ -115,18 +115,28 @@ export async function closeDb(): Promise<void> {
 // removes the DB file, and reopens so migrations can run on next init.
 export async function resetDb() {
   dbInitialized = false
-  if (database) {
-    try {
-      await database.closeAsync()
-    } catch {}
+  const release = await txMutex.acquire()
+  try {
+    _dbProxy = null
+    if (database) {
+      try {
+        await database.closeAsync()
+      } catch {}
+    }
+    await SQLite.deleteDatabaseAsync(dbName, dbDirectory)
+    database = await SQLite.openDatabaseAsync(
+      dbName,
+      { useNewConnection: true },
+      dbDirectory,
+    )
+    await database.execAsync(
+      'PRAGMA journal_mode = WAL; PRAGMA busy_timeout = 5000; PRAGMA foreign_keys = ON',
+    )
+    await runMigrations(database, migrations, { log: logger })
+    dbInitialized = true
+  } finally {
+    release()
   }
-  await SQLite.deleteDatabaseAsync(dbName, dbDirectory)
-  database = await SQLite.openDatabaseAsync(dbName, undefined, dbDirectory)
-  await database.execAsync(
-    'PRAGMA journal_mode = WAL; PRAGMA busy_timeout = 5000; PRAGMA foreign_keys = ON',
-  )
-  await runMigrations(database, migrations, { log: logger })
-  dbInitialized = true
 }
 
 const RECOVERY_METHODS = new Set([

--- a/apps/mobile/src/managers/app.ts
+++ b/apps/mobile/src/managers/app.ts
@@ -1,6 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { shutdownAllServiceIntervals } from '@siastorage/core/lib/serviceInterval'
 import { activateSyncGate } from '@siastorage/core/services/syncDownEvents'
+import { stopLogAppender } from '@siastorage/logger'
 import { mutate } from 'swr'
 import { initializeDB, resetDb } from '../db'
 import { autoPurgeOldTrashedFiles } from '../lib/deleteFile'
@@ -171,7 +172,10 @@ export async function resetApp() {
         // 4. Cancel uploads and downloads (side-effect cleanup).
         await cancelAllTransfers()
 
-        // 5. Drop and recreate all database tables.
+        // 5. Flush remaining logs and stop the appender before touching the DB.
+        await stopLogAppender()
+
+        // 6. Drop and recreate all database tables.
         await resetDb()
 
         // 5. Wipe all persisted state.

--- a/packages/logger/src/logAppender.ts
+++ b/packages/logger/src/logAppender.ts
@@ -1,6 +1,6 @@
 import type { LogEntry } from './logger'
 
-type LogAppender = (entries: LogEntry[]) => void
+type LogAppender = (entries: LogEntry[]) => Promise<void> | void
 
 let appender: LogAppender | null = null
 const buffer: LogEntry[] = []
@@ -33,11 +33,19 @@ export function flushLogs(): void {
   flush()
 }
 
-/** Stop the flush interval and flush remaining entries. */
-export function stopLogAppender(): void {
+/**
+ * Gracefully stop the log appender: stop the flush interval, flush remaining
+ * entries to the appender, then clear the appender. After this call no more
+ * entries will be written.
+ */
+export async function stopLogAppender(): Promise<void> {
   if (flushTimer) {
     clearInterval(flushTimer)
     flushTimer = null
   }
-  flush()
+  if (buffer.length > 0 && appender) {
+    const entries = buffer.splice(0)
+    await appender(entries)
+  }
+  appender = null
 }


### PR DESCRIPTION
- Close database properly before deletion during app reset
- The log appender's flush interval could fire DB writes while resetDb was closing the connection, causing "database is currently open" on Android.
- stopLogAppender now awaits a final flush then clears the appender, so no writes can race with the DB close/delete.

