### PR TITLE
fix(mobile): add database suspension lifecycle to prevent iOS 0xdead10cc kills

### DIFF
--- a/.changeset/fix-background-db-suspension.md
+++ b/.changeset/fix-background-db-suspension.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Fixed background crashes (iOS 0xdead10cc) caused by SQLite file locks held during app suspension. The database now gates queries, drains in-flight operations, and checkpoints the WAL before closing.

--- a/apps/mobile/src/db/index.ts
+++ b/apps/mobile/src/db/index.ts
@@ -7,6 +7,77 @@ import * as SQLite from 'expo-sqlite'
 import { getSharedDbDirectory } from '../lib/sharedContainer'
 import { migrations } from './migrations'
 
+// Thrown by the adapter when a query is attempted while the database is
+// suspending or closed. SWR hooks and other callers see this instead of
+// "Access to closed resource", and withRecovery knows not to reopen.
+export class DatabaseSuspendedError extends Error {
+  constructor() {
+    super('Database is suspended for background transition')
+    this.name = 'DatabaseSuspendedError'
+  }
+}
+
+// Suspension lifecycle state (separate from dbInitialized).
+// - 'active':     queries flow normally through the adapter.
+// - 'suspending': new queries are rejected instantly; in-flight queries drain.
+// - 'closed':     database handle is closed, WAL lock released.
+//
+// This prevents iOS 0xdead10cc kills by ensuring no SQLite operations are
+// dispatched to expo-sqlite's native GCD queue during background suspension.
+// Without this gate, SWR hooks and other callers keep dispatching queries
+// that race with closeAsync() on the same concurrent native queue.
+type DbState = 'active' | 'suspending' | 'closed'
+
+let state: DbState = 'active'
+
+// Tracks how many queries are currently dispatched to native but haven't
+// resolved yet. The suspension manager waits for this to hit 0 before
+// closing the database, ensuring no in-progress queries hold the WAL lock.
+let inflightCount = 0
+let idleResolvers: Array<() => void> = []
+
+function trackStart(): void {
+  inflightCount++
+}
+
+function trackEnd(): void {
+  inflightCount--
+  if (inflightCount === 0) {
+    const resolvers = idleResolvers
+    idleResolvers = []
+    for (const r of resolvers) r()
+  }
+}
+
+export function getDbState(): DbState {
+  return state
+}
+
+// Called by the suspension manager as the first step when the app backgrounds.
+// After this, any new query through db() rejects immediately.
+export function suspendDb(): void {
+  state = 'suspending'
+  logger.debug('db', 'suspended')
+}
+
+// Called by the suspension manager after initializeDB({ reopen: true })
+// succeeds, so queries flow to a valid connection.
+export function resumeDb(): void {
+  state = 'active'
+  inflightCount = 0
+  idleResolvers = []
+  logger.debug('db', 'resumed')
+}
+
+// Resolves when all in-flight queries have completed. Used by the suspension
+// manager to wait for the native GCD queue to drain before closing.
+export function waitForQueriesIdle(): Promise<void> {
+  if (inflightCount === 0) return Promise.resolve()
+  return new Promise<void>((r) => {
+    idleResolvers.push(r)
+  })
+}
+
 export let database: SQLite.SQLiteDatabase
 export let dbInitialized = false
 let dbName = 'app.db'
@@ -20,6 +91,15 @@ export async function initializeDB(options?: {
 }): Promise<void> {
   const name = options?.databaseName ?? dbName
   dbName = name
+  // Close any existing connection before opening a new one. Without this,
+  // a suspend → resume (reopen=true) → full reinit (reopen=false) sequence
+  // leaks the intermediate connection, and expo-sqlite refuses to delete
+  // the database file while any connection is open.
+  if (database) {
+    try {
+      await database.closeAsync()
+    } catch {}
+  }
   const openOptions = options?.reopen ? { useNewConnection: true } : undefined
   logger.info('db', 'initializing', {
     name,
@@ -99,6 +179,11 @@ export async function withRecovery<T>(fn: () => Promise<T>): Promise<T> {
   try {
     return await fn()
   } catch (error) {
+    // During suspension or close, never attempt to reopen — the close is
+    // intentional and reopening would fight the suspension manager.
+    if (error instanceof DatabaseSuspendedError || state !== 'active') {
+      throw error
+    }
     if (isNativeHandleError(error)) {
       // If the DB was already reopened by the suspension manager,
       // just retry against the current connection.
@@ -110,15 +195,28 @@ export async function withRecovery<T>(fn: () => Promise<T>): Promise<T> {
   }
 }
 
-/** Close the database connection (for test cleanup). */
 export async function closeDb(): Promise<void> {
   if (database && dbInitialized) {
+    // Set these BEFORE any async work so that withRecovery — which may be
+    // triggered by racing queries — sees the closed state and doesn't reopen.
+    dbInitialized = false
+    state = 'closed'
+    try {
+      // Zero the busy timeout so any straggler query blocked on the SQLite
+      // mutex fails immediately instead of waiting up to 5 seconds.
+      await database.execAsync('PRAGMA busy_timeout = 0')
+      // Flush WAL pages to the main database file and truncate the WAL.
+      // This releases the WAL file lock — the actual cause of 0xdead10cc —
+      // even if closeAsync() subsequently fails.
+      await database.execAsync('PRAGMA wal_checkpoint(TRUNCATE)')
+    } catch (e) {
+      logger.debug('db', 'pre_close_pragma_error', { error: e as Error })
+    }
     try {
       await database.closeAsync()
     } catch (e) {
       logger.debug('db', 'close_error', { error: e as Error })
     }
-    dbInitialized = false
   }
 }
 
@@ -126,8 +224,14 @@ const txMutex = new Mutex()
 
 // Delete the database and start fresh. Closes the existing connection,
 // removes the DB file, and reopens so migrations can run on next init.
+// Also resets the suspension state machine — resetDb is only called from
+// the foreground (settings reset button / forced reset on boot), so the
+// suspension state should always be active afterward.
 export async function resetDb() {
   dbInitialized = false
+  state = 'active'
+  inflightCount = 0
+  idleResolvers = []
   const release = await txMutex.acquire()
   try {
     if (database) {
@@ -164,6 +268,13 @@ export async function resetDb() {
 // so connection swaps from initializeDB/resetDb/reopenDb are transparent.
 class MobileDbAdapter implements DatabaseAdapter {
   private query<T>(method: string, args: unknown[]): Promise<T> {
+    // Gate: reject queries while suspending or closed. This is the key
+    // mechanism that prevents SWR hooks from dispatching work to the
+    // native GCD queue during background suspension.
+    if (state !== 'active') return Promise.reject(new DatabaseSuspendedError())
+    // Track in-flight count so the suspension manager can wait for all
+    // dispatched queries to drain before closing the database.
+    trackStart()
     return withRecovery(async () => {
       const start = performance.now()
       const result = await (database as any)[method](...args)
@@ -177,7 +288,7 @@ class MobileDbAdapter implements DatabaseAdapter {
         })
       }
       return result
-    })
+    }).finally(trackEnd)
   }
 
   getAllAsync<T>(sql: string, ...params: SQLParam[]): Promise<T[]> {
@@ -197,7 +308,11 @@ class MobileDbAdapter implements DatabaseAdapter {
   }
 
   withTransactionAsync(fn: () => Promise<void>): Promise<void> {
-    return txMutex.runExclusive(() => withRecovery(() => database.withTransactionAsync(fn)))
+    if (state !== 'active') return Promise.reject(new DatabaseSuspendedError())
+    trackStart()
+    return txMutex
+      .runExclusive(() => withRecovery(() => database.withTransactionAsync(fn)))
+      .finally(trackEnd)
   }
 }
 

--- a/apps/mobile/src/db/suspension.test.ts
+++ b/apps/mobile/src/db/suspension.test.ts
@@ -1,0 +1,325 @@
+import {
+  closeDb,
+  DatabaseSuspendedError,
+  database,
+  db,
+  dbInitialized,
+  getDbState,
+  initializeDB,
+  resetDb,
+  resumeDb,
+  suspendDb,
+  waitForQueriesIdle,
+  withRecovery,
+} from '.'
+
+const NPE_MESSAGE = 'Call to function has been rejected. java.lang.NullPointerException'
+
+beforeEach(async () => {
+  await initializeDB({ databaseName: ':memory:' })
+})
+
+afterEach(async () => {
+  await resetDb()
+})
+
+describe('state transitions', () => {
+  it('starts in active state', () => {
+    expect(getDbState()).toBe('active')
+  })
+
+  it('suspendDb transitions to suspending', () => {
+    suspendDb()
+    expect(getDbState()).toBe('suspending')
+  })
+
+  it('resumeDb transitions back to active', () => {
+    suspendDb()
+    resumeDb()
+    expect(getDbState()).toBe('active')
+  })
+
+  it('closeDb transitions to closed', async () => {
+    await closeDb()
+    expect(getDbState()).toBe('closed')
+  })
+
+  it('full cycle: active → suspending → closed → active', async () => {
+    expect(getDbState()).toBe('active')
+    suspendDb()
+    expect(getDbState()).toBe('suspending')
+    await closeDb()
+    expect(getDbState()).toBe('closed')
+    await initializeDB({ databaseName: ':memory:', reopen: true })
+    resumeDb()
+    expect(getDbState()).toBe('active')
+  })
+})
+
+describe('query gating', () => {
+  it('getAllAsync rejects when suspended', async () => {
+    suspendDb()
+    await expect(db().getAllAsync('SELECT 1')).rejects.toThrow(DatabaseSuspendedError)
+  })
+
+  it('getFirstAsync rejects when suspended', async () => {
+    suspendDb()
+    await expect(db().getFirstAsync('SELECT 1')).rejects.toThrow(DatabaseSuspendedError)
+  })
+
+  it('runAsync rejects when suspended', async () => {
+    suspendDb()
+    await expect(db().runAsync('CREATE TABLE IF NOT EXISTS test (id TEXT)')).rejects.toThrow(
+      DatabaseSuspendedError,
+    )
+  })
+
+  it('execAsync rejects when suspended', async () => {
+    suspendDb()
+    await expect(db().execAsync('SELECT 1')).rejects.toThrow(DatabaseSuspendedError)
+  })
+
+  it('withTransactionAsync rejects when suspended', async () => {
+    suspendDb()
+    await expect(db().withTransactionAsync(async () => {})).rejects.toThrow(DatabaseSuspendedError)
+  })
+
+  it('queries work normally after resumeDb', async () => {
+    suspendDb()
+    await expect(db().getAllAsync('SELECT 1 as v')).rejects.toThrow(DatabaseSuspendedError)
+    resumeDb()
+    const rows = await db().getAllAsync<{ v: number }>('SELECT 1 as v')
+    expect(rows).toEqual([{ v: 1 }])
+  })
+
+  it('queries also reject in closed state', async () => {
+    await closeDb()
+    await expect(db().getAllAsync('SELECT 1')).rejects.toThrow(DatabaseSuspendedError)
+  })
+})
+
+describe('withRecovery during suspension', () => {
+  it('does not attempt recovery for DatabaseSuspendedError', async () => {
+    const fn = jest.fn().mockRejectedValue(new DatabaseSuspendedError())
+    await expect(withRecovery(fn)).rejects.toThrow(DatabaseSuspendedError)
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not reopen when state is suspending', async () => {
+    suspendDb()
+    const fn = jest.fn().mockRejectedValue(new Error(NPE_MESSAGE))
+    await expect(withRecovery(fn)).rejects.toThrow(NPE_MESSAGE)
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not reopen when state is closed', async () => {
+    await closeDb()
+    const fn = jest.fn().mockRejectedValue(new Error(NPE_MESSAGE))
+    await expect(withRecovery(fn)).rejects.toThrow(NPE_MESSAGE)
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('still recovers from NPE in active state', async () => {
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(new Error(NPE_MESSAGE))
+      .mockResolvedValueOnce('recovered')
+    const result = await withRecovery(fn)
+    expect(result).toBe('recovered')
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('in-flight tracking', () => {
+  it('waitForQueriesIdle resolves immediately with no in-flight queries', async () => {
+    await waitForQueriesIdle()
+  })
+
+  it('waitForQueriesIdle waits for an in-flight query to complete', async () => {
+    let resolveQuery!: () => void
+    const blockingPromise = new Promise<void>((r) => {
+      resolveQuery = r
+    })
+    jest.spyOn(database, 'getAllAsync').mockImplementationOnce(() => blockingPromise as any)
+
+    const queryPromise = db().getAllAsync('SELECT 1')
+
+    let idleDone = false
+    const idlePromise = waitForQueriesIdle().then(() => {
+      idleDone = true
+    })
+
+    await Promise.resolve()
+    expect(idleDone).toBe(false)
+
+    resolveQuery()
+    await queryPromise
+    await idlePromise
+    expect(idleDone).toBe(true)
+  })
+
+  it('waitForQueriesIdle waits for multiple in-flight queries', async () => {
+    let resolveFirst!: () => void
+    let resolveSecond!: () => void
+    jest
+      .spyOn(database, 'getAllAsync')
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((r) => {
+            resolveFirst = r
+          }) as any,
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((r) => {
+            resolveSecond = r
+          }) as any,
+      )
+
+    const q1 = db().getAllAsync('SELECT 1')
+    const q2 = db().getAllAsync('SELECT 2')
+
+    let idleDone = false
+    const idlePromise = waitForQueriesIdle().then(() => {
+      idleDone = true
+    })
+
+    resolveFirst()
+    await q1
+    await Promise.resolve()
+    expect(idleDone).toBe(false)
+
+    resolveSecond()
+    await q2
+    await idlePromise
+    expect(idleDone).toBe(true)
+  })
+
+  it('counter resets to 0 on resumeDb', async () => {
+    let resolveQuery!: () => void
+    jest.spyOn(database, 'getAllAsync').mockImplementationOnce(
+      () =>
+        new Promise<void>((r) => {
+          resolveQuery = r
+        }) as any,
+    )
+
+    db().getAllAsync('SELECT 1')
+    resumeDb()
+    await waitForQueriesIdle()
+    resolveQuery()
+  })
+})
+
+describe('closeDb', () => {
+  it('sets dbInitialized to false before closing', async () => {
+    expect(dbInitialized).toBe(true)
+    const closeSpy = jest.spyOn(database, 'closeAsync')
+    let initDuringClose: boolean | undefined
+    closeSpy.mockImplementationOnce(async () => {
+      initDuringClose = dbInitialized
+    })
+    await closeDb()
+    expect(initDuringClose).toBe(false)
+  })
+
+  it('runs WAL checkpoint before close', async () => {
+    const execSpy = jest.spyOn(database, 'execAsync')
+    await closeDb()
+    const calls = execSpy.mock.calls.map((c) => c[0])
+    expect(calls).toContain('PRAGMA busy_timeout = 0')
+    expect(calls).toContain('PRAGMA wal_checkpoint(TRUNCATE)')
+  })
+
+  it('succeeds even if checkpoint fails', async () => {
+    const execSpy = jest.spyOn(database, 'execAsync')
+    execSpy.mockRejectedValue(new Error('checkpoint failed'))
+    await closeDb()
+    expect(getDbState()).toBe('closed')
+  })
+
+  it('succeeds even if closeAsync throws', async () => {
+    jest.spyOn(database, 'closeAsync').mockRejectedValueOnce(new Error('SQLITE_BUSY'))
+    await closeDb()
+    expect(dbInitialized).toBe(false)
+    expect(getDbState()).toBe('closed')
+  })
+})
+
+describe('full suspend/resume cycle', () => {
+  it('queries work → suspend → rejected → close → reopen → resume → queries work', async () => {
+    const rows1 = await db().getAllAsync<{ v: number }>('SELECT 1 as v')
+    expect(rows1).toEqual([{ v: 1 }])
+
+    suspendDb()
+    await expect(db().getAllAsync('SELECT 1')).rejects.toThrow(DatabaseSuspendedError)
+
+    await closeDb()
+    expect(dbInitialized).toBe(false)
+
+    await initializeDB({ databaseName: ':memory:', reopen: true })
+    resumeDb()
+
+    const rows2 = await db().getAllAsync<{ v: number }>('SELECT 2 as v')
+    expect(rows2).toEqual([{ v: 2 }])
+  })
+
+  it('in-flight query at suspend time completes, then drain resolves', async () => {
+    let resolveQuery!: () => void
+    jest.spyOn(database, 'getAllAsync').mockImplementationOnce(
+      () =>
+        new Promise<void>((r) => {
+          resolveQuery = r
+        }) as any,
+    )
+
+    const queryPromise = db().getAllAsync('SELECT 1')
+
+    suspendDb()
+    await expect(db().getAllAsync('SELECT 2')).rejects.toThrow(DatabaseSuspendedError)
+
+    let drained = false
+    waitForQueriesIdle().then(() => {
+      drained = true
+    })
+    await Promise.resolve()
+    expect(drained).toBe(false)
+
+    resolveQuery()
+    await queryPromise
+    await Promise.resolve()
+    expect(drained).toBe(true)
+  })
+
+  it('resetDb works after suspend → resume → reinit sequence', async () => {
+    // Simulate: boot → suspend → resume (reopen) → full reinit → reset.
+    // This is the exact sequence that happens when the app suspends during
+    // initial auth, resumes, then the full init completes. Without closing
+    // the previous connection in initializeDB, the intermediate reopen
+    // connection leaks and deleteDatabaseAsync fails.
+    suspendDb()
+    await closeDb()
+
+    await initializeDB({ databaseName: ':memory:', reopen: true })
+    resumeDb()
+
+    // Full reinit (as if the app's init flow completed after resume).
+    await initializeDB({ databaseName: ':memory:' })
+
+    // Reset should not throw.
+    await resetDb()
+    expect(dbInitialized).toBe(true)
+    expect(getDbState()).toBe('active')
+  })
+
+  it('rapid suspend/resume does not corrupt state', async () => {
+    suspendDb()
+    resumeDb()
+    suspendDb()
+    resumeDb()
+    expect(getDbState()).toBe('active')
+
+    const rows = await db().getAllAsync<{ v: number }>('SELECT 1 as v')
+    expect(rows).toEqual([{ v: 1 }])
+  })
+})

--- a/apps/mobile/src/managers/suspension.ts
+++ b/apps/mobile/src/managers/suspension.ts
@@ -8,7 +8,14 @@ import {
 import { logger, stopLogAppender } from '@siastorage/logger'
 import { AppState, type AppStateStatus } from 'react-native'
 import BackgroundTimer from 'react-native-background-timer'
-import { closeDb, dbInitialized, initializeDB } from '../db'
+import {
+  closeDb,
+  dbInitialized,
+  initializeDB,
+  resumeDb,
+  suspendDb,
+  waitForQueriesIdle,
+} from '../db'
 import { resumeLogger } from '../stores/logs'
 import { getIsBackgroundTaskRunning } from './backgroundTasks'
 import { getUploadManager } from './uploader'
@@ -76,6 +83,14 @@ async function doSuspend(): Promise<void> {
   await BackgroundTimer.start(0)
 
   try {
+    // Phase 0: Flush logs while the DB adapter is still open, then gate
+    // all new queries. After suspendDb(), any query from SWR hooks or
+    // other callers throws DatabaseSuspendedError instantly without
+    // reaching the native GCD queue.
+    await stopLogAppender()
+    suspendDb()
+    logger.debug('suspension', 'db_gated')
+
     // Phase 1: Signal all services to stop.
     // pause prevents new ticks, abort signals in-flight workers to exit
     // at their next signal.aborted check.
@@ -84,10 +99,11 @@ async function doSuspend(): Promise<void> {
     await getUploadManager()?.suspend()
     logger.debug('suspension', 'services_paused')
 
-    // Phase 2: Wait for in-flight work to finish, with a hard deadline.
+    // Phase 2: Wait for in-flight work AND in-flight DB queries to
+    // finish, with a hard deadline.
     const drainStart = Date.now()
     const drained = await Promise.race([
-      waitForAllServiceIntervalsIdle().then(() => true),
+      Promise.all([waitForAllServiceIntervalsIdle(), waitForQueriesIdle()]).then(() => true),
       new Promise<false>((r) => setTimeout(() => r(false), HARD_DEADLINE_MS)),
     ])
 
@@ -101,12 +117,13 @@ async function doSuspend(): Promise<void> {
       })
     }
 
-    // Phase 3: Close DB to release WAL file lock.
-    await stopLogAppender()
+    // Phase 3: Checkpoint WAL to release file locks, then close.
     await closeDb()
     state = 'suspended'
   } catch (e) {
     logger.error('suspension', 'suspend_error', { error: e as Error })
+    // Lift the query gate so the app remains usable if it comes back.
+    resumeDb()
     state = 'active'
   } finally {
     BackgroundTimer.stop()
@@ -130,6 +147,9 @@ async function doResume(): Promise<void> {
     return
   }
 
+  // Lift the query gate AFTER the new connection is ready, so queries
+  // flow to a valid database handle.
+  resumeDb()
   resumeLogger()
   logger.debug('suspension', 'db_reopened')
 


### PR DESCRIPTION
Fix iOS 0xdead10cc kills by draining in-flight SWR queries before releasing the database lock. The existing suspension lifecycle closed the DB but didn't account for queries already dispatched by React hooks.

