### PR TITLE
fix(core): batch unbounded SQL operations to bound memory and yield between batches

### DIFF
--- a/.changeset/fix-sqlite-bind-var-limit.md
+++ b/.changeset/fix-sqlite-bind-var-limit.md
@@ -1,0 +1,5 @@
+---
+core: patch
+---
+
+Add operation-level batching for unbounded SQL queries (auto-purge, delete lost files, delete directory) to keep memory bounded and yield to the event loop between batches.

--- a/apps/integration/test/directory-cascade.test.ts
+++ b/apps/integration/test/directory-cascade.test.ts
@@ -20,8 +20,8 @@ describe('Directory Cascade', () => {
     await app.moveFileToDirectory(files[0].id, dir.id)
     await app.moveFileToDirectory(files[1].id, dir.id)
 
-    const trashedIds = await app.app.directories.deleteAndTrashFiles(dir.id)
-    expect(trashedIds.sort()).toEqual([files[0].id, files[1].id].sort())
+    const trashedCount = await app.app.directories.deleteAndTrashFiles(dir.id)
+    expect(trashedCount).toBe(2)
 
     const allFiles = await app.getFiles()
     const trashed = allFiles.filter((f) => f.trashedAt !== null)

--- a/apps/integration/test/trash-restore.test.ts
+++ b/apps/integration/test/trash-restore.test.ts
@@ -52,9 +52,8 @@ describe('Trash and Restore', () => {
       await app.app.files.update({ id: file.id, trashedAt: 1 })
     }
 
-    const purged = await app.app.files.autoPurge()
-    expect(purged).toHaveLength(2)
-    expect(purged.sort()).toEqual([files[0].id, files[1].id].sort())
+    const purgedCount = await app.app.files.autoPurge()
+    expect(purgedCount).toBe(2)
 
     const remaining = await getActiveFiles()
     expect(remaining).toHaveLength(1)

--- a/apps/mobile/src/stores/files.ts
+++ b/apps/mobile/src/stores/files.ts
@@ -3,8 +3,7 @@ import { app } from './appService'
 
 export async function deleteLostFiles(): Promise<number> {
   const currentIndexerURL = await app().settings.getIndexerURL()
-  const lostIds = await app().files.deleteLost(currentIndexerURL)
-  return lostIds.length
+  return app().files.deleteLost(currentIndexerURL)
 }
 
 type FileRecordCursorColumn = 'createdAt' | 'updatedAt'

--- a/packages/core/src/app/namespaces/db.ts
+++ b/packages/core/src/app/namespaces/db.ts
@@ -298,11 +298,11 @@ export function buildDbNamespaces(
       recalculateCurrent: (fileIds) => ops.recalculateCurrentForFileIds(db, fileIds),
       recalculateCurrentForGroups: (groups) => ops.recalculateCurrentForGroups(db, groups),
       deleteLost: async (indexerURL) => {
-        const lostIds = await ops.deleteLostFiles(db, indexerURL)
-        if (lostIds.length > 0) {
+        const count = await ops.deleteLostFiles(db, indexerURL)
+        if (count > 0) {
           invalidateLibrary()
         }
-        return lostIds
+        return count
       },
       trash: async (ids) => {
         await ops.trashFiles(db, ids)
@@ -334,14 +334,14 @@ export function buildDbNamespaces(
         invalidateLibrary()
       },
       autoPurgeWithCleanup: async () => {
-        const purgedIds = await ops.autoPurgeOldTrashedFiles(db)
-        if (purgedIds.length === 0) return
-        const files = await ops.readFileRecordsByIds(db, purgedIds)
-        if (files.length === 0) return
-        uploads.removeMany(purgedIds)
-        const thumbs = await ops.queryThumbnailFileInfoByFileIds(db, purgedIds)
-        await Promise.all([...files, ...thumbs].map((f) => fsNamespace.removeFile(f)))
-        invalidateLibrary()
+        const total = await ops.autoPurgeOldTrashedFiles(db, async (batchIds) => {
+          const files = await ops.readFileRecordsByIds(db, batchIds)
+          if (files.length === 0) return
+          uploads.removeMany(batchIds)
+          const thumbs = await ops.queryThumbnailFileInfoByFileIds(db, batchIds)
+          await Promise.all([...files, ...thumbs].map((f) => fsNamespace.removeFile(f)))
+        })
+        if (total > 0) invalidateLibrary()
       },
       getVersionHistory: async (name, directoryId) => {
         const rows = await ops.queryFileVersions(db, name, directoryId)
@@ -403,11 +403,11 @@ export function buildDbNamespaces(
         caches.libraryVersion.invalidate()
       },
       deleteAndTrashFiles: async (id) => {
-        const fileIds = await ops.deleteDirectoryAndTrashFiles(db, id)
+        const count = await ops.deleteDirectoryAndTrashFiles(db, id)
         caches.directories.invalidateAll()
         await caches.library.invalidateAll()
         caches.libraryVersion.invalidate()
-        return fileIds
+        return count
       },
       rename: async (id, name) => {
         const dir = await ops.renameDirectory(db, id, name)

--- a/packages/core/src/app/service.ts
+++ b/packages/core/src/app/service.ts
@@ -199,7 +199,7 @@ export interface AppService {
     /** Soft-deletes multiple files and all their associated thumbnails. */
     deleteManyAndThumbnails(ids: string[]): Promise<void>
     /** Deletes files that have no remaining remote objects on the given indexer. */
-    deleteLost(indexerURL: string): Promise<string[]>
+    deleteLost(indexerURL: string): Promise<number>
     /** Recalculates the current column for all version groups containing the given file IDs. */
     recalculateCurrent(fileIds: string[]): Promise<void>
     /** Recalculates the current column for the given version groups. */
@@ -219,7 +219,7 @@ export interface AppService {
     /** Returns IDs of files that have been uploaded to the given indexer. */
     getUploadedIds(indexerUrl: string): Promise<string[]>
     /** Permanently deletes files past the trash retention period. */
-    autoPurge(): Promise<string[]>
+    autoPurge(): Promise<number>
     /** Permanently deletes file records by ID (hard delete). */
     permanentlyDelete(ids: string[]): Promise<void>
     /** Permanently deletes files and cleans up local files and uploads. */
@@ -264,7 +264,7 @@ export interface AppService {
     /** Deletes a directory and all descendants without affecting files. */
     delete(id: string): Promise<void>
     /** Deletes a directory, all descendants, and trashes their files. */
-    deleteAndTrashFiles(id: string): Promise<string[]>
+    deleteAndTrashFiles(id: string): Promise<number>
     /** Renames a directory and updates all descendant paths. Returns the updated directory. */
     rename(id: string, name: string): Promise<Directory>
     /** Moves a directory under a new parent (null for root). */

--- a/packages/core/src/db/operations/directories.test.ts
+++ b/packages/core/src/db/operations/directories.test.ts
@@ -540,8 +540,8 @@ describe('deleteDirectoryAndTrashFiles', () => {
     await moveFileToDirectory(db(), 'f2', vacation.id)
     await moveFileToDirectory(db(), 'f3', deep.id)
 
-    const trashedIds = await deleteDirectoryAndTrashFiles(db(), dir.id)
-    expect(trashedIds.sort()).toEqual(['f1', 'f2', 'f3'].sort())
+    const trashedCount = await deleteDirectoryAndTrashFiles(db(), dir.id)
+    expect(trashedCount).toBe(3)
 
     const dirs = await queryAllDirectoriesWithCounts(db())
     expect(dirs).toHaveLength(0)
@@ -563,8 +563,8 @@ describe('deleteDirectoryAndTrashFiles', () => {
 
     await db().runAsync('UPDATE files SET trashedAt = ? WHERE id = ?', Date.now(), 'f2')
 
-    const trashedIds = await deleteDirectoryAndTrashFiles(db(), dir.id)
-    expect(trashedIds).toEqual(['f1'])
+    const trashedCount = await deleteDirectoryAndTrashFiles(db(), dir.id)
+    expect(trashedCount).toBe(1)
   })
 
   it('does not affect sibling directories or their files', async () => {
@@ -589,10 +589,10 @@ describe('deleteDirectoryAndTrashFiles', () => {
     expect(path2).toBe('Videos/Work')
   })
 
-  it('returns empty array for empty directory', async () => {
+  it('returns 0 for empty directory', async () => {
     const dir = await insertDirectory(db(), 'Empty')
-    const trashedIds = await deleteDirectoryAndTrashFiles(db(), dir.id)
-    expect(trashedIds).toEqual([])
+    const trashedCount = await deleteDirectoryAndTrashFiles(db(), dir.id)
+    expect(trashedCount).toBe(0)
   })
 })
 

--- a/packages/core/src/db/operations/directories.ts
+++ b/packages/core/src/db/operations/directories.ts
@@ -299,12 +299,9 @@ export async function syncManyDirectoriesFromMetadata(
   }
 
   const fileIds = entries.map((e) => e.fileId)
-  const placeholders = fileIds.map(() => '?').join(',')
-  const oldGroups = await db.getAllAsync<{
-    name: string
-    directoryId: string | null
-  }>(
-    `SELECT DISTINCT f.name, f.directoryId FROM files f WHERE f.id IN (${placeholders}) AND f.kind = 'file'`,
+  const ph = fileIds.map(() => '?').join(',')
+  const oldGroups = await db.getAllAsync<{ name: string; directoryId: string | null }>(
+    `SELECT DISTINCT f.name, f.directoryId FROM files f WHERE f.id IN (${ph}) AND f.kind = 'file'`,
     ...fileIds,
   )
 
@@ -316,8 +313,8 @@ export async function syncManyDirectoriesFromMetadata(
     byDirId.set(dirId, list)
   }
   for (const [dirId, ids] of byDirId) {
-    const ph = ids.map(() => '?').join(',')
-    await db.runAsync(`UPDATE files SET directoryId = ? WHERE id IN (${ph})`, dirId, ...ids)
+    const idsPh = ids.map(() => '?').join(',')
+    await db.runAsync(`UPDATE files SET directoryId = ? WHERE id IN (${idsPh})`, dirId, ...ids)
   }
 
   return oldGroups
@@ -345,17 +342,14 @@ export async function moveFilesToDirectory(
   dirId: string | null,
 ): Promise<void> {
   if (fileIds.length === 0) return
-  const placeholders = fileIds.map(() => '?').join(',')
-  const groups = await db.getAllAsync<{
-    name: string
-    directoryId: string | null
-  }>(
-    `SELECT DISTINCT name, directoryId FROM files WHERE id IN (${placeholders}) AND kind = 'file'`,
+  const ph = fileIds.map(() => '?').join(',')
+  const groups = await db.getAllAsync<{ name: string; directoryId: string | null }>(
+    `SELECT DISTINCT name, directoryId FROM files WHERE id IN (${ph}) AND kind = 'file'`,
     ...fileIds,
   )
   const now = Date.now()
   await db.runAsync(
-    `UPDATE files SET directoryId = ?, updatedAt = ? WHERE id IN (${placeholders})`,
+    `UPDATE files SET directoryId = ?, updatedAt = ? WHERE id IN (${ph})`,
     dirId,
     now,
     ...fileIds,
@@ -384,13 +378,16 @@ export async function deleteDirectory(db: DatabaseAdapter, id: string): Promise<
   )
   const dirIds = subtreeDirIds.map((d) => d.id)
 
-  const ph = dirIds.map(() => '?').join(',')
+  const dirPh = dirIds.map(() => '?').join(',')
   const groups = await db.getAllAsync<{ name: string }>(
-    `SELECT DISTINCT name FROM files WHERE directoryId IN (${ph}) AND kind = 'file'`,
+    `SELECT DISTINCT name FROM files WHERE directoryId IN (${dirPh}) AND kind = 'file'`,
     ...dirIds,
   )
 
-  await db.runAsync(`UPDATE files SET directoryId = NULL WHERE directoryId IN (${ph})`, ...dirIds)
+  await db.runAsync(
+    `UPDATE files SET directoryId = NULL WHERE directoryId IN (${dirPh})`,
+    ...dirIds,
+  )
 
   await db.runAsync(
     `DELETE FROM directories WHERE path = ? OR path LIKE ? || '/%' ESCAPE '\\'`,
@@ -406,25 +403,27 @@ export async function deleteDirectory(db: DatabaseAdapter, id: string): Promise<
 export async function deleteDirectoryAndTrashFiles(
   db: DatabaseAdapter,
   id: string,
-): Promise<string[]> {
+): Promise<number> {
   const dir = await queryDirectoryById(db, id)
-  if (!dir) return []
+  if (!dir) return 0
 
   const escaped = escapeLikePattern(dir.path)
 
-  const files = await db.getAllAsync<{ id: string }>(
+  const totalTrashed = await sql.processInBatches<{ id: string }>(
+    db,
     `SELECT f.id FROM files f
      INNER JOIN directories d ON f.directoryId = d.id
      WHERE (d.path = ? OR d.path LIKE ? || '/%' ESCAPE '\\')
        AND f.kind = 'file' AND f.trashedAt IS NULL AND f.deletedAt IS NULL`,
-    dir.path,
-    escaped,
+    [dir.path, escaped],
+    500,
+    async (rows) => {
+      await trashFiles(
+        db,
+        rows.map((r) => r.id),
+      )
+    },
   )
-
-  const fileIds = files.map((f) => f.id)
-  if (fileIds.length > 0) {
-    await trashFiles(db, fileIds)
-  }
 
   await db.runAsync(
     `DELETE FROM directories WHERE path = ? OR path LIKE ? || '/%' ESCAPE '\\'`,
@@ -432,7 +431,7 @@ export async function deleteDirectoryAndTrashFiles(
     escaped,
   )
 
-  return fileIds
+  return totalTrashed
 }
 
 export async function queryCountFilesWithDirectories(
@@ -440,9 +439,9 @@ export async function queryCountFilesWithDirectories(
   fileIds: string[],
 ): Promise<number> {
   if (fileIds.length === 0) return 0
-  const placeholders = fileIds.map(() => '?').join(',')
+  const ph = fileIds.map(() => '?').join(',')
   const row = await db.getFirstAsync<{ count: number }>(
-    `SELECT COUNT(*) as count FROM files WHERE id IN (${placeholders}) AND directoryId IS NOT NULL`,
+    `SELECT COUNT(*) as count FROM files WHERE id IN (${ph}) AND directoryId IS NOT NULL`,
     ...fileIds,
   )
   return row?.count ?? 0

--- a/packages/core/src/db/operations/files.test.ts
+++ b/packages/core/src/db/operations/files.test.ts
@@ -256,19 +256,19 @@ describe('deleteLostFiles', () => {
       usedAt: 1000,
     })
     await insertFileRecord(db(), makeFileRecord('lost'))
-    const deleted = await deleteLostFiles(db(), indexerURL)
-    expect(deleted).toEqual(['lost'])
+    const deletedCount = await deleteLostFiles(db(), indexerURL)
+    expect(deletedCount).toBe(1)
     expect(await readFileRecord(db(), 'pinned')).not.toBeNull()
     expect(await readFileRecord(db(), 'local-only')).not.toBeNull()
     expect(await readFileRecord(db(), 'lost')).toBeNull()
   })
 
-  it('returns empty when no files are lost', async () => {
+  it('returns 0 when no files are lost', async () => {
     const indexerURL = 'https://indexer.example.com'
     await insertFileRecord(db(), makeFileRecord('pinned'))
     await insertLocalObject(db(), makeLocalObject('pinned', { indexerURL }))
-    const deleted = await deleteLostFiles(db(), indexerURL)
-    expect(deleted).toEqual([])
+    const deletedCount = await deleteLostFiles(db(), indexerURL)
+    expect(deletedCount).toBe(0)
   })
 })
 

--- a/packages/core/src/db/operations/files.ts
+++ b/packages/core/src/db/operations/files.ts
@@ -52,45 +52,39 @@ export async function recalculateCurrentForFileIds(
   fileIds: string[],
 ): Promise<void> {
   if (fileIds.length === 0) return
-  const chunkSize = MAX_SQL_VARS
-  for (let i = 0; i < fileIds.length; i += chunkSize) {
-    const chunk = fileIds.slice(i, i + chunkSize)
-    const placeholders = chunk.map(() => '?').join(',')
-    const groupsCte = `SELECT DISTINCT name, directoryId FROM files WHERE id IN (${placeholders}) AND kind = 'file'`
-    await db.runAsync(
-      `UPDATE files SET current = 0
-       WHERE current = 1 AND kind = 'file' AND trashedAt IS NULL AND deletedAt IS NULL
-         AND id IN (
-           SELECT f2.id FROM files f2
-           INNER JOIN (${groupsCte}) g
-             ON f2.name = g.name AND f2.directoryId IS g.directoryId
-           WHERE f2.kind = 'file' AND f2.trashedAt IS NULL AND f2.deletedAt IS NULL
-         )`,
-      ...chunk,
-    )
-    await db.runAsync(
-      `UPDATE files SET current = 1
-       WHERE id IN (
-         SELECT id FROM (
-           SELECT f2.id, ROW_NUMBER() OVER (
-             PARTITION BY f2.name, f2.directoryId
-             ORDER BY f2.updatedAt DESC, f2.id DESC
-           ) AS rn
-           FROM files f2
-           INNER JOIN (${groupsCte}) g
-             ON f2.name = g.name AND f2.directoryId IS g.directoryId
-           WHERE f2.kind = 'file' AND f2.trashedAt IS NULL AND f2.deletedAt IS NULL
-         ) sub WHERE sub.rn = 1
+  const ph = fileIds.map(() => '?').join(',')
+  const groupsCte = `SELECT DISTINCT name, directoryId FROM files WHERE id IN (${ph}) AND kind = 'file'`
+  await db.runAsync(
+    `UPDATE files SET current = 0
+     WHERE current = 1 AND kind = 'file' AND trashedAt IS NULL AND deletedAt IS NULL
+       AND id IN (
+         SELECT f2.id FROM files f2
+         INNER JOIN (${groupsCte}) g
+           ON f2.name = g.name AND f2.directoryId IS g.directoryId
+         WHERE f2.kind = 'file' AND f2.trashedAt IS NULL AND f2.deletedAt IS NULL
        )`,
-      ...chunk,
-    )
-  }
+    ...fileIds,
+  )
+  await db.runAsync(
+    `UPDATE files SET current = 1
+     WHERE id IN (
+       SELECT id FROM (
+         SELECT f2.id, ROW_NUMBER() OVER (
+           PARTITION BY f2.name, f2.directoryId
+           ORDER BY f2.updatedAt DESC, f2.id DESC
+         ) AS rn
+         FROM files f2
+         INNER JOIN (${groupsCte}) g
+           ON f2.name = g.name AND f2.directoryId IS g.directoryId
+         WHERE f2.kind = 'file' AND f2.trashedAt IS NULL AND f2.deletedAt IS NULL
+       ) sub WHERE sub.rn = 1
+     )`,
+    ...fileIds,
+  )
 }
 
 const FILE_ROW_COLUMNS =
   'id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize, trashedAt, deletedAt, lostReason'
-
-const MAX_SQL_VARS = 999
 
 export async function queryFileRecordRowsByIds(
   db: DatabaseAdapter,
@@ -98,16 +92,13 @@ export async function queryFileRecordRowsByIds(
 ): Promise<Map<string, FileRecordRow>> {
   const result = new Map<string, FileRecordRow>()
   if (ids.length === 0) return result
-  for (let i = 0; i < ids.length; i += MAX_SQL_VARS) {
-    const chunk = ids.slice(i, i + MAX_SQL_VARS)
-    const placeholders = chunk.map(() => '?').join(',')
-    const rows = await db.getAllAsync<FileRecordRow>(
-      `SELECT ${FILE_ROW_COLUMNS} FROM files WHERE id IN (${placeholders})`,
-      ...chunk,
-    )
-    for (const row of rows) {
-      result.set(row.id, row)
-    }
+  const ph = ids.map(() => '?').join(',')
+  const rows = await db.getAllAsync<FileRecordRow>(
+    `SELECT ${FILE_ROW_COLUMNS} FROM files WHERE id IN (${ph})`,
+    ...ids,
+  )
+  for (const row of rows) {
+    result.set(row.id, row)
   }
   return result
 }
@@ -119,21 +110,17 @@ export async function queryFileRecordRowsByObjectIds(
 ): Promise<Map<string, FileRecordRow>> {
   const result = new Map<string, FileRecordRow>()
   if (objectIds.length === 0) return result
-  const chunkSize = MAX_SQL_VARS - 1
-  for (let i = 0; i < objectIds.length; i += chunkSize) {
-    const chunk = objectIds.slice(i, i + chunkSize)
-    const placeholders = chunk.map(() => '?').join(',')
-    const rows = await db.getAllAsync<FileRecordRow & { objectId: string }>(
-      `SELECT o.id AS objectId, f.${FILE_ROW_COLUMNS.split(', ').join(', f.')}
-       FROM objects o
-       JOIN files f ON f.id = o.fileId
-       WHERE o.indexerURL = ? AND o.id IN (${placeholders})`,
-      indexerURL,
-      ...chunk,
-    )
-    for (const row of rows) {
-      result.set(row.objectId, row)
-    }
+  const ph = objectIds.map(() => '?').join(',')
+  const rows = await db.getAllAsync<FileRecordRow & { objectId: string }>(
+    `SELECT o.id AS objectId, f.${FILE_ROW_COLUMNS.split(', ').join(', f.')}
+     FROM objects o
+     JOIN files f ON f.id = o.fileId
+     WHERE o.indexerURL = ? AND o.id IN (${ph})`,
+    indexerURL,
+    ...objectIds,
+  )
+  for (const row of rows) {
+    result.set(row.objectId, row)
   }
   return result
 }
@@ -412,10 +399,10 @@ export async function queryFileRecordsByLocalIds(
   db: DatabaseAdapter,
   localIds: string[],
 ): Promise<FileRecordRow[]> {
+  if (localIds.length === 0) return []
+  const ph = localIds.map(() => '?').join(',')
   return db.getAllAsync<FileRecordRow>(
-    `SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize, trashedAt, deletedAt, lostReason FROM files WHERE deletedAt IS NULL AND trashedAt IS NULL AND localId IN (${localIds
-      .map((_) => `?`)
-      .join(',')})`,
+    `SELECT ${FILE_ROW_COLUMNS} FROM files WHERE deletedAt IS NULL AND trashedAt IS NULL AND localId IN (${ph})`,
     ...localIds,
   )
 }
@@ -424,10 +411,10 @@ export async function queryFileRecordsByContentHashes(
   db: DatabaseAdapter,
   contentHashes: string[],
 ): Promise<FileRecordRow[]> {
+  if (contentHashes.length === 0) return []
+  const ph = contentHashes.map(() => '?').join(',')
   return db.getAllAsync<FileRecordRow>(
-    `SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize, trashedAt, deletedAt, lostReason FROM files WHERE deletedAt IS NULL AND trashedAt IS NULL AND hash IN (${contentHashes
-      .map((_) => `?`)
-      .join(',')})`,
+    `SELECT ${FILE_ROW_COLUMNS} FROM files WHERE deletedAt IS NULL AND trashedAt IS NULL AND hash IN (${ph})`,
     ...contentHashes,
   )
 }
@@ -559,19 +546,15 @@ export async function tombstoneFileRecords(
   now: number,
 ): Promise<void> {
   if (fileIds.length === 0) return
-  const chunkSize = MAX_SQL_VARS - 3
-  for (let i = 0; i < fileIds.length; i += chunkSize) {
-    const chunk = fileIds.slice(i, i + chunkSize)
-    const placeholders = chunk.map(() => '?').join(',')
-    await db.runAsync(
-      `UPDATE files SET deletedAt = ?, trashedAt = COALESCE(trashedAt, ?), updatedAt = ?
-       WHERE id IN (${placeholders}) AND deletedAt IS NULL`,
-      now,
-      now,
-      now,
-      ...chunk,
-    )
-  }
+  const ph = fileIds.map(() => '?').join(',')
+  await db.runAsync(
+    `UPDATE files SET deletedAt = ?, trashedAt = COALESCE(trashedAt, ?), updatedAt = ?
+     WHERE id IN (${ph}) AND deletedAt IS NULL`,
+    now,
+    now,
+    now,
+    ...fileIds,
+  )
 }
 
 export async function deleteFileRecordsByThumbForId(
@@ -604,14 +587,11 @@ export async function deleteFileRecordsAndThumbnails(
   ids: string[],
 ): Promise<void> {
   if (ids.length === 0) return
-  const placeholders = ids.map(() => '?').join(',')
+  const ph = ids.map(() => '?').join(',')
   const rows = await db.getAllAsync<{
     name: string
     directoryId: string | null
-  }>(
-    `SELECT DISTINCT name, directoryId FROM files WHERE id IN (${placeholders}) AND kind = 'file'`,
-    ...ids,
-  )
+  }>(`SELECT DISTINCT name, directoryId FROM files WHERE id IN (${ph}) AND kind = 'file'`, ...ids)
   await db.withTransactionAsync(async () => {
     for (const id of ids) {
       await sql.del(db, 'files', { thumbForId: id })
@@ -779,7 +759,11 @@ export async function readFileRecordsByIds(
   ids: string[],
 ): Promise<FileRecord[]> {
   if (ids.length === 0) return []
-  const placeholders = ids.map(() => '?').join(',')
+
+  const byId: Map<string, FileRecordRow> = new Map()
+  const objectsById: Map<string, LocalObject[]> = new Map()
+
+  const ph = ids.map(() => '?').join(',')
   const joined = await db.getAllAsync<
     FileRecordRow &
       LocalObjectRow & {
@@ -795,12 +779,9 @@ export async function readFileRecordsByIds(
             o.metadataSignature as metadataSignature, o.createdAt as objectCreatedAt, o.updatedAt as objectUpdatedAt
      FROM files f
      LEFT JOIN objects o ON o.fileId = f.id
-     WHERE f.id IN (${placeholders})`,
+     WHERE f.id IN (${ph})`,
     ...ids,
   )
-
-  const byId: Map<string, FileRecordRow> = new Map()
-  const objectsById: Map<string, LocalObject[]> = new Map()
 
   for (const r of joined) {
     if (!byId.has(r.id)) {
@@ -857,12 +838,12 @@ export async function insertManyFileRecords(
   if (options?.skipCurrentRecalc) return
   const fileIds = records.filter((r) => r.kind === 'file').map((r) => r.id)
   if (fileIds.length > 0) {
-    const placeholders = fileIds.map(() => '?').join(',')
+    const ph = fileIds.map(() => '?').join(',')
     const groups = await db.getAllAsync<{
       name: string
       directoryId: string | null
     }>(
-      `SELECT DISTINCT name, directoryId FROM files WHERE id IN (${placeholders}) AND kind = 'file'`,
+      `SELECT DISTINCT name, directoryId FROM files WHERE id IN (${ph}) AND kind = 'file'`,
       ...fileIds,
     )
     await recalculateCurrentForGroups(db, groups)
@@ -918,12 +899,12 @@ export async function upsertManyFileRecords(
   if (options?.skipCurrentRecalc) return
   const fileIds = records.filter((r) => r.kind === 'file').map((r) => r.id)
   if (fileIds.length > 0) {
-    const placeholders = fileIds.map(() => '?').join(',')
+    const ph = fileIds.map(() => '?').join(',')
     const groups = await db.getAllAsync<{
       name: string
       directoryId: string | null
     }>(
-      `SELECT DISTINCT name, directoryId FROM files WHERE id IN (${placeholders}) AND kind = 'file'`,
+      `SELECT DISTINCT name, directoryId FROM files WHERE id IN (${ph}) AND kind = 'file'`,
       ...fileIds,
     )
     await recalculateCurrentForGroups(db, groups)
@@ -951,14 +932,11 @@ export async function deleteManyFileRecordsByIds(
   ids: string[],
 ): Promise<void> {
   if (ids.length === 0) return
-  const placeholders = ids.map(() => '?').join(',')
+  const ph = ids.map(() => '?').join(',')
   const groups = await db.getAllAsync<{
     name: string
     directoryId: string | null
-  }>(
-    `SELECT DISTINCT name, directoryId FROM files WHERE id IN (${placeholders}) AND kind = 'file'`,
-    ...ids,
-  )
+  }>(`SELECT DISTINCT name, directoryId FROM files WHERE id IN (${ph}) AND kind = 'file'`, ...ids)
   await db.withTransactionAsync(async () => {
     for (const id of ids) {
       await deleteFileRecordById(db, id)
@@ -1039,8 +1017,9 @@ export async function queryUploadedFileIds(
   return rows.map((r) => r.fileId)
 }
 
-export async function deleteLostFiles(db: DatabaseAdapter, indexerURL: string): Promise<string[]> {
-  const lost = await db.getAllAsync<{ id: string }>(
+export async function deleteLostFiles(db: DatabaseAdapter, indexerURL: string): Promise<number> {
+  return sql.processInBatches<{ id: string }>(
+    db,
     `SELECT f.id FROM files f
      WHERE f.trashedAt IS NULL AND f.deletedAt IS NULL
      AND (
@@ -1049,12 +1028,15 @@ export async function deleteLostFiles(db: DatabaseAdapter, indexerURL: string): 
         AND f.hash != '')
        OR f.lostReason IS NOT NULL
      )`,
-    indexerURL,
+    [indexerURL],
+    500,
+    async (rows) => {
+      await deleteFileRecordsAndThumbnails(
+        db,
+        rows.map((r) => r.id),
+      )
+    },
   )
-  if (lost.length === 0) return []
-  const ids = lost.map((f) => f.id)
-  await deleteFileRecordsAndThumbnails(db, ids)
-  return ids
 }
 
 export async function queryFileVersions(

--- a/packages/core/src/db/operations/fs.ts
+++ b/packages/core/src/db/operations/fs.ts
@@ -49,8 +49,8 @@ export async function deleteFsFileMetadataBatch(
   fileIds: string[],
 ): Promise<void> {
   if (fileIds.length === 0) return
-  const placeholders = fileIds.map(() => '?').join(',')
-  await db.runAsync(`DELETE FROM fs WHERE fileId IN (${placeholders})`, ...fileIds)
+  const ph = fileIds.map(() => '?').join(',')
+  await db.runAsync(`DELETE FROM fs WHERE fileId IN (${ph})`, ...fileIds)
 }
 
 export async function queryFsCacheEvictionCandidates(

--- a/packages/core/src/db/operations/localObjects.ts
+++ b/packages/core/src/db/operations/localObjects.ts
@@ -68,10 +68,10 @@ export async function queryLocalObjectsForFiles(
   fileIds: string[],
 ): Promise<Record<string, LocalObject[]>> {
   if (fileIds.length === 0) return {}
-  const placeholders = fileIds.map(() => '?').join(',')
+  const ph = fileIds.map(() => '?').join(',')
   const rows = await db.getAllAsync<LocalObjectRow>(
     `SELECT id, fileId, indexerURL, slabs, encryptedDataKey, encryptedMetadataKey, encryptedMetadata, dataSignature, metadataSignature, createdAt, updatedAt
-     FROM objects WHERE fileId IN (${placeholders})`,
+     FROM objects WHERE fileId IN (${ph})`,
     ...fileIds,
   )
   const map: Record<string, LocalObject[]> = {}
@@ -107,24 +107,18 @@ export async function insertManyLocalObjects(
   await sql.insertMany(db, 'objects', rows, { conflictClause: 'OR REPLACE' })
 }
 
-const MAX_SQL_VARS = 999
-
 export async function deleteManyLocalObjectsByObjectIds(
   db: DatabaseAdapter,
   objectIds: string[],
   indexerURL: string,
 ): Promise<void> {
   if (objectIds.length === 0) return
-  const chunkSize = MAX_SQL_VARS - 1
-  for (let i = 0; i < objectIds.length; i += chunkSize) {
-    const chunk = objectIds.slice(i, i + chunkSize)
-    const placeholders = chunk.map(() => '?').join(',')
-    await db.runAsync(
-      `DELETE FROM objects WHERE indexerURL = ? AND id IN (${placeholders})`,
-      indexerURL,
-      ...chunk,
-    )
-  }
+  const ph = objectIds.map(() => '?').join(',')
+  await db.runAsync(
+    `DELETE FROM objects WHERE indexerURL = ? AND id IN (${ph})`,
+    indexerURL,
+    ...objectIds,
+  )
 }
 
 export async function queryFilesWithNoObjects(
@@ -132,20 +126,13 @@ export async function queryFilesWithNoObjects(
   fileIds: string[],
 ): Promise<string[]> {
   if (fileIds.length === 0) return []
-  const result: string[] = []
-  for (let i = 0; i < fileIds.length; i += MAX_SQL_VARS) {
-    const chunk = fileIds.slice(i, i + MAX_SQL_VARS)
-    const placeholders = chunk.map(() => '?').join(',')
-    const rows = await db.getAllAsync<{ id: string }>(
-      `SELECT id FROM files WHERE id IN (${placeholders})
-       AND NOT EXISTS (SELECT 1 FROM objects WHERE fileId = files.id)`,
-      ...chunk,
-    )
-    for (const row of rows) {
-      result.push(row.id)
-    }
-  }
-  return result
+  const ph = fileIds.map(() => '?').join(',')
+  const rows = await db.getAllAsync<{ id: string }>(
+    `SELECT id FROM files WHERE id IN (${ph})
+     AND NOT EXISTS (SELECT 1 FROM objects WHERE fileId = files.id)`,
+    ...fileIds,
+  )
+  return rows.map((row) => row.id)
 }
 
 export async function deleteManyLocalObjectsByFileIds(

--- a/packages/core/src/db/operations/tags.ts
+++ b/packages/core/src/db/operations/tags.ts
@@ -162,9 +162,9 @@ export async function syncManyTagsFromMetadata(
   }
 
   const fileIds = entries.map((e) => e.fileId)
-  const placeholders = fileIds.map(() => '?').join(',')
+  const ph = fileIds.map(() => '?').join(',')
   await db.runAsync(
-    `DELETE FROM file_tags WHERE fileId IN (${placeholders}) AND tagId NOT IN (
+    `DELETE FROM file_tags WHERE fileId IN (${ph}) AND tagId NOT IN (
       SELECT id FROM tags WHERE system = 1
     )`,
     ...fileIds,
@@ -315,12 +315,8 @@ export async function addTagToFiles(
       await sql.insert(db, 'file_tags', { fileId, tagId: tag.id }, { conflictClause: 'OR IGNORE' })
     }
     const now = Date.now()
-    const placeholders = fileIds.map(() => '?').join(',')
-    await db.runAsync(
-      `UPDATE files SET updatedAt = ? WHERE id IN (${placeholders})`,
-      now,
-      ...fileIds,
-    )
+    const ph = fileIds.map(() => '?').join(',')
+    await db.runAsync(`UPDATE files SET updatedAt = ? WHERE id IN (${ph})`, now, ...fileIds)
   })
 }
 
@@ -342,17 +338,13 @@ export async function removeTagFromFiles(
 ): Promise<void> {
   if (fileIds.length === 0) return
   await db.withTransactionAsync(async () => {
-    const placeholders = fileIds.map(() => '?').join(',')
+    const now = Date.now()
+    const ph = fileIds.map(() => '?').join(',')
     await db.runAsync(
-      `DELETE FROM file_tags WHERE tagId = ? AND fileId IN (${placeholders})`,
+      `DELETE FROM file_tags WHERE tagId = ? AND fileId IN (${ph})`,
       tagId,
       ...fileIds,
     )
-    const now = Date.now()
-    await db.runAsync(
-      `UPDATE files SET updatedAt = ? WHERE id IN (${placeholders})`,
-      now,
-      ...fileIds,
-    )
+    await db.runAsync(`UPDATE files SET updatedAt = ? WHERE id IN (${ph})`, now, ...fileIds)
   })
 }

--- a/packages/core/src/db/operations/thumbnails.ts
+++ b/packages/core/src/db/operations/thumbnails.ts
@@ -80,11 +80,12 @@ export async function queryThumbnailFileInfoByFileIds(
   fileIds: string[],
 ): Promise<{ id: string; type: string; localId: string | null }[]> {
   if (fileIds.length === 0) return []
-  const placeholders = fileIds.map(() => '?').join(',')
-  return db.getAllAsync<{ id: string; type: string; localId: string | null }>(
-    `SELECT id, type, localId FROM files WHERE thumbForId IN (${placeholders})`,
-    ...fileIds,
-  )
+  const ph = fileIds.map(() => '?').join(',')
+  return db.getAllAsync<{
+    id: string
+    type: string
+    localId: string | null
+  }>(`SELECT id, type, localId FROM files WHERE thumbForId IN (${ph})`, ...fileIds)
 }
 
 export async function queryThumbnailRecordByFileIdAndSize(

--- a/packages/core/src/db/operations/trash.test.ts
+++ b/packages/core/src/db/operations/trash.test.ts
@@ -145,9 +145,9 @@ describe('autoPurgeOldTrashedFiles', () => {
     const oldTrashedAt = 1
     await insertFileRecord(db(), makeFileRecord('f1', { trashedAt: oldTrashedAt }))
 
-    const purgedIds = await autoPurgeOldTrashedFiles(db())
+    const purgedCount = await autoPurgeOldTrashedFiles(db())
 
-    expect(purgedIds).toContain('f1')
+    expect(purgedCount).toBe(1)
     const f1 = await getFile('f1')
     expect(f1!.deletedAt).not.toBeNull()
   })
@@ -155,17 +155,17 @@ describe('autoPurgeOldTrashedFiles', () => {
   it('does not purge recently trashed files', async () => {
     await insertFileRecord(db(), makeFileRecord('f1', { trashedAt: Date.now() }))
 
-    const purgedIds = await autoPurgeOldTrashedFiles(db())
+    const purgedCount = await autoPurgeOldTrashedFiles(db())
 
-    expect(purgedIds).toEqual([])
+    expect(purgedCount).toBe(0)
   })
 
   it('does not purge already-deleted files', async () => {
     await insertFileRecord(db(), makeFileRecord('f1', { trashedAt: 1, deletedAt: 2 }))
 
-    const purgedIds = await autoPurgeOldTrashedFiles(db())
+    const purgedCount = await autoPurgeOldTrashedFiles(db())
 
-    expect(purgedIds).toEqual([])
+    expect(purgedCount).toBe(0)
   })
 
   it('only purges kind=file, not thumbnails', async () => {
@@ -179,8 +179,8 @@ describe('autoPurgeOldTrashedFiles', () => {
       }),
     )
 
-    const purgedIds = await autoPurgeOldTrashedFiles(db())
+    const purgedCount = await autoPurgeOldTrashedFiles(db())
 
-    expect(purgedIds).toEqual([])
+    expect(purgedCount).toBe(0)
   })
 })

--- a/packages/core/src/db/operations/trash.ts
+++ b/packages/core/src/db/operations/trash.ts
@@ -1,14 +1,15 @@
 import type { DatabaseAdapter } from '../../adapters/db'
 import { TRASH_AUTO_PURGE_AGE } from '../../config'
+import { processInBatches } from '../sql'
 import { recalculateCurrentForGroups } from './files'
 
 async function getGroupsForFileIds(
   db: DatabaseAdapter,
   fileIds: string[],
 ): Promise<{ name: string; directoryId: string | null }[]> {
-  const placeholders = fileIds.map(() => '?').join(',')
+  const ph = fileIds.map(() => '?').join(',')
   return db.getAllAsync<{ name: string; directoryId: string | null }>(
-    `SELECT DISTINCT name, directoryId FROM files WHERE id IN (${placeholders}) AND kind = 'file'`,
+    `SELECT DISTINCT name, directoryId FROM files WHERE id IN (${ph}) AND kind = 'file'`,
     ...fileIds,
   )
 }
@@ -17,16 +18,16 @@ export async function trashFiles(db: DatabaseAdapter, fileIds: string[]): Promis
   if (fileIds.length === 0) return
   const groups = await getGroupsForFileIds(db, fileIds)
   const now = Date.now()
-  const placeholders = fileIds.map(() => '?').join(',')
+  const ph = fileIds.map(() => '?').join(',')
   await db.withTransactionAsync(async () => {
     await db.runAsync(
-      `UPDATE files SET trashedAt = ?, updatedAt = ? WHERE id IN (${placeholders})`,
+      `UPDATE files SET trashedAt = ?, updatedAt = ? WHERE id IN (${ph})`,
       now,
       now,
       ...fileIds,
     )
     await db.runAsync(
-      `UPDATE files SET trashedAt = ?, updatedAt = ? WHERE thumbForId IN (${placeholders})`,
+      `UPDATE files SET trashedAt = ?, updatedAt = ? WHERE thumbForId IN (${ph})`,
       now,
       now,
       ...fileIds,
@@ -39,15 +40,15 @@ export async function restoreFiles(db: DatabaseAdapter, fileIds: string[]): Prom
   if (fileIds.length === 0) return
   const groups = await getGroupsForFileIds(db, fileIds)
   const now = Date.now()
-  const placeholders = fileIds.map(() => '?').join(',')
+  const ph = fileIds.map(() => '?').join(',')
   await db.withTransactionAsync(async () => {
     await db.runAsync(
-      `UPDATE files SET trashedAt = NULL, updatedAt = ? WHERE id IN (${placeholders})`,
+      `UPDATE files SET trashedAt = NULL, updatedAt = ? WHERE id IN (${ph})`,
       now,
       ...fileIds,
     )
     await db.runAsync(
-      `UPDATE files SET trashedAt = NULL, updatedAt = ? WHERE thumbForId IN (${placeholders})`,
+      `UPDATE files SET trashedAt = NULL, updatedAt = ? WHERE thumbForId IN (${ph})`,
       now,
       ...fileIds,
     )
@@ -62,17 +63,17 @@ export async function permanentlyDeleteFiles(
   if (fileIds.length === 0) return
   const groups = await getGroupsForFileIds(db, fileIds)
   const now = Date.now()
-  const placeholders = fileIds.map(() => '?').join(',')
+  const ph = fileIds.map(() => '?').join(',')
   await db.withTransactionAsync(async () => {
     await db.runAsync(
-      `UPDATE files SET deletedAt = ?, trashedAt = COALESCE(trashedAt, ?), updatedAt = ? WHERE id IN (${placeholders})`,
+      `UPDATE files SET deletedAt = ?, trashedAt = COALESCE(trashedAt, ?), updatedAt = ? WHERE id IN (${ph})`,
       now,
       now,
       now,
       ...fileIds,
     )
     await db.runAsync(
-      `UPDATE files SET deletedAt = ?, trashedAt = COALESCE(trashedAt, ?), updatedAt = ? WHERE thumbForId IN (${placeholders})`,
+      `UPDATE files SET deletedAt = ?, trashedAt = COALESCE(trashedAt, ?), updatedAt = ? WHERE thumbForId IN (${ph})`,
       now,
       now,
       now,
@@ -82,14 +83,20 @@ export async function permanentlyDeleteFiles(
   await recalculateCurrentForGroups(db, groups)
 }
 
-export async function autoPurgeOldTrashedFiles(db: DatabaseAdapter): Promise<string[]> {
+export async function autoPurgeOldTrashedFiles(
+  db: DatabaseAdapter,
+  onBatch?: (purgedIds: string[]) => Promise<void>,
+): Promise<number> {
   const cutoff = Date.now() - TRASH_AUTO_PURGE_AGE
-  const rows = await db.getAllAsync<{ id: string }>(
+  return processInBatches<{ id: string }>(
+    db,
     `SELECT id FROM files WHERE trashedAt IS NOT NULL AND trashedAt < ? AND deletedAt IS NULL AND kind = 'file'`,
-    cutoff,
+    [cutoff],
+    500,
+    async (rows) => {
+      const ids = rows.map((r) => r.id)
+      await permanentlyDeleteFiles(db, ids)
+      if (onBatch) await onBatch(ids)
+    },
   )
-  if (rows.length === 0) return []
-  const ids = rows.map((r) => r.id)
-  await permanentlyDeleteFiles(db, ids)
-  return ids
 }

--- a/packages/core/src/db/sql.test.ts
+++ b/packages/core/src/db/sql.test.ts
@@ -1,0 +1,81 @@
+import type { DatabaseAdapter } from '../adapters/db'
+import { processInBatches } from './sql'
+
+function mockDb(batches: Record<string, unknown>[][]): DatabaseAdapter {
+  let callCount = 0
+  return {
+    getAllAsync: async () => {
+      const result = batches[callCount] ?? []
+      callCount++
+      return result as never[]
+    },
+    getFirstAsync: async () => null,
+    runAsync: async () => ({ changes: 0, lastInsertRowId: 0 }),
+    execAsync: async () => {},
+    withTransactionAsync: async (fn) => fn(),
+  }
+}
+
+describe('processInBatches', () => {
+  it('returns 0 for empty result set', async () => {
+    const db = mockDb([[]])
+    const total = await processInBatches(
+      db,
+      'SELECT id FROM t WHERE x = ?',
+      [1],
+      500,
+      async () => {},
+    )
+    expect(total).toBe(0)
+  })
+
+  it('processes a single batch', async () => {
+    const rows = [{ id: 'a' }, { id: 'b' }]
+    const db = mockDb([rows, []])
+    const processed: string[][] = []
+    const total = await processInBatches<{ id: string }>(
+      db,
+      'SELECT id FROM t WHERE done = 0',
+      [],
+      500,
+      async (batch) => {
+        processed.push(batch.map((r) => r.id))
+      },
+    )
+    expect(total).toBe(2)
+    expect(processed).toEqual([['a', 'b']])
+  })
+
+  it('processes multiple batches until empty', async () => {
+    const db = mockDb([[{ id: '1' }, { id: '2' }], [{ id: '3' }], []])
+    const processed: string[][] = []
+    const total = await processInBatches<{ id: string }>(
+      db,
+      'SELECT id FROM t WHERE done = 0',
+      [],
+      2,
+      async (batch) => {
+        processed.push(batch.map((r) => r.id))
+      },
+    )
+    expect(total).toBe(3)
+    expect(processed).toEqual([['1', '2'], ['3']])
+  })
+
+  it('passes params and batchSize to query', async () => {
+    const calls: { sql: string; params: unknown[] }[] = []
+    const db: DatabaseAdapter = {
+      getAllAsync: async (sql, ...params) => {
+        calls.push({ sql, params })
+        return []
+      },
+      getFirstAsync: async () => null,
+      runAsync: async () => ({ changes: 0, lastInsertRowId: 0 }),
+      execAsync: async () => {},
+      withTransactionAsync: async (fn) => fn(),
+    }
+    await processInBatches(db, 'SELECT id FROM t WHERE x = ?', [42], 100, async () => {})
+    expect(calls[0].sql).toBe('SELECT id FROM t WHERE x = ? LIMIT ?')
+    expect(calls[0].params).toEqual([42, 100])
+  })
+})

--- a/packages/core/src/db/sql.ts
+++ b/packages/core/src/db/sql.ts
@@ -40,11 +40,30 @@ export async function insert<
   return await run(db, sql, params)
 }
 
-// SQLite limits the number of ? placeholders per statement
-// (SQLITE_MAX_VARIABLE_NUMBER, default 999). Each row contributes one
-// placeholder per non-null column, so the chunk size is computed from the
-// column count to stay safely under the limit.
-const MAX_VARIABLES = 999
+// SQLITE_MAX_VARIABLE_NUMBER: 32766 (pre-3.32.0 was 999).
+const MAX_VARIABLES = 32766
+
+// Repeatedly executes a SELECT with LIMIT, processes each batch, then
+// re-queries. fn must cause processed rows to no longer match query
+// (e.g. by deleting, trashing, or updating them so the WHERE no longer hits).
+export async function processInBatches<T>(
+  db: DatabaseAdapter,
+  query: string,
+  params: SqlValue[],
+  batchSize: number,
+  fn: (batch: T[]) => Promise<void>,
+): Promise<number> {
+  const limitedQuery = `${query} LIMIT ?`
+  const normalized = params.map((v) => normalizeSqlValue(v))
+  let total = 0
+  while (true) {
+    const rows = await db.getAllAsync<T>(limitedQuery, ...normalized, batchSize)
+    if (rows.length === 0) break
+    await fn(rows)
+    total += rows.length
+  }
+  return total
+}
 
 export async function insertMany<
   T extends Record<string, string | number | boolean | null | undefined>,


### PR DESCRIPTION
- Add processInBatches utility for operation-level batching of unbounded queries
- Convert autoPurge, deleteLostFiles, deleteDirectoryAndTrashFiles to batch at 500
- insertMany/upsertMany use the modern SQLite bind variable limit of 32766 (3.32.0+)
