### PR TITLE
fix(core): standardize SQL file query filters

### DIFF
--- a/.changeset/standardize-query-filters.md
+++ b/.changeset/standardize-query-filters.md
@@ -1,0 +1,5 @@
+---
+core: patch
+---
+
+Standardized and fixed SQL filters across file queries.

--- a/packages/core/src/db/operations/directories.ts
+++ b/packages/core/src/db/operations/directories.ts
@@ -4,7 +4,7 @@ import { uniqueId } from '../../lib/uniqueId'
 import type { FileRecordRow } from '../../types/files'
 import * as sql from '../sql'
 import { recalculateCurrentForGroup, recalculateCurrentForGroups } from './files'
-import { buildLatestVersionFilter } from './library'
+import { buildActiveFileFilter, buildActiveRecordFilter } from './library'
 import { trashFiles } from './trash'
 
 export type Directory = {
@@ -202,7 +202,7 @@ export async function queryDirectoryChildren(
   if (parentPath === null) {
     rows = await db.getAllAsync<Row>(
       `SELECT d.id, d.path, d.createdAt,
-        (SELECT COUNT(*) FROM files f WHERE f.directoryId = d.id AND f.kind = 'file' AND f.trashedAt IS NULL AND f.deletedAt IS NULL AND ${buildLatestVersionFilter('f')}) as fileCount,
+        (SELECT COUNT(*) FROM files f WHERE f.directoryId = d.id AND ${buildActiveFileFilter('f')}) as fileCount,
         (SELECT COUNT(*) FROM directories c WHERE c.path LIKE ${sqlEscapeLike('d.path')} || '/%' ESCAPE '\\' AND c.path NOT LIKE ${sqlEscapeLike('d.path')} || '/%/%' ESCAPE '\\') as subdirectoryCount
        FROM directories d
        WHERE d.path NOT LIKE '%/%' ESCAPE '\\'
@@ -212,7 +212,7 @@ export async function queryDirectoryChildren(
     const escaped = escapeLikePattern(parentPath)
     rows = await db.getAllAsync<Row>(
       `SELECT d.id, d.path, d.createdAt,
-        (SELECT COUNT(*) FROM files f WHERE f.directoryId = d.id AND f.kind = 'file' AND f.trashedAt IS NULL AND f.deletedAt IS NULL AND ${buildLatestVersionFilter('f')}) as fileCount,
+        (SELECT COUNT(*) FROM files f WHERE f.directoryId = d.id AND ${buildActiveFileFilter('f')}) as fileCount,
         (SELECT COUNT(*) FROM directories c WHERE c.path LIKE ${sqlEscapeLike('d.path')} || '/%' ESCAPE '\\' AND c.path NOT LIKE ${sqlEscapeLike('d.path')} || '/%/%' ESCAPE '\\') as subdirectoryCount
        FROM directories d
        WHERE d.path LIKE ? || '/%' ESCAPE '\\' AND d.path NOT LIKE ? || '/%/%' ESCAPE '\\'
@@ -236,7 +236,7 @@ export async function queryAllDirectoriesWithCounts(
 
   const rows = await db.getAllAsync<Row>(
     `SELECT d.id, d.path, d.createdAt,
-      (SELECT COUNT(*) FROM files f WHERE f.directoryId = d.id AND f.kind = 'file' AND f.trashedAt IS NULL AND f.deletedAt IS NULL AND ${buildLatestVersionFilter('f')}) as fileCount,
+      (SELECT COUNT(*) FROM files f WHERE f.directoryId = d.id AND ${buildActiveFileFilter('f')}) as fileCount,
       (SELECT COUNT(*) FROM directories c WHERE c.path LIKE ${sqlEscapeLike('d.path')} || '/%' ESCAPE '\\' AND c.path NOT LIKE ${sqlEscapeLike('d.path')} || '/%/%' ESCAPE '\\') as subdirectoryCount
      FROM directories d
      ORDER BY d.nameSortKey`,
@@ -414,7 +414,7 @@ export async function deleteDirectoryAndTrashFiles(
     `SELECT f.id FROM files f
      INNER JOIN directories d ON f.directoryId = d.id
      WHERE (d.path = ? OR d.path LIKE ? || '/%' ESCAPE '\\')
-       AND f.kind = 'file' AND f.trashedAt IS NULL AND f.deletedAt IS NULL`,
+       AND f.kind = 'file' AND ${buildActiveRecordFilter('f')}`,
     [dir.path, escaped],
     500,
     async (rows) => {
@@ -441,7 +441,7 @@ export async function queryCountFilesWithDirectories(
   if (fileIds.length === 0) return 0
   const ph = fileIds.map(() => '?').join(',')
   const row = await db.getFirstAsync<{ count: number }>(
-    `SELECT COUNT(*) as count FROM files WHERE id IN (${ph}) AND directoryId IS NOT NULL`,
+    `SELECT COUNT(*) as count FROM files f WHERE f.id IN (${ph}) AND f.directoryId IS NOT NULL AND ${buildActiveFileFilter('f')}`,
     ...fileIds,
   )
   return row?.count ?? 0
@@ -458,10 +458,8 @@ export async function queryFileByNameInDirectory(
             f.localId, f.hash, f.addedAt, f.thumbForId, f.thumbSize, f.trashedAt, f.deletedAt
      FROM files f
      INNER JOIN directories d ON f.directoryId = d.id
-     WHERE f.name = ? AND f.kind = 'file'
-       AND f.trashedAt IS NULL AND f.deletedAt IS NULL
+     WHERE f.name = ? AND ${buildActiveFileFilter('f')}
        AND d.path = ?
-       AND ${buildLatestVersionFilter('f')}
      ORDER BY f.updatedAt DESC, f.id DESC
      LIMIT 1`,
     fileName,
@@ -478,9 +476,7 @@ export async function queryFilesByDirectoryPath(
             f.localId, f.hash, f.addedAt, f.thumbForId, f.thumbSize, f.trashedAt, f.deletedAt
      FROM files f
      INNER JOIN directories d ON f.directoryId = d.id
-     WHERE d.path = ? AND f.kind = 'file'
-       AND f.trashedAt IS NULL AND f.deletedAt IS NULL
-       AND ${buildLatestVersionFilter('f')}
+     WHERE d.path = ? AND ${buildActiveFileFilter('f')}
      ORDER BY f.nameSortKey`,
     directoryPath,
   )

--- a/packages/core/src/db/operations/fileStats.ts
+++ b/packages/core/src/db/operations/fileStats.ts
@@ -1,5 +1,5 @@
 import type { DatabaseAdapter } from '../../adapters/db'
-import { buildLatestVersionFilter } from './library'
+import { buildActiveFileFilter, buildActiveRecordFilter } from './library'
 
 export type UploadCategoryStats = {
   total: number
@@ -88,21 +88,18 @@ export async function queryUploadStats(
 ): Promise<UploadStats> {
   // Exclude pending imports (hash = '') — they have no size yet and are
   // shown separately in the "Pending import" row.
-  const active = `f.trashedAt IS NULL AND f.deletedAt IS NULL AND f.hash != ''`
-  const latestVersion = buildLatestVersionFilter('f')
+  const activeFile = `${buildActiveFileFilter('f')} AND f.hash != ''`
   const q = (where: string) => queryStatsForWhere(db, where, indexerURL)
 
   const [photos, videos, audio, docs, other, thumbnails] = await Promise.all([
-    q(`f.kind = 'file' AND ${active} AND f.type LIKE 'image/%' AND ${latestVersion}`),
-    q(`f.kind = 'file' AND ${active} AND f.type LIKE 'video/%' AND ${latestVersion}`),
-    q(`f.kind = 'file' AND ${active} AND f.type LIKE 'audio/%' AND ${latestVersion}`),
+    q(`${activeFile} AND f.type LIKE 'image/%'`),
+    q(`${activeFile} AND f.type LIKE 'video/%'`),
+    q(`${activeFile} AND f.type LIKE 'audio/%'`),
+    q(`${activeFile} AND (f.type LIKE 'text/%' OR f.type LIKE 'application/%')`),
     q(
-      `f.kind = 'file' AND ${active} AND (f.type LIKE 'text/%' OR f.type LIKE 'application/%') AND ${latestVersion}`,
+      `${activeFile} AND f.type NOT LIKE 'image/%' AND f.type NOT LIKE 'video/%' AND f.type NOT LIKE 'audio/%' AND f.type NOT LIKE 'text/%' AND f.type NOT LIKE 'application/%'`,
     ),
-    q(
-      `f.kind = 'file' AND ${active} AND f.type NOT LIKE 'image/%' AND f.type NOT LIKE 'video/%' AND f.type NOT LIKE 'audio/%' AND f.type NOT LIKE 'text/%' AND f.type NOT LIKE 'application/%' AND ${latestVersion}`,
-    ),
-    q(`f.kind = 'thumb' AND ${active}`),
+    q(`f.kind = 'thumb' AND ${buildActiveRecordFilter('f')} AND f.hash != ''`),
   ])
 
   const fileCategories = [photos, videos, audio, docs, other]

--- a/packages/core/src/db/operations/files.ts
+++ b/packages/core/src/db/operations/files.ts
@@ -5,7 +5,7 @@ import { localObjectFromStorageRow } from '../../encoding/localObject'
 import { naturalSortKey } from '../../lib/naturalSortKey'
 import type { FileRecord, FileRecordRow } from '../../types/files'
 import * as sql from '../sql'
-import { buildLatestVersionFilter } from './library'
+import { buildActiveFileFilter, buildActiveRecordFilter } from './library'
 import { insertLocalObject, queryLocalObjectsForFile } from './localObjects'
 import { trashFiles } from './trash'
 
@@ -593,10 +593,8 @@ export async function deleteFileRecordsAndThumbnails(
     directoryId: string | null
   }>(`SELECT DISTINCT name, directoryId FROM files WHERE id IN (${ph}) AND kind = 'file'`, ...ids)
   await db.withTransactionAsync(async () => {
-    for (const id of ids) {
-      await sql.del(db, 'files', { thumbForId: id })
-      await sql.del(db, 'files', { id })
-    }
+    await db.runAsync(`DELETE FROM files WHERE thumbForId IN (${ph})`, ...ids)
+    await db.runAsync(`DELETE FROM files WHERE id IN (${ph})`, ...ids)
   })
   await recalculateCurrentForGroups(db, rows)
 }
@@ -698,7 +696,7 @@ export async function updateFileRecordWithLocalObject(
 export async function queryLostFileCount(db: DatabaseAdapter, indexerURL: string): Promise<number> {
   const row = await db.getFirstAsync<{ count: number }>(
     `SELECT COUNT(*) as count FROM files f
-     WHERE f.trashedAt IS NULL AND f.deletedAt IS NULL
+     WHERE ${buildActiveFileFilter('f')}
      AND (
        (NOT EXISTS (SELECT 1 FROM objects s WHERE s.fileId = f.id AND s.indexerURL = ?)
         AND NOT EXISTS (SELECT 1 FROM fs fsMeta WHERE fsMeta.fileId = f.id)
@@ -716,7 +714,7 @@ export async function queryLostFileStats(
 ): Promise<{ count: number; totalBytes: number }> {
   const row = await db.getFirstAsync<{ count: number; totalBytes: number }>(
     `SELECT COUNT(*) as count, COALESCE(SUM(size), 0) as totalBytes FROM files f
-     WHERE f.trashedAt IS NULL AND f.deletedAt IS NULL
+     WHERE ${buildActiveFileFilter('f')}
      AND (
        (NOT EXISTS (SELECT 1 FROM objects s WHERE s.fileId = f.id AND s.indexerURL = ?)
         AND NOT EXISTS (SELECT 1 FROM fs fsMeta WHERE fsMeta.fileId = f.id)
@@ -937,11 +935,7 @@ export async function deleteManyFileRecordsByIds(
     name: string
     directoryId: string | null
   }>(`SELECT DISTINCT name, directoryId FROM files WHERE id IN (${ph}) AND kind = 'file'`, ...ids)
-  await db.withTransactionAsync(async () => {
-    for (const id of ids) {
-      await deleteFileRecordById(db, id)
-    }
-  })
+  await db.runAsync(`DELETE FROM files WHERE id IN (${ph})`, ...ids)
   await recalculateCurrentForGroups(db, groups)
 }
 
@@ -951,8 +945,7 @@ export async function queryFileRecordByName(
 ): Promise<FileRecordRow | null> {
   return db.getFirstAsync<FileRecordRow>(
     `SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize, trashedAt, deletedAt, lostReason
-     FROM files f WHERE f.name = ? AND f.kind = 'file' AND f.trashedAt IS NULL AND f.deletedAt IS NULL
-       AND ${buildLatestVersionFilter('f')}
+     FROM files f WHERE f.name = ? AND ${buildActiveFileFilter('f')}
      ORDER BY f.updatedAt DESC, f.id DESC`,
     name,
   )
@@ -971,8 +964,7 @@ export async function readFileRecordByName(
 export async function queryUnuploadedFileCount(db: DatabaseAdapter): Promise<number> {
   const row = await db.getFirstAsync<{ count: number }>(
     `SELECT COUNT(*) as count FROM files f
-     WHERE f.kind = 'file'
-       AND f.trashedAt IS NULL AND f.deletedAt IS NULL
+     WHERE ${buildActiveFileFilter('f')}
        AND NOT EXISTS (SELECT 1 FROM objects o WHERE o.fileId = f.id)`,
   )
   return row?.count ?? 0
@@ -988,8 +980,7 @@ export async function queryUnuploadedFiles(
     size: number
   }>(
     `SELECT f.id, f.name, f.type, f.size FROM files f
-     WHERE f.kind = 'file'
-       AND f.trashedAt IS NULL AND f.deletedAt IS NULL
+     WHERE ${buildActiveFileFilter('f')}
        AND NOT EXISTS (SELECT 1 FROM objects o WHERE o.fileId = f.id)
      ORDER BY f.addedAt DESC`,
   )
@@ -1003,7 +994,7 @@ export async function queryActiveFileSummaries(
     kind: string
     type: string
     size: number
-  }>('SELECT id, kind, type, size FROM files WHERE trashedAt IS NULL AND deletedAt IS NULL')
+  }>(`SELECT f.id, f.kind, f.type, f.size FROM files f WHERE ${buildActiveFileFilter('f')}`)
 }
 
 export async function queryUploadedFileIds(
@@ -1021,7 +1012,7 @@ export async function deleteLostFiles(db: DatabaseAdapter, indexerURL: string): 
   return sql.processInBatches<{ id: string }>(
     db,
     `SELECT f.id FROM files f
-     WHERE f.trashedAt IS NULL AND f.deletedAt IS NULL
+     WHERE f.kind = 'file' AND ${buildActiveRecordFilter('f')}
      AND (
        (NOT EXISTS (SELECT 1 FROM objects s WHERE s.fileId = f.id AND s.indexerURL = ?)
         AND NOT EXISTS (SELECT 1 FROM fs fsMeta WHERE fsMeta.fileId = f.id)

--- a/packages/core/src/db/operations/index.ts
+++ b/packages/core/src/db/operations/index.ts
@@ -95,6 +95,8 @@ export {
 } from './fs'
 export {
   ALL_CATEGORIES,
+  buildActiveFileFilter,
+  buildActiveRecordFilter,
   buildLatestVersionFilter,
   buildLibraryQueryParts,
   type Category,

--- a/packages/core/src/db/operations/library.ts
+++ b/packages/core/src/db/operations/library.ts
@@ -24,6 +24,23 @@ export function buildLatestVersionFilter(alias: string): string {
   return `${alias}.current = 1`
 }
 
+/**
+ * Filters to active, user-visible file records: non-trashed, non-deleted,
+ * kind = 'file', latest version only. Do NOT use for thumbnail queries
+ * (thumbnails don't maintain the `current` column).
+ */
+export function buildActiveFileFilter(alias: string): string {
+  return `${alias}.kind = 'file' AND ${alias}.trashedAt IS NULL AND ${alias}.deletedAt IS NULL AND ${alias}.current = 1`
+}
+
+/**
+ * Filters to non-trashed, non-deleted records of any kind.
+ * Use for thumbnail queries or when kind/version filtering is handled separately.
+ */
+export function buildActiveRecordFilter(alias: string): string {
+  return `${alias}.trashedAt IS NULL AND ${alias}.deletedAt IS NULL`
+}
+
 export function buildLibraryQueryParts(
   opts: {
     sortBy?: SortBy
@@ -58,9 +75,7 @@ export function buildLibraryQueryParts(
 
   const whereParts: string[] = []
   const params: (string | number)[] = []
-  whereParts.push(`${tableAlias}.kind = 'file'`)
-  whereParts.push(`${tableAlias}.trashedAt IS NULL`)
-  whereParts.push(`${tableAlias}.deletedAt IS NULL`)
+  whereParts.push(buildActiveFileFilter(tableAlias))
 
   if (!allSelected && (mediaCategories.length > 0 || includesFiles)) {
     const categoryConditions: string[] = []
@@ -103,7 +118,6 @@ export function buildLibraryQueryParts(
     whereParts.push(`${tableAlias}.directoryId = ?`)
     params.push(directoryId)
   }
-  whereParts.push(buildLatestVersionFilter(tableAlias))
   const where = whereParts.length ? `WHERE ${whereParts.join(' AND ')}` : ''
 
   let orderExpr: string
@@ -136,7 +150,7 @@ export type LibraryQueryParams = {
 
 export async function queryLibraryFileCount(db: DatabaseAdapter): Promise<number> {
   const row = await db.getFirstAsync<{ count: number }>(
-    `SELECT COUNT(*) as count FROM files f WHERE f.kind = 'file' AND f.trashedAt IS NULL AND f.deletedAt IS NULL AND ${buildLatestVersionFilter('f')}`,
+    `SELECT COUNT(*) as count FROM files f WHERE ${buildActiveFileFilter('f')}`,
   )
   return row?.count ?? 0
 }
@@ -144,10 +158,8 @@ export async function queryLibraryFileCount(db: DatabaseAdapter): Promise<number
 export async function queryMediaFileCount(db: DatabaseAdapter): Promise<number> {
   const row = await db.getFirstAsync<{ count: number }>(
     `SELECT COUNT(*) as count FROM files f
-     WHERE f.kind = 'file'
-       AND f.trashedAt IS NULL AND f.deletedAt IS NULL
-       AND (f.type LIKE 'image/%' OR f.type LIKE 'video/%' OR f.type LIKE 'audio/%')
-       AND ${buildLatestVersionFilter('f')}`,
+     WHERE ${buildActiveFileFilter('f')}
+       AND (f.type LIKE 'image/%' OR f.type LIKE 'video/%' OR f.type LIKE 'audio/%')`,
   )
   return row?.count ?? 0
 }
@@ -156,8 +168,7 @@ export async function queryTagFileCount(db: DatabaseAdapter, tagId: string): Pro
   const row = await db.getFirstAsync<{ count: number }>(
     `SELECT COUNT(*) as count FROM files f
      INNER JOIN file_tags ft ON ft.fileId = f.id
-     WHERE ft.tagId = ? AND f.kind = 'file' AND f.trashedAt IS NULL AND f.deletedAt IS NULL
-       AND ${buildLatestVersionFilter('f')}`,
+     WHERE ft.tagId = ? AND ${buildActiveFileFilter('f')}`,
     tagId,
   )
   return row?.count ?? 0
@@ -172,8 +183,7 @@ export async function queryDirectoryFileCount(
   }
   const row = await db.getFirstAsync<{ count: number }>(
     `SELECT COUNT(*) as count FROM files f
-     WHERE f.directoryId = ? AND f.kind = 'file' AND f.trashedAt IS NULL AND f.deletedAt IS NULL
-       AND ${buildLatestVersionFilter('f')}`,
+     WHERE f.directoryId = ? AND ${buildActiveFileFilter('f')}`,
     directoryId,
   )
   return row?.count ?? 0
@@ -182,8 +192,7 @@ export async function queryDirectoryFileCount(
 export async function queryUnfiledFileCount(db: DatabaseAdapter): Promise<number> {
   const row = await db.getFirstAsync<{ count: number }>(
     `SELECT COUNT(*) as count FROM files f
-     WHERE f.directoryId IS NULL AND f.kind = 'file' AND f.trashedAt IS NULL AND f.deletedAt IS NULL
-       AND ${buildLatestVersionFilter('f')}`,
+     WHERE f.directoryId IS NULL AND ${buildActiveFileFilter('f')}`,
   )
   return row?.count ?? 0
 }

--- a/packages/core/src/db/operations/tags.ts
+++ b/packages/core/src/db/operations/tags.ts
@@ -1,6 +1,7 @@
 import type { DatabaseAdapter } from '../../adapters/db'
 import { uniqueId } from '../../lib/uniqueId'
 import * as sql from '../sql'
+import { buildActiveFileFilter } from './library'
 
 export const SYSTEM_TAGS = {
   favorites: { id: 'sys:favorites', name: 'Favorites' },
@@ -111,7 +112,7 @@ export async function queryAllTagsWithCounts(db: DatabaseAdapter): Promise<TagWi
     `SELECT t.id, t.name, t.createdAt, t.usedAt, t.system, COUNT(f.id) as fileCount
      FROM tags t
      LEFT JOIN file_tags ft ON ft.tagId = t.id
-     LEFT JOIN files f ON f.id = ft.fileId AND f.kind = 'file' AND f.trashedAt IS NULL AND f.deletedAt IS NULL
+     LEFT JOIN files f ON f.id = ft.fileId AND ${buildActiveFileFilter('f')}
      GROUP BY t.id
      ORDER BY t.system DESC, t.name`,
   )

--- a/packages/core/src/db/operations/thumbnails.ts
+++ b/packages/core/src/db/operations/thumbnails.ts
@@ -2,7 +2,7 @@ import type { DatabaseAdapter } from '../../adapters/db'
 import type { FileRecord, FileRecordRow, ThumbSize } from '../../types/files'
 import { ThumbSizes } from '../../types/files'
 import { transformRow } from './files'
-import { buildLatestVersionFilter } from './library'
+import { buildActiveFileFilter, buildActiveRecordFilter } from './library'
 import { queryLocalObjectsForFile } from './localObjects'
 
 export type ThumbnailCandidateRow = {
@@ -124,10 +124,8 @@ export async function queryThumbnailCandidatePage(
       AND t.thumbSize IN (${ThumbSizes.join(',')})
      WHERE (f.type LIKE 'image/%' OR f.type LIKE 'video/%')
        AND f.type != 'image/tiff'
-       AND f.kind = 'file'
+       AND ${buildActiveFileFilter('f')}
        AND f.hash != ''
-       AND f.trashedAt IS NULL AND f.deletedAt IS NULL
-       AND ${buildLatestVersionFilter('f')}
        ${cursorClause}
      GROUP BY f.id
      HAVING COUNT(DISTINCT t.thumbSize) < ${ThumbSizes.length}
@@ -141,10 +139,10 @@ export async function queryThumbnailScanProgress(
   db: DatabaseAdapter,
 ): Promise<{ originals: number; thumbs: number }> {
   const originalsRow = await db.getFirstAsync<{ count: number }>(
-    `SELECT COUNT(*) as count FROM files f WHERE (f.type LIKE 'image/%' OR f.type LIKE 'video/%') AND f.kind = 'file' AND f.trashedAt IS NULL AND f.deletedAt IS NULL AND ${buildLatestVersionFilter('f')}`,
+    `SELECT COUNT(*) as count FROM files f WHERE (f.type LIKE 'image/%' OR f.type LIKE 'video/%') AND ${buildActiveFileFilter('f')}`,
   )
   const thumbsRow = await db.getFirstAsync<{ count: number }>(
-    `SELECT COUNT(*) as count FROM files WHERE kind = 'thumb' AND deletedAt IS NULL AND thumbSize IN (${ThumbSizes.join(',')})`,
+    `SELECT COUNT(*) as count FROM files f WHERE f.kind = 'thumb' AND ${buildActiveRecordFilter('f')} AND f.thumbSize IN (${ThumbSizes.join(',')})`,
   )
   return {
     originals: originalsRow?.count ?? 0,


### PR DESCRIPTION
Extract shared SQL filter helpers (buildActiveFileFilter, buildActiveRecordFilter) so every query uses the same definition of "active file." Fixes inconsistencies where some queries forgot a filter condition.
