### PR TITLE
fix(mobile): include importing files in status sheet file counts

### DIFF
--- a/.changeset/fix-status-file-counts.md
+++ b/.changeset/fix-status-file-counts.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+File counts in the status sheet now include files pending import.

--- a/apps/mobile/src/components/LibraryStatusSheet.tsx
+++ b/apps/mobile/src/components/LibraryStatusSheet.tsx
@@ -1,5 +1,6 @@
 import type { UploadCategoryStats, UploadStats } from '@siastorage/core/db/operations'
 import { useSyncState } from '@siastorage/core/stores'
+import { TriangleAlertIcon } from 'lucide-react-native'
 import { useCallback } from 'react'
 import { Alert, Platform, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native'
 import useSWR from 'swr'
@@ -68,16 +69,6 @@ export function LibraryStatusSheet() {
     {
       refreshInterval,
     },
-  )
-  const importing = useSWR(
-    ['importing-stats', isOpen ?? null],
-    async () =>
-      app().files.queryStats({
-        hashEmpty: true,
-        activeOnly: true,
-        order: 'ASC',
-      }),
-    { refreshInterval },
   )
   const onDevice = useFileStatsLocal({ localOnly: false }, { refreshInterval })
   const pendingBackup = useFileStatsLocal({ localOnly: true }, { refreshInterval })
@@ -190,15 +181,22 @@ export function LibraryStatusSheet() {
         </RowGroup>
 
         <RowGroup title="Files" indicator={toggle} style={styles.groupSpacing}>
+          {displayMode === 'size' && (stats.data?.importingCount ?? 0) > 0 && (
+            <View style={styles.warningRow}>
+              <TriangleAlertIcon color={palette.yellow[400]} size={14} />
+              <Text style={styles.warningText}>
+                Sizes do not include {(stats.data?.importingCount ?? 0).toLocaleString()} file
+                {stats.data?.importingCount === 1 ? '' : 's'} pending import.
+              </Text>
+            </View>
+          )}
           <RowSubGroup title="Library" style={styles.subGroupSpacing}>
-            <Text style={styles.sectionDesc}>
-              All files tracked in the library. Pending imports are waiting to be copied from your
-              device's photo library.
-            </Text>
+            <Text style={styles.sectionDesc}>All files tracked in the library.</Text>
             <InfoCard>
               <LabeledValueRow
-                label="Device and network"
-                labelWidth={180}
+                label="Total"
+                labelStyle={styles.boldLabel}
+                labelWidth={120}
                 value={
                   <View style={styles.valueRight}>
                     <Text style={styles.valueText}>
@@ -209,14 +207,15 @@ export function LibraryStatusSheet() {
                 align="right"
                 canCopy={false}
               />
-              {(importing.data?.count ?? 0) > 0 && (
+              {(stats.data?.importingCount ?? 0) > 0 && (
                 <LabeledValueRow
                   label="Pending import"
+                  labelStyle={styles.indentedLabel}
                   labelWidth={120}
                   value={
                     <View style={styles.valueRight}>
                       <Text style={styles.valueText}>
-                        {`${(importing.data?.count ?? 0).toLocaleString()} files`}
+                        {`${(stats.data?.importingCount ?? 0).toLocaleString()} files`}
                       </Text>
                       <View style={styles.dotSyncing} />
                     </View>
@@ -226,26 +225,10 @@ export function LibraryStatusSheet() {
                   showDividerTop
                 />
               )}
-              <LabeledValueRow
-                label="Total"
-                labelWidth={120}
-                value={
-                  <View style={styles.valueRight}>
-                    <Text style={styles.valueText}>
-                      {`${((stats.data?.files.total ?? 0) + (importing.data?.count ?? 0)).toLocaleString()} files`}
-                    </Text>
-                  </View>
-                }
-                align="right"
-                canCopy={false}
-                showDividerTop
-              />
             </InfoCard>
           </RowSubGroup>
           <RowSubGroup title="Sync" style={styles.subGroupSpacing}>
-            <Text style={styles.sectionDesc}>
-              Upload progress across all files ready to be synced to the network.
-            </Text>
+            <Text style={styles.sectionDesc}>Upload progress across all files in the library.</Text>
             {(batch.data?.count ?? 0) > 0 && (
               <InfoCard>
                 <LabeledValueRow
@@ -540,8 +523,20 @@ const styles = StyleSheet.create({
     fontSize: 12,
     marginBottom: 8,
   },
+  warningRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginBottom: 8,
+  },
+  warningText: {
+    color: palette.yellow[400],
+    fontSize: 12,
+    flex: 1,
+  },
   networkGroupGap: { height: 8 },
   boldLabel: { fontWeight: '700' },
+  indentedLabel: { paddingLeft: 12 },
   toggleTrack: {
     flexDirection: 'row',
     backgroundColor: whiteA.a08,

--- a/packages/core/src/db/operations/fileStats.ts
+++ b/packages/core/src/db/operations/fileStats.ts
@@ -20,6 +20,7 @@ export type UploadStats = {
   docs: UploadCategoryStats
   other: UploadCategoryStats
   thumbnails: UploadCategoryStats
+  importingCount: number
 }
 
 async function queryStatsForWhere(
@@ -86,12 +87,12 @@ export async function queryUploadStats(
   db: DatabaseAdapter,
   indexerURL: string,
 ): Promise<UploadStats> {
-  // Exclude pending imports (hash = '') — they have no size yet and are
-  // shown separately in the "Pending import" row.
-  const activeFile = `${buildActiveFileFilter('f')} AND f.hash != ''`
+  // Include all active files. Importing files (hash = '') have size = 0,
+  // so byte totals remain accurate while counts reflect the full library.
+  const activeFile = buildActiveFileFilter('f')
   const q = (where: string) => queryStatsForWhere(db, where, indexerURL)
 
-  const [photos, videos, audio, docs, other, thumbnails] = await Promise.all([
+  const [photos, videos, audio, docs, other, thumbnails, importingRow] = await Promise.all([
     q(`${activeFile} AND f.type LIKE 'image/%'`),
     q(`${activeFile} AND f.type LIKE 'video/%'`),
     q(`${activeFile} AND f.type LIKE 'audio/%'`),
@@ -99,7 +100,10 @@ export async function queryUploadStats(
     q(
       `${activeFile} AND f.type NOT LIKE 'image/%' AND f.type NOT LIKE 'video/%' AND f.type NOT LIKE 'audio/%' AND f.type NOT LIKE 'text/%' AND f.type NOT LIKE 'application/%'`,
     ),
-    q(`f.kind = 'thumb' AND ${buildActiveFilter('f')} AND f.hash != ''`),
+    q(`f.kind = 'thumb' AND ${buildActiveFilter('f')}`),
+    db.getFirstAsync<{ count: number }>(
+      `SELECT COUNT(*) as count FROM files f WHERE ${activeFile} AND f.hash = ''`,
+    ),
   ])
 
   const fileCategories = [photos, videos, audio, docs, other]
@@ -113,5 +117,6 @@ export async function queryUploadStats(
     docs,
     other,
     thumbnails,
+    importingCount: importingRow?.count ?? 0,
   }
 }


### PR DESCRIPTION
- File counts in the status sheet now include files pending imports, and we now show a warning explaining the sizes do not include files that have not been fully imported.
- Previously files in the importing state were not included in the files stats because we don't know their sizes yet so we could not calculate accurate data when in size mode. The issue is these files are treated as library files in every other way, making the file stats extremely confusing because they would we smaller than the numbers you see throughout the app and they also would not account any files if the latest version of that file was in an importing state.