### PR TITLE
fix(mobile): request camera permission instead of photo library for camera capture

### DIFF
--- a/.changeset/fix-camera-permission.md
+++ b/.changeset/fix-camera-permission.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Fixed camera capture requesting photo library permission instead of camera permission.

--- a/apps/mobile/src/hooks/useCameraCapture.ts
+++ b/apps/mobile/src/hooks/useCameraCapture.ts
@@ -20,7 +20,9 @@ export function useCameraCapture() {
       const result = await ImagePicker.launchCamera({
         mediaType: 'mixed',
         saveToPhotos: false,
-        includeExtra: true,
+        // Keep false — includeExtra triggers a photo library permission request on iOS,
+        // preventing users who only grant camera access from using capture.
+        includeExtra: false,
         // Docs: A mode that determines which representation to use if an asset
         // contains more than one on iOS or disables HEIC/HEIF to JPEG conversion on Android
         // if set to 'current'.


### PR DESCRIPTION
Fix camera capture requesting photo library permission instead of camera permission. The includeExtra option in react-native-image-picker triggers a photo library access request on iOS, some users may only want to grant camera access.

