### PR TITLE
fix(mobile): reorder suspension phases and fix DB gate/reopen race

### DIFF
--- a/.changeset/fix-suspension-phase-ordering.md
+++ b/.changeset/fix-suspension-phase-ordering.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Fixed background suspension draining services cleanly instead of rejecting their queries.

--- a/.changeset/suspension-manager-core.md
+++ b/.changeset/suspension-manager-core.md
@@ -1,0 +1,5 @@
+---
+core: minor
+---
+
+Add `createSuspensionManager` with dependency-injected adapters for scheduler, uploader, and DB lifecycle.

--- a/apps/integration/test/adapters/upload.ts
+++ b/apps/integration/test/adapters/upload.ts
@@ -28,7 +28,10 @@ export function createTestUploaderAdapters(): UploaderAdapters {
       return {
         async read() {
           const data = nodeFs.readFileSync(filePath)
-          return data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength)
+          return data.buffer.slice(
+            data.byteOffset,
+            data.byteOffset + data.byteLength,
+          ) as ArrayBuffer
         },
       }
     },

--- a/apps/integration/test/app.ts
+++ b/apps/integration/test/app.ts
@@ -16,7 +16,7 @@ import type {
   TagWithCount,
 } from '@siastorage/core/db/operations'
 import type { LocalObject } from '@siastorage/core/encoding/localObject'
-import { CoalescingQueue } from '@siastorage/core/lib/coalescingQueue'
+import { createSuspensionManager } from '@siastorage/core/services/suspension'
 import { detectMimeType } from '@siastorage/core/lib/detectMimeType'
 import { ServiceScheduler } from '@siastorage/core/lib/serviceInterval'
 import type { FsIOAdapter } from '@siastorage/core/services/fsFileUri'
@@ -55,16 +55,26 @@ export {
   waitForCondition,
 } from './utils'
 
+export class DatabaseSuspendedError extends Error {
+  constructor() {
+    super('Database is suspended')
+    this.name = 'DatabaseSuspendedError'
+  }
+}
+
 /**
  * Mirrors the real mobile app's DB lifecycle (initializeDB / closeDb / reopen).
  * Uses a file-backed better-sqlite3 database with the same PRAGMAs
  * (WAL, busy_timeout, foreign_keys) and runs migrations on open.
- * The proxy delegates to the active connection; calls throw after close.
+ * The adapter delegates to the active connection; calls throw after close.
+ * Supports a query gate that rejects queries while suspended.
  */
 function createTestDatabase(dbPath: string) {
   let inner: (DatabaseAdapter & { close(): void }) | null = null
+  let gated = false
 
   function requireOpen(): DatabaseAdapter & { close(): void } {
+    if (gated) throw new DatabaseSuspendedError()
     if (!inner) throw new Error('Database is closed')
     return inner
   }
@@ -94,13 +104,21 @@ function createTestDatabase(dbPath: string) {
       await inner.execAsync(
         'PRAGMA journal_mode = WAL; PRAGMA busy_timeout = 5000; PRAGMA foreign_keys = ON',
       )
-      await runMigrations(proxy, sortMigrations(coreMigrations))
+      // Run migrations on the raw connection (not the proxy) so open()
+      // works while the gate is active during resume.
+      await runMigrations(inner, sortMigrations(coreMigrations))
     },
     close() {
       if (inner) {
         inner.close()
         inner = null
       }
+    },
+    gate() {
+      gated = true
+    },
+    ungate() {
+      gated = false
     },
     get isOpen() {
       return inner !== null
@@ -221,9 +239,7 @@ export function createTestApp(
   const appKey = sdk.appKey()
   const thumbnailScanner = new ThumbnailScanner()
   let connected = true
-  let suspended = false
   let background = false
-  const suspensionQueue = new CoalescingQueue()
 
   const secrets = createInMemoryStorage()
   const crypto = options?.crypto ?? {
@@ -319,6 +335,28 @@ export function createTestApp(
     interval: DB_OPTIMIZE_INTERVAL,
   })
 
+  const suspensionManager = createSuspensionManager({
+    scheduler: {
+      pause: () => scheduler.pause(),
+      abort: () => scheduler.abortAll(),
+      resume: () => scheduler.resume(),
+      waitForIdle: () => scheduler.waitForIdle(),
+    },
+    uploader: {
+      suspend: () => uploadManager.suspend(),
+      resume: () => uploadManager.resume(),
+      adjustBatchForSuspension: () => uploadManager.adjustBatchForSuspension(),
+    },
+    db: {
+      gate: () => testDb.gate(),
+      ungate: () => testDb.ungate(),
+      waitForIdle: () => Promise.resolve(),
+      close: async () => testDb.close(),
+      reopen: () => testDb.open(),
+    },
+    hardDeadlineMs: 15_000,
+  })
+
   return {
     app: appService,
     internal,
@@ -366,46 +404,16 @@ export function createTestApp(
       scheduler.resume()
     },
 
-    async suspend() {
-      return suspensionQueue.enqueue(async () => {
-        if (suspended) return
-        scheduler.pause()
-        await uploadManager.suspend()
-        await scheduler.waitForIdle()
-        testDb.close()
-        suspended = true
-      })
-    },
+    suspend: () => suspensionManager.suspend(),
 
-    async resumeFromSuspension() {
-      return suspensionQueue.enqueue(async () => {
-        if (!suspended) {
-          uploadManager.adjustBatchForSuspension()
-          return
-        }
-        await testDb.open()
-        suspended = false
-        uploadManager.adjustBatchForSuspension()
-        uploadManager.resume()
-        scheduler.resume()
-      })
-    },
+    resumeFromSuspension: () => suspensionManager.resume(),
 
     async suspendIfBackground() {
       if (!background) return
-      return suspensionQueue.enqueue(async () => {
-        if (suspended) return
-        scheduler.pause()
-        await uploadManager.suspend()
-        await scheduler.waitForIdle()
-        testDb.close()
-        suspended = true
-      })
+      return suspensionManager.suspend()
     },
 
-    isSuspended() {
-      return suspended
-    },
+    isSuspended: () => suspensionManager.isSuspended(),
 
     get isBackground() {
       return background

--- a/apps/integration/test/suspension.test.ts
+++ b/apps/integration/test/suspension.test.ts
@@ -1,11 +1,18 @@
 /**
- * Tests the suspension coordination protocol: scheduler pause/drain,
- * upload manager suspend/resume, and DB close/reopen. The test harness
- * mirrors the mobile lifecycle but is independent of suspension.ts —
- * these verify the building blocks, not the mobile orchestration.
+ * Tests the suspension coordination protocol using the shared
+ * createSuspensionManager from core. The test harness and mobile both
+ * use the same orchestration code — these tests exercise the real
+ * phase ordering with real services, uploads, and DB operations.
  */
 import { createEmptyIndexerStorage } from '@siastorage/sdk-mock'
-import { createTestApp, generateTestFiles, sleep, type TestApp, waitForCondition } from './app'
+import {
+  createTestApp,
+  DatabaseSuspendedError,
+  generateTestFiles,
+  sleep,
+  type TestApp,
+  waitForCondition,
+} from './app'
 
 describe('Suspension', () => {
   let app: TestApp
@@ -315,6 +322,99 @@ describe('Suspension', () => {
 
     // App should still work normally
     await app.addFiles(generateTestFiles(2, { startId: 100 }))
+    await app.waitForNoActiveUploads()
+    expect(app.sdk.getStoredObjects().length).toBe(5)
+  }, 60_000)
+
+  it('DB queries are rejected after suspend and work after resume', async () => {
+    await app.addFiles(generateTestFiles(2, { startId: 1 }))
+    await app.waitForNoActiveUploads()
+
+    await app.suspend()
+
+    // DB is gated — queries should throw DatabaseSuspendedError.
+    await expect(app.app.files.queryCount({ order: 'ASC' })).rejects.toThrow(DatabaseSuspendedError)
+
+    await app.resumeFromSuspension()
+
+    // DB is open again — queries work.
+    const count = await app.app.files.queryCount({ order: 'ASC' })
+    expect(count).toBe(2)
+  }, 60_000)
+
+  it('sync-down writes reach the DB during drain', async () => {
+    // Inject objects so sync-down has work to do.
+    const now = Date.now()
+    for (let i = 0; i < 10; i++) {
+      app.sdk.injectObject({
+        metadata: {
+          id: `drain-file-${i}`,
+          name: `drain-photo-${i}.jpg`,
+          type: 'image/jpeg',
+          kind: 'file',
+          size: 1024,
+          hash: `drain-hash-${i}`,
+          createdAt: now - i * 1000,
+          updatedAt: now - i * 1000,
+          trashedAt: null,
+        },
+      })
+    }
+
+    // Trigger sync-down and let it start processing.
+    app.triggerSyncDown()
+    await waitForCondition(async () => (await app.getFiles()).length > 0, {
+      timeout: 10_000,
+      message: 'At least one file synced before suspend',
+    })
+
+    // Record how many files were synced before suspend.
+    const countBeforeSuspend = (await app.getFiles()).length
+
+    // Suspend while sync-down may still be processing. The drain phase
+    // lets the in-flight batch finish its DB writes before the gate closes.
+    await app.suspend()
+    await app.resumeFromSuspension()
+
+    // Pause the scheduler immediately so no new sync ticks run.
+    app.pause()
+
+    // The drain should have allowed sync-down to write at least as many
+    // files as were present before suspend — no work should be lost.
+    const countAfterResume = (await app.getFiles()).length
+    expect(countAfterResume).toBeGreaterThanOrEqual(countBeforeSuspend)
+
+    // Resume and let everything finish.
+    app.resume()
+    await app.waitForFileCount(10, 30_000)
+    expect((await app.getFiles()).length).toBe(10)
+  }, 60_000)
+
+  it('upload DB writes succeed during drain', async () => {
+    await app.addFiles(generateTestFiles(5, { startId: 1 }))
+
+    // Wait for at least one file to be packing.
+    await waitForCondition(
+      () => {
+        const uploads = app.app.uploads.getState().uploads
+        return Object.values(uploads).some((u) => u.status === 'packing' || u.status === 'packed')
+      },
+      { timeout: 10_000, message: 'At least one file packing' },
+    )
+
+    // Record upload progress before suspend.
+    const packedBefore = app.uploadManager.packedCount
+
+    // Suspend — upload manager parks after finishing its current
+    // packer.add() call. The DB write should succeed during drain.
+    await app.suspend()
+    await app.resumeFromSuspension()
+
+    // No packed work should be lost — the upload manager's count
+    // should not have regressed.
+    expect(app.uploadManager.packedCount).toBeGreaterThanOrEqual(packedBefore)
+
+    // All files should upload successfully after resume.
     await app.waitForNoActiveUploads()
     expect(app.sdk.getStoredObjects().length).toBe(5)
   }, 60_000)

--- a/apps/mobile/src/Root.tsx
+++ b/apps/mobile/src/Root.tsx
@@ -1,6 +1,8 @@
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet'
 import { DarkTheme, NavigationContainer, useNavigationContainerRef } from '@react-navigation/native'
 import { AppProvider } from '@siastorage/core/app'
+import { SWRConfig } from 'swr'
+import { isSWREnabled } from './lib/swr'
 import { uniqueId } from '@siastorage/core/lib/uniqueId'
 import { useHasOnboarded, useShowSplash } from '@siastorage/core/stores'
 import * as ScreenOrientation from 'expo-screen-orientation'
@@ -76,7 +78,9 @@ export function Root() {
                 })}
               />
               <AppProvider value={app()}>
-                <RootContent />
+                <SWRConfig value={{ isPaused: () => !isSWREnabled() }}>
+                  <RootContent />
+                </SWRConfig>
               </AppProvider>
             </SafeAreaView>
           </ToastProvider>

--- a/apps/mobile/src/lib/swr.ts
+++ b/apps/mobile/src/lib/swr.ts
@@ -1,0 +1,13 @@
+// Global SWR enabled flag for background suspension.
+// SWR's isPaused callback polls this on each revalidation attempt.
+// Flipping the flag is synchronous and takes effect immediately.
+
+let enabled = true
+
+export function setSWREnabled(value: boolean): void {
+  enabled = value
+}
+
+export function isSWREnabled(): boolean {
+  return enabled
+}

--- a/apps/mobile/src/managers/suspension.ts
+++ b/apps/mobile/src/managers/suspension.ts
@@ -1,10 +1,10 @@
-import { CoalescingQueue } from '@siastorage/core/lib/coalescingQueue'
 import {
   abortAllServiceIntervals,
   pauseAllServiceIntervals,
   resumeAllServiceIntervals,
   waitForAllServiceIntervalsIdle,
 } from '@siastorage/core/lib/serviceInterval'
+import { createSuspensionManager } from '@siastorage/core/services/suspension'
 import { logger, stopLogAppender } from '@siastorage/logger'
 import { AppState, type AppStateStatus } from 'react-native'
 import BackgroundTimer from 'react-native-background-timer'
@@ -16,21 +16,53 @@ import {
   suspendDb,
   waitForQueriesIdle,
 } from '../db'
+import { setSWREnabled } from '../lib/swr'
 import { resumeLogger } from '../stores/logs'
 import { getIsBackgroundTaskRunning } from './backgroundTasks'
 import { getUploadManager } from './uploader'
 
-type State = 'active' | 'suspending' | 'suspended' | 'resuming'
+// Hard deadline for service drain. iOS gives ~30s via beginBackgroundTask
+// before freezing the process. The DB stays open during drain so services
+// can finish their work, so we keep this conservative to leave margin for
+// gate + WAL checkpoint + close. On Android this entire sequence is
+// unnecessary (Android's cached apps freezer doesn't enforce file lock
+// checks like iOS's 0xdead10cc), but it runs harmlessly.
+const HARD_DEADLINE_MS = 15_000
 
-// Hard deadline for drain — if services haven't drained by this time,
-// close the DB anyway. iOS gives ~30s with beginBackgroundTask; we use
-// 25s to leave margin for the close + cleanup.
-const HARD_DEADLINE_MS = 25_000
+const manager = createSuspensionManager({
+  scheduler: {
+    pause: pauseAllServiceIntervals,
+    abort: abortAllServiceIntervals,
+    resume: resumeAllServiceIntervals,
+    waitForIdle: waitForAllServiceIntervalsIdle,
+  },
+  uploader: {
+    suspend: () => getUploadManager()?.suspend() ?? Promise.resolve(),
+    resume: () => getUploadManager()?.resume(),
+    adjustBatchForSuspension: () => getUploadManager()?.adjustBatchForSuspension(),
+  },
+  db: {
+    gate: suspendDb,
+    ungate: resumeDb,
+    waitForIdle: waitForQueriesIdle,
+    close: closeDb,
+    reopen: () => initializeDB({ reopen: true }),
+  },
+  hooks: {
+    onBeforeSuspend: async () => {
+      await stopLogAppender()
+      setSWREnabled(false)
+    },
+    onAfterResume: () => {
+      setSWREnabled(true)
+      resumeLogger()
+    },
+  },
+  hardDeadlineMs: HARD_DEADLINE_MS,
+})
 
 let subscription: ReturnType<typeof AppState.addEventListener> | null = null
 let appStateRef: AppStateStatus = AppState.currentState
-let state: State = 'active'
-const queue = new CoalescingQueue()
 
 export function initSuspensionManager(): void {
   if (subscription) return
@@ -51,23 +83,15 @@ function onAppStateChange(nextState: AppStateStatus): void {
   appStateRef = nextState
 
   if (nextState === 'background') {
-    queue.enqueue(doSuspend)
+    suspendForBackground()
   } else if (nextState === 'active') {
-    queue.enqueue(doResume)
+    resumeFromSuspension()
   }
 }
 
-async function doSuspend(): Promise<void> {
-  if (state !== 'active') {
-    logger.debug('suspension', 'skipped', {
-      reason: state === 'suspended' ? 'already_suspended' : state,
-    })
-    return
-  }
+export async function suspendForBackground(): Promise<void> {
   if (getIsBackgroundTaskRunning()) {
-    logger.debug('suspension', 'skipped', {
-      reason: 'background_task_running',
-    })
+    logger.debug('suspension', 'skipped', { reason: 'background_task_running' })
     return
   }
   if (!dbInitialized) {
@@ -75,100 +99,20 @@ async function doSuspend(): Promise<void> {
     return
   }
 
-  state = 'suspending'
-  logger.info('suspension', 'starting')
-
   // Request extra execution time from iOS (~30s) before it suspends
   // the process. On Android this is a no-op.
   await BackgroundTimer.start(0)
-
   try {
-    // Phase 0: Flush logs while the DB adapter is still open, then gate
-    // all new queries. After suspendDb(), any query from SWR hooks or
-    // other callers throws DatabaseSuspendedError instantly without
-    // reaching the native GCD queue.
-    await stopLogAppender()
-    suspendDb()
-    logger.debug('suspension', 'db_gated')
-
-    // Phase 1: Signal all services to stop.
-    // pause prevents new ticks, abort signals in-flight workers to exit
-    // at their next signal.aborted check.
-    pauseAllServiceIntervals()
-    abortAllServiceIntervals()
-    await getUploadManager()?.suspend()
-    logger.debug('suspension', 'services_paused')
-
-    // Phase 2: Wait for in-flight work AND in-flight DB queries to
-    // finish, with a hard deadline.
-    const drainStart = Date.now()
-    const drained = await Promise.race([
-      Promise.all([waitForAllServiceIntervalsIdle(), waitForQueriesIdle()]).then(() => true),
-      new Promise<false>((r) => setTimeout(() => r(false), HARD_DEADLINE_MS)),
-    ])
-
-    if (drained) {
-      logger.debug('suspension', 'services_drained', {
-        drainMs: Date.now() - drainStart,
-      })
-    } else {
-      logger.warn('suspension', 'hard_deadline_reached', {
-        drainMs: Date.now() - drainStart,
-      })
-    }
-
-    // Phase 3: Checkpoint WAL to release file locks, then close.
-    await closeDb()
-    state = 'suspended'
-  } catch (e) {
-    logger.error('suspension', 'suspend_error', { error: e as Error })
-    // Lift the query gate so the app remains usable if it comes back.
-    resumeDb()
-    state = 'active'
+    await manager.suspend()
   } finally {
     BackgroundTimer.stop()
   }
 }
 
-async function doResume(): Promise<void> {
-  if (state !== 'suspended') {
-    getUploadManager()?.adjustBatchForSuspension()
-    return
-  }
-
-  state = 'resuming'
-  logger.info('suspension', 'resuming')
-
-  try {
-    await initializeDB({ reopen: true })
-  } catch (e) {
-    logger.error('suspension', 'resume_error', { error: e as Error })
-    state = 'suspended'
-    return
-  }
-
-  // Lift the query gate AFTER the new connection is ready, so queries
-  // flow to a valid database handle.
-  resumeDb()
-  resumeLogger()
-  logger.debug('suspension', 'db_reopened')
-
-  const manager = getUploadManager()
-  manager?.adjustBatchForSuspension()
-  manager?.resume()
-  resumeAllServiceIntervals()
-  state = 'active'
-  logger.info('suspension', 'resumed')
-}
-
 export function resumeFromSuspension(): Promise<void> {
-  return queue.enqueue(doResume)
-}
-
-export function suspendForBackground(): Promise<void> {
-  return queue.enqueue(doSuspend)
+  return manager.resume()
 }
 
 export function getIsSuspended(): boolean {
-  return state === 'suspended'
+  return manager.isSuspended()
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,6 +38,7 @@
     "./services/thumbnailScanner": "./src/services/thumbnailScanner.ts",
     "./services/cacheEviction": "./src/services/cacheEviction.ts",
     "./services/importScanner": "./src/services/importScanner.ts",
+    "./services/suspension": "./src/services/suspension.ts",
     "./services/uploader": "./src/services/uploader.ts",
     "./services/fsFileUri": "./src/services/fsFileUri.ts",
     "./app": "./src/app/index.ts",

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -13,6 +13,7 @@ export {
 } from './importScanner'
 export { LOG_ROTATION_INTERVAL, runLogRotation } from './logRotation'
 export { type OrphanScannerResult, runOrphanScanner } from './orphanScanner'
+export { type SuspensionAdapters, createSuspensionManager } from './suspension'
 export { syncDownEventsBatch } from './syncDownEvents'
 export { diffFileMetadata, type SyncUpCursor, syncUpMetadataBatch } from './syncUpMetadata'
 export {

--- a/packages/core/src/services/suspension.ts
+++ b/packages/core/src/services/suspension.ts
@@ -1,0 +1,156 @@
+import { CoalescingQueue } from '../lib/coalescingQueue'
+import { logger } from '@siastorage/logger'
+
+export type SuspensionAdapters = {
+  scheduler: {
+    pause(): void
+    abort(): void
+    resume(): void
+    waitForIdle(): Promise<void>
+  }
+  uploader: {
+    suspend(): Promise<void>
+    resume(): void
+    adjustBatchForSuspension(): void
+  }
+  db: {
+    gate(): void
+    ungate(): void
+    waitForIdle(): Promise<void>
+    close(): Promise<void>
+    reopen(): Promise<void>
+  }
+  hooks?: {
+    onBeforeSuspend?(): void | Promise<void>
+    onAfterResume?(): void
+  }
+  hardDeadlineMs: number
+}
+
+type State = 'active' | 'suspending' | 'suspended' | 'resuming'
+
+export function createSuspensionManager(adapters: SuspensionAdapters) {
+  const { scheduler, uploader, db, hooks, hardDeadlineMs } = adapters
+  let state: State = 'active'
+  const queue = new CoalescingQueue()
+
+  async function doSuspend(): Promise<void> {
+    if (state !== 'active') {
+      logger.debug('suspension', 'skipped', {
+        reason: state === 'suspended' ? 'already_suspended' : state,
+      })
+      return
+    }
+
+    state = 'suspending'
+    logger.info('suspension', 'starting')
+
+    try {
+      // Phase 0: Platform-specific pre-work (e.g. flush logs, disable SWR).
+      await hooks?.onBeforeSuspend?.()
+
+      // Phase 1: Signal services to stop. pause() prevents new scheduler
+      // ticks, abort() tells in-flight workers to exit at their next
+      // signal.aborted check, upload manager parks its async loop.
+      scheduler.pause()
+      scheduler.abort()
+      await uploader.suspend()
+      logger.debug('suspension', 'services_paused')
+
+      // Phase 2: Drain services with a hard deadline. DB is still open so
+      // workers can complete their current unit of work (DB writes, cursor
+      // updates) without hitting DatabaseSuspendedError.
+      const drainStart = Date.now()
+      let deadlineTimer: ReturnType<typeof setTimeout>
+      const deadlinePromise = new Promise<false>((r) => {
+        deadlineTimer = setTimeout(() => r(false), hardDeadlineMs)
+      })
+      let drained: boolean
+      try {
+        drained = await Promise.race([scheduler.waitForIdle().then(() => true), deadlinePromise])
+      } finally {
+        clearTimeout(deadlineTimer!)
+      }
+
+      if (drained) {
+        logger.debug('suspension', 'services_drained', {
+          drainMs: Date.now() - drainStart,
+        })
+      } else {
+        logger.warn('suspension', 'hard_deadline_reached', {
+          drainMs: Date.now() - drainStart,
+        })
+      }
+
+      // Phase 3: Gate the DB so straggler queries throw
+      // DatabaseSuspendedError instead of reaching the native queue.
+      db.gate()
+      logger.debug('suspension', 'db_gated')
+
+      // Phase 4: Drain queries already dispatched to the native queue.
+      // Use remaining budget from the hard deadline so a stuck query
+      // can't block suspension indefinitely.
+      const elapsedMs = Date.now() - drainStart
+      const remainingMs = Math.max(hardDeadlineMs - elapsedMs, 1000)
+      const dbDrained = await Promise.race([
+        db.waitForIdle().then(() => true),
+        new Promise<false>((r) => setTimeout(() => r(false), remainingMs)),
+      ])
+      if (!dbDrained) {
+        logger.warn('suspension', 'db_drain_timeout', {
+          remainingMs,
+        })
+      }
+
+      // Phase 5: Checkpoint WAL to release file locks, then close.
+      await db.close()
+      state = 'suspended'
+    } catch (e) {
+      // Unlikely — each phase handles its own errors internally.
+      // Try to undo partial suspension so the app remains usable.
+      logger.error('suspension', 'suspend_error', { error: e as Error })
+      hooks?.onAfterResume?.()
+      db.ungate()
+      uploader.resume()
+      scheduler.resume()
+      state = 'active'
+    }
+  }
+
+  async function doResume(): Promise<void> {
+    if (state !== 'suspended') {
+      uploader.adjustBatchForSuspension()
+      return
+    }
+
+    state = 'resuming'
+    logger.info('suspension', 'resuming')
+
+    try {
+      await db.reopen()
+    } catch (e) {
+      logger.error('suspension', 'resume_error', { error: e as Error })
+      state = 'suspended'
+      return
+    }
+
+    // Ungate after reopen so queries can't reach a closed handle.
+    // reopen() uses the raw database connection (not the gated adapter),
+    // so the gate being active during reopen is harmless.
+    db.ungate()
+    hooks?.onAfterResume?.()
+    logger.debug('suspension', 'db_reopened')
+
+    uploader.adjustBatchForSuspension()
+    uploader.resume()
+    scheduler.resume()
+    state = 'active'
+    logger.info('suspension', 'resumed')
+  }
+
+  return {
+    suspend: () => queue.enqueue(doSuspend),
+    resume: () => queue.enqueue(doResume),
+    isSuspended: () => state === 'suspended',
+  }
+}


### PR DESCRIPTION
- Services now drain before the DB closes, so in-flight writes complete instead of hitting DatabaseSuspendedError. SWR is paused during suspension so the UI stops querying immediately.
- Extracted suspension orchestration into shared core (createSuspensionManager) with dependency-injected adapters so mobile and integration tests use the same phase ordering.
- Fixed a race condition where ungating the DB before reopen allowed queries to reach a closed handle. The gate now stays active until reopen completes.
- Added a timeout to the DB query drain phase so a stuck native query can't block suspension past the iOS background time budget.