### PR TITLE
fix(core): split import scanner queries and add backoff for transient failures

### DIFF
--- a/.changeset/fix-import-scanner-pagination.md
+++ b/.changeset/fix-import-scanner-pagination.md
@@ -1,0 +1,5 @@
+---
+core: minor
+---
+
+Split import scanner into two targeted queries and add BackoffTracker for exponential backoff on transiently-failing files.

--- a/apps/mobile/src/managers/importScanner.ts
+++ b/apps/mobile/src/managers/importScanner.ts
@@ -1,6 +1,7 @@
 import { IMPORT_SCANNER_BACKLOG_LIMIT, IMPORT_SCANNER_INTERVAL } from '@siastorage/core/config'
 import { createServiceInterval } from '@siastorage/core/lib/serviceInterval'
 import { ImportScanner, type ImportScannerResult } from '@siastorage/core/services/importScanner'
+import { logger } from '@siastorage/logger'
 import { calculateContentHash } from '../lib/contentHash'
 import { getMimeType } from '../lib/fileTypes'
 import { getMediaLibraryUri } from '../lib/mediaLibrary'
@@ -28,8 +29,14 @@ async function computeMaxDeferred(): Promise<number> {
     activeOnly: true,
     hashNotEmpty: true,
   })
-  if (pendingUpload >= IMPORT_SCANNER_BACKLOG_LIMIT) return 0
-  return IMPORT_SCANNER_BACKLOG_LIMIT - pendingUpload
+  const maxDeferred =
+    pendingUpload >= IMPORT_SCANNER_BACKLOG_LIMIT ? 0 : IMPORT_SCANNER_BACKLOG_LIMIT - pendingUpload
+  logger.debug('importScanner', 'backpressure', {
+    pendingUpload,
+    limit: IMPORT_SCANNER_BACKLOG_LIMIT,
+    maxDeferred,
+  })
+  return maxDeferred
 }
 
 export async function runImportScanner(signal?: AbortSignal): Promise<ImportScannerResult> {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,7 @@
     "./lib/timeout": "./src/lib/timeout.ts",
     "./lib/types": "./src/lib/types.ts",
     "./lib/localObjects": "./src/lib/localObjects.ts",
+    "./lib/backoffTracker": "./src/lib/backoffTracker.ts",
     "./lib/progressThrottle": "./src/lib/progressThrottle.ts",
     "./lib/uniqueId": "./src/lib/uniqueId.ts",
     "./lib/yieldToEventLoop": "./src/lib/yieldToEventLoop.ts",

--- a/packages/core/src/lib/backoffTracker.test.ts
+++ b/packages/core/src/lib/backoffTracker.test.ts
@@ -1,0 +1,118 @@
+import { BackoffTracker } from './backoffTracker'
+
+describe('BackoffTracker', () => {
+  let tracker: BackoffTracker
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    tracker = new BackoffTracker()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('shouldSkip returns false for unknown IDs', () => {
+    expect(tracker.shouldSkip('unknown')).toBe(false)
+  })
+
+  it('shouldSkip returns true after recordSkip', () => {
+    tracker.recordSkip('a')
+    expect(tracker.shouldSkip('a')).toBe(true)
+  })
+
+  it('expires after first backoff interval (5 min)', () => {
+    tracker.recordSkip('a')
+    jest.advanceTimersByTime(5 * 60 * 1000)
+    expect(tracker.shouldSkip('a')).toBe(false)
+  })
+
+  it('does not expire before backoff interval', () => {
+    tracker.recordSkip('a')
+    jest.advanceTimersByTime(5 * 60 * 1000 - 1)
+    expect(tracker.shouldSkip('a')).toBe(true)
+  })
+
+  it('escalates backoff: 5 min → 15 min → 60 min', () => {
+    // First skip: 5 min
+    tracker.recordSkip('a')
+    jest.advanceTimersByTime(5 * 60 * 1000)
+    expect(tracker.shouldSkip('a')).toBe(false)
+
+    // Second skip: 15 min
+    tracker.recordSkip('a')
+    jest.advanceTimersByTime(15 * 60 * 1000 - 1)
+    expect(tracker.shouldSkip('a')).toBe(true)
+    jest.advanceTimersByTime(1)
+    expect(tracker.shouldSkip('a')).toBe(false)
+
+    // Third skip: 45 min (5 * 3^2)
+    tracker.recordSkip('a')
+    jest.advanceTimersByTime(45 * 60 * 1000 - 1)
+    expect(tracker.shouldSkip('a')).toBe(true)
+    jest.advanceTimersByTime(1)
+    expect(tracker.shouldSkip('a')).toBe(false)
+
+    // Fourth skip: capped at 60 min (5 * 3^3 = 135, capped to 60)
+    tracker.recordSkip('a')
+    jest.advanceTimersByTime(60 * 60 * 1000 - 1)
+    expect(tracker.shouldSkip('a')).toBe(true)
+    jest.advanceTimersByTime(1)
+    expect(tracker.shouldSkip('a')).toBe(false)
+  })
+
+  it('cap never exceeds 60 min even after many attempts', () => {
+    for (let i = 0; i < 10; i++) {
+      tracker.recordSkip('a')
+      jest.advanceTimersByTime(60 * 60 * 1000)
+    }
+    tracker.recordSkip('a')
+    jest.advanceTimersByTime(60 * 60 * 1000 - 1)
+    expect(tracker.shouldSkip('a')).toBe(true)
+    jest.advanceTimersByTime(1)
+    expect(tracker.shouldSkip('a')).toBe(false)
+  })
+
+  it('getExcludeIds returns all active backoff IDs', () => {
+    tracker.recordSkip('a')
+    tracker.recordSkip('b')
+    tracker.recordSkip('c')
+    expect(tracker.getExcludeIds().sort()).toEqual(['a', 'b', 'c'])
+  })
+
+  it('getExcludeIds excludes expired entries', () => {
+    tracker.recordSkip('a')
+    tracker.recordSkip('b')
+    jest.advanceTimersByTime(5 * 60 * 1000)
+    expect(tracker.getExcludeIds()).toEqual([])
+  })
+
+  it('clear removes a specific ID', () => {
+    tracker.recordSkip('a')
+    tracker.recordSkip('b')
+    tracker.clear('a')
+    expect(tracker.shouldSkip('a')).toBe(false)
+    expect(tracker.shouldSkip('b')).toBe(true)
+  })
+
+  it('reset clears all entries', () => {
+    tracker.recordSkip('a')
+    tracker.recordSkip('b')
+    tracker.reset()
+    expect(tracker.shouldSkip('a')).toBe(false)
+    expect(tracker.shouldSkip('b')).toBe(false)
+    expect(tracker.getExcludeIds()).toEqual([])
+  })
+
+  it('tracks independent backoff per ID', () => {
+    tracker.recordSkip('a')
+    jest.advanceTimersByTime(3 * 60 * 1000)
+    tracker.recordSkip('b')
+    jest.advanceTimersByTime(2 * 60 * 1000)
+
+    // a: 5 min elapsed, should be expired
+    expect(tracker.shouldSkip('a')).toBe(false)
+    // b: 2 min elapsed, still in backoff
+    expect(tracker.shouldSkip('b')).toBe(true)
+  })
+})

--- a/packages/core/src/lib/backoffTracker.ts
+++ b/packages/core/src/lib/backoffTracker.ts
@@ -1,0 +1,54 @@
+import { minutesInMs } from './time'
+
+const BASE_MS = minutesInMs(5)
+const MAX_MS = minutesInMs(60)
+
+type Entry = { attempts: number; retryAfter: number }
+
+/**
+ * In-memory backoff tracker for temporarily-failing items.
+ *
+ * Tracks IDs with exponential backoff (5 min → 15 min → 60 min cap).
+ * Entries auto-expire when their retryAfter timestamp passes.
+ * Resets on app restart, giving every item a clean retry.
+ */
+export class BackoffTracker {
+  private entries = new Map<string, Entry>()
+
+  /** True if the ID is in backoff and the retry window hasn't passed. */
+  shouldSkip(id: string): boolean {
+    const entry = this.entries.get(id)
+    if (!entry) return false
+    return Date.now() < entry.retryAfter
+  }
+
+  /** Record a skip, incrementing attempts and setting the next retry time. */
+  recordSkip(id: string): void {
+    const existing = this.entries.get(id)
+    const attempts = (existing?.attempts ?? 0) + 1
+    const delay = Math.min(BASE_MS * Math.pow(3, attempts - 1), MAX_MS)
+    this.entries.set(id, { attempts, retryAfter: Date.now() + delay })
+  }
+
+  /** All IDs currently in backoff (not yet expired). */
+  getExcludeIds(): string[] {
+    const now = Date.now()
+    const ids: string[] = []
+    for (const [id, entry] of this.entries) {
+      if (now < entry.retryAfter) {
+        ids.push(id)
+      }
+    }
+    return ids
+  }
+
+  /** Remove an ID from tracking (item succeeded). */
+  clear(id: string): void {
+    this.entries.delete(id)
+  }
+
+  /** Clear all entries (shutdown/reset). */
+  reset(): void {
+    this.entries.clear()
+  }
+}

--- a/packages/core/src/services/importScanner.test.ts
+++ b/packages/core/src/services/importScanner.test.ts
@@ -24,10 +24,14 @@ function createMockApp(): MockHelper {
   const app: any = {
     files: {
       query: jest.fn(async (opts: any) => {
+        const excludeSet = new Set(opts.excludeIds ?? [])
         const results: any[] = []
         for (const [, file] of fileRecords) {
+          if (excludeSet.has(file.id)) continue
           if (opts.activeOnly && (file.trashedAt || file.deletedAt)) continue
           if (opts.hashEmpty && file.hash !== '') continue
+          if (opts.fileExistsLocally === true && !fsFiles.has(file.id)) continue
+          if (opts.fileExistsLocally === false && fsFiles.has(file.id)) continue
           results.push({ ...file, objects: {} })
         }
         results.sort((a: any, b: any) =>
@@ -108,6 +112,7 @@ describe('ImportScanner', () => {
   const mockMimeType = jest.fn(async () => 'image/jpeg')
 
   beforeEach(() => {
+    jest.useFakeTimers()
     scanner = new ImportScanner()
     mock = createMockApp()
     scanner.initialize(mock.app, mockHash, mockMimeType)
@@ -116,6 +121,7 @@ describe('ImportScanner', () => {
 
   afterEach(() => {
     scanner.reset()
+    jest.useRealTimers()
   })
 
   describe('initialization', () => {
@@ -134,7 +140,7 @@ describe('ImportScanner', () => {
     })
   })
 
-  describe('requires hash (local file exists)', () => {
+  describe('phase 1: requires hash (local file exists)', () => {
     it('hashes local file and updates record', async () => {
       mock.addFile('f1')
       mock.addLocalFile('f1', '/local/f1.jpg')
@@ -152,7 +158,7 @@ describe('ImportScanner', () => {
       ])
     })
 
-    it('processes regardless of maxDeferred=0', async () => {
+    it('processes local files regardless of maxDeferred=0', async () => {
       mock.addFile('f1')
       mock.addLocalFile('f1', '/local/f1.jpg')
 
@@ -160,9 +166,21 @@ describe('ImportScanner', () => {
 
       expect(result.finalized).toBe(1)
     })
+
+    it('queries with fileExistsLocally: true for phase 1', async () => {
+      await scanner.runScan()
+
+      expect(mock.app.files.query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hashEmpty: true,
+          fileExistsLocally: true,
+          activeOnly: true,
+        }),
+      )
+    })
   })
 
-  describe('requires copy and hash (photo library placeholder)', () => {
+  describe('phase 2: requires copy and hash (photo library placeholder)', () => {
     it('resolves localId and copies', async () => {
       mock.addFile('f4', { localId: 'ph://asset-123' })
       const resolveLocalId = jest.fn(
@@ -182,7 +200,7 @@ describe('ImportScanner', () => {
       )
     })
 
-    it('throttles when maxDeferred is reached', async () => {
+    it('limits deferred candidates to maxDeferred', async () => {
       mock.addFile('f1', { localId: 'ph://1', addedAt: 3000 })
       mock.addFile('f2', { localId: 'ph://2', addedAt: 2000 })
       mock.addFile('f3', { localId: 'ph://3', addedAt: 1000 })
@@ -196,11 +214,10 @@ describe('ImportScanner', () => {
       const result = await scanner.runScan(undefined, resolveLocalId, 1)
 
       expect(result.finalized).toBe(1)
-      expect(result.skipped).toBe(2)
       expect(resolveLocalId).toHaveBeenCalledTimes(1)
     })
 
-    it('skips entirely when maxDeferred=0', async () => {
+    it('skips phase 2 entirely when maxDeferred=0', async () => {
       mock.addFile('f1', { localId: 'ph://1' })
       const resolveLocalId = jest.fn(
         async (): Promise<ResolveLocalIdResult> => ({
@@ -212,8 +229,32 @@ describe('ImportScanner', () => {
       const result = await scanner.runScan(undefined, resolveLocalId, 0)
 
       expect(result.finalized).toBe(0)
-      expect(result.skipped).toBe(1)
       expect(resolveLocalId).not.toHaveBeenCalled()
+      // Only phase 1 query runs
+      expect(mock.app.files.query).toHaveBeenCalledTimes(1)
+      expect(mock.app.files.query).toHaveBeenCalledWith(
+        expect.objectContaining({ fileExistsLocally: true }),
+      )
+    })
+
+    it('queries with fileExistsLocally: false for phase 2', async () => {
+      mock.addFile('f1', { localId: 'ph://1' })
+      const resolveLocalId = jest.fn(
+        async (): Promise<ResolveLocalIdResult> => ({
+          status: 'resolved',
+          uri: 'file:///photo.jpg',
+        }),
+      )
+
+      await scanner.runScan(undefined, resolveLocalId)
+
+      expect(mock.app.files.query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hashEmpty: true,
+          fileExistsLocally: false,
+          activeOnly: true,
+        }),
+      )
     })
 
     it('skips files with localId when no resolver is provided', async () => {
@@ -244,7 +285,7 @@ describe('ImportScanner', () => {
       ])
     })
 
-    it('marks file lost when copy from localId fails', async () => {
+    it('retries copy failure with backoff instead of marking lost', async () => {
       mock.addFile('f6', { localId: 'ph://asset' })
       const resolveLocalId = jest.fn(
         async (): Promise<ResolveLocalIdResult> => ({
@@ -256,13 +297,12 @@ describe('ImportScanner', () => {
 
       const result = await scanner.runScan(undefined, resolveLocalId)
 
-      expect(result.lost).toBe(1)
-      expect(mock.app.files.updateMany).toHaveBeenCalledWith([
-        expect.objectContaining({
-          id: 'f6',
-          lostReason: 'Failed to copy from device',
-        }),
-      ])
+      expect(result.failed).toBe(1)
+      expect(result.lost).toBe(0)
+      // No lostReason written to DB
+      expect(mock.app.files.updateMany).not.toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ lostReason: expect.any(String) })]),
+      )
     })
 
     it('skips file when content is temporarily unavailable (not lost)', async () => {
@@ -276,23 +316,6 @@ describe('ImportScanner', () => {
       expect(result.skipped).toBe(1)
       expect(result.lost).toBe(0)
       expect(mock.app.files.updateMany).not.toHaveBeenCalled()
-    })
-
-    it('counts unavailable asset against deferred budget', async () => {
-      mock.addFile('f-unavail', { localId: 'ph://unavail', addedAt: 2000 })
-      mock.addFile('f-ok', { localId: 'ph://ok', addedAt: 1000 })
-      const resolveLocalId = jest.fn(
-        async (id: string): Promise<ResolveLocalIdResult> =>
-          id === 'ph://unavail'
-            ? { status: 'unavailable' }
-            : { status: 'resolved', uri: 'file:///photo.jpg' },
-      )
-
-      const result = await scanner.runScan(undefined, resolveLocalId, 1)
-
-      expect(result.skipped).toBe(2) // 1 unavailable + 1 throttled
-      expect(result.finalized).toBe(0)
-      expect(result.lost).toBe(0)
     })
 
     it('marks orphan file (no local file, no localId) as lost', async () => {
@@ -310,6 +333,140 @@ describe('ImportScanner', () => {
     })
   })
 
+  describe('backoff tracking', () => {
+    it('unavailable files enter backoff and are excluded on next tick', async () => {
+      mock.addFile('f-cloud', { localId: 'ph://cloud' })
+      const resolveLocalId = jest.fn(
+        async (): Promise<ResolveLocalIdResult> => ({ status: 'unavailable' }),
+      )
+
+      // First scan: file is skipped
+      const r1 = await scanner.runScan(undefined, resolveLocalId)
+      expect(r1.skipped).toBe(1)
+
+      // Second scan (immediately): file excluded via backoff
+      jest.clearAllMocks()
+      const r2 = await scanner.runScan(undefined, resolveLocalId)
+      expect(r2.skipped).toBe(0)
+      expect(resolveLocalId).not.toHaveBeenCalled()
+    })
+
+    it('backed-off files are retried after cooldown expires', async () => {
+      mock.addFile('f-cloud', { localId: 'ph://cloud' })
+      let callCount = 0
+      const resolveLocalId = jest.fn(async (): Promise<ResolveLocalIdResult> => {
+        callCount++
+        if (callCount === 1) return { status: 'unavailable' }
+        return { status: 'resolved', uri: 'file:///photo.jpg' }
+      })
+
+      // First scan: unavailable → backoff
+      await scanner.runScan(undefined, resolveLocalId)
+
+      // Advance past 5-min backoff
+      jest.advanceTimersByTime(5 * 60 * 1000)
+
+      // Second scan: retried and succeeds
+      const r2 = await scanner.runScan(undefined, resolveLocalId)
+      expect(r2.finalized).toBe(1)
+    })
+
+    it('copy failure enters backoff and is retried', async () => {
+      mock.addFile('f-copy', { localId: 'ph://asset' })
+      const resolveLocalId = jest.fn(
+        async (): Promise<ResolveLocalIdResult> => ({
+          status: 'resolved',
+          uri: 'file:///photo.jpg',
+        }),
+      )
+
+      // First scan: copy fails
+      mock.app.fs.copyFile.mockRejectedValueOnce(new Error('Copy failed'))
+      const r1 = await scanner.runScan(undefined, resolveLocalId)
+      expect(r1.failed).toBe(1)
+
+      // Immediately: excluded via backoff
+      jest.clearAllMocks()
+      await scanner.runScan(undefined, resolveLocalId)
+      expect(resolveLocalId).not.toHaveBeenCalled()
+
+      // After backoff: retried
+      jest.advanceTimersByTime(5 * 60 * 1000)
+      jest.clearAllMocks()
+      const r3 = await scanner.runScan(undefined, resolveLocalId)
+      expect(r3.finalized).toBe(1)
+    })
+
+    it('successful finalization clears backoff', async () => {
+      mock.addFile('f1', { localId: 'ph://1' })
+      let callCount = 0
+      const resolveLocalId = jest.fn(async (): Promise<ResolveLocalIdResult> => {
+        callCount++
+        if (callCount === 1) return { status: 'unavailable' }
+        return { status: 'resolved', uri: 'file:///photo.jpg' }
+      })
+
+      // Skip → backoff
+      await scanner.runScan(undefined, resolveLocalId)
+
+      // Advance past backoff, finalize
+      jest.advanceTimersByTime(5 * 60 * 1000)
+      await scanner.runScan(undefined, resolveLocalId)
+
+      // File is now finalized (hash set), so it won't appear in hashEmpty queries.
+      // If it were still in backoff, it would be excluded. Verify backoff was cleared
+      // by checking no excludeIds are passed.
+      jest.clearAllMocks()
+      await scanner.runScan(undefined, resolveLocalId)
+      const phase2Call = mock.app.files.query.mock.calls.find(
+        (c: any[]) => c[0].fileExistsLocally === false,
+      )
+      expect(phase2Call?.[0].excludeIds).toBeUndefined()
+    })
+
+    it('hash failure enters backoff', async () => {
+      mock.addFile('f-hash')
+      mock.addLocalFile('f-hash', '/local/f-hash.jpg')
+      mockHash.mockResolvedValueOnce(null)
+
+      const r1 = await scanner.runScan()
+      expect(r1.failed).toBe(1)
+
+      // Immediately: excluded via backoff
+      jest.clearAllMocks()
+      mockHash.mockResolvedValue('sha256:ok')
+      const r2 = await scanner.runScan()
+      expect(r2.finalized).toBe(0)
+
+      // After backoff: retried
+      jest.advanceTimersByTime(5 * 60 * 1000)
+      const r3 = await scanner.runScan()
+      expect(r3.finalized).toBe(1)
+    })
+
+    it('excludeIds from backoff are passed to both queries', async () => {
+      mock.addFile('f-local')
+      mock.addLocalFile('f-local', '/local/f-local.jpg')
+      mock.addFile('f-deferred', { localId: 'ph://1' })
+      const resolveLocalId = jest.fn(
+        async (): Promise<ResolveLocalIdResult> => ({
+          status: 'resolved',
+          uri: 'file:///photo.jpg',
+        }),
+      )
+
+      // Put a file in backoff
+      ;(scanner as any).backoff.recordSkip('some-backed-off-id')
+
+      await scanner.runScan(undefined, resolveLocalId)
+
+      // Both queries should include the backed-off ID
+      for (const call of mock.app.files.query.mock.calls) {
+        expect(call[0].excludeIds).toContain('some-backed-off-id')
+      }
+    })
+  })
+
   describe('skip in-progress files', () => {
     it('skips files currently being processed', async () => {
       mock.addFile('f7')
@@ -320,28 +477,6 @@ describe('ImportScanner', () => {
 
       expect(result.skipped).toBe(1)
       expect(result.finalized).toBe(0)
-    })
-  })
-
-  describe('error cooldown', () => {
-    it('skips files that recently errored', async () => {
-      mock.addFile('f8')
-      ;(scanner as any).erroredFiles.set('f8', Date.now())
-
-      const result = await scanner.runScan()
-
-      expect(result.skipped).toBe(1)
-      expect(result.finalized).toBe(0)
-    })
-
-    it('retries files after cooldown expires', async () => {
-      mock.addFile('f9')
-      mock.addLocalFile('f9', '/local/f9.jpg')
-      ;(scanner as any).erroredFiles.set('f9', Date.now() - 10 * 60 * 1000)
-
-      const result = await scanner.runScan()
-
-      expect(result.finalized).toBe(1)
     })
   })
 
@@ -362,7 +497,7 @@ describe('ImportScanner', () => {
   })
 
   describe('batch limit', () => {
-    it('processes at most MAX_PER_TICK files', async () => {
+    it('processes at most MAX_PER_TICK local files', async () => {
       for (let i = 0; i < 25; i++) {
         mock.addFile(`batch-${i}`, { addedAt: Date.now() - i })
         mock.addLocalFile(`batch-${i}`, `/local/batch-${i}.jpg`)
@@ -447,14 +582,14 @@ describe('ImportScanner', () => {
       const result = await scanner.runScan()
 
       expect(result.finalized).toBe(0)
-      expect(mock.app.files.query).toHaveBeenCalledWith(
-        expect.objectContaining({ hashEmpty: true }),
-      )
+      for (const call of mock.app.files.query.mock.calls) {
+        expect(call[0].hashEmpty).toBe(true)
+      }
     })
   })
 
-  describe('multiple files in one tick', () => {
-    it('processes mix of local files and localIds', async () => {
+  describe('split queries: mixed file types', () => {
+    it('processes local files in phase 1 and deferred files in phase 2', async () => {
       mock.addFile('local-file', { addedAt: 3000 })
       mock.addLocalFile('local-file', '/local/local-file.jpg')
 
@@ -472,23 +607,8 @@ describe('ImportScanner', () => {
       expect(result.finalized).toBe(2)
       expect(result.lost).toBe(0)
     })
-  })
 
-  describe('hash failure', () => {
-    it('marks file as failed when hash returns null', async () => {
-      mock.addFile('hash-fail')
-      mock.addLocalFile('hash-fail', '/local/hash-fail.jpg')
-      mockHash.mockResolvedValueOnce(null)
-
-      const result = await scanner.runScan()
-
-      expect(result.failed).toBe(1)
-      expect(result.finalized).toBe(0)
-    })
-  })
-
-  describe('requires hash + requires copy and hash mixed with maxDeferred', () => {
-    it('always hashes local files but limits copy and hash files', async () => {
+    it('always hashes local files but limits deferred files', async () => {
       mock.addFile('local1', { addedAt: 5000 })
       mock.addLocalFile('local1', '/local/local1.jpg')
 
@@ -508,7 +628,19 @@ describe('ImportScanner', () => {
       const result = await scanner.runScan(undefined, resolveLocalId, 1)
 
       expect(result.finalized).toBe(3) // 2 local + 1 deferred
-      expect(result.skipped).toBe(1) // 1 deferred throttled
+    })
+  })
+
+  describe('hash failure', () => {
+    it('marks file as failed when hash returns null', async () => {
+      mock.addFile('hash-fail')
+      mock.addLocalFile('hash-fail', '/local/hash-fail.jpg')
+      mockHash.mockResolvedValueOnce(null)
+
+      const result = await scanner.runScan()
+
+      expect(result.failed).toBe(1)
+      expect(result.finalized).toBe(0)
     })
   })
 })

--- a/packages/core/src/services/importScanner.ts
+++ b/packages/core/src/services/importScanner.ts
@@ -1,8 +1,8 @@
 import { logger } from '@siastorage/logger'
 import type { AppService } from '../app/service'
+import { BackoffTracker } from '../lib/backoffTracker'
 
 const MAX_PER_TICK = 20
-const ERROR_COOLDOWN_MS = 5 * 60 * 1000 // 5 minutes
 
 export type ImportScannerResult = {
   finalized: number
@@ -22,7 +22,7 @@ export type GetMimeType = (opts: { name?: string; uri?: string }) => Promise<str
 export class ImportScanner {
   private app: AppService | null = null
   private processingFiles = new Set<string>()
-  private erroredFiles = new Map<string, number>()
+  private backoff = new BackoffTracker()
   private _calculateContentHash: CalculateContentHash | null = null
   private _getMimeType: GetMimeType | null = null
 
@@ -41,7 +41,7 @@ export class ImportScanner {
     this._calculateContentHash = null
     this._getMimeType = null
     this.processingFiles.clear()
-    this.erroredFiles.clear()
+    this.backoff.reset()
   }
 
   isInitialized(): boolean {
@@ -52,40 +52,30 @@ export class ImportScanner {
     return this.processingFiles.has(fileId)
   }
 
-  isFileInErrorCooldown(fileId: string): boolean {
-    const lastError = this.erroredFiles.get(fileId)
-    if (!lastError) return false
-    const elapsed = Date.now() - lastError
-    if (elapsed >= ERROR_COOLDOWN_MS) {
-      this.erroredFiles.delete(fileId)
-      return false
-    }
-    return true
-  }
-
-  private markFileErrored(fileId: string): void {
-    this.erroredFiles.set(fileId, Date.now())
-  }
-
   private getApp(): AppService {
     if (!this.app) throw new Error('ImportScanner not initialized')
     return this.app
   }
 
   /**
-   * Finalizes placeholder files (hash: '') in two passes:
+   * Finalizes placeholder files (hash: '') in two phases:
    *
-   * 1. File already on disk (importFiles background copy landed, or
-   *    manually added): hash the local file and update the record.
-   *    Always processed — no I/O pressure since the file is local.
+   * Phase 1 — requires hash: file is already on disk (user import, camera
+   * capture, or background copy). Just hash and update the record.
+   * Always runs regardless of backpressure — the source may be a
+   * temp file that gets cleaned up, so delaying risks data loss.
    *
-   * 2. File has localId but no local copy (catalogAssets placeholder):
-   *    copy from the media library, then hash. Throttled by maxDeferred
-   *    to avoid filling device storage faster than uploads drain it.
+   * Phase 2 — requires copy and hash: file has a localId but no local copy
+   * (archive sync placeholder). Copy from the media library, then hash.
+   * Throttled by maxDeferred to avoid filling device storage faster
+   * than uploads drain it. When maxDeferred=0, this phase is skipped.
    *
-   * Files that cannot be recovered (localId doesn't resolve, no local
-   * file and no localId) are marked with lostReason so the UI can
-   * surface them to the user.
+   * Files that fail transiently (unavailable cloud content, copy errors,
+   * hash errors) enter the BackoffTracker and are excluded from queries
+   * on subsequent ticks until their backoff expires (5m → 15m → 60m cap).
+   *
+   * Files that cannot be recovered (deleted from device, no local file
+   * and no localId) are marked with lostReason for the UI.
    */
   async runScan(
     signal?: AbortSignal,
@@ -101,21 +91,6 @@ export class ImportScanner {
     }
 
     try {
-      const candidates = await app.files.query({
-        hashEmpty: true,
-        activeOnly: true,
-        limit: MAX_PER_TICK,
-        order: 'DESC',
-        orderBy: 'addedAt',
-      })
-
-      if (candidates.length === 0) return result
-
-      logger.debug('importScanner', 'tick', { candidates: candidates.length })
-
-      const effectiveMaxDeferred = maxDeferred ?? Infinity
-      let deferredProcessed = 0
-
       const updates: Array<{
         id: string
         hash: string
@@ -127,28 +102,44 @@ export class ImportScanner {
         lostReason: string
       }> = []
 
-      for (const file of candidates) {
-        if (signal?.aborted) break
+      const excludeIds = this.backoff.getExcludeIds()
+      const excludeOpt = excludeIds.length > 0 ? excludeIds : undefined
 
-        if (this.processingFiles.has(file.id)) {
-          result.skipped++
-          continue
-        }
+      // Phase 1: files already on disk, just need hashing.
+      if (!signal?.aborted) {
+        const localCandidates = await app.files.query({
+          hashEmpty: true,
+          fileExistsLocally: true,
+          activeOnly: true,
+          limit: MAX_PER_TICK,
+          order: 'DESC',
+          orderBy: 'addedAt',
+          excludeIds: excludeOpt,
+        })
 
-        if (this.isFileInErrorCooldown(file.id)) {
-          result.skipped++
-          continue
-        }
-
-        this.processingFiles.add(file.id)
-        try {
-          const localFileUri = await app.fs.getFileUri({
-            id: file.id,
-            type: file.type,
+        if (localCandidates.length > 0) {
+          logger.debug('importScanner', 'tick_local', {
+            candidates: localCandidates.length,
           })
+        }
 
-          // Pass 1: local file on disk — hash and finalize.
-          if (localFileUri) {
+        for (const file of localCandidates) {
+          if (signal?.aborted) break
+          if (this.processingFiles.has(file.id)) {
+            result.skipped++
+            continue
+          }
+
+          this.processingFiles.add(file.id)
+          try {
+            const localFileUri = await app.fs.getFileUri({
+              id: file.id,
+              type: file.type,
+            })
+            if (!localFileUri) {
+              result.skipped++
+              continue
+            }
             // Exit early on suspension before starting CPU-intensive hash.
             if (signal?.aborted) break
             const outcome = await this.hashExistingFile(file, localFileUri)
@@ -160,98 +151,136 @@ export class ImportScanner {
                 type: outcome.type,
               })
               result.finalized++
+              this.backoff.clear(file.id)
             } else {
-              this.markFileErrored(file.id)
+              this.backoff.recordSkip(file.id)
               result.failed++
             }
-            continue
+          } catch (e) {
+            logger.error('importScanner', 'process_error', {
+              fileId: file.id,
+              error: e as Error,
+            })
+            this.backoff.recordSkip(file.id)
+            result.failed++
+          } finally {
+            this.processingFiles.delete(file.id)
           }
+        }
+      }
 
-          // Pass 2: has localId, no local file — copy from media library
-          // then hash. Throttled by maxDeferred to limit storage pressure.
-          if (file.localId && resolveLocalId) {
-            if (deferredProcessed >= effectiveMaxDeferred) {
-              result.skipped++
-              continue
-            }
-            deferredProcessed++
+      // Phase 2: files needing copy from media library, throttled by maxDeferred.
+      const effectiveMaxDeferred = maxDeferred ?? Infinity
+      if (!signal?.aborted && effectiveMaxDeferred > 0) {
+        const deferredLimit =
+          effectiveMaxDeferred === Infinity
+            ? MAX_PER_TICK
+            : Math.min(effectiveMaxDeferred, MAX_PER_TICK)
 
-            const resolved = await resolveLocalId(file.localId)
-            if (resolved.status === 'deleted') {
-              logger.debug('importScanner', 'localId_not_resolved', {
-                fileId: file.id,
-                localId: file.localId,
-              })
-              lostUpdates.push({
-                id: file.id,
-                lostReason: 'Source photo deleted from device',
-              })
-              result.lost++
-              continue
-            }
-            if (resolved.status === 'unavailable') {
-              logger.debug('importScanner', 'localId_content_unavailable', {
-                fileId: file.id,
-                localId: file.localId,
-              })
-              result.skipped++
-              continue
-            }
+        const deferredCandidates = await app.files.query({
+          hashEmpty: true,
+          fileExistsLocally: false,
+          activeOnly: true,
+          limit: deferredLimit,
+          order: 'DESC',
+          orderBy: 'addedAt',
+          excludeIds: excludeOpt,
+        })
 
-            try {
-              // Exit early on suspension before starting file copy + hash.
-              if (signal?.aborted) break
-              const uri = await app.fs.copyFile({ id: file.id, type: file.type }, resolved.uri)
-              if (signal?.aborted) break
-              const outcome = await this.hashExistingFile(file, uri)
-              if (outcome.action === 'finalized') {
-                updates.push({
-                  id: file.id,
-                  hash: outcome.hash,
-                  size: outcome.size,
-                  type: outcome.type,
-                })
-                result.finalized++
-              } else {
-                this.markFileErrored(file.id)
-                result.failed++
-              }
-            } catch (e) {
-              logger.error('importScanner', 'copy_from_localId_failed', {
-                fileId: file.id,
-                error: e as Error,
-              })
-              lostUpdates.push({
-                id: file.id,
-                lostReason: 'Failed to copy from device',
-              })
-              result.lost++
-            }
-            continue
-          }
+        if (deferredCandidates.length > 0) {
+          logger.debug('importScanner', 'tick_deferred', {
+            candidates: deferredCandidates.length,
+          })
+        }
 
-          // Has localId but no resolver available — skip, don't mark lost.
-          if (file.localId) {
+        for (const file of deferredCandidates) {
+          if (signal?.aborted) break
+          if (this.processingFiles.has(file.id)) {
             result.skipped++
             continue
           }
 
-          // No local file, no localId — orphan.
-          logger.debug('importScanner', 'orphan', { fileId: file.id })
-          lostUpdates.push({
-            id: file.id,
-            lostReason: 'No local file or source available',
-          })
-          result.lost++
-        } catch (e) {
-          logger.error('importScanner', 'process_error', {
-            fileId: file.id,
-            error: e as Error,
-          })
-          this.markFileErrored(file.id)
-          result.failed++
-        } finally {
-          this.processingFiles.delete(file.id)
+          this.processingFiles.add(file.id)
+          try {
+            if (file.localId && resolveLocalId) {
+              const resolved = await resolveLocalId(file.localId)
+              if (resolved.status === 'deleted') {
+                logger.debug('importScanner', 'localId_not_resolved', {
+                  fileId: file.id,
+                  localId: file.localId,
+                })
+                lostUpdates.push({
+                  id: file.id,
+                  lostReason: 'Source photo deleted from device',
+                })
+                result.lost++
+                continue
+              }
+              if (resolved.status === 'unavailable') {
+                logger.debug('importScanner', 'localId_content_unavailable', {
+                  fileId: file.id,
+                  localId: file.localId,
+                })
+                this.backoff.recordSkip(file.id)
+                result.skipped++
+                continue
+              }
+
+              try {
+                // Exit early on suspension before starting file copy + hash.
+                if (signal?.aborted) break
+                const uri = await app.fs.copyFile({ id: file.id, type: file.type }, resolved.uri)
+                if (signal?.aborted) break
+                const outcome = await this.hashExistingFile(file, uri)
+                if (outcome.action === 'finalized') {
+                  updates.push({
+                    id: file.id,
+                    hash: outcome.hash,
+                    size: outcome.size,
+                    type: outcome.type,
+                  })
+                  result.finalized++
+                  this.backoff.clear(file.id)
+                } else {
+                  this.backoff.recordSkip(file.id)
+                  result.failed++
+                }
+              } catch (e) {
+                logger.error('importScanner', 'copy_from_localId_failed', {
+                  fileId: file.id,
+                  error: e as Error,
+                })
+                this.backoff.recordSkip(file.id)
+                result.failed++
+              }
+              continue
+            }
+
+            if (file.localId) {
+              logger.debug('importScanner', 'skipped_no_resolver', {
+                fileId: file.id,
+              })
+              this.backoff.recordSkip(file.id)
+              result.skipped++
+              continue
+            }
+
+            logger.debug('importScanner', 'orphan', { fileId: file.id })
+            lostUpdates.push({
+              id: file.id,
+              lostReason: 'No local file or source available',
+            })
+            result.lost++
+          } catch (e) {
+            logger.error('importScanner', 'process_error', {
+              fileId: file.id,
+              error: e as Error,
+            })
+            this.backoff.recordSkip(file.id)
+            result.failed++
+          } finally {
+            this.processingFiles.delete(file.id)
+          }
         }
       }
 


### PR DESCRIPTION
- The import scanner used a single mixed query for both files-on-disk (need hashing) and archive-sync placeholders (need copy from media library). During backpressure or when cloud files were unavailable, skipped files filled the query results every tick and the scanner couldn't reach processable files further down.
- Split into two targeted queries using fileExistsLocally: phase 1 always hashes files already on disk, phase 2 fetches only as many copy-and-hash files as the backpressure budget allows (limit: maxDeferred).
- Added a BackoffTracker for transient per-file failures (unavailable cloud content, copy errors, hash errors). Files enter exponential backoff (5m → 15m → 60m cap) and are excluded from queries via excludeIds until their cooldown expires. Replaces the fixed 5-minute erroredFiles cooldown.
- Copy failures are now retried with backoff instead of being permanently marked as lost.