### PR TITLE
perf(core): exclude slabs from default object queries

### DIFF
--- a/.changeset/exclude-slabs-from-queries.md
+++ b/.changeset/exclude-slabs-from-queries.md
@@ -1,0 +1,6 @@
+---
+core: minor
+mobile: patch
+---
+
+Exclude slabs from default object queries for faster reads. Add getForFileWithSlabs for callers that need slab data.

--- a/apps/mobile/src/components/FileDetails/FileMap.tsx
+++ b/apps/mobile/src/components/FileDetails/FileMap.tsx
@@ -1,18 +1,22 @@
 import { AddressProtocol, type Host } from '@siastorage/core/adapters'
+import type { Slab } from '@siastorage/core/types'
 import { useHosts } from '@siastorage/core/stores'
-import type { FileRecord } from '@siastorage/core/types'
 import { useMemo } from 'react'
 import { StyleSheet, View } from 'react-native'
-import { getOneSealedObject } from '../../lib/file'
+import useSWR from 'swr'
+import { app } from '../../stores/appService'
 import Map from '../Map/Map'
 import { MapMarker } from '../Map/MapMarker'
 import { determineBestRegion } from '../Map/mapHelpers'
 import { SWROverlay } from '../SWROverlay'
 
-export function FileMap({ file }: { file: FileRecord }) {
+export function FileMap({ fileId }: { fileId: string }) {
   const hosts = useHosts()
 
-  const firstSlab = getOneSealedObject(file)?.sealedObject.slabs[0]
+  const { data: firstSlab } = useSWR<Slab | null>(['fileMap:firstSlab', fileId], async () => {
+    const objects = await app().localObjects.getForFileWithSlabs(fileId)
+    return objects[0]?.slabs[0] ?? null
+  })
 
   const matchingHosts: Host[] = useMemo(() => {
     if (!hosts.data || !firstSlab) return []

--- a/apps/mobile/src/components/FileDetails/FileMeta.tsx
+++ b/apps/mobile/src/components/FileDetails/FileMeta.tsx
@@ -33,7 +33,7 @@ export function FileMeta({ file, status }: { file: FileRecord; status: FileStatu
       app().files.update({ id: file.id, name: value })
     },
   })
-  const pinnedObjects = usePinnedObjects(file)
+  const pinnedObjects = usePinnedObjects(file.id)
   const thumbnails = useSWR(
     showAdvanced.data ? app().caches.thumbnails.byFileId.key(file.id) : null,
     async () => {
@@ -129,7 +129,7 @@ export function FileMeta({ file, status }: { file: FileRecord; status: FileStatu
       <RowGroup title="File shard storage locations">
         <InfoCard>
           <View style={{ height: Math.round(windowHeight * 0.5) }}>
-            <FileMap file={file} />
+            <FileMap fileId={file.id} />
           </View>
         </InfoCard>
       </RowGroup>

--- a/apps/mobile/src/hooks/usePinnedObjects.tsx
+++ b/apps/mobile/src/hooks/usePinnedObjects.tsx
@@ -1,27 +1,26 @@
-import type { FileRecord } from '@siastorage/core/types'
 import { logger } from '@siastorage/logger'
 import { PinnedObject, type PinnedObjectInterface } from 'react-native-sia'
 import useSWR from 'swr'
 import { getAppKeyForIndexer } from '../stores/appKey'
+import { app } from '../stores/appService'
 
-export function usePinnedObjects(file: FileRecord) {
+export function usePinnedObjects(fileId: string) {
   return useSWR<{ indexerURL: string; pinnedObject: PinnedObjectInterface }[]>(
-    ['pinnedObjects', file.id],
+    ['pinnedObjects', fileId],
     async () => {
-      const objects = Object.entries(file.objects)
+      const objects = await app().localObjects.getForFileWithSlabs(fileId)
       const results = await Promise.all(
-        objects.map(async ([indexerURL, so]) => {
-          const appKey = await getAppKeyForIndexer(indexerURL)
+        objects.map(async (so) => {
+          const appKey = await getAppKeyForIndexer(so.indexerURL)
           if (!appKey) {
-            // TODO: Figure out how to handle this situation.
             logger.warn('usePinnedObjects', 'no_app_key', {
-              fileId: file.id,
-              indexerURL,
+              fileId,
+              indexerURL: so.indexerURL,
             })
             return null
           }
           return {
-            indexerURL,
+            indexerURL: so.indexerURL,
             pinnedObject: PinnedObject.open(appKey, so),
           }
         }),

--- a/apps/mobile/src/hooks/useShareAction.tsx
+++ b/apps/mobile/src/hooks/useShareAction.tsx
@@ -2,10 +2,12 @@ import Clipboard from '@react-native-clipboard/clipboard'
 import { useFileDetails, useSdk } from '@siastorage/core/stores'
 import { logger } from '@siastorage/logger'
 import { useCallback } from 'react'
+import { PinnedObject } from 'react-native-sia'
 import Share from 'react-native-share'
-import { getOneSealedObject, getPinnedObject, useFileStatus } from '../lib/file'
+import { useFileStatus } from '../lib/file'
 import { useToast } from '../lib/toastContext'
-import { internal } from '../stores/appService'
+import { getAppKeyForIndexer } from '../stores/appKey'
+import { app, internal } from '../stores/appService'
 
 export function useShareAction({ fileId }: { fileId: string }) {
   const toast = useToast()
@@ -19,9 +21,12 @@ export function useShareAction({ fileId }: { fileId: string }) {
     const sdk = internal().getSdk()
     if (!sdk) return
 
-    const result = getOneSealedObject(file)
-    if (!result) return
-    const pinnedObject = await getPinnedObject(result.indexerURL, result.sealedObject)
+    const objects = await app().localObjects.getForFileWithSlabs(file.id)
+    if (!objects.length) return
+    const obj = objects[0]
+    const appKey = await getAppKeyForIndexer(obj.indexerURL)
+    if (!appKey) return
+    const pinnedObject = PinnedObject.open(appKey, obj)
     const expiresAt = new Date()
     expiresAt.setDate(expiresAt.getDate() + 1)
     return sdk.shareObject(pinnedObject, expiresAt)

--- a/apps/mobile/src/lib/file.ts
+++ b/apps/mobile/src/lib/file.ts
@@ -3,8 +3,6 @@ import type { LocalObject } from '@siastorage/core/encoding/localObject'
 import { useDownloadEntry } from '@siastorage/core/stores'
 import type { FileRecord } from '@siastorage/core/types'
 import { useMemo } from 'react'
-import { PinnedObject, type PinnedObjectInterface, type SealedObject } from 'react-native-sia'
-import { getAppKeyForIndexer } from '../stores/appKey'
 import { app } from '../stores/appService'
 import { useFsFileUri } from '../stores/fs'
 import { type UploadState, useUploadState } from '../stores/uploads'
@@ -182,22 +180,11 @@ export function getFileTypeName(
           : 'other'
 }
 
-export function getOneSealedObject(file: {
+export function getOneObject(file: {
   objects: Record<string, LocalObject> | null
-}): { indexerURL: string; sealedObject: SealedObject } | null {
+}): { indexerURL: string; object: LocalObject } | null {
   const entries = Object.entries(file.objects ?? {})
   if (entries.length === 0) return null
-  const [indexerURL, sealedObject] = entries[0]
-  return { indexerURL, sealedObject }
-}
-
-export async function getPinnedObject(
-  indexerURL: string,
-  sealedObject: SealedObject,
-): Promise<PinnedObjectInterface> {
-  const appKey = await getAppKeyForIndexer(indexerURL)
-  if (!appKey) {
-    throw new Error(`No AppKey found for indexer: ${indexerURL}`)
-  }
-  return PinnedObject.open(appKey, sealedObject)
+  const [indexerURL, object] = entries[0]
+  return { indexerURL, object }
 }

--- a/apps/mobile/src/lib/localObjects.ts
+++ b/apps/mobile/src/lib/localObjects.ts
@@ -1,4 +1,4 @@
-import type { LocalObject } from '@siastorage/core/encoding/localObject'
+import type { LocalObjectWithSlabs } from '@siastorage/core/encoding/localObject'
 import { sealPinnedObject } from '@siastorage/core/lib/localObjects'
 import type { PinnedObjectInterface } from 'react-native-sia'
 import { getAppKeyForIndexer } from '../stores/appKey'
@@ -7,7 +7,7 @@ export async function pinnedObjectToLocalObject(
   fileId: string,
   indexerURL: string,
   pinnedObject: PinnedObjectInterface,
-): Promise<LocalObject> {
+): Promise<LocalObjectWithSlabs> {
   const appKey = await getAppKeyForIndexer(indexerURL)
   if (!appKey) {
     throw new Error(`No AppKey found for indexer: ${indexerURL}`)

--- a/apps/mobile/src/managers/downloader.ts
+++ b/apps/mobile/src/managers/downloader.ts
@@ -5,7 +5,7 @@ import type { FileRecord } from '@siastorage/core/types'
 import { logger } from '@siastorage/logger'
 import { useCallback } from 'react'
 import type { Writer } from 'react-native-sia'
-import { getOneSealedObject } from '../lib/file'
+import { getOneObject } from '../lib/file'
 import { streamToCache } from '../lib/streamToCache'
 import { useToast } from '../lib/toastContext'
 import { app, internal } from '../stores/appService'
@@ -24,8 +24,8 @@ export function useDownload(file?: FileRecord | null) {
   return useCallback(() => {
     if (!file) return
     if (!isConnected) return
-    const sealedObject = getOneSealedObject(file)
-    if (!sealedObject) {
+    const obj = getOneObject(file)
+    if (!obj) {
       toast.show('No slabs available for this file')
       return
     }

--- a/apps/mobile/src/managers/fsEvictionScanner.test.ts
+++ b/apps/mobile/src/managers/fsEvictionScanner.test.ts
@@ -1,5 +1,5 @@
 import { daysInMs } from '@siastorage/core'
-import type { LocalObject } from '@siastorage/core/encoding/localObject'
+import type { LocalObjectWithSlabs } from '@siastorage/core/encoding/localObject'
 import type { FileRecord } from '@siastorage/core/types'
 import { initializeDB, resetDb } from '../db'
 import { app } from '../stores/appService'
@@ -165,7 +165,7 @@ function makeLocalObject(params: {
   indexerURL: string
   createdAt: number
   updatedAt: number
-}): LocalObject {
+}): LocalObjectWithSlabs {
   return {
     id: params.objectId,
     fileId: params.fileId,

--- a/apps/mobile/src/managers/syncDownEvents.test.ts
+++ b/apps/mobile/src/managers/syncDownEvents.test.ts
@@ -1,5 +1,5 @@
 import { encodeFileMetadata } from '@siastorage/core/encoding/fileMetadata'
-import type { LocalObject } from '@siastorage/core/encoding/localObject'
+import type { LocalObjectWithSlabs } from '@siastorage/core/encoding/localObject'
 import type { FileMetadata, FileRecord } from '@siastorage/core/types'
 import type { ObjectEvent, PinnedObjectInterface } from 'react-native-sia'
 import { initializeDB, resetDb } from '../db'
@@ -12,7 +12,7 @@ function makeLocalObject(params: {
   indexerURL: string
   createdAt: number
   updatedAt: number
-}): LocalObject {
+}): LocalObjectWithSlabs {
   return {
     id: params.objectId,
     fileId: params.fileId,

--- a/apps/mobile/src/managers/syncUpMetadata.test.ts
+++ b/apps/mobile/src/managers/syncUpMetadata.test.ts
@@ -1,4 +1,4 @@
-import type { LocalObject } from '@siastorage/core/encoding/localObject'
+import type { LocalObjectWithSlabs } from '@siastorage/core/encoding/localObject'
 import type { FileRecord } from '@siastorage/core/types'
 import { initializeDB, resetDb } from '../db'
 import { app, internal } from '../stores/appService'
@@ -15,7 +15,7 @@ function makeLocalObject(params: {
   indexerURL: string
   createdAt: number
   updatedAt: number
-}): LocalObject {
+}): LocalObjectWithSlabs {
   return {
     id: params.objectId,
     fileId: params.fileId,

--- a/packages/core/src/app/namespaces/db.ts
+++ b/packages/core/src/app/namespaces/db.ts
@@ -478,8 +478,9 @@ export function buildDbNamespaces(
       },
     },
     localObjects: {
-      getForFile: (fileId) => ops.queryObjectsForFile(db, fileId),
-      getForFiles: (fileIds) => ops.queryObjectsForFiles(db, fileIds),
+      getForFile: (fileId) => ops.queryObjectMetasForFile(db, fileId),
+      getForFiles: (fileIds) => ops.queryObjectMetasForFiles(db, fileIds),
+      getForFileWithSlabs: (fileId) => ops.queryObjectsForFileWithSlabs(db, fileId),
       upsert: async (object, opts) => {
         await ops.insertObject(db, object)
         if (!opts?.skipInvalidation) {

--- a/packages/core/src/app/namespaces/downloads.ts
+++ b/packages/core/src/app/namespaces/downloads.ts
@@ -3,7 +3,7 @@ import type { SdkAdapter } from '../../adapters/sdk'
 import type { StorageAdapter } from '../../adapters/storage'
 import { DEFAULT_MAX_DOWNLOADS } from '../../config'
 import * as ops from '../../db/operations'
-import type { LocalObject } from '../../encoding/localObject'
+import type { LocalObjectWithSlabs } from '../../encoding/localObject'
 import { SlotPool } from '../../lib/slotPool'
 import type { FsIOAdapter } from '../../services/fsFileUri'
 import type { AppCaches, AppService } from '../service'
@@ -13,7 +13,7 @@ import type { DownloadsState } from '../stores'
 export type DownloadObjectAdapter = {
   download(params: {
     file: { id: string; type: string; size: number }
-    object: LocalObject
+    object: LocalObjectWithSlabs
     sdk: SdkAdapter
     onProgress: (progress: number) => void
     signal: AbortSignal
@@ -76,7 +76,7 @@ export function buildDownloadsNamespace(
 
     const sdk = getSdk()
     if (!sdk) throw new Error('SDK not initialized')
-    const objects = await ops.queryObjectsForFile(db, fileId)
+    const objects = await ops.queryObjectsForFileWithSlabs(db, fileId)
     if (!objects.length) throw new Error('No object available for download')
 
     register(fileId)

--- a/packages/core/src/app/service.ts
+++ b/packages/core/src/app/service.ts
@@ -9,7 +9,7 @@ import type {
   TagWithCount,
   UploadStats,
 } from '../db/operations'
-import type { LocalObject } from '../encoding/localObject'
+import type { LocalObject, LocalObjectWithSlabs } from '../encoding/localObject'
 import type { SyncUpCursor } from '../services/syncUpMetadata'
 import type { FileMetadata, FileRecord, FileRecordRow, ThumbSize } from '../types/files'
 import type {
@@ -142,7 +142,7 @@ export interface AppService {
     /** Creates a file, optionally with a local object. */
     create(
       record: Omit<FileRecord, 'objects'>,
-      localObject?: LocalObject,
+      localObject?: LocalObjectWithSlabs,
       opts?: { skipInvalidation?: boolean; skipCurrentRecalc?: boolean },
     ): Promise<void>
     /** Creates multiple files. */
@@ -183,7 +183,7 @@ export interface AppService {
     /** Updates a file and upserts its local object. */
     updateWithLocalObject(
       update: Partial<FileRecordRow> & { id: string },
-      localObject: LocalObject,
+      localObject: LocalObjectWithSlabs,
       opts?: { includeUpdatedAt?: boolean; skipInvalidation?: boolean },
     ): Promise<void>
     /** Hard-deletes a file by ID. */
@@ -334,13 +334,15 @@ export interface AppService {
   }
   /** Local object (remote reference) CRUD for file-to-indexer mappings. */
   localObjects: {
-    /** Returns all local objects for a file. */
+    /** Returns local objects for a file (without slabs). */
     getForFile(fileId: string): Promise<LocalObject[]>
-    /** Returns local objects for multiple files, keyed by file ID. */
+    /** Returns local objects for multiple files (without slabs). */
     getForFiles(fileIds: string[]): Promise<Record<string, LocalObject[]>>
-    /** Creates or updates a local object reference. */
-    upsert(object: LocalObject, opts?: { skipInvalidation?: boolean }): Promise<void>
-    /** Deletes a specific local object by its object ID and indexer URL. */
+    /** Returns local objects for a file with full slab data. */
+    getForFileWithSlabs(fileId: string): Promise<LocalObjectWithSlabs[]>
+    /** Creates or updates a local object. */
+    upsert(object: LocalObjectWithSlabs, opts?: { skipInvalidation?: boolean }): Promise<void>
+    /** Deletes a local object by object ID and indexer URL. */
     delete(
       objectId: string,
       indexerURL: string,
@@ -350,11 +352,14 @@ export interface AppService {
     deleteForFile(fileId: string, opts?: { skipInvalidation?: boolean }): Promise<void>
     /** Deletes all local objects for multiple files. */
     deleteManyForFiles(fileIds: string[]): Promise<void>
-    /** Creates or updates multiple local objects in a single transaction. */
-    upsertMany(objects: LocalObject[], opts?: { skipInvalidation?: boolean }): Promise<void>
-    /** Returns the number of local objects for a file. */
+    /** Creates or updates multiple local objects. */
+    upsertMany(
+      objects: LocalObjectWithSlabs[],
+      opts?: { skipInvalidation?: boolean },
+    ): Promise<void>
+    /** Returns the count of local objects for a file. */
     countForFile(fileId: string): Promise<number>
-    /** Batch deletes local objects by their object IDs for a given indexer. */
+    /** Deletes local objects by object IDs for a given indexer. */
     deleteManyByObjectIds(
       objectIds: string[],
       indexerURL: string,

--- a/packages/core/src/db/operations/files.test.ts
+++ b/packages/core/src/db/operations/files.test.ts
@@ -14,6 +14,7 @@ import {
   queryFileCount,
   queryFileStats,
   readFile,
+  readFileWithSlabs,
   readFilesByIds,
   updateFile,
   updateManyFiles,
@@ -85,6 +86,27 @@ describe('readFile', () => {
   it('returns null for non-existent ID', async () => {
     const result = await readFile(db(), 'does-not-exist')
     expect(result).toBeNull()
+  })
+
+  it('excludes slabs from objects', async () => {
+    await insertFile(db(), makeFileRecord('file-1'))
+    await insertObject(db(), makeLocalObject('file-1'))
+    const result = await readFile(db(), 'file-1')
+    const obj = result!.objects['https://indexer.example.com']
+    expect(obj).toBeDefined()
+    expect(obj).not.toHaveProperty('slabs')
+  })
+})
+
+describe('readFileWithSlabs', () => {
+  it('includes slabs in objects', async () => {
+    await insertFile(db(), makeFileRecord('file-1'))
+    await insertObject(db(), makeLocalObject('file-1'))
+    const result = await readFileWithSlabs(db(), 'file-1')
+    expect(result).not.toBeNull()
+    const obj = result!.objects['https://indexer.example.com']
+    expect(obj).toBeDefined()
+    expect(obj).toHaveProperty('slabs')
   })
 })
 

--- a/packages/core/src/db/operations/files.ts
+++ b/packages/core/src/db/operations/files.ts
@@ -1,12 +1,12 @@
 import { logger } from '@siastorage/logger'
 import type { DatabaseAdapter } from '../../adapters/db'
-import type { LocalObject, LocalObjectRow } from '../../encoding/localObject'
+import type { LocalObject, LocalObjectRow, LocalObjectWithSlabs } from '../../encoding/localObject'
 import { localObjectFromStorageRow } from '../../encoding/localObject'
 import { naturalSortKey } from '../../lib/naturalSortKey'
 import type { FileRecord, FileRecordRow } from '../../types/files'
 import * as sql from '../sql'
 import { buildActiveFileFilter, buildActiveFilter } from './library'
-import { insertObject, queryObjectsForFile } from './localObjects'
+import { insertObject, queryObjectMetasForFile, queryObjectsForFileWithSlabs } from './localObjects'
 import { trashFilesAndThumbnails } from './trash'
 
 export async function recalculateCurrentForGroup(
@@ -125,8 +125,11 @@ export async function queryFilesByObjectIds(
   return result
 }
 
-export function transformRow(row: FileRecordRow, objects?: LocalObject[]): FileRecord {
-  const objectsMap: Record<string, LocalObject> = {}
+export function transformRow<T extends LocalObject = LocalObject>(
+  row: FileRecordRow,
+  objects?: T[],
+): FileRecordRow & { objects: Record<string, T> } {
+  const objectsMap: Record<string, T> = {}
   for (const o of objects || []) {
     objectsMap[o.indexerURL] = o
   }
@@ -340,7 +343,7 @@ export async function queryFiles(db: DatabaseAdapter, opts: FileQueryOpts): Prom
       }
   >(
     `SELECT f.id, f.name, f.size, f.createdAt, f.updatedAt, f.type, f.kind, f.localId, f.hash, f.addedAt, f.thumbForId, f.thumbSize, f.trashedAt, f.deletedAt, f.lostReason,
-            o.fileId as fileId, o.indexerURL as indexerURL, o.id as objectId, o.slabs as slabs,
+            o.fileId as fileId, o.indexerURL as indexerURL, o.id as objectId,
             o.encryptedDataKey as encryptedDataKey, o.encryptedMetadataKey as encryptedMetadataKey,
             o.encryptedMetadata as encryptedMetadata, o.dataSignature as dataSignature,
             o.metadataSignature as metadataSignature, o.createdAt as objectCreatedAt, o.updatedAt as objectUpdatedAt
@@ -594,7 +597,17 @@ export async function deleteAllFiles(db: DatabaseAdapter): Promise<void> {
 export async function readFile(db: DatabaseAdapter, id: string): Promise<FileRecord | null> {
   const row = await queryFileById(db, id)
   if (!row) return null
-  const objects = await queryObjectsForFile(db, id)
+  const objects = await queryObjectMetasForFile(db, id)
+  return transformRow(row, objects)
+}
+
+export async function readFileWithSlabs(
+  db: DatabaseAdapter,
+  id: string,
+): Promise<(FileRecordRow & { objects: Record<string, LocalObjectWithSlabs> }) | null> {
+  const row = await queryFileById(db, id)
+  if (!row) return null
+  const objects = await queryObjectsForFileWithSlabs(db, id)
   return transformRow(row, objects)
 }
 
@@ -605,7 +618,7 @@ export async function readFileByObjectId(
 ): Promise<FileRecord | null> {
   const row = await queryFileByObjectId(db, objectId, indexerURL)
   if (!row) return null
-  const objects = await queryObjectsForFile(db, row.id)
+  const objects = await queryObjectMetasForFile(db, row.id)
   return transformRow(row, objects)
 }
 
@@ -615,7 +628,7 @@ export async function readFileByContentHash(
 ): Promise<FileRecord | null> {
   const row = await queryFileByContentHash(db, hash)
   if (!row) return null
-  const objects = await queryObjectsForFile(db, row.id)
+  const objects = await queryObjectMetasForFile(db, row.id)
   return transformRow(row, objects)
 }
 
@@ -661,7 +674,7 @@ export async function queryLocalOnlyFiles(
 export async function createFileWithLocalObject(
   db: DatabaseAdapter,
   record: Omit<FileRecord, 'objects'>,
-  localObject: LocalObject,
+  localObject: LocalObjectWithSlabs,
 ): Promise<void> {
   await db.withTransactionAsync(async () => {
     await insertFile(db, record)
@@ -672,7 +685,7 @@ export async function createFileWithLocalObject(
 export async function updateFileWithLocalObject(
   db: DatabaseAdapter,
   update: Partial<FileRecordRow> & { id: string },
-  localObject: LocalObject,
+  localObject: LocalObjectWithSlabs,
   options?: { includeUpdatedAt?: boolean },
 ): Promise<void> {
   await db.withTransactionAsync(async () => {
@@ -756,7 +769,7 @@ export async function readFilesByIds(db: DatabaseAdapter, ids: string[]): Promis
       }
   >(
     `SELECT f.id, f.name, f.size, f.createdAt, f.updatedAt, f.type, f.kind, f.localId, f.hash, f.addedAt, f.thumbForId, f.thumbSize, f.trashedAt, f.deletedAt, f.lostReason,
-            o.fileId as fileId, o.indexerURL as indexerURL, o.id as objectId, o.slabs as slabs,
+            o.fileId as fileId, o.indexerURL as indexerURL, o.id as objectId,
             o.encryptedDataKey as encryptedDataKey, o.encryptedMetadataKey as encryptedMetadataKey,
             o.encryptedMetadata as encryptedMetadata, o.dataSignature as dataSignature,
             o.metadataSignature as metadataSignature, o.createdAt as objectCreatedAt, o.updatedAt as objectUpdatedAt
@@ -939,7 +952,7 @@ export async function readFileByName(
 ): Promise<FileRecord | null> {
   const row = await queryFileByName(db, name)
   if (!row) return null
-  const objects = await queryObjectsForFile(db, row.id)
+  const objects = await queryObjectMetasForFile(db, row.id)
   return transformRow(row, objects)
 }
 

--- a/packages/core/src/db/operations/index.ts
+++ b/packages/core/src/db/operations/index.ts
@@ -66,6 +66,7 @@ export {
   readFileByContentHash,
   readFileByName,
   readFileByObjectId,
+  readFileWithSlabs,
   readFilesByContentHashes,
   readFilesByIds,
   readFilesByLocalIds,
@@ -124,8 +125,10 @@ export {
   insertObject,
   insertManyObjects,
   queryFilesWithNoObjects,
-  queryObjectsForFile,
-  queryObjectsForFiles,
+  queryObjectMetasForFile,
+  queryObjectMetasForFiles,
+  queryObjectsForFileWithSlabs,
+  queryObjectsForFilesWithSlabs,
 } from './localObjects'
 export {
   deleteAllLogs,

--- a/packages/core/src/db/operations/localObjects.test.ts
+++ b/packages/core/src/db/operations/localObjects.test.ts
@@ -5,8 +5,10 @@ import {
   deleteObjectsForFile,
   deleteManyObjectsForFiles,
   insertObject,
-  queryObjectsForFile,
-  queryObjectsForFiles,
+  queryObjectMetasForFile,
+  queryObjectMetasForFiles,
+  queryObjectsForFileWithSlabs,
+  queryObjectsForFilesWithSlabs,
 } from './localObjects'
 import { db, setupTestDb, teardownTestDb } from './test-setup'
 
@@ -53,7 +55,7 @@ describe('insertObject', () => {
     const obj = makeLocalObject('f1', 'https://idx.example.com', 'obj1')
     await insertObject(db(), obj)
 
-    const results = await queryObjectsForFile(db(), 'f1')
+    const results = await queryObjectMetasForFile(db(), 'f1')
     expect(results).toHaveLength(1)
     expect(results[0].id).toBe('obj1')
     expect(results[0].fileId).toBe('f1')
@@ -61,39 +63,66 @@ describe('insertObject', () => {
   })
 })
 
-describe('queryObjectsForFile', () => {
-  it('returns objects for a file', async () => {
+describe('queryObjectMetasForFile', () => {
+  it('returns objects without slabs', async () => {
     await createTestFile('f1')
     await insertObject(db(), makeLocalObject('f1', 'https://a.com', 'obj1'))
     await insertObject(db(), makeLocalObject('f1', 'https://b.com', 'obj2'))
 
-    const results = await queryObjectsForFile(db(), 'f1')
+    const results = await queryObjectMetasForFile(db(), 'f1')
     expect(results).toHaveLength(2)
+    expect(results[0]).not.toHaveProperty('slabs')
+    expect(results[0].id).toBeDefined()
+    expect(results[0].encryptedDataKey).toBeInstanceOf(ArrayBuffer)
   })
 
   it('returns empty for non-existent file', async () => {
-    const results = await queryObjectsForFile(db(), 'nonexistent')
+    const results = await queryObjectMetasForFile(db(), 'nonexistent')
     expect(results).toEqual([])
   })
 })
 
-describe('queryObjectsForFiles', () => {
-  it('returns map keyed by fileId', async () => {
+describe('queryObjectsForFileWithSlabs', () => {
+  it('returns objects with slabs', async () => {
+    await createTestFile('f1')
+    await insertObject(db(), makeLocalObject('f1', 'https://a.com', 'obj1'))
+
+    const results = await queryObjectsForFileWithSlabs(db(), 'f1')
+    expect(results).toHaveLength(1)
+    expect(results[0]).toHaveProperty('slabs')
+    expect(results[0].slabs).toEqual([])
+  })
+})
+
+describe('queryObjectMetasForFiles', () => {
+  it('returns map keyed by fileId without slabs', async () => {
     await createTestFile('f1')
     await createTestFile('f2')
     await insertObject(db(), makeLocalObject('f1', 'https://a.com', 'obj1'))
     await insertObject(db(), makeLocalObject('f2', 'https://a.com', 'obj2'))
 
-    const map = await queryObjectsForFiles(db(), ['f1', 'f2'])
+    const map = await queryObjectMetasForFiles(db(), ['f1', 'f2'])
     expect(map.f1).toHaveLength(1)
     expect(map.f1[0].id).toBe('obj1')
+    expect(map.f1[0]).not.toHaveProperty('slabs')
     expect(map.f2).toHaveLength(1)
     expect(map.f2[0].id).toBe('obj2')
   })
 
   it('returns empty object for empty input', async () => {
-    const map = await queryObjectsForFiles(db(), [])
+    const map = await queryObjectMetasForFiles(db(), [])
     expect(map).toEqual({})
+  })
+})
+
+describe('queryObjectsForFilesWithSlabs', () => {
+  it('returns map with slabs included', async () => {
+    await createTestFile('f1')
+    await insertObject(db(), makeLocalObject('f1', 'https://a.com', 'obj1'))
+
+    const map = await queryObjectsForFilesWithSlabs(db(), ['f1'])
+    expect(map.f1).toHaveLength(1)
+    expect(map.f1[0]).toHaveProperty('slabs')
   })
 })
 
@@ -122,7 +151,7 @@ describe('deleteObject', () => {
 
     await deleteObject(db(), 'obj1', 'https://a.com')
 
-    const results = await queryObjectsForFile(db(), 'f1')
+    const results = await queryObjectMetasForFile(db(), 'f1')
     expect(results).toHaveLength(1)
     expect(results[0].id).toBe('obj2')
   })
@@ -136,7 +165,7 @@ describe('deleteObjectsForFile', () => {
 
     await deleteObjectsForFile(db(), 'f1')
 
-    const results = await queryObjectsForFile(db(), 'f1')
+    const results = await queryObjectMetasForFile(db(), 'f1')
     expect(results).toEqual([])
   })
 })
@@ -152,9 +181,9 @@ describe('deleteManyObjectsForFiles', () => {
 
     await deleteManyObjectsForFiles(db(), ['f1', 'f2'])
 
-    expect(await queryObjectsForFile(db(), 'f1')).toEqual([])
-    expect(await queryObjectsForFile(db(), 'f2')).toEqual([])
-    expect(await queryObjectsForFile(db(), 'f3')).toHaveLength(1)
+    expect(await queryObjectMetasForFile(db(), 'f1')).toEqual([])
+    expect(await queryObjectMetasForFile(db(), 'f2')).toEqual([])
+    expect(await queryObjectMetasForFile(db(), 'f3')).toHaveLength(1)
   })
 
   it('handles empty array', async () => {

--- a/packages/core/src/db/operations/localObjects.ts
+++ b/packages/core/src/db/operations/localObjects.ts
@@ -1,22 +1,49 @@
 import type { DatabaseAdapter } from '../../adapters/db'
-import type { LocalObject, LocalObjectRow } from '../../encoding/localObject'
-import { localObjectFromStorageRow, localObjectToStorageRow } from '../../encoding/localObject'
+import type {
+  LocalObject,
+  LocalObjectRow,
+  LocalObjectRowWithSlabs,
+  LocalObjectWithSlabs,
+} from '../../encoding/localObject'
+import {
+  localObjectFromStorageRow,
+  localObjectWithSlabsFromStorageRow,
+  localObjectWithSlabsToStorageRow,
+} from '../../encoding/localObject'
 import * as sql from '../sql'
 
-export async function queryObjectsForFile(
+const OBJECT_META_COLUMNS =
+  'id, fileId, indexerURL, encryptedDataKey, encryptedMetadataKey, encryptedMetadata, dataSignature, metadataSignature, createdAt, updatedAt'
+
+const OBJECT_ALL_COLUMNS = `${OBJECT_META_COLUMNS}, slabs`
+
+export async function queryObjectMetasForFile(
   db: DatabaseAdapter,
   fileId: string,
 ): Promise<LocalObject[]> {
   const rows = await db.getAllAsync<LocalObjectRow>(
-    `SELECT id, fileId, indexerURL, slabs, encryptedDataKey, encryptedMetadataKey, encryptedMetadata, dataSignature, metadataSignature, createdAt, updatedAt
-     FROM objects WHERE fileId = ?`,
+    `SELECT ${OBJECT_META_COLUMNS} FROM objects WHERE fileId = ?`,
     fileId,
   )
   return rows.map(localObjectFromStorageRow)
 }
 
-export async function insertObject(db: DatabaseAdapter, object: LocalObject): Promise<void> {
-  const e = localObjectToStorageRow(object)
+export async function queryObjectsForFileWithSlabs(
+  db: DatabaseAdapter,
+  fileId: string,
+): Promise<LocalObjectWithSlabs[]> {
+  const rows = await db.getAllAsync<LocalObjectRowWithSlabs>(
+    `SELECT ${OBJECT_ALL_COLUMNS} FROM objects WHERE fileId = ?`,
+    fileId,
+  )
+  return rows.map(localObjectWithSlabsFromStorageRow)
+}
+
+export async function insertObject(
+  db: DatabaseAdapter,
+  object: LocalObjectWithSlabs,
+): Promise<void> {
+  const e = localObjectWithSlabsToStorageRow(object)
   await sql.insert(
     db,
     'objects',
@@ -57,15 +84,14 @@ export async function deleteObjectsForFile(db: DatabaseAdapter, fileId: string):
   await sql.del(db, 'objects', { fileId })
 }
 
-export async function queryObjectsForFiles(
+export async function queryObjectMetasForFiles(
   db: DatabaseAdapter,
   fileIds: string[],
 ): Promise<Record<string, LocalObject[]>> {
   if (fileIds.length === 0) return {}
   const ph = fileIds.map(() => '?').join(',')
   const rows = await db.getAllAsync<LocalObjectRow>(
-    `SELECT id, fileId, indexerURL, slabs, encryptedDataKey, encryptedMetadataKey, encryptedMetadata, dataSignature, metadataSignature, createdAt, updatedAt
-     FROM objects WHERE fileId IN (${ph})`,
+    `SELECT ${OBJECT_META_COLUMNS} FROM objects WHERE fileId IN (${ph})`,
     ...fileIds,
   )
   const map: Record<string, LocalObject[]> = {}
@@ -77,13 +103,32 @@ export async function queryObjectsForFiles(
   return map
 }
 
+export async function queryObjectsForFilesWithSlabs(
+  db: DatabaseAdapter,
+  fileIds: string[],
+): Promise<Record<string, LocalObjectWithSlabs[]>> {
+  if (fileIds.length === 0) return {}
+  const ph = fileIds.map(() => '?').join(',')
+  const rows = await db.getAllAsync<LocalObjectRowWithSlabs>(
+    `SELECT ${OBJECT_ALL_COLUMNS} FROM objects WHERE fileId IN (${ph})`,
+    ...fileIds,
+  )
+  const map: Record<string, LocalObjectWithSlabs[]> = {}
+  for (const r of rows) {
+    const lo = localObjectWithSlabsFromStorageRow(r)
+    if (!map[r.fileId]) map[r.fileId] = []
+    map[r.fileId].push(lo)
+  }
+  return map
+}
+
 export async function insertManyObjects(
   db: DatabaseAdapter,
-  objects: LocalObject[],
+  objects: LocalObjectWithSlabs[],
 ): Promise<void> {
   if (objects.length === 0) return
   const rows = objects.map((o) => {
-    const e = localObjectToStorageRow(o)
+    const e = localObjectWithSlabsToStorageRow(o)
     return {
       fileId: e.fileId,
       indexerURL: e.indexerURL,

--- a/packages/core/src/db/operations/thumbnails.ts
+++ b/packages/core/src/db/operations/thumbnails.ts
@@ -3,7 +3,7 @@ import type { FileRecord, FileRecordRow, ThumbSize } from '../../types/files'
 import { ThumbSizes } from '../../types/files'
 import { transformRow } from './files'
 import { buildActiveFileFilter, buildActiveFilter } from './library'
-import { queryObjectsForFile } from './localObjects'
+import { queryObjectMetasForFile } from './localObjects'
 
 export type ThumbnailCandidateRow = {
   id: string
@@ -71,7 +71,7 @@ export async function queryBestThumbnailByFileId(
     requiredSize,
   )
   if (!row) return null
-  const objects = await queryObjectsForFile(db, row.id)
+  const objects = await queryObjectMetasForFile(db, row.id)
   return transformRow(row, objects)
 }
 
@@ -100,7 +100,7 @@ export async function queryThumbnailByFileIdAndSize(
     size,
   )
   if (!row) return null
-  const objects = await queryObjectsForFile(db, row.id)
+  const objects = await queryObjectMetasForFile(db, row.id)
   return transformRow(row, objects)
 }
 

--- a/packages/core/src/encoding/localObject.ts
+++ b/packages/core/src/encoding/localObject.ts
@@ -60,10 +60,10 @@ const localObjectStorageCodec = z.codec(
   },
 )
 
-export type LocalObject = ReturnType<typeof localObjectStorageCodec.decode>
-export type LocalObjectsMap = Record<string, LocalObject>
+export type LocalObjectWithSlabs = ReturnType<typeof localObjectStorageCodec.decode>
+export type LocalObject = Omit<LocalObjectWithSlabs, 'slabs'>
 
-export type LocalObjectRow = {
+export type LocalObjectRowWithSlabs = {
   id: string
   fileId: string
   indexerURL: string
@@ -77,7 +77,11 @@ export type LocalObjectRow = {
   updatedAt: number
 }
 
-export function localObjectToStorageRow(lo: LocalObject): LocalObjectRow {
+export type LocalObjectRow = Omit<LocalObjectRowWithSlabs, 'slabs'>
+
+export function localObjectWithSlabsToStorageRow(
+  lo: LocalObjectWithSlabs,
+): LocalObjectRowWithSlabs {
   const e = localObjectStorageCodec.encode({
     id: lo.id,
     fileId: lo.fileId,
@@ -106,7 +110,9 @@ export function localObjectToStorageRow(lo: LocalObject): LocalObjectRow {
   }
 }
 
-export function localObjectFromStorageRow(row: LocalObjectRow): LocalObject {
+export function localObjectWithSlabsFromStorageRow(
+  row: LocalObjectRowWithSlabs,
+): LocalObjectWithSlabs {
   return localObjectStorageCodec.decode({
     id: row.id,
     fileId: row.fileId,
@@ -120,4 +126,19 @@ export function localObjectFromStorageRow(row: LocalObjectRow): LocalObject {
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   })
+}
+
+export function localObjectFromStorageRow(row: LocalObjectRow): LocalObject {
+  return {
+    id: row.id,
+    fileId: row.fileId,
+    indexerURL: row.indexerURL,
+    encryptedDataKey: hexArrayBufferCodec.decode(row.encryptedDataKey),
+    encryptedMetadataKey: hexArrayBufferCodec.decode(row.encryptedMetadataKey),
+    encryptedMetadata: hexArrayBufferCodec.decode(row.encryptedMetadata),
+    dataSignature: hexArrayBufferCodec.decode(row.dataSignature),
+    metadataSignature: hexArrayBufferCodec.decode(row.metadataSignature),
+    createdAt: isoToEpochCodec.decode(row.createdAt),
+    updatedAt: isoToEpochCodec.decode(row.updatedAt),
+  }
 }

--- a/packages/core/src/lib/localObjects.ts
+++ b/packages/core/src/lib/localObjects.ts
@@ -1,12 +1,12 @@
 import type { AppKeyRef, PinnedObjectRef } from '../adapters/sdk'
-import type { LocalObject } from '../encoding/localObject'
+import type { LocalObjectWithSlabs } from '../encoding/localObject'
 
 export function sealPinnedObject(
   fileId: string,
   indexerURL: string,
   pinnedObject: PinnedObjectRef,
   appKey: AppKeyRef,
-): LocalObject {
+): LocalObjectWithSlabs {
   const sealed = pinnedObject.seal(appKey)
   return {
     ...sealed,

--- a/packages/core/src/services/syncDownEvents.ts
+++ b/packages/core/src/services/syncDownEvents.ts
@@ -7,7 +7,7 @@ import {
   hasCompleteFileMetadata,
   hasCompleteThumbnailMetadata,
 } from '../encoding/fileMetadata'
-import type { LocalObject } from '../encoding/localObject'
+import type { LocalObjectWithSlabs } from '../encoding/localObject'
 import { sealPinnedObject } from '../lib/localObjects'
 import type { FileMetadata, FileRecordRow } from '../types/files'
 
@@ -33,7 +33,7 @@ type Counts = {
 type PreparedCreate = {
   kind: 'create'
   fileRecord: FileRecordRow
-  localObject: LocalObject
+  localObject: LocalObjectWithSlabs
   tags?: string[]
   directory?: string
   isFile: boolean
@@ -43,7 +43,7 @@ type PreparedCreate = {
 type PreparedUpdate = {
   kind: 'update'
   fileRecord: FileRecordRow
-  localObject: LocalObject
+  localObject: LocalObjectWithSlabs
   fileId: string
   tags?: string[]
   directory?: string

--- a/packages/core/src/services/uploader.ts
+++ b/packages/core/src/services/uploader.ts
@@ -18,7 +18,7 @@ import {
   UPLOAD_PARITY_SHARDS,
 } from '../config'
 import { encodeFileMetadata } from '../encoding/fileMetadata'
-import type { LocalObject } from '../encoding/localObject'
+import type { LocalObjectWithSlabs } from '../encoding/localObject'
 import { sealPinnedObject } from '../lib/localObjects'
 import { retry } from '../lib/retry'
 import { SlotPool } from '../lib/slotPool'
@@ -985,7 +985,7 @@ export class UploadManager {
           type: 'success'
           fileId: string
           size: number
-          localObject: LocalObject
+          localObject: LocalObjectWithSlabs
         }
       | { type: 'deleted'; fileId: string }
       | { type: 'error'; fileId: string }


### PR DESCRIPTION
Exclude slabs from default object queries. Slabs are large JSON blobs that get deserialized on every file read but are only needed for downloads, sharing, and the file map. Callers that need them use the new getForFileWithSlabs path.
