### PR TITLE
chore: move oxlint and oxfmt to root devDependencies

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -108,8 +108,6 @@
     "expo-sqlite-mock": "3.0.2",
     "jest": "29.7.0",
     "jest-expo": "55.0.9",
-    "oxfmt": "0.43.0",
-    "oxlint": "1.58.0",
     "react-test-renderer": "19.2.0",
     "semver": "7.7.4",
     "sharp": "0.33.5",

--- a/bun.lock
+++ b/bun.lock
@@ -1,11 +1,12 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "siastorage",
       "devDependencies": {
         "knip": "6.3.0",
+        "oxfmt": "0.43.0",
+        "oxlint": "1.58.0",
       },
     },
     "apps/benchmark": {
@@ -122,8 +123,6 @@
         "expo-sqlite-mock": "3.0.2",
         "jest": "29.7.0",
         "jest-expo": "55.0.9",
-        "oxfmt": "0.43.0",
-        "oxlint": "1.58.0",
         "react-test-renderer": "19.2.0",
         "semver": "7.7.4",
         "sharp": "0.33.5",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "knip": "6.3.0"
+    "knip": "6.3.0",
+    "oxfmt": "0.43.0",
+    "oxlint": "1.58.0"
   },
   "patchedDependencies": {
     "react-native-fs@2.20.0": "patches/react-native-fs@2.20.0.patch"


### PR DESCRIPTION
- These ox tools should be root deps.
