### PR TITLE
fix(mobile): skip forced reset on fresh installs

### DIFF
--- a/.changeset/fix-fresh-install-reset.md
+++ b/.changeset/fix-fresh-install-reset.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Fixed an issue where fresh installs would loop back to the welcome screen after completing onboarding.

--- a/apps/mobile/src/managers/app.ts
+++ b/apps/mobile/src/managers/app.ts
@@ -36,9 +36,12 @@ export async function initApp(): Promise<void> {
   if (FORCED_RESET_VERSION) {
     const completed = await app().settings.getCompletedResetVersion()
     const hasOnboarded = await app().settings.getHasOnboarded()
-    if (completed !== FORCED_RESET_VERSION && hasOnboarded) {
-      await resetApp()
-      return
+    if (completed !== FORCED_RESET_VERSION) {
+      if (hasOnboarded) {
+        await resetApp()
+        return
+      }
+      await app().settings.setCompletedResetVersion(FORCED_RESET_VERSION)
     }
   }
 


### PR DESCRIPTION
Skip forced reset on fresh installs. Users who just signed in would get bounced back to the start of onboarding once before continuing normally.
