### PR TITLE
fix(core,mobile): distinguish temporarily unavailable assets from deleted in import scanner

### DIFF
--- a/.changeset/fix-icloud-lost-files.md
+++ b/.changeset/fix-icloud-lost-files.md
@@ -1,0 +1,6 @@
+---
+core: patch
+mobile: patch
+---
+
+Distinguish temporarily unavailable assets from permanently deleted ones in the import scanner.

--- a/apps/mobile/src/components/FileViewer/index.tsx
+++ b/apps/mobile/src/components/FileViewer/index.tsx
@@ -48,7 +48,8 @@ export function FileViewer({
   const mediaLibrarySwr = useSWR(localId ? ['mediaLibraryUri', localId] : null, () =>
     getMediaLibraryUri(localId),
   )
-  const mediaLibraryUri = mediaLibrarySwr.data
+  const mediaLibraryUri =
+    mediaLibrarySwr.data?.status === 'resolved' ? mediaLibrarySwr.data.uri : null
   const mediaLibraryLoading = localId ? !mediaLibrarySwr.data && !mediaLibrarySwr.error : false
 
   const baseMediaStyle = styles.media

--- a/apps/mobile/src/lib/mediaLibrary.test.ts
+++ b/apps/mobile/src/lib/mediaLibrary.test.ts
@@ -1,0 +1,123 @@
+import * as MediaLibrary from 'expo-media-library'
+import { getMediaLibraryUri } from './mediaLibrary'
+
+jest.mock('expo-media-library', () => ({
+  getAssetInfoAsync: jest.fn(),
+}))
+
+const getAssetInfoAsyncMock = jest.mocked(MediaLibrary.getAssetInfoAsync)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('getMediaLibraryUri', () => {
+  it('returns deleted for null localId', async () => {
+    expect(await getMediaLibraryUri(null)).toEqual({ status: 'deleted' })
+    expect(getAssetInfoAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('returns resolved when asset is available locally', async () => {
+    getAssetInfoAsyncMock.mockResolvedValue({
+      localUri: 'file:///photos/IMG_001.jpg',
+    } as any)
+
+    expect(await getMediaLibraryUri('ph://asset-1')).toEqual({
+      status: 'resolved',
+      uri: 'file:///photos/IMG_001.jpg',
+    })
+    expect(getAssetInfoAsyncMock).toHaveBeenCalledWith('ph://asset-1', {
+      shouldDownloadFromNetwork: true,
+    })
+  })
+
+  // iOS: getAssetInfoAsync sometimes appends a hash index to localUri
+  // that the file system API can't open.
+  it('normalizes localUri by stripping hash suffix', async () => {
+    getAssetInfoAsyncMock.mockResolvedValue({
+      localUri: 'file:///photos/IMG_001.jpg#hash-index',
+    } as any)
+
+    expect(await getMediaLibraryUri('ph://asset-1')).toEqual({
+      status: 'resolved',
+      uri: 'file:///photos/IMG_001.jpg',
+    })
+  })
+
+  // Both platforms: asset was deleted from the device photo library.
+  it('returns deleted when asset is gone', async () => {
+    getAssetInfoAsyncMock.mockResolvedValue(null as any)
+
+    expect(await getMediaLibraryUri('ph://deleted')).toEqual({ status: 'deleted' })
+  })
+
+  // iOS: asset is in iCloud and the download hasn't completed or the
+  // content can't be exported (e.g. slow-mo video). The asset record
+  // exists but localUri is null.
+  // iOS: iCloud content that hasn't finished downloading. Asset exists
+  // but localUri is null because the content isn't on disk yet.
+  it('returns unavailable when asset exists but localUri is null', async () => {
+    getAssetInfoAsyncMock.mockResolvedValue({
+      localUri: null,
+      id: 'ph://icloud-video',
+    } as any)
+
+    expect(await getMediaLibraryUri('ph://icloud-video')).toEqual({ status: 'unavailable' })
+  })
+
+  // Android: cloud-only file (Google Photos "Free up space"). localUri
+  // is undefined because expo-media-library only sets it when
+  // ExifInterface can read the file on disk.
+  it('returns unavailable when asset exists but localUri is undefined', async () => {
+    getAssetInfoAsyncMock.mockResolvedValue({
+      localUri: undefined,
+      id: 'ph://icloud-video',
+    } as any)
+
+    expect(await getMediaLibraryUri('ph://icloud-video')).toEqual({ status: 'unavailable' })
+  })
+
+  // iOS: iCloud download or video export can throw. Android ignores the
+  // shouldDownloadFromNetwork option and never does network downloads in
+  // getAssetInfoAsync, so this path is iOS-only. We retry without
+  // download to check if the asset still exists.
+  describe('iOS: iCloud download/export failure with fallback', () => {
+    it('returns unavailable when fetch throws but asset still exists', async () => {
+      getAssetInfoAsyncMock
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValueOnce({ id: 'ph://asset', localUri: null } as any)
+
+      expect(await getMediaLibraryUri('ph://asset')).toEqual({ status: 'unavailable' })
+      expect(getAssetInfoAsyncMock).toHaveBeenCalledTimes(2)
+      expect(getAssetInfoAsyncMock).toHaveBeenNthCalledWith(2, 'ph://asset', {
+        shouldDownloadFromNetwork: false,
+      })
+    })
+
+    it('returns deleted when fetch throws and asset is gone', async () => {
+      getAssetInfoAsyncMock
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValueOnce(null as any)
+
+      expect(await getMediaLibraryUri('ph://gone')).toEqual({ status: 'deleted' })
+    })
+
+    it('returns deleted when both fetch and fallback throw', async () => {
+      getAssetInfoAsyncMock
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockRejectedValueOnce(new Error('Photos DB unavailable'))
+
+      expect(await getMediaLibraryUri('ph://broken')).toEqual({ status: 'deleted' })
+    })
+
+    // iOS-specific: slow-mo and edited videos throw
+    // ExportSessionFailedException during export.
+    it('returns unavailable on ExportSessionFailedException', async () => {
+      getAssetInfoAsyncMock
+        .mockRejectedValueOnce(new Error('ExportSessionFailedException'))
+        .mockResolvedValueOnce({ id: 'ph://slowmo', localUri: null } as any)
+
+      expect(await getMediaLibraryUri('ph://slowmo')).toEqual({ status: 'unavailable' })
+    })
+  })
+})

--- a/apps/mobile/src/lib/mediaLibrary.ts
+++ b/apps/mobile/src/lib/mediaLibrary.ts
@@ -1,19 +1,71 @@
+import type { ResolveLocalIdResult } from '@siastorage/core/services/importScanner'
+import { logger } from '@siastorage/logger'
 import * as MediaLibrary from 'expo-media-library'
 
+const resolved = (uri: string): ResolveLocalIdResult => ({ status: 'resolved', uri })
+const deleted: ResolveLocalIdResult = { status: 'deleted' }
+const unavailable: ResolveLocalIdResult = { status: 'unavailable' }
+
 /**
- * Get the local URI for a file record. If the file has a local ID, use the
- * local URI from the MediaLibrary. The media may need to be downloaded from
- * the network if it is not already cached.
+ * Resolve a media library local ID to a file URI.
+ *
+ * On iOS, getAssetInfoAsync with shouldDownloadFromNetwork triggers an
+ * iCloud download for assets not cached locally. This can fail with
+ * network errors, ExportSessionFailedException (slow-mo/edited videos),
+ * or return an asset with null localUri when content isn't available
+ * yet. We distinguish "temporarily unavailable" from "permanently
+ * deleted" so the import scanner doesn't mark iCloud files as lost.
+ *
+ * On Android, getAssetInfoAsync only queries MediaStore — the options
+ * parameter is ignored and no network download occurs. localUri is
+ * only set when ExifInterface can read the file on disk (images only),
+ * so cloud-only files (Google Photos "Free up space") return with
+ * localUri undefined and we return unavailable. This is an
+ * expo-media-library limitation — it uses file:// paths from the
+ * deprecated DATA column instead of content:// URIs that could
+ * trigger an on-demand download via ContentResolver.
+ *
+ * The three return states drive the import scanner's behavior:
+ * - resolved: file is available, proceed with copy and hash
+ * - unavailable: file exists but can't be accessed right now, skip
+ *   without marking as lost (retry on next scan)
+ * - deleted: file is gone from the device, mark as lost
  */
-export async function getMediaLibraryUri(localId: string | null): Promise<string | null> {
-  if (!localId) return null
+export async function getMediaLibraryUri(localId: string | null): Promise<ResolveLocalIdResult> {
+  if (!localId) return deleted
   try {
     const asset = await MediaLibrary.getAssetInfoAsync(localId, {
       shouldDownloadFromNetwork: true,
     })
-    return normalizeUri(asset.localUri)
-  } catch (_e) {
-    return null
+    if (!asset) {
+      logger.debug('mediaLibrary', 'asset_deleted', { localId })
+      return deleted
+    }
+    const uri = normalizeUri(asset.localUri)
+    if (uri) return resolved(uri)
+    // Asset exists but localUri is null — iCloud content that hasn't
+    // finished downloading or can't be exported.
+    logger.debug('mediaLibrary', 'asset_no_local_uri', { localId })
+    return unavailable
+  } catch (e) {
+    // The download/export threw. Retry without download to distinguish
+    // "asset exists but is inaccessible" from "asset was deleted."
+    logger.debug('mediaLibrary', 'asset_info_failed', {
+      localId,
+      error: e as Error,
+    })
+    try {
+      const check = await MediaLibrary.getAssetInfoAsync(localId, {
+        shouldDownloadFromNetwork: false,
+      })
+      return check ? unavailable : deleted
+    } catch (fallbackError) {
+      logger.debug('mediaLibrary', 'asset_info_fallback_failed', {
+        localId,
+        error: fallbackError as Error,
+      })
+      return deleted
+    }
   }
 }
 

--- a/apps/mobile/src/lib/processAssets.test.ts
+++ b/apps/mobile/src/lib/processAssets.test.ts
@@ -215,8 +215,8 @@ describe('syncAssets — eager background sync for recent photos', () => {
       })
 
       jest.mocked(getMediaLibraryUri).mockImplementation(async (localId) => {
-        if (localId === '1') return 'file://1'
-        return null
+        if (localId === '1') return { status: 'resolved', uri: 'file://1' }
+        return { status: 'deleted' }
       })
       const assets = [
         {
@@ -276,7 +276,7 @@ describe('syncAssets — eager background sync for recent photos', () => {
 
     it('allows same-hash files within a single batch', async () => {
       jest.mocked(getMediaLibraryUri).mockImplementation(async () => {
-        return null
+        return { status: 'deleted' }
       })
       jest.mocked(calculateContentHash).mockImplementation(async () => 'sha256:same-for-all')
       const assets = [
@@ -331,7 +331,7 @@ describe('syncAssets — eager background sync for recent photos', () => {
 
     it('prefers full-quality media library URI over sourceUri', async () => {
       jest.mocked(getMediaLibraryUri).mockImplementation(async () => {
-        return 'file:///full-quality.jpg'
+        return { status: 'resolved', uri: 'file:///full-quality.jpg' }
       })
       const assets = [
         {
@@ -359,7 +359,7 @@ describe('syncAssets — eager background sync for recent photos', () => {
 
     it('falls back to sourceUri when media library URI is unavailable', async () => {
       jest.mocked(getMediaLibraryUri).mockImplementation(async () => {
-        return null
+        return { status: 'deleted' }
       })
       const assets = [
         {
@@ -389,7 +389,7 @@ describe('syncAssets — eager background sync for recent photos', () => {
 
     it('retries MIME detection from local file when initial returns octet-stream', async () => {
       jest.mocked(getMediaLibraryUri).mockImplementation(async () => {
-        return 'file:///local/photo'
+        return { status: 'resolved', uri: 'file:///local/photo' }
       })
       jest
         .mocked(getMimeType)
@@ -458,8 +458,8 @@ describe('syncAssets — eager background sync for recent photos', () => {
       })
 
       jest.mocked(getMediaLibraryUri).mockImplementation(async (localId) => {
-        if (localId === '1') return 'file://1'
-        return null
+        if (localId === '1') return { status: 'resolved', uri: 'file://1' }
+        return { status: 'deleted' }
       })
       const assets = [
         {
@@ -497,8 +497,8 @@ describe('syncAssets — eager background sync for recent photos', () => {
       })
 
       jest.mocked(getMediaLibraryUri).mockImplementation(async (localId) => {
-        if (localId === '1') return 'file://1'
-        return null
+        if (localId === '1') return { status: 'resolved', uri: 'file://1' }
+        return { status: 'deleted' }
       })
       const assets = [
         {

--- a/apps/mobile/src/lib/processAssets.ts
+++ b/apps/mobile/src/lib/processAssets.ts
@@ -187,12 +187,12 @@ export async function syncAssets(
     candidateFiles.filter((f) => f.status === 'new'),
     BATCH_SIZE,
     async (f) => {
-      const localUri = await getMediaLibraryUri(f.localId)
-      if (!localUri) {
+      const resolved = await getMediaLibraryUri(f.localId)
+      if (resolved.status === 'deleted') {
         f.localId = null
       }
 
-      const bestUri = localUri ?? f.sourceUri
+      const bestUri = (resolved.status === 'resolved' ? resolved.uri : null) ?? f.sourceUri
       if (!bestUri) {
         f.status = 'incomplete'
         f.statusDetails = 'noUri'

--- a/packages/core/src/services/importScanner.test.ts
+++ b/packages/core/src/services/importScanner.test.ts
@@ -1,4 +1,4 @@
-import { ImportScanner } from './importScanner'
+import { ImportScanner, type ResolveLocalIdResult } from './importScanner'
 
 type MockHelper = {
   app: any
@@ -165,7 +165,12 @@ describe('ImportScanner', () => {
   describe('requires copy and hash (photo library placeholder)', () => {
     it('resolves localId and copies', async () => {
       mock.addFile('f4', { localId: 'ph://asset-123' })
-      const resolveLocalId = jest.fn(async () => 'file:///photo.jpg')
+      const resolveLocalId = jest.fn(
+        async (): Promise<ResolveLocalIdResult> => ({
+          status: 'resolved',
+          uri: 'file:///photo.jpg',
+        }),
+      )
 
       const result = await scanner.runScan(undefined, resolveLocalId)
 
@@ -181,7 +186,12 @@ describe('ImportScanner', () => {
       mock.addFile('f1', { localId: 'ph://1', addedAt: 3000 })
       mock.addFile('f2', { localId: 'ph://2', addedAt: 2000 })
       mock.addFile('f3', { localId: 'ph://3', addedAt: 1000 })
-      const resolveLocalId = jest.fn(async () => 'file:///photo.jpg')
+      const resolveLocalId = jest.fn(
+        async (): Promise<ResolveLocalIdResult> => ({
+          status: 'resolved',
+          uri: 'file:///photo.jpg',
+        }),
+      )
 
       const result = await scanner.runScan(undefined, resolveLocalId, 1)
 
@@ -192,7 +202,12 @@ describe('ImportScanner', () => {
 
     it('skips entirely when maxDeferred=0', async () => {
       mock.addFile('f1', { localId: 'ph://1' })
-      const resolveLocalId = jest.fn(async () => 'file:///photo.jpg')
+      const resolveLocalId = jest.fn(
+        async (): Promise<ResolveLocalIdResult> => ({
+          status: 'resolved',
+          uri: 'file:///photo.jpg',
+        }),
+      )
 
       const result = await scanner.runScan(undefined, resolveLocalId, 0)
 
@@ -214,7 +229,9 @@ describe('ImportScanner', () => {
   describe('lostReason marking', () => {
     it('marks file lost when localId does not resolve', async () => {
       mock.addFile('f5', { localId: 'ph://deleted-asset' })
-      const resolveLocalId = jest.fn(async () => null)
+      const resolveLocalId = jest.fn(
+        async (): Promise<ResolveLocalIdResult> => ({ status: 'deleted' }),
+      )
 
       const result = await scanner.runScan(undefined, resolveLocalId)
 
@@ -229,7 +246,12 @@ describe('ImportScanner', () => {
 
     it('marks file lost when copy from localId fails', async () => {
       mock.addFile('f6', { localId: 'ph://asset' })
-      const resolveLocalId = jest.fn(async () => 'file:///photo.jpg')
+      const resolveLocalId = jest.fn(
+        async (): Promise<ResolveLocalIdResult> => ({
+          status: 'resolved',
+          uri: 'file:///photo.jpg',
+        }),
+      )
       mock.app.fs.copyFile.mockRejectedValueOnce(new Error('Copy failed'))
 
       const result = await scanner.runScan(undefined, resolveLocalId)
@@ -241,6 +263,36 @@ describe('ImportScanner', () => {
           lostReason: 'Failed to copy from device',
         }),
       ])
+    })
+
+    it('skips file when content is temporarily unavailable (not lost)', async () => {
+      mock.addFile('f-icloud', { localId: 'ph://icloud-video' })
+      const resolveLocalId = jest.fn(
+        async (): Promise<ResolveLocalIdResult> => ({ status: 'unavailable' }),
+      )
+
+      const result = await scanner.runScan(undefined, resolveLocalId)
+
+      expect(result.skipped).toBe(1)
+      expect(result.lost).toBe(0)
+      expect(mock.app.files.updateMany).not.toHaveBeenCalled()
+    })
+
+    it('counts unavailable asset against deferred budget', async () => {
+      mock.addFile('f-unavail', { localId: 'ph://unavail', addedAt: 2000 })
+      mock.addFile('f-ok', { localId: 'ph://ok', addedAt: 1000 })
+      const resolveLocalId = jest.fn(
+        async (id: string): Promise<ResolveLocalIdResult> =>
+          id === 'ph://unavail'
+            ? { status: 'unavailable' }
+            : { status: 'resolved', uri: 'file:///photo.jpg' },
+      )
+
+      const result = await scanner.runScan(undefined, resolveLocalId, 1)
+
+      expect(result.skipped).toBe(2) // 1 unavailable + 1 throttled
+      expect(result.finalized).toBe(0)
+      expect(result.lost).toBe(0)
     })
 
     it('marks orphan file (no local file, no localId) as lost', async () => {
@@ -408,7 +460,12 @@ describe('ImportScanner', () => {
 
       mock.addFile('photo-file', { localId: 'ph://123', addedAt: 1000 })
 
-      const resolveLocalId = jest.fn(async () => 'file:///photo.jpg')
+      const resolveLocalId = jest.fn(
+        async (): Promise<ResolveLocalIdResult> => ({
+          status: 'resolved',
+          uri: 'file:///photo.jpg',
+        }),
+      )
 
       const result = await scanner.runScan(undefined, resolveLocalId)
 
@@ -441,7 +498,12 @@ describe('ImportScanner', () => {
       mock.addFile('deferred1', { localId: 'ph://1', addedAt: 3000 })
       mock.addFile('deferred2', { localId: 'ph://2', addedAt: 2000 })
 
-      const resolveLocalId = jest.fn(async () => 'file:///photo.jpg')
+      const resolveLocalId = jest.fn(
+        async (): Promise<ResolveLocalIdResult> => ({
+          status: 'resolved',
+          uri: 'file:///photo.jpg',
+        }),
+      )
 
       const result = await scanner.runScan(undefined, resolveLocalId, 1)
 

--- a/packages/core/src/services/importScanner.ts
+++ b/packages/core/src/services/importScanner.ts
@@ -11,7 +11,11 @@ export type ImportScannerResult = {
   skipped: number
 }
 
-export type ResolveLocalId = (localId: string) => Promise<string | null>
+export type ResolveLocalIdResult =
+  | { status: 'resolved'; uri: string }
+  | { status: 'deleted' }
+  | { status: 'unavailable' }
+export type ResolveLocalId = (localId: string) => Promise<ResolveLocalIdResult>
 export type CalculateContentHash = (uri: string) => Promise<string | null>
 export type GetMimeType = (opts: { name?: string; uri?: string }) => Promise<string>
 
@@ -172,8 +176,8 @@ export class ImportScanner {
             }
             deferredProcessed++
 
-            const resolvedUri = await resolveLocalId(file.localId)
-            if (!resolvedUri) {
+            const resolved = await resolveLocalId(file.localId)
+            if (resolved.status === 'deleted') {
               logger.debug('importScanner', 'localId_not_resolved', {
                 fileId: file.id,
                 localId: file.localId,
@@ -185,11 +189,19 @@ export class ImportScanner {
               result.lost++
               continue
             }
+            if (resolved.status === 'unavailable') {
+              logger.debug('importScanner', 'localId_content_unavailable', {
+                fileId: file.id,
+                localId: file.localId,
+              })
+              result.skipped++
+              continue
+            }
 
             try {
               // Exit early on suspension before starting file copy + hash.
               if (signal?.aborted) break
-              const uri = await app.fs.copyFile({ id: file.id, type: file.type }, resolvedUri)
+              const uri = await app.fs.copyFile({ id: file.id, type: file.type }, resolved.uri)
               if (signal?.aborted) break
               const outcome = await this.hashExistingFile(file, uri)
               if (outcome.action === 'finalized') {

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -10,6 +10,7 @@ export {
   ImportScanner,
   type ImportScannerResult,
   type ResolveLocalId,
+  type ResolveLocalIdResult,
 } from './importScanner'
 export { LOG_ROTATION_INTERVAL, runLogRotation } from './logRotation'
 export { type OrphanScannerResult, runOrphanScanner } from './orphanScanner'


### PR DESCRIPTION
- getMediaLibraryUri returned null for both "asset deleted" and "asset temporarily unavailable," causing the import scanner to permanently mark files as lost when they were just inaccessible at that moment.
- Added a third resolution status (unavailable) so the scanner skips these files without marking them lost. On iOS, a fallback call without network download distinguishes "exists but can't access" from "gone." Covers iCloud-backed files, slow-mo/edited video export failures, storage-pressure evictions, and any other case where getAssetInfoAsync throws or returns a null localUri. On Android, covers cloud-only files where ExifInterface can't read the local path.