### PR TITLE
fix(core): include tags and directory in upload metadata

### DIFF
--- a/.changeset/fix-upload-metadata.md
+++ b/.changeset/fix-upload-metadata.md
@@ -1,0 +1,5 @@
+---
+core: patch
+---
+
+Include tags and directory in file metadata during upload so other devices see the full folder and tag assignments immediately after sync-down.

--- a/apps/integration/test/sync-up-metadata.test.ts
+++ b/apps/integration/test/sync-up-metadata.test.ts
@@ -257,4 +257,36 @@ describe('Sync Up Metadata', () => {
       { timeout: 10_000, message: 'Remote metadata to have renamed directory' },
     )
   }, 30_000)
+
+  it('upload includes tags and directory in initial metadata', async () => {
+    const [file] = await app.addFiles(generateTestFiles(1, { startId: 1 }))
+
+    // Assign tag and directory before the upload scanner picks up the file.
+    await app.addTagToFile(file.id, 'vacation')
+    const dir = await app.createDirectory('Photos')
+    await app.moveFileToDirectory(file.id, dir.id)
+
+    // Pause the scheduler so sync-up-metadata cannot run and "fix" the
+    // metadata after the upload. The upload manager runs on its own loop
+    // independent of the scheduler, so uploads still proceed.
+    app.pause()
+
+    await waitForCondition(() => app.getUploadState(file.id) !== undefined, {
+      timeout: 10_000,
+      message: 'File to be detected by scanner',
+    })
+    await app.waitForNoActiveUploads()
+
+    const localObjects = await app.readLocalObjectsForFile(file.id)
+    expect(localObjects.length).toBeGreaterThan(0)
+    const objectId = localObjects[0].id
+
+    const remote = await app.sdk.getPinnedObject(objectId)
+    const remoteMeta = decodeFileMetadata(remote.metadata())
+
+    // The uploader should include tags and directory in the initial upload
+    // so other devices see the full metadata immediately after sync-down.
+    expect(remoteMeta.tags).toEqual(['vacation'])
+    expect(remoteMeta.directory).toBe('Photos')
+  }, 30_000)
 })

--- a/packages/core/src/app/namespaces/db.ts
+++ b/packages/core/src/app/namespaces/db.ts
@@ -4,6 +4,7 @@ import type { ThumbnailAdapter } from '../../adapters/thumbnail'
 import * as ops from '../../db/operations'
 import type { FsIOAdapter } from '../../services/fsFileUri'
 import { getFsFileUri } from '../../services/fsFileUri'
+import type { FileMetadata } from '../../types/files'
 import type { AppCaches, AppService } from '../service'
 
 function parseLogRow(row: {
@@ -180,6 +181,18 @@ export function buildDbNamespaces(
     },
     files: {
       getById: (id) => ops.readFileRecord(db, id),
+      getMetadata: async (id) => {
+        const record = await ops.readFileRecord(db, id)
+        if (!record) return null
+        let metadata: FileMetadata = record
+        if (record.kind === 'file') {
+          const tags = await ops.queryTagNamesForFile(db, id)
+          if (tags && tags.length > 0) metadata = { ...metadata, tags }
+          const directory = await ops.queryDirectoryPathForFile(db, id)
+          if (directory) metadata = { ...metadata, directory }
+        }
+        return metadata
+      },
       getByIds: (ids) => ops.readFileRecordsByIds(db, ids),
       getByObjectId: (objectId, indexerURL) =>
         ops.readFileRecordByObjectId(db, objectId, indexerURL),

--- a/packages/core/src/app/service.ts
+++ b/packages/core/src/app/service.ts
@@ -11,7 +11,12 @@ import type {
 } from '../db/operations'
 import type { LocalObject } from '../encoding/localObject'
 import type { SyncUpCursor } from '../services/syncUpMetadata'
-import type { FileRecord, FileRecordRow, ThumbSize } from '../types/files'
+import type {
+  FileMetadata,
+  FileRecord,
+  FileRecordRow,
+  ThumbSize,
+} from '../types/files'
 import type {
   ConnectionState,
   DownloadEntry,
@@ -162,6 +167,8 @@ export interface AppService {
       records: Omit<FileRecord, 'objects'>[],
       opts?: { skipCurrentRecalc?: boolean },
     ): Promise<void>
+    /** Returns the full encodable metadata for a file, including tags and directory. */
+    getMetadata(id: string): Promise<FileMetadata | null>
     /** Returns file record rows by IDs (no objects join). */
     getRowsByIds(ids: string[]): Promise<Map<string, FileRecordRow>>
     /** Returns file record rows by object IDs and indexer URL (no objects join). */

--- a/packages/core/src/services/syncUpMetadata.ts
+++ b/packages/core/src/services/syncUpMetadata.ts
@@ -7,7 +7,6 @@ import {
   MAX_SUPPORTED_VERSION,
 } from '../encoding/fileMetadata'
 import { SlotPool } from '../lib/slotPool'
-import type { FileMetadata } from '../types/files'
 import { fileMetadataKeys } from '../types/files'
 
 type DiffEntry = { local: unknown; remote: unknown }
@@ -209,17 +208,8 @@ export async function syncUpMetadataBatch(
         })
 
         if (isLocalNewer) {
-          let fileToEncode: FileMetadata = f
-          if (f.kind === 'file') {
-            const tags = await app.tags.getNamesForFile(f.id)
-            if (tags) {
-              fileToEncode = { ...fileToEncode, tags }
-            }
-            const directory = await app.directories.getPathForFile(f.id)
-            if (directory) {
-              fileToEncode = { ...fileToEncode, directory }
-            }
-          }
+          const fileToEncode = await app.files.getMetadata(f.id)
+          if (!fileToEncode) return
           logger.info('syncUpMetadata', 'pushing_v1', {
             fileId: fileToEncode.id,
             objectId: obj.id,

--- a/packages/core/src/services/uploader.ts
+++ b/packages/core/src/services/uploader.ts
@@ -982,15 +982,14 @@ export class UploadManager {
           }
 
           try {
-            const fileRecord = await this.app.files.getById(entry.fileId)
-            if (!fileRecord) {
+            const metadata = await this.app.files.getMetadata(entry.fileId)
+            if (!metadata) {
               logger.warn('uploadManager', 'file_deleted_during_upload', {
                 fileId: entry.fileId,
               })
               return { type: 'deleted', fileId: entry.fileId }
             }
-
-            pinnedObject.updateMetadata(encodeFileMetadata(entry.file))
+            pinnedObject.updateMetadata(encodeFileMetadata(metadata))
             await retry('pinObject', () => sdk.pinObject(pinnedObject), 3, 1000)
 
             const appKey = sdk.appKey()


### PR DESCRIPTION
The uploader encoded file metadata from the FileRecord which omits tags and directory (stored in separate join tables). Other devices would see uploaded files without folder or tag assignments until sync-up-metadata ran later.

