### PR TITLE
fix(mobile): release SQLite WAL lock before background suspension

### DIFF
--- a/.changeset/fix-background-suspension-crash.md
+++ b/.changeset/fix-background-suspension-crash.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Fixed iOS killing the app when backgrounded by closing the database connection before suspension to release SQLite WAL file locks.

--- a/apps/integration/test/app.ts
+++ b/apps/integration/test/app.ts
@@ -1,4 +1,9 @@
-import type { ThumbnailAdapter } from '@siastorage/core/adapters'
+import type {
+  DatabaseAdapter,
+  SQLParam,
+  SQLRunResult,
+  ThumbnailAdapter,
+} from '@siastorage/core/adapters'
 import type { AppService, AppServiceInternal } from '@siastorage/core/app'
 import { createAppService } from '@siastorage/core/app'
 import { runMigrations } from '@siastorage/core/db'
@@ -10,6 +15,7 @@ import type {
   TagWithCount,
 } from '@siastorage/core/db/operations'
 import type { LocalObject } from '@siastorage/core/encoding/localObject'
+import { CoalescingQueue } from '@siastorage/core/lib/coalescingQueue'
 import { detectMimeType } from '@siastorage/core/lib/detectMimeType'
 import { ServiceScheduler } from '@siastorage/core/lib/serviceInterval'
 import type { FsIOAdapter } from '@siastorage/core/services/fsFileUri'
@@ -52,6 +58,59 @@ export {
   waitForCondition,
 } from './utils'
 
+/**
+ * Mirrors the real mobile app's DB lifecycle (initializeDB / closeDb / reopen).
+ * Uses a file-backed better-sqlite3 database with the same PRAGMAs
+ * (WAL, busy_timeout, foreign_keys) and runs migrations on open.
+ * The proxy delegates to the active connection; calls throw after close.
+ */
+function createTestDatabase(dbPath: string) {
+  let inner: (DatabaseAdapter & { close(): void }) | null = null
+
+  function requireOpen(): DatabaseAdapter & { close(): void } {
+    if (!inner) throw new Error('Database is closed')
+    return inner
+  }
+
+  const proxy: DatabaseAdapter = {
+    getAllAsync<T>(sql: string, ...params: SQLParam[]): Promise<T[]> {
+      return requireOpen().getAllAsync(sql, ...params)
+    },
+    getFirstAsync<T>(sql: string, ...params: SQLParam[]): Promise<T | null> {
+      return requireOpen().getFirstAsync(sql, ...params)
+    },
+    runAsync(sql: string, ...params: SQLParam[]): Promise<SQLRunResult> {
+      return requireOpen().runAsync(sql, ...params)
+    },
+    execAsync(sql: string): Promise<void> {
+      return requireOpen().execAsync(sql)
+    },
+    withTransactionAsync(fn: () => Promise<void>): Promise<void> {
+      return requireOpen().withTransactionAsync(fn)
+    },
+  }
+
+  return {
+    proxy,
+    async open() {
+      inner = createBetterSqlite3Database(dbPath)
+      await inner.execAsync(
+        'PRAGMA journal_mode = WAL; PRAGMA busy_timeout = 5000; PRAGMA foreign_keys = ON',
+      )
+      await runMigrations(proxy, sortMigrations(coreMigrations))
+    },
+    close() {
+      if (inner) {
+        inner.close()
+        inner = null
+      }
+    },
+    get isOpen() {
+      return inner !== null
+    },
+  }
+}
+
 const INDEXER_URL = 'https://test.indexer'
 const SYNC_INTERVAL = 200
 const THUMBNAIL_SCAN_INTERVAL = 1000
@@ -69,6 +128,11 @@ export interface TestApp {
   shutdown(): Promise<void>
   pause(): void
   resume(): void
+  suspend(): Promise<void>
+  resumeFromSuspension(): Promise<void>
+  suspendIfBackground(): Promise<void>
+  isSuspended(): boolean
+  isBackground: boolean
 
   app: AppService
   internal: AppServiceInternal
@@ -153,18 +217,25 @@ export function createTestApp(
   indexerStorage?: MockIndexerStorage,
   options?: TestAppOptions,
 ): TestApp {
-  const db = createBetterSqlite3Database()
+  const hasMockAdapters = options?.fsIO || options?.thumbnail
+  const tempDir = hasMockAdapters
+    ? ''
+    : nodeFs.mkdtempSync(path.join(os.tmpdir(), 'core-test-'))
+  const dbDir = nodeFs.mkdtempSync(path.join(os.tmpdir(), 'core-test-db-'))
+  const dbPath = path.join(dbDir, 'test.db')
+
+  const testDb = createTestDatabase(dbPath)
+  const db = testDb.proxy
+
   const storage = createInMemoryStorage()
   const scheduler = new ServiceScheduler()
   const sdk = new MockSdk(indexerStorage ?? createEmptyIndexerStorage())
   const appKey = sdk.appKey()
   const thumbnailScanner = new ThumbnailScanner()
   let connected = true
-
-  const hasMockAdapters = options?.fsIO || options?.thumbnail
-  const tempDir = hasMockAdapters
-    ? ''
-    : nodeFs.mkdtempSync(path.join(os.tmpdir(), 'core-test-'))
+  let suspended = false
+  let background = false
+  const suspensionQueue = new CoalescingQueue()
 
   const secrets = createInMemoryStorage()
   const crypto = options?.crypto ?? {
@@ -271,7 +342,7 @@ export function createTestApp(
     tempDir,
 
     async start() {
-      await runMigrations(db, sortMigrations(coreMigrations))
+      await testDb.open()
       await appService.optimize()
       internal.setSdk(testSdkAdapter)
       appService.connection.setState({ isConnected: true })
@@ -289,12 +360,14 @@ export function createTestApp(
       thumbnailScanner.reset()
       await scheduler.shutdown()
       await new Promise((r) => setTimeout(r, 100))
-      db.close()
-      if (tempDir) {
-        try {
-          nodeFs.rmSync(tempDir, { recursive: true })
-        } catch {
-          // ignore cleanup errors
+      testDb.close()
+      for (const dir of [tempDir, dbDir]) {
+        if (dir) {
+          try {
+            nodeFs.rmSync(dir, { recursive: true })
+          } catch {
+            // ignore cleanup errors
+          }
         }
       }
     },
@@ -305,6 +378,55 @@ export function createTestApp(
 
     resume() {
       scheduler.resume()
+    },
+
+    async suspend() {
+      return suspensionQueue.enqueue(async () => {
+        if (suspended) return
+        scheduler.pause()
+        await uploadManager.suspend()
+        await scheduler.waitForIdle()
+        testDb.close()
+        suspended = true
+      })
+    },
+
+    async resumeFromSuspension() {
+      return suspensionQueue.enqueue(async () => {
+        if (!suspended) {
+          uploadManager.adjustBatchForSuspension()
+          return
+        }
+        await testDb.open()
+        suspended = false
+        uploadManager.adjustBatchForSuspension()
+        uploadManager.resume()
+        scheduler.resume()
+      })
+    },
+
+    async suspendIfBackground() {
+      if (!background) return
+      return suspensionQueue.enqueue(async () => {
+        if (suspended) return
+        scheduler.pause()
+        await uploadManager.suspend()
+        await scheduler.waitForIdle()
+        testDb.close()
+        suspended = true
+      })
+    },
+
+    isSuspended() {
+      return suspended
+    },
+
+    get isBackground() {
+      return background
+    },
+
+    set isBackground(value: boolean) {
+      background = value
     },
 
     triggerSyncDown() {

--- a/apps/integration/test/suspension.test.ts
+++ b/apps/integration/test/suspension.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Tests the suspension coordination protocol: scheduler pause/drain,
+ * upload manager suspend/resume, and DB close/reopen. The test harness
+ * mirrors the mobile lifecycle but is independent of suspension.ts —
+ * these verify the building blocks, not the mobile orchestration.
+ */
+import { createEmptyIndexerStorage } from '@siastorage/sdk-mock'
+import {
+  createTestApp,
+  generateTestFiles,
+  sleep,
+  type TestApp,
+  waitForCondition,
+} from './app'
+
+describe('Suspension', () => {
+  let app: TestApp
+
+  beforeEach(async () => {
+    app = createTestApp(createEmptyIndexerStorage())
+    await app.start()
+  })
+
+  afterEach(async () => {
+    if (app.isSuspended()) {
+      await app.resumeFromSuspension()
+    }
+    await app.shutdown()
+  })
+
+  it('suspend and resume during idle', async () => {
+    await app.addFiles(generateTestFiles(3, { startId: 1 }))
+    await app.waitForNoActiveUploads()
+    expect(app.sdk.getStoredObjects().length).toBe(3)
+
+    await app.suspend()
+    expect(app.isSuspended()).toBe(true)
+    expect(app.uploadManager.isSuspended).toBe(true)
+
+    await sleep(1000)
+
+    await app.resumeFromSuspension()
+    expect(app.isSuspended()).toBe(false)
+    expect(app.uploadManager.isSuspended).toBe(false)
+
+    await app.addFiles(generateTestFiles(3, { startId: 100 }))
+    await app.waitForNoActiveUploads()
+    expect(app.sdk.getStoredObjects().length).toBe(6)
+  }, 60_000)
+
+  it('suspend freezes in-flight uploads and resume continues them', async () => {
+    await app.addFiles(generateTestFiles(10, { startId: 1 }))
+
+    await waitForCondition(
+      () => {
+        const uploads = app.app.uploads.getState().uploads
+        return Object.values(uploads).some(
+          (u) => u.status === 'packing' || u.status === 'packed',
+        )
+      },
+      { timeout: 10_000, message: 'At least one file packing' },
+    )
+
+    await app.suspend()
+    expect(app.uploadManager.isSuspended).toBe(true)
+
+    const countAtSuspend = app.getActiveUploadCount()
+
+    await sleep(2000)
+
+    const countAfterWait = app.getActiveUploadCount()
+    expect(countAfterWait).toBe(countAtSuspend)
+
+    await app.resumeFromSuspension()
+    await app.waitForNoActiveUploads()
+    expect(app.sdk.getStoredObjects().length).toBe(10)
+  }, 60_000)
+
+  it('suspend during sync-down batch', async () => {
+    const now = Date.now()
+    for (let i = 0; i < 20; i++) {
+      app.sdk.injectObject({
+        metadata: {
+          id: `file-${i}`,
+          name: `photo-${i}.jpg`,
+          type: 'image/jpeg',
+          kind: 'file',
+          size: 1024,
+          hash: `hash-${i}`,
+          createdAt: now - i * 1000,
+          updatedAt: now - i * 1000,
+          trashedAt: null,
+        },
+      })
+    }
+
+    // Wait for sync to start processing but not finish all objects
+    app.triggerSyncDown()
+    await waitForCondition(async () => (await app.getFiles()).length > 0, {
+      timeout: 10_000,
+      message: 'At least one file synced',
+    })
+
+    await app.suspend()
+    await app.resumeFromSuspension()
+    await app.waitForFileCount(20, 30_000)
+    expect((await app.getFiles()).length).toBe(20)
+  }, 60_000)
+
+  it('rapid suspend/resume cycles', async () => {
+    await app.addFiles(generateTestFiles(5, { startId: 1 }))
+
+    // Wait for uploads to be in-flight before cycling
+    await waitForCondition(
+      () => {
+        const uploads = app.app.uploads.getState().uploads
+        return Object.values(uploads).some(
+          (u) => u.status === 'packing' || u.status === 'packed',
+        )
+      },
+      { timeout: 10_000, message: 'At least one file packing' },
+    )
+
+    for (let i = 0; i < 5; i++) {
+      await app.suspend()
+      await app.resumeFromSuspension()
+    }
+
+    await app.waitForNoActiveUploads()
+    expect(app.sdk.getStoredObjects().length).toBe(5)
+  }, 60_000)
+
+  it('suspend preserves packer batch state', async () => {
+    const files1 = await app.addFiles(
+      generateTestFiles(1, { startId: 1, sizeBytes: 100 }),
+    )
+
+    await app.waitForCondition(() => {
+      const entry = app.app.uploads.getEntry(files1[0].id)
+      return entry?.status === 'packed'
+    })
+
+    const flushCountBefore = app.uploadManager.flushHistory.length
+    expect(flushCountBefore).toBe(0)
+
+    await app.suspend()
+    await app.resumeFromSuspension()
+
+    const files2 = await app.addFiles(
+      generateTestFiles(1, { startId: 2, sizeBytes: 100 }),
+    )
+
+    await app.waitForCondition(() => {
+      const entry = app.app.uploads.getEntry(files2[0].id)
+      return entry?.status === 'packed'
+    })
+
+    expect(app.uploadManager.flushHistory.length).toBe(0)
+
+    await app.waitForNoActiveUploads()
+    expect(app.uploadManager.flushHistory.length).toBe(1)
+
+    const flush = app.uploadManager.flushHistory[0]
+    expect(flush.fileCount).toBe(2)
+  }, 60_000)
+
+  it('suspend with no services running', async () => {
+    await app.suspend()
+    expect(app.isSuspended()).toBe(true)
+
+    await app.resumeFromSuspension()
+    expect(app.isSuspended()).toBe(false)
+
+    await app.addFiles(generateTestFiles(2, { startId: 1 }))
+    await app.waitForNoActiveUploads()
+    expect(app.sdk.getStoredObjects().length).toBe(2)
+  }, 30_000)
+
+  it('suspend during multi-device sync', async () => {
+    const shared = createEmptyIndexerStorage()
+    const deviceA = createTestApp(shared)
+    const deviceB = createTestApp(shared)
+    await deviceA.start()
+    await deviceB.start()
+
+    try {
+      await deviceA.addFiles(generateTestFiles(5, { startId: 1 }))
+      await deviceA.waitForNoActiveUploads()
+      expect(deviceA.sdk.getStoredObjects().length).toBe(5)
+
+      deviceB.triggerSyncDown()
+      await sleep(100)
+      await deviceB.suspend()
+
+      await deviceB.resumeFromSuspension()
+      await deviceB.waitForFileCount(5, 30_000)
+      expect((await deviceB.getFiles()).length).toBe(5)
+    } finally {
+      if (deviceB.isSuspended()) await deviceB.resumeFromSuspension()
+      await deviceA.shutdown()
+      await deviceB.shutdown()
+    }
+  }, 60_000)
+
+  it('background task resumes from suspension', async () => {
+    await app.addFiles(generateTestFiles(3, { startId: 1 }))
+    await app.waitForNoActiveUploads()
+
+    await app.suspend()
+    expect(app.isSuspended()).toBe(true)
+
+    await app.resumeFromSuspension()
+    await app.addFiles(generateTestFiles(2, { startId: 100 }))
+    await app.waitForNoActiveUploads()
+    expect(app.sdk.getStoredObjects().length).toBe(5)
+
+    await app.suspend()
+    expect(app.isSuspended()).toBe(true)
+
+    await app.resumeFromSuspension()
+    expect(app.isSuspended()).toBe(false)
+    expect(app.areServicesRunning()).toBe(true)
+  }, 60_000)
+
+  it('foreground while background task has DB open', async () => {
+    await app.addFiles(generateTestFiles(5, { startId: 1 }))
+    await app.waitForNoActiveUploads()
+
+    await app.suspend()
+    expect(app.isSuspended()).toBe(true)
+
+    await app.resumeFromSuspension()
+    expect(app.isSuspended()).toBe(false)
+
+    await app.addFiles(generateTestFiles(3, { startId: 100 }))
+
+    await app.resumeFromSuspension()
+    expect(app.isSuspended()).toBe(false)
+    expect(app.areServicesRunning()).toBe(true)
+
+    await app.waitForNoActiveUploads()
+    expect(app.sdk.getStoredObjects().length).toBe(8)
+  }, 60_000)
+
+  it('background task finishes and re-suspends then user opens app', async () => {
+    await app.suspend()
+
+    await app.resumeFromSuspension()
+    await app.addFiles(generateTestFiles(3, { startId: 1 }))
+    await app.waitForNoActiveUploads()
+    await app.suspend()
+
+    expect(app.isSuspended()).toBe(true)
+    expect(app.sdk.getStoredObjects().length).toBe(3)
+
+    await app.resumeFromSuspension()
+    expect(app.isSuspended()).toBe(false)
+
+    await app.addFiles(generateTestFiles(2, { startId: 100 }))
+    await app.waitForNoActiveUploads()
+    expect(app.sdk.getStoredObjects().length).toBe(5)
+  }, 60_000)
+
+  it('multiple background tasks overlap with foreground', async () => {
+    await app.suspend()
+
+    await app.resumeFromSuspension()
+    await app.addFiles(generateTestFiles(3, { startId: 1 }))
+
+    await app.resumeFromSuspension()
+
+    await app.addFiles(generateTestFiles(2, { startId: 100 }))
+
+    await app.waitForNoActiveUploads()
+    expect(app.sdk.getStoredObjects().length).toBe(5)
+    expect(app.isSuspended()).toBe(false)
+    expect(app.areServicesRunning()).toBe(true)
+  }, 60_000)
+
+  it('resume during in-flight suspension waits then resumes', async () => {
+    await app.addFiles(generateTestFiles(5, { startId: 1 }))
+
+    await waitForCondition(
+      () => {
+        const uploads = app.app.uploads.getState().uploads
+        return Object.values(uploads).some(
+          (u) => u.status === 'packing' || u.status === 'packed',
+        )
+      },
+      { timeout: 10_000, message: 'At least one file packing' },
+    )
+
+    // Fire suspend WITHOUT await — simulates AppState callback
+    const suspendPromise = app.suspend()
+
+    // Immediately resume — simulates user switching back before suspension completes
+    await app.resumeFromSuspension()
+
+    // Should be fully resumed
+    expect(app.isSuspended()).toBe(false)
+    expect(app.areServicesRunning()).toBe(true)
+
+    await suspendPromise
+
+    // All files should still upload successfully
+    await app.waitForNoActiveUploads()
+    expect(app.sdk.getStoredObjects().length).toBe(5)
+  }, 60_000)
+
+  it('background task ending while foregrounded does not suspend', async () => {
+    // Simulate: app backgrounded → suspended → background task starts
+    app.isBackground = true
+    await app.suspend()
+    expect(app.isSuspended()).toBe(true)
+
+    // Background task resumes the DB to do work
+    await app.resumeFromSuspension()
+    await app.addFiles(generateTestFiles(3, { startId: 1 }))
+    await app.waitForNoActiveUploads()
+
+    // User opens the app while background task is still "running"
+    app.isBackground = false
+    await app.resumeFromSuspension()
+
+    // Background task ends — calls suspendIfBackground
+    // Since app is foregrounded, this should be a no-op
+    await app.suspendIfBackground()
+
+    expect(app.isSuspended()).toBe(false)
+    expect(app.areServicesRunning()).toBe(true)
+
+    // App should still work normally
+    await app.addFiles(generateTestFiles(2, { startId: 100 }))
+    await app.waitForNoActiveUploads()
+    expect(app.sdk.getStoredObjects().length).toBe(5)
+  }, 60_000)
+})

--- a/apps/mobile/src/Root.tsx
+++ b/apps/mobile/src/Root.tsx
@@ -7,17 +7,10 @@ import {
 import { AppProvider } from '@siastorage/core/app'
 import { uniqueId } from '@siastorage/core/lib/uniqueId'
 import { useHasOnboarded, useShowSplash } from '@siastorage/core/stores'
-import { logger } from '@siastorage/logger'
 import * as ScreenOrientation from 'expo-screen-orientation'
 import { ShareIntentProvider } from 'expo-share-intent'
-import { useEffect, useRef } from 'react'
-import {
-  AppState,
-  type AppStateStatus,
-  Platform,
-  StatusBar,
-  StyleSheet,
-} from 'react-native'
+import { useEffect } from 'react'
+import { Platform, StatusBar, StyleSheet } from 'react-native'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context'
 import { AppSplash } from './components/AppSplash'
@@ -42,32 +35,11 @@ const darkNavigationTheme = {
 }
 
 export function Root() {
-  // Track the previous AppState for logging transitions.
-  const appStateRef = useRef(AppState.currentState)
-
   useEffect(() => {
     initApp()
     return () => {
       shutdownApp()
     }
-  }, [])
-
-  // Log AppState changes.
-  useEffect(() => {
-    logger.info('appState', 'initial_state', { state: appStateRef.current })
-
-    const subscription = AppState.addEventListener(
-      'change',
-      (nextAppState: AppStateStatus) => {
-        logger.info('appState', 'state_changed', {
-          from: appStateRef.current,
-          to: nextAppState,
-        })
-        appStateRef.current = nextAppState
-      },
-    )
-
-    return () => subscription.remove()
   }, [])
 
   useEffect(() => {

--- a/apps/mobile/src/db/index.ts
+++ b/apps/mobile/src/db/index.ts
@@ -14,15 +14,26 @@ export async function initializeDB(options?: {
   onProgress?: MigrationProgressHandler
   /** Custom database name (for test isolation) */
   databaseName?: string
+  /** Bypass expo-sqlite connection cache when reopening after suspension. */
+  reopen?: boolean
 }): Promise<void> {
   const name = options?.databaseName ?? dbName
   dbName = name
-  logger.info('db', 'initializing', { name, directory: dbDirectory })
-  database = await SQLite.openDatabaseAsync(name, undefined, dbDirectory)
-  await db().execAsync(
+  // Clear the cached proxy so db() creates a fresh one bound to the new connection.
+  _dbProxy = null
+  const openOptions = options?.reopen ? { useNewConnection: true } : undefined
+  logger.info('db', 'initializing', {
+    name,
+    directory: dbDirectory,
+    reopen: !!options?.reopen,
+  })
+  database = await SQLite.openDatabaseAsync(name, openOptions, dbDirectory)
+  // Use database directly (not the db() proxy) to avoid triggering
+  // withRecovery during init, which would open a competing connection.
+  await database.execAsync(
     'PRAGMA journal_mode = WAL; PRAGMA busy_timeout = 5000; PRAGMA foreign_keys = ON',
   )
-  await runMigrations(db(), migrations, {
+  await runMigrations(database, migrations, {
     log: logger,
     onProgress: options?.onProgress,
   })
@@ -31,16 +42,18 @@ export async function initializeDB(options?: {
 }
 
 /**
- * Detects expo-sqlite Android NullPointerException where the native
- * database handle becomes invalid while operations are still in flight.
- * The exact cause is unconfirmed — possibly related to SharedObject
- * lifecycle or native resource management on Android.
+ * Detects errors from an invalidated native database handle:
+ * - Android NullPointerException: SharedObject lifecycle issue.
+ * - "Access to closed resource": DB was closed for background suspension
+ *   while a query was in-flight (e.g., from a SWR React hook).
+ * In both cases, reopening the connection and retrying resolves it.
  */
 function isNativeHandleError(error: unknown): boolean {
   return (
     error instanceof Error &&
     error.message.includes('has been rejected') &&
-    error.message.includes('NullPointerException')
+    (error.message.includes('NullPointerException') ||
+      error.message.includes('closed resource'))
   )
 }
 
@@ -92,8 +105,12 @@ export async function withRecovery<T>(fn: () => Promise<T>): Promise<T> {
   try {
     return await fn()
   } catch (error) {
-    if (isNativeHandleError(error) && (await reopenDb())) {
-      return await fn()
+    if (isNativeHandleError(error)) {
+      // If the DB was already reopened by the suspension manager,
+      // just retry against the current connection.
+      if (dbInitialized || (await reopenDb())) {
+        return await fn()
+      }
     }
     throw error
   }
@@ -125,8 +142,15 @@ export async function resetDb() {
     }
     try {
       await SQLite.deleteDatabaseAsync(dbName, dbDirectory)
-    } catch {
-      // Database may not exist at this path (e.g. upgrading from pre-app-group location).
+    } catch (e) {
+      // TODO: Remove after all users have upgraded past v1.9 (app group migration).
+      // Ignore "not found" on upgrade from pre-app-group location.
+      // Re-throw other errors so reset failures aren't silently swallowed.
+      if (e instanceof Error && e.message.includes('not found')) {
+        // Expected on first upgrade — DB was at old location.
+      } else {
+        throw e
+      }
     }
     database = await SQLite.openDatabaseAsync(
       dbName,

--- a/apps/mobile/src/lib/logAppender.test.ts
+++ b/apps/mobile/src/lib/logAppender.test.ts
@@ -1,0 +1,154 @@
+jest.unmock('@siastorage/logger')
+
+import {
+  appendLog,
+  flushLogs,
+  type LogEntry,
+  setLogAppender,
+  stopLogAppender,
+} from '@siastorage/logger'
+
+function makeEntry(msg: string): LogEntry {
+  return {
+    timestamp: new Date().toISOString(),
+    level: 'info',
+    scope: 'test',
+    message: msg,
+  }
+}
+
+describe('logAppender', () => {
+  afterEach(async () => {
+    await stopLogAppender()
+  })
+
+  it('buffers entries before appender is set', () => {
+    appendLog(makeEntry('before'))
+    appendLog(makeEntry('before2'))
+
+    const received: LogEntry[] = []
+    setLogAppender((entries) => {
+      received.push(...entries)
+    })
+
+    expect(received).toHaveLength(2)
+    expect(received[0].message).toBe('before')
+    expect(received[1].message).toBe('before2')
+  })
+
+  it('flushes buffered entries when appender is registered', () => {
+    appendLog(makeEntry('buffered'))
+
+    const received: LogEntry[] = []
+    setLogAppender((entries) => {
+      received.push(...entries)
+    })
+
+    expect(received).toHaveLength(1)
+    expect(received[0].message).toBe('buffered')
+  })
+
+  it('flushLogs writes buffered entries immediately', () => {
+    const received: LogEntry[] = []
+    setLogAppender((entries) => {
+      received.push(...entries)
+    })
+
+    appendLog(makeEntry('manual'))
+    expect(received).toHaveLength(0)
+
+    flushLogs()
+    expect(received).toHaveLength(1)
+    expect(received[0].message).toBe('manual')
+  })
+
+  it('stopLogAppender flushes remaining entries then clears appender', async () => {
+    const received: LogEntry[] = []
+    setLogAppender((entries) => {
+      received.push(...entries)
+    })
+
+    appendLog(makeEntry('final1'))
+    appendLog(makeEntry('final2'))
+
+    await stopLogAppender()
+
+    expect(received).toHaveLength(2)
+    expect(received[0].message).toBe('final1')
+    expect(received[1].message).toBe('final2')
+
+    appendLog(makeEntry('after-stop'))
+    flushLogs()
+    expect(received).toHaveLength(2)
+  })
+
+  it('entries buffered after stop are flushed when appender is re-registered', async () => {
+    const received1: LogEntry[] = []
+    setLogAppender((entries) => {
+      received1.push(...entries)
+    })
+
+    await stopLogAppender()
+
+    appendLog(makeEntry('during-suspension'))
+    appendLog(makeEntry('during-suspension-2'))
+
+    const received2: LogEntry[] = []
+    setLogAppender((entries) => {
+      received2.push(...entries)
+    })
+
+    expect(received2).toHaveLength(2)
+    expect(received2[0].message).toBe('during-suspension')
+    expect(received2[1].message).toBe('during-suspension-2')
+  })
+
+  it('preserves timestamps from when entries were created', async () => {
+    const before = new Date().toISOString()
+    const entry = makeEntry('timestamped')
+    const after = new Date().toISOString()
+
+    await stopLogAppender()
+    appendLog(entry)
+
+    const received: LogEntry[] = []
+    setLogAppender((entries) => {
+      received.push(...entries)
+    })
+
+    expect(received[0].timestamp).toBe(entry.timestamp)
+    expect(received[0].timestamp >= before).toBe(true)
+    expect(received[0].timestamp <= after).toBe(true)
+  })
+
+  it('multiple stop/resume cycles preserve buffer', async () => {
+    const received: LogEntry[] = []
+
+    setLogAppender((entries) => {
+      received.push(...entries)
+    })
+    appendLog(makeEntry('cycle1'))
+    await stopLogAppender()
+
+    appendLog(makeEntry('between'))
+
+    setLogAppender((entries) => {
+      received.push(...entries)
+    })
+    appendLog(makeEntry('cycle2'))
+    await stopLogAppender()
+
+    appendLog(makeEntry('between2'))
+
+    setLogAppender((entries) => {
+      received.push(...entries)
+    })
+
+    expect(received.map((e) => e.message)).toEqual([
+      'cycle1',
+      'between',
+      'cycle2',
+      'between2',
+    ])
+  })
+})

--- a/apps/mobile/src/lib/serviceInterval.test.ts
+++ b/apps/mobile/src/lib/serviceInterval.test.ts
@@ -3,8 +3,12 @@ jest.mock('@siastorage/logger', () => ({
 }))
 
 import {
+  abortAllServiceIntervals,
   createServiceInterval,
+  pauseAllServiceIntervals,
+  resumeAllServiceIntervals,
   shutdownAllServiceIntervals,
+  waitForAllServiceIntervalsIdle,
 } from '@siastorage/core/lib/serviceInterval'
 
 beforeEach(async () => {
@@ -153,4 +157,119 @@ test('triggerNow is a noop while worker is running', async () => {
   triggerNow()
   await jest.advanceTimersByTimeAsync(0)
   expect(callCount).toBe(2)
+
+  resolveWork!()
+  await shutdownAllServiceIntervals()
+})
+
+test('waitForIdle resolves immediately when no workers are running', async () => {
+  await waitForAllServiceIntervalsIdle()
+})
+
+test('waitForIdle waits for in-flight worker without aborting', async () => {
+  let resolveWork: (() => void) | null = null
+  let workerRan = false
+
+  const { init } = createServiceInterval({
+    name: 'idleTest',
+    worker: async () => {
+      workerRan = true
+      await new Promise<void>((r) => {
+        resolveWork = r
+      })
+    },
+    interval: 100,
+  })
+
+  init()
+  await jest.advanceTimersByTimeAsync(100)
+  expect(workerRan).toBe(true)
+
+  let idleDone = false
+  const idlePromise = waitForAllServiceIntervalsIdle().then(() => {
+    idleDone = true
+  })
+
+  await jest.advanceTimersByTimeAsync(0)
+  expect(idleDone).toBe(false)
+
+  resolveWork!()
+  await jest.advanceTimersByTimeAsync(0)
+  await idlePromise
+  expect(idleDone).toBe(true)
+})
+
+test('pause then waitForIdle then resume', async () => {
+  const ticks: number[] = []
+  let resolveWork: (() => void) | null = null
+
+  const { init } = createServiceInterval({
+    name: 'pauseIdleTest',
+    worker: async () => {
+      ticks.push(ticks.length + 1)
+      await new Promise<void>((r) => {
+        resolveWork = r
+      })
+    },
+    interval: 100,
+  })
+
+  init()
+  await jest.advanceTimersByTimeAsync(100)
+  expect(ticks).toEqual([1])
+
+  pauseAllServiceIntervals()
+
+  resolveWork!()
+  await jest.advanceTimersByTimeAsync(0)
+  await waitForAllServiceIntervalsIdle()
+
+  // Paused — advancing time should not trigger another tick
+  await jest.advanceTimersByTimeAsync(500)
+  expect(ticks).toEqual([1])
+
+  resumeAllServiceIntervals()
+  await jest.advanceTimersByTimeAsync(100)
+  expect(ticks).toEqual([1, 2])
+
+  resolveWork!()
+  await shutdownAllServiceIntervals()
+})
+
+test('abortAll aborts in-flight worker and provides fresh signal on next tick', async () => {
+  let signalAborted = false
+  let tickCount = 0
+  let resolveWork: (() => void) | null = null
+
+  const { init } = createServiceInterval({
+    name: 'abortTest',
+    worker: async (signal) => {
+      tickCount++
+      signalAborted = signal.aborted
+      await new Promise<void>((r) => {
+        resolveWork = r
+      })
+    },
+    interval: 100,
+  })
+
+  init()
+  await jest.advanceTimersByTimeAsync(100)
+  expect(tickCount).toBe(1)
+  expect(signalAborted).toBe(false)
+
+  // Abort while worker is in-flight.
+  abortAllServiceIntervals()
+
+  // Complete the worker so the tick finishes.
+  resolveWork!()
+  await jest.advanceTimersByTimeAsync(0)
+
+  // Next tick should get a fresh (non-aborted) signal.
+  await jest.advanceTimersByTimeAsync(100)
+  expect(tickCount).toBe(2)
+  expect(signalAborted).toBe(false)
+
+  resolveWork!()
+  await shutdownAllServiceIntervals()
 })

--- a/apps/mobile/src/managers/app.ts
+++ b/apps/mobile/src/managers/app.ts
@@ -20,6 +20,7 @@ import { runFsOrphanScanner } from './fsOrphanScanner'
 import { initImportScanner } from './importScanner'
 import { initLogRotation } from './logRotation'
 import { initPerfMonitor } from './perfMonitor'
+import { initSuspensionManager, teardownSuspensionManager } from './suspension'
 import { initSyncDownEvents, triggerSyncDownEvents } from './syncDownEvents'
 import { initSyncNewPhotos } from './syncNewPhotos'
 import { resetPhotosArchiveCursor } from './syncPhotosArchive'
@@ -68,8 +69,8 @@ export async function initApp(): Promise<void> {
             updateDetail(event.message)
           },
         })
-        await initLogger()
         await app().optimize()
+        await initLogger()
       },
     },
   ]
@@ -130,6 +131,7 @@ export async function initApp(): Promise<void> {
   const success = await runSteps(steps)
   if (success) {
     endInitState()
+    initSuspensionManager()
   }
 }
 
@@ -141,6 +143,7 @@ async function cancelAllTransfers() {
 }
 
 export async function shutdownApp() {
+  teardownSuspensionManager()
   await cancelAllTransfers()
 }
 

--- a/apps/mobile/src/managers/backgroundTasks.ts
+++ b/apps/mobile/src/managers/backgroundTasks.ts
@@ -9,6 +9,11 @@ import { app } from '../stores/appService'
 import { getFileStatsLocal } from '../stores/files'
 import { runFsEvictionScanner } from './fsEvictionScanner'
 import { runFsOrphanScanner } from './fsOrphanScanner'
+import {
+  getIsSuspended,
+  resumeFromSuspension,
+  suspendForBackground,
+} from './suspension'
 import { triggerRecentScanIfNeeded } from './syncPhotosArchive'
 import { getUploadManager } from './uploader'
 
@@ -95,6 +100,12 @@ export function getIsBackgroundTaskRunning(): boolean {
   return Object.values(taskStates).some((s) => s.status === 'running')
 }
 
+function hasOtherRunningTasks(excludeId: TaskId): boolean {
+  return Object.entries(taskStates).some(
+    ([id, s]) => id !== excludeId && s.status === 'running',
+  )
+}
+
 function createFreshTaskState(): TaskState {
   return {
     startTime: 0,
@@ -152,6 +163,15 @@ export async function initBackgroundTasks() {
       transitionTaskState(state, 'running')
       await runBackgroundWork(config, state)
       transitionTaskState(state, 'finished')
+      // Only re-suspend if the app is still in background.
+      // If the user opened the app during the task, skip — the
+      // AppState listener will handle suspension on next background.
+      if (
+        !hasOtherRunningTasks(config.id) &&
+        AppState.currentState !== 'active'
+      ) {
+        await suspendForBackground()
+      }
       BackgroundFetch.finish(config.id)
     },
     (taskId: string) => {
@@ -246,6 +266,12 @@ async function runBackgroundWork(config: TaskConfig, state: TaskState) {
   // Create instance-based cancellable delay for this invocation
   const { delay: delayFn, abort } = createBackgroundDelay()
   state.abort = abort
+
+  const wasSuspended = getIsSuspended()
+  if (wasSuspended) {
+    log('resuming_from_suspension')
+    await resumeFromSuspension()
+  }
 
   // Check if user has onboarded - if not, there's nothing to do
   const hasOnboarded = await app().settings.getHasOnboarded()

--- a/apps/mobile/src/managers/suspension.ts
+++ b/apps/mobile/src/managers/suspension.ts
@@ -1,0 +1,153 @@
+import { CoalescingQueue } from '@siastorage/core/lib/coalescingQueue'
+import {
+  abortAllServiceIntervals,
+  pauseAllServiceIntervals,
+  resumeAllServiceIntervals,
+  waitForAllServiceIntervalsIdle,
+} from '@siastorage/core/lib/serviceInterval'
+import { logger, stopLogAppender } from '@siastorage/logger'
+import { AppState, type AppStateStatus } from 'react-native'
+import BackgroundTimer from 'react-native-background-timer'
+import { closeDb, dbInitialized, initializeDB } from '../db'
+import { resumeLogger } from '../stores/logs'
+import { getIsBackgroundTaskRunning } from './backgroundTasks'
+import { getUploadManager } from './uploader'
+
+type State = 'active' | 'suspending' | 'suspended' | 'resuming'
+
+// Hard deadline for drain — if services haven't drained by this time,
+// close the DB anyway. iOS gives ~30s with beginBackgroundTask; we use
+// 25s to leave margin for the close + cleanup.
+const HARD_DEADLINE_MS = 25_000
+
+let subscription: ReturnType<typeof AppState.addEventListener> | null = null
+let appStateRef: AppStateStatus = AppState.currentState
+let state: State = 'active'
+const queue = new CoalescingQueue()
+
+export function initSuspensionManager(): void {
+  logger.info('suspension', 'init', { state: appStateRef })
+  subscription = AppState.addEventListener('change', onAppStateChange)
+}
+
+export function teardownSuspensionManager(): void {
+  subscription?.remove()
+  subscription = null
+}
+
+function onAppStateChange(nextState: AppStateStatus): void {
+  logger.info('appState', 'state_changed', {
+    from: appStateRef,
+    to: nextState,
+  })
+  appStateRef = nextState
+
+  if (nextState === 'background') {
+    queue.enqueue(doSuspend)
+  } else if (nextState === 'active') {
+    queue.enqueue(doResume)
+  }
+}
+
+async function doSuspend(): Promise<void> {
+  if (state !== 'active') {
+    logger.debug('suspension', 'skipped', {
+      reason: state === 'suspended' ? 'already_suspended' : state,
+    })
+    return
+  }
+  if (getIsBackgroundTaskRunning()) {
+    logger.debug('suspension', 'skipped', {
+      reason: 'background_task_running',
+    })
+    return
+  }
+  if (!dbInitialized) {
+    logger.debug('suspension', 'skipped', { reason: 'db_not_initialized' })
+    return
+  }
+
+  state = 'suspending'
+  logger.info('suspension', 'starting')
+
+  // Request extra execution time from iOS (~30s) before it suspends
+  // the process. On Android this is a no-op.
+  await BackgroundTimer.start(0)
+
+  try {
+    // Phase 1: Signal all services to stop.
+    // pause prevents new ticks, abort signals in-flight workers to exit
+    // at their next signal.aborted check.
+    pauseAllServiceIntervals()
+    abortAllServiceIntervals()
+    await getUploadManager()?.suspend()
+    logger.debug('suspension', 'services_paused')
+
+    // Phase 2: Wait for in-flight work to finish, with a hard deadline.
+    const drainStart = Date.now()
+    const drained = await Promise.race([
+      waitForAllServiceIntervalsIdle().then(() => true),
+      new Promise<false>((r) => setTimeout(() => r(false), HARD_DEADLINE_MS)),
+    ])
+
+    if (drained) {
+      logger.debug('suspension', 'services_drained', {
+        drainMs: Date.now() - drainStart,
+      })
+    } else {
+      logger.warn('suspension', 'hard_deadline_reached', {
+        drainMs: Date.now() - drainStart,
+      })
+    }
+
+    // Phase 3: Close DB to release WAL file lock.
+    await stopLogAppender()
+    await closeDb()
+    state = 'suspended'
+  } catch (e) {
+    logger.error('suspension', 'suspend_error', { error: e as Error })
+    state = 'active'
+  } finally {
+    BackgroundTimer.stop()
+  }
+}
+
+async function doResume(): Promise<void> {
+  if (state !== 'suspended') {
+    getUploadManager()?.adjustBatchForSuspension()
+    return
+  }
+
+  state = 'resuming'
+  logger.info('suspension', 'resuming')
+
+  try {
+    await initializeDB({ reopen: true })
+  } catch (e) {
+    logger.error('suspension', 'resume_error', { error: e as Error })
+    state = 'suspended'
+    return
+  }
+
+  resumeLogger()
+  logger.debug('suspension', 'db_reopened')
+
+  const manager = getUploadManager()
+  manager?.adjustBatchForSuspension()
+  manager?.resume()
+  resumeAllServiceIntervals()
+  state = 'active'
+  logger.info('suspension', 'resumed')
+}
+
+export function resumeFromSuspension(): Promise<void> {
+  return queue.enqueue(doResume)
+}
+
+export function suspendForBackground(): Promise<void> {
+  return queue.enqueue(doSuspend)
+}
+
+export function getIsSuspended(): boolean {
+  return state === 'suspended'
+}

--- a/apps/mobile/src/managers/suspension.ts
+++ b/apps/mobile/src/managers/suspension.ts
@@ -26,6 +26,7 @@ let state: State = 'active'
 const queue = new CoalescingQueue()
 
 export function initSuspensionManager(): void {
+  if (subscription) return
   logger.info('suspension', 'init', { state: appStateRef })
   subscription = AppState.addEventListener('change', onAppStateChange)
 }

--- a/apps/mobile/src/managers/uploader.test.ts
+++ b/apps/mobile/src/managers/uploader.test.ts
@@ -1393,4 +1393,56 @@ describe('UploadManager', () => {
       getManagerSpy.mockRestore()
     })
   })
+
+  describe('suspend / resume', () => {
+    it('suspend sets isSuspended and resume clears it', () => {
+      expect(manager.isSuspended).toBe(false)
+      manager.suspend()
+      expect(manager.isSuspended).toBe(true)
+      manager.resume()
+      expect(manager.isSuspended).toBe(false)
+    })
+
+    it('resume is a no-op when not suspended', () => {
+      manager.resume()
+      expect(manager.isSuspended).toBe(false)
+    })
+
+    it('suspend pauses the loop and resume unblocks it', async () => {
+      manager.initialize(app(), internal(), defaultAdapters())
+
+      const entry = await createTestFile('suspend-test', 1000)
+      manager.enqueue([entry])
+
+      // Let the loop process
+      await jest.advanceTimersByTimeAsync(0)
+
+      manager.suspend()
+      expect(manager.isSuspended).toBe(true)
+
+      // Enqueue another file while suspended
+      const entry2 = await createTestFile('suspend-test-2', 1000)
+      manager.enqueue([entry2])
+
+      // Advance time — the loop should be parked, not processing
+      await jest.advanceTimersByTimeAsync(10_000)
+      const uploadsWhileSuspended = getActiveUploads()
+      const suspendedIds = uploadsWhileSuspended.map((u) => u.id)
+      expect(suspendedIds).toContain('suspend-test-2')
+
+      manager.resume()
+      expect(manager.isSuspended).toBe(false)
+
+      // Let the loop process the queued file
+      await jest.advanceTimersByTimeAsync(0)
+    })
+
+    it('shutdown while suspended resolves without hanging', async () => {
+      manager.initialize(app(), internal(), defaultAdapters())
+      manager.suspend()
+
+      await manager.shutdown()
+      expect(manager.isSuspended).toBe(true)
+    })
+  })
 })

--- a/apps/mobile/src/managers/uploader.ts
+++ b/apps/mobile/src/managers/uploader.ts
@@ -1,29 +1,16 @@
 import type { FileEntry, FlushRecord } from '@siastorage/core/services/uploader'
 import { useCallback } from 'react'
-import { AppState } from 'react-native'
 import { app, getUploadManager, internal } from '../stores/appService'
 
 export { getUploadManager }
 export type { FileEntry, FlushRecord }
-
-let appStateSubscription: ReturnType<typeof AppState.addEventListener> | null =
-  null
 
 export async function initializeUploader(): Promise<void> {
   const currentManager = getUploadManager()
   if (currentManager) {
     await currentManager.shutdown()
   }
-  appStateSubscription?.remove()
   internal().initUploader()
-  const manager = getUploadManager()
-  if (manager) {
-    appStateSubscription = AppState.addEventListener('change', (state) => {
-      if (state === 'active') {
-        manager.adjustBatchForSuspension()
-      }
-    })
-  }
 }
 
 export function useUploader() {

--- a/apps/mobile/src/stores/logs.ts
+++ b/apps/mobile/src/stores/logs.ts
@@ -33,6 +33,12 @@ export async function initLogger(): Promise<void> {
   hasInit = true
 }
 
+/** Re-register the log appender after suspension without re-reading
+ * settings. initLogger() can't be reused due to its hasInit guard. */
+export function resumeLogger(): void {
+  setLogAppender(appendLogsToDb)
+}
+
 export function useAvailableScopes() {
   return useSWR(cache.key('availableScopes'), () =>
     app().logs.availableScopes(),

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,6 +15,7 @@
     "./lib/fileTypes": "./src/lib/fileTypes.ts",
     "./lib/mutex": "./src/lib/mutex.ts",
     "./lib/retry": "./src/lib/retry.ts",
+    "./lib/coalescingQueue": "./src/lib/coalescingQueue.ts",
     "./lib/serviceInterval": "./src/lib/serviceInterval.ts",
     "./lib/singleflight": "./src/lib/singleflight.ts",
     "./lib/slotPool": "./src/lib/slotPool.ts",

--- a/packages/core/src/lib/coalescingQueue.test.ts
+++ b/packages/core/src/lib/coalescingQueue.test.ts
@@ -1,0 +1,129 @@
+import { CoalescingQueue } from './coalescingQueue'
+
+describe('CoalescingQueue', () => {
+  it('runs a single operation immediately', async () => {
+    const queue = new CoalescingQueue()
+    let ran = false
+    await queue.enqueue(async () => {
+      ran = true
+    })
+    expect(ran).toBe(true)
+  })
+
+  it('serializes sequential operations', async () => {
+    const queue = new CoalescingQueue()
+    const order: number[] = []
+    await queue.enqueue(async () => {
+      order.push(1)
+    })
+    await queue.enqueue(async () => {
+      order.push(2)
+    })
+    expect(order).toEqual([1, 2])
+  })
+
+  it('collapses redundant pending operations', async () => {
+    const queue = new CoalescingQueue()
+    const executed: string[] = []
+
+    let resolveFirst!: () => void
+    const firstBlocking = new Promise<void>((r) => {
+      resolveFirst = r
+    })
+
+    // Start a blocking operation
+    const first = queue.enqueue(async () => {
+      executed.push('first')
+      await firstBlocking
+    })
+
+    // Queue several more while first is running — only the last should execute
+    const second = queue.enqueue(async () => {
+      executed.push('second')
+    })
+    const third = queue.enqueue(async () => {
+      executed.push('third')
+    })
+    const fourth = queue.enqueue(async () => {
+      executed.push('fourth')
+    })
+
+    // Unblock the first operation
+    resolveFirst()
+    await first
+    await second
+    await third
+    await fourth
+
+    expect(executed).toEqual(['first', 'fourth'])
+  })
+
+  it('discarded operations resolve without running', async () => {
+    const queue = new CoalescingQueue()
+    const executed: string[] = []
+
+    let resolveFirst!: () => void
+    const firstBlocking = new Promise<void>((r) => {
+      resolveFirst = r
+    })
+
+    const first = queue.enqueue(async () => {
+      executed.push('first')
+      await firstBlocking
+    })
+
+    // These will be discarded
+    const discarded1 = queue.enqueue(async () => {
+      executed.push('should-not-run-1')
+    })
+    const discarded2 = queue.enqueue(async () => {
+      executed.push('should-not-run-2')
+    })
+
+    // This replaces the above
+    const last = queue.enqueue(async () => {
+      executed.push('last')
+    })
+
+    resolveFirst()
+
+    // All promises should resolve
+    await Promise.all([first, discarded1, discarded2, last])
+
+    expect(executed).toEqual(['first', 'last'])
+  })
+
+  it('handles errors without breaking the queue', async () => {
+    const queue = new CoalescingQueue()
+    const executed: string[] = []
+
+    await queue
+      .enqueue(async () => {
+        executed.push('error')
+        throw new Error('test error')
+      })
+      .catch(() => {})
+
+    await queue.enqueue(async () => {
+      executed.push('after-error')
+    })
+
+    expect(executed).toEqual(['error', 'after-error'])
+  })
+
+  it('new operations after queue drains run immediately', async () => {
+    const queue = new CoalescingQueue()
+    const executed: string[] = []
+
+    await queue.enqueue(async () => {
+      executed.push('first')
+    })
+
+    // Queue is now idle
+    await queue.enqueue(async () => {
+      executed.push('second')
+    })
+
+    expect(executed).toEqual(['first', 'second'])
+  })
+})

--- a/packages/core/src/lib/coalescingQueue.test.ts
+++ b/packages/core/src/lib/coalescingQueue.test.ts
@@ -111,6 +111,39 @@ describe('CoalescingQueue', () => {
     expect(executed).toEqual(['error', 'after-error'])
   })
 
+  it('pending resolvers resolve even when the pending operation throws', async () => {
+    const queue = new CoalescingQueue()
+    const executed: string[] = []
+
+    let resolveFirst!: () => void
+    const firstBlocking = new Promise<void>((r) => {
+      resolveFirst = r
+    })
+
+    const first = queue.enqueue(async () => {
+      executed.push('first')
+      await firstBlocking
+    })
+
+    // This gets discarded
+    const discarded = queue.enqueue(async () => {
+      executed.push('discarded')
+    })
+
+    // This replaces the above and will throw
+    const failing = queue.enqueue(async () => {
+      executed.push('failing')
+      throw new Error('boom')
+    })
+
+    resolveFirst()
+
+    // All promises should resolve (failing's error is caught)
+    await Promise.all([first, discarded, failing.catch(() => {})])
+
+    expect(executed).toEqual(['first', 'failing'])
+  })
+
   it('new operations after queue drains run immediately', async () => {
     const queue = new CoalescingQueue()
     const executed: string[] = []

--- a/packages/core/src/lib/coalescingQueue.ts
+++ b/packages/core/src/lib/coalescingQueue.ts
@@ -1,0 +1,61 @@
+/**
+ * A queue that collapses redundant operations.
+ *
+ * Only the most recently enqueued operation is kept pending. If
+ * multiple operations are enqueued while one is running, only the
+ * last one executes after the current one completes. Earlier
+ * pending operations are discarded.
+ *
+ * This is useful for state machines driven by external events
+ * (e.g., AppState changes) where rapid toggling should not queue
+ * up a long chain of transitions — only the latest intent matters.
+ */
+export class CoalescingQueue {
+  private running: Promise<void> | null = null
+  private pending: (() => Promise<void>) | null = null
+  private pendingResolvers: Array<() => void> = []
+
+  /**
+   * Enqueue an operation. If an operation is already running, this
+   * replaces any previously pending operation (collapsing the queue).
+   * Returns a promise that resolves when this specific operation
+   * completes or is discarded.
+   */
+  enqueue(fn: () => Promise<void>): Promise<void> {
+    if (!this.running) {
+      return this.run(fn)
+    }
+
+    // Resolve any previously pending operation that we're replacing
+    for (const resolve of this.pendingResolvers) {
+      resolve()
+    }
+    this.pendingResolvers = []
+
+    return new Promise<void>((resolve) => {
+      this.pending = fn
+      this.pendingResolvers.push(resolve)
+    })
+  }
+
+  private async run(fn: () => Promise<void>): Promise<void> {
+    this.running = (async () => {
+      try {
+        await fn()
+      } finally {
+        this.running = null
+        if (this.pending) {
+          const next = this.pending
+          const resolvers = this.pendingResolvers
+          this.pending = null
+          this.pendingResolvers = []
+          await this.run(next)
+          for (const resolve of resolvers) {
+            resolve()
+          }
+        }
+      }
+    })()
+    return this.running
+  }
+}

--- a/packages/core/src/lib/coalescingQueue.ts
+++ b/packages/core/src/lib/coalescingQueue.ts
@@ -49,7 +49,9 @@ export class CoalescingQueue {
           const resolvers = this.pendingResolvers
           this.pending = null
           this.pendingResolvers = []
-          await this.run(next)
+          // Errors from the pending operation should not propagate
+          // to the caller of the operation that just completed.
+          await this.run(next).catch(() => {})
           for (const resolve of resolvers) {
             resolve()
           }

--- a/packages/core/src/lib/serviceInterval.ts
+++ b/packages/core/src/lib/serviceInterval.ts
@@ -57,12 +57,11 @@ export class ServiceScheduler {
 
       // Increment the token to invalidate any previously scheduled or in-flight ticks.
       const token = (existing?.token ?? 0) + 1
-      const abortController = new AbortController()
       running = false
       this.schedulerStateMap.set(name, {
         token,
         timeoutId: null,
-        abortController,
+        abortController: new AbortController(),
       })
 
       runTick = () => {
@@ -84,9 +83,10 @@ export class ServiceScheduler {
         running = true
         let nextInterval = interval
         try {
-          const customInterval = await Promise.resolve(
-            worker(abortController.signal),
-          )
+          // Always read signal from the map so abortAll() replacements
+          // take effect on subsequent ticks.
+          const signal = current.abortController.signal
+          const customInterval = await Promise.resolve(worker(signal))
           if (typeof customInterval === 'number') {
             nextInterval = customInterval
           }
@@ -102,13 +102,14 @@ export class ServiceScheduler {
         if (!current || current.token !== token) return
 
         if (this.paused) {
-          // Defer the tick until resumed
+          // Defer the tick until resumed.
           this.pausedCallbacks.push(() => scheduleNextRun(interval))
           return
         }
 
         const timeoutId = setTimeout(runTick!, interval)
-        this.schedulerStateMap.set(name, { token, timeoutId, abortController })
+        // Update only the timeoutId, preserving the current abortController.
+        current.timeoutId = timeoutId
       }
 
       scheduleNextRun(interval)
@@ -119,12 +120,27 @@ export class ServiceScheduler {
       if (!current || !runTick || running) return
       if (current.timeoutId) {
         clearTimeout(current.timeoutId)
-        this.schedulerStateMap.set(name, { ...current, timeoutId: null })
+        current.timeoutId = null
       }
       runTick()
     }
 
     return { init, triggerNow }
+  }
+
+  /** Abort all in-flight workers and replace their AbortControllers
+   * with fresh ones so subsequent ticks get clean signals. */
+  abortAll(): void {
+    this.schedulerStateMap.forEach((state) => {
+      state.abortController.abort()
+      state.abortController = new AbortController()
+    })
+  }
+
+  async waitForIdle(): Promise<void> {
+    while (this.runningPromises.size > 0) {
+      await Promise.allSettled([...this.runningPromises])
+    }
   }
 
   async shutdown(): Promise<void> {
@@ -159,6 +175,14 @@ export function createServiceInterval(opts: ServiceIntervalOptions): {
   triggerNow: () => void
 } {
   return defaultScheduler.createInterval(opts)
+}
+
+export function abortAllServiceIntervals(): void {
+  defaultScheduler.abortAll()
+}
+
+export async function waitForAllServiceIntervalsIdle(): Promise<void> {
+  return defaultScheduler.waitForIdle()
 }
 
 export async function shutdownAllServiceIntervals(): Promise<void> {

--- a/packages/core/src/services/importScanner.ts
+++ b/packages/core/src/services/importScanner.ts
@@ -148,6 +148,8 @@ export class ImportScanner {
 
           // Pass 1: local file on disk — hash and finalize.
           if (localFileUri) {
+            // Exit early on suspension before starting CPU-intensive hash.
+            if (signal?.aborted) break
             const outcome = await this.hashExistingFile(file, localFileUri)
             if (outcome.action === 'finalized') {
               updates.push({
@@ -188,10 +190,13 @@ export class ImportScanner {
             }
 
             try {
+              // Exit early on suspension before starting file copy + hash.
+              if (signal?.aborted) break
               const uri = await app.fs.copyFile(
                 { id: file.id, type: file.type },
                 resolvedUri,
               )
+              if (signal?.aborted) break
               const outcome = await this.hashExistingFile(file, uri)
               if (outcome.action === 'finalized') {
                 updates.push({

--- a/packages/core/src/services/syncDownEvents.ts
+++ b/packages/core/src/services/syncDownEvents.ts
@@ -424,8 +424,10 @@ async function processBatch(
   const deletedFileIdSet = new Set(deletedFileIds)
   let needsLibraryInvalidation = false
 
-  // 3A: FS cleanup (non-fatal).
+  // 3A: FS cleanup (non-fatal). Check signal between deletions so
+  // suspension can close the DB promptly.
   for (const event of deletes) {
+    if (signal.aborted) break
     if (deletedFileIdSet.has(event.fileId)) {
       try {
         await app.fs.removeFile({
@@ -455,6 +457,7 @@ async function processBatch(
   )
 
   // 3B: Batch directory sync.
+  if (signal.aborted) return
   const dirEntries = syncableEvents
     .filter((e) => e.directory !== undefined)
     .map((e) => ({ fileId: e.fileRecord.id, directoryPath: e.directory! }))
@@ -467,6 +470,7 @@ async function processBatch(
   }
 
   // 3C: Batch tag sync.
+  if (signal.aborted) return
   const tagEntries = syncableEvents
     .filter((e) => e.tags !== undefined && e.tags.length > 0)
     .map((e) => ({ fileId: e.fileRecord.id, tagNames: e.tags! }))

--- a/packages/core/src/services/thumbnailScanner.ts
+++ b/packages/core/src/services/thumbnailScanner.ts
@@ -515,7 +515,8 @@ export class ThumbnailScanner {
           })
 
           for (const size of missingSizes) {
-            if (producedCount >= MAX_THUMBS_PER_TICK) break
+            // Exit early on suspension so the DB can close promptly.
+            if (signal?.aborted || producedCount >= MAX_THUMBS_PER_TICK) break
             logger.debug('thumbnailScanner', 'attempt', { id: c.id, size })
             summary.attempts.push({
               originalId: c.id,

--- a/packages/core/src/services/uploader.ts
+++ b/packages/core/src/services/uploader.ts
@@ -369,20 +369,27 @@ export class UploadManager {
     this.wake()
   }
 
+  /** Cached promise so multiple suspend() calls return the same promise
+   * instead of overwriting _parkedResolve and leaving earlier callers hanging. */
+  private _suspendPromise: Promise<void> | null = null
+
   suspend(): Promise<void> {
+    if (this._suspendPromise) return this._suspendPromise
     logger.info('uploadManager', 'suspending')
     this._suspended = true
     this.wake()
     if (!this.active) return Promise.resolve()
-    return new Promise<void>((resolve) => {
+    this._suspendPromise = new Promise<void>((resolve) => {
       this._parkedResolve = resolve
     })
+    return this._suspendPromise
   }
 
   resume(): void {
     if (!this._suspended) return
     logger.info('uploadManager', 'resuming')
     this._suspended = false
+    this._suspendPromise = null // Allow future suspend() calls to create a new promise.
     if (this._resumeResolve) {
       this._resumeResolve()
       this._resumeResolve = null

--- a/packages/core/src/services/uploader.ts
+++ b/packages/core/src/services/uploader.ts
@@ -147,6 +147,12 @@ export class UploadManager {
   private polledFiles: FileEntry[] = []
   /** Whether the async loop is running; set false by shutdown() to exit. */
   private active = false
+  /** Whether the loop is parked waiting for DB to become available. */
+  private _suspended = false
+  /** Resolves to unblock the loop when resume() is called. */
+  private _resumeResolve: (() => void) | null = null
+  /** Resolves to signal the caller of suspend() that the loop has parked. */
+  private _parkedResolve: (() => void) | null = null
   /** Resolves the waitForWorkOrTimeout promise when wake() is called. */
   private wakeResolver: (() => void) | null = null
   /** Whether saveBatchObjects succeeded and invalidation is pending. */
@@ -307,6 +313,14 @@ export class UploadManager {
   /** Stop the loop, cancel in-flight uploads, and clean up upload state. */
   async shutdown(): Promise<void> {
     this.active = false
+    if (this._resumeResolve) {
+      this._resumeResolve()
+      this._resumeResolve = null
+    }
+    if (this._parkedResolve) {
+      this._parkedResolve()
+      this._parkedResolve = null
+    }
 
     if (this.packer) {
       logger.info('uploadManager', 'batch_cancel', {
@@ -353,6 +367,37 @@ export class UploadManager {
     this.batch = null
 
     this.wake()
+  }
+
+  suspend(): Promise<void> {
+    logger.info('uploadManager', 'suspending')
+    this._suspended = true
+    this.wake()
+    if (!this.active) return Promise.resolve()
+    return new Promise<void>((resolve) => {
+      this._parkedResolve = resolve
+    })
+  }
+
+  resume(): void {
+    if (!this._suspended) return
+    logger.info('uploadManager', 'resuming')
+    this._suspended = false
+    if (this._resumeResolve) {
+      this._resumeResolve()
+      this._resumeResolve = null
+    }
+  }
+
+  get isSuspended(): boolean {
+    return this._suspended
+  }
+
+  private async waitForResume(): Promise<void> {
+    if (!this._suspended) return
+    return new Promise<void>((resolve) => {
+      this._resumeResolve = resolve
+    })
   }
 
   get flushHistory(): FlushRecord[] {
@@ -458,6 +503,16 @@ export class UploadManager {
    */
   private async runLoop(): Promise<void> {
     while (this.active) {
+      if (this._suspended) {
+        if (this._parkedResolve) {
+          this._parkedResolve()
+          this._parkedResolve = null
+        }
+        await this.waitForResume()
+        if (!this.active) break
+        continue
+      }
+
       const next =
         this.explicitQueue.shift() ?? this.polledFiles.shift() ?? null
 
@@ -623,7 +678,7 @@ export class UploadManager {
   private async processEntries(entries: FileEntry[]): Promise<void> {
     let i = 0
 
-    while (i < entries.length && this.active) {
+    while (i < entries.length && this.active && !this._suspended) {
       // computeWindowEnd needs a packer+batch — when neither exists or
       // when the next file would trigger a pre-flush, fall back to
       // processEntry which handles packer creation and pre-flush checks.
@@ -642,6 +697,12 @@ export class UploadManager {
         await this.flush('max_duration')
       }
     }
+
+    // Re-queue unprocessed entries so they're picked up on resume.
+    // drainQueues() already removed them from the original queues.
+    if (this._suspended && i < entries.length) {
+      this.explicitQueue.unshift(...entries.slice(i))
+    }
   }
 
   /**
@@ -657,7 +718,8 @@ export class UploadManager {
 
     const inflight = []
     for (let j = from; j < end; j++) {
-      if (!this.active) break
+      // Stop launching new packer.add() calls on shutdown or suspension.
+      if (!this.active || this._suspended) break
       const entry = entries[j]
       this.app.uploads.setStatus(entry.fileId, 'packing')
       logger.debug('uploadManager', 'file_packing', {
@@ -685,7 +747,8 @@ export class UploadManager {
       try {
         const t1 = Date.now()
         await promise
-        if (!this.active || !this.batch) break
+        // Exit after current add completes if shutting down or suspending.
+        if (!this.active || !this.batch || this._suspended) break
         const t2 = Date.now()
         const addMs = t2 - t1
         const slabsBefore = this.batch.slabsFilled


### PR DESCRIPTION
User reported crashes when backgrounding the app. iOS was killing the process for holding SQLite WAL file locks while suspended.

Adds a suspension manager that signals services to exit via their abort signals, then closes the database before iOS suspends the process. Resuming the app reopens the database and restarts services. The suspension manager handles both normal app backgrounding and background task execution, resuming the database when a task fires and re-suspending when it finishes. The suspension manager was tested and should work even when the user is opening and closing the app frequently.
