### PR TITLE
fix: add tsconfig paths for workspace package resolution

### DIFF
--- a/apps/integration/tsconfig.json
+++ b/apps/integration/tsconfig.json
@@ -1,11 +1,4 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true
-  },
+  "extends": "../../tsconfig.json",
   "include": ["test"]
 }

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -1,6 +1,11 @@
 {
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
-    "strict": true
+    "strict": true,
+    "paths": {
+      "@siastorage/core": ["../../packages/core/src/index.ts"],
+      "@siastorage/core/*": ["../../packages/core/src/*"],
+      "@siastorage/logger": ["../../packages/logger/src/index.ts"]
+    }
   }
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,14 +1,4 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "outDir": "dist",
-    "rootDir": "src"
-  },
+  "extends": "../../tsconfig.json",
   "include": ["src"]
 }

--- a/packages/node-adapters/tsconfig.json
+++ b/packages/node-adapters/tsconfig.json
@@ -1,14 +1,4 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "outDir": "dist",
-    "rootDir": "src"
-  },
+  "extends": "../../tsconfig.json",
   "include": ["src"]
 }

--- a/packages/sdk-mock/tsconfig.json
+++ b/packages/sdk-mock/tsconfig.json
@@ -1,14 +1,4 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "outDir": "dist",
-    "rootDir": "src"
-  },
+  "extends": "../../tsconfig.json",
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "paths": {
+      "@siastorage/core": ["./packages/core/src/index.ts"],
+      "@siastorage/core/*": ["./packages/core/src/*"],
+      "@siastorage/logger": ["./packages/logger/src/index.ts"],
+      "@siastorage/node-adapters": ["./packages/node-adapters/src/index.ts"],
+      "@siastorage/node-adapters/*": ["./packages/node-adapters/src/*.ts"],
+      "@siastorage/sdk-mock": ["./packages/sdk-mock/src/index.ts"]
+    }
+  }
+}


### PR DESCRIPTION
Fix TypeScript failing to resolve @siastorage/* subpath exports across workspace packages. Adds a root tsconfig with paths mappings that all packages extend.
