### PR TITLE
perf(core): debounced SWR cache invalidation and batch-aware upload updates

### DIFF
--- a/.changeset/debounced-swr-invalidation.md
+++ b/.changeset/debounced-swr-invalidation.md
@@ -1,0 +1,6 @@
+---
+core: minor
+mobile: patch
+---
+
+Add debounced cache invalidation API to SWR cache helpers. Batch upload operations now use single bulk invalidation instead of per-item cascades.

--- a/packages/core/src/app/namespaces/uploads.ts
+++ b/packages/core/src/app/namespaces/uploads.ts
@@ -4,28 +4,30 @@ import type { UploadsState } from '../stores'
 /** Builds the uploads namespace: register, update, and clear in-progress uploads. */
 export function buildUploadsNamespace(caches: AppCaches): AppService['uploads'] {
   let state: UploadsState = { uploads: {} }
+  const debounced = caches.uploads.debounced(1000)
 
   const namespace: AppService['uploads'] = {
     getState: () => ({ ...state }),
     getEntry: (id) => state.uploads[id],
     register: (entry) => {
       state = { uploads: { ...state.uploads, [entry.id]: entry } }
-      caches.uploads.invalidate('all')
-      caches.uploads.invalidate('counts')
+      debounced.flush('all')
+      debounced.flush('counts')
       caches.uploads.invalidate(entry.id)
     },
     update: (id, patch) => {
       const existing = state.uploads[id]
       if (!existing) return
       state = { uploads: { ...state.uploads, [id]: { ...existing, ...patch } } }
-      caches.uploads.invalidate('all')
+      debounced.invalidate('all')
+      debounced.invalidate('counts')
       caches.uploads.invalidate(id)
     },
     remove: (id) => {
       const { [id]: _, ...rest } = state.uploads
       state = { uploads: rest }
-      caches.uploads.invalidate('all')
-      caches.uploads.invalidate('counts')
+      debounced.flush('all')
+      debounced.flush('counts')
       caches.uploads.invalidate(id)
     },
     removeMany: (ids) => {
@@ -40,9 +42,12 @@ export function buildUploadsNamespace(caches: AppCaches): AppService['uploads'] 
       caches.uploads.invalidateAll()
     },
     registerMany: (entries) => {
+      const next = { ...state.uploads }
       for (const { id, size } of entries) {
-        namespace.register({ id, size, status: 'queued', progress: 0 })
+        next[id] = { id, size, status: 'queued', progress: 0 }
       }
+      state = { uploads: next }
+      caches.uploads.invalidateAll()
     },
     setStatus: (id, status) => {
       if (!state.uploads[id]) return
@@ -52,13 +57,19 @@ export function buildUploadsNamespace(caches: AppCaches): AppService['uploads'] 
       namespace.update(id, { status: 'error', error: message })
     },
     setBatchUploading: (ids, batchId) => {
+      const next = { ...state.uploads }
       for (const id of ids) {
-        namespace.update(id, {
+        const existing = next[id]
+        if (!existing) continue
+        next[id] = {
+          ...existing,
           status: 'uploading',
           batchId,
           batchFileCount: ids.length,
-        })
+        }
       }
+      state = { uploads: next }
+      caches.uploads.invalidateAll()
     },
     getActiveIds: () => {
       return Object.values(state.uploads)

--- a/packages/core/src/app/service.ts
+++ b/packages/core/src/app/service.ts
@@ -34,6 +34,12 @@ export type SwrCacheBy<T = unknown> = {
   invalidateAll: () => Promise<any>
   /** Directly sets the cached data for the given key parts. */
   set: (data: T, ...parts: string[]) => Promise<any>
+  /** Returns debounced invalidate/invalidateAll that coalesce calls within `ms`. */
+  debounced: (ms: number) => {
+    invalidate: (...parts: string[]) => void
+    invalidateAll: () => void
+    flush: (...parts: string[]) => void
+  }
 }
 
 /** Cache that tracks library data version changes via a monotonic counter. */

--- a/packages/core/src/lib/debouncedAction.test.ts
+++ b/packages/core/src/lib/debouncedAction.test.ts
@@ -1,0 +1,50 @@
+import { createDebouncedAction } from './debouncedAction'
+
+describe('createDebouncedAction', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('coalesces rapid triggers into a single call', () => {
+    const fn = jest.fn()
+    const d = createDebouncedAction(fn, 1000)
+    d.trigger()
+    d.trigger()
+    d.trigger()
+    expect(fn).not.toHaveBeenCalled()
+    jest.advanceTimersByTime(999)
+    expect(fn).not.toHaveBeenCalled()
+    jest.advanceTimersByTime(1)
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('allows a subsequent trigger after the window elapses', () => {
+    const fn = jest.fn()
+    const d = createDebouncedAction(fn, 1000)
+    d.trigger()
+    jest.advanceTimersByTime(1000)
+    d.trigger()
+    jest.advanceTimersByTime(1000)
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('flush cancels the pending timer and invokes fn immediately', () => {
+    const fn = jest.fn()
+    const d = createDebouncedAction(fn, 1000)
+    d.trigger()
+    d.flush()
+    expect(fn).toHaveBeenCalledTimes(1)
+    jest.advanceTimersByTime(1000)
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('flush invokes fn even when no trigger is pending', () => {
+    const fn = jest.fn()
+    const d = createDebouncedAction(fn, 1000)
+    d.flush()
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core/src/stores/swr.test.ts
+++ b/packages/core/src/stores/swr.test.ts
@@ -1,0 +1,62 @@
+import { mutate } from 'swr'
+import { swrCacheBy } from './swr'
+
+jest.mock('swr', () => ({
+  __esModule: true,
+  default: jest.fn(),
+  mutate: jest.fn(() => Promise.resolve()),
+}))
+
+const mockMutate = mutate as jest.MockedFunction<typeof mutate>
+
+describe('swrCacheBy', () => {
+  beforeEach(() => {
+    mockMutate.mockClear()
+    jest.useFakeTimers()
+  })
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  describe('debounced', () => {
+    it('coalesces rapid invalidate calls into one mutate per window', () => {
+      const cache = swrCacheBy()
+      const d = cache.debounced(1000)
+      d.invalidate('all')
+      d.invalidate('all')
+      d.invalidate('all')
+      expect(mockMutate).not.toHaveBeenCalled()
+      jest.advanceTimersByTime(1000)
+      expect(mockMutate).toHaveBeenCalledTimes(1)
+    })
+
+    it('flush invalidates the key even when no prior trigger exists', () => {
+      const cache = swrCacheBy()
+      const d = cache.debounced(1000)
+      d.flush('all')
+      expect(mockMutate).toHaveBeenCalledTimes(1)
+      const key = mockMutate.mock.calls[0][0] as string[]
+      expect(Array.isArray(key)).toBe(true)
+      expect(key[0].endsWith('/all')).toBe(true)
+    })
+
+    it('flush invalidates all when called without parts and no prior trigger', () => {
+      const cache = swrCacheBy()
+      const d = cache.debounced(1000)
+      d.flush()
+      expect(mockMutate).toHaveBeenCalledTimes(1)
+      expect(typeof mockMutate.mock.calls[0][0]).toBe('function')
+    })
+
+    it('flush fires a pending trigger immediately and does not double-fire', () => {
+      const cache = swrCacheBy()
+      const d = cache.debounced(1000)
+      d.invalidate('all')
+      expect(mockMutate).not.toHaveBeenCalled()
+      d.flush('all')
+      expect(mockMutate).toHaveBeenCalledTimes(1)
+      jest.advanceTimersByTime(1000)
+      expect(mockMutate).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/packages/core/src/stores/swr.ts
+++ b/packages/core/src/stores/swr.ts
@@ -1,4 +1,5 @@
 import useSWR, { mutate } from 'swr'
+import { createDebouncedAction } from '../lib/debouncedAction'
 
 let nextId = 0
 
@@ -40,7 +41,9 @@ export function swrState<T>(initial: T) {
 /** Creates a prefix-scoped SWR cache supporting keyed and bulk invalidation. */
 export function swrCacheBy<T = unknown>() {
   const prefix = `swr/${nextId++}`
-  return {
+  const debouncers = new Map<string, ReturnType<typeof createDebouncedAction>>()
+
+  const cache = {
     key: (...parts: string[]) => [`${prefix}/${parts.join('/')}`],
     invalidate: (...parts: string[]) => mutate([`${prefix}/${parts.join('/')}`]),
     invalidateAll: () =>
@@ -52,5 +55,36 @@ export function swrCacheBy<T = unknown>() {
       mutate([`${prefix}/${parts.join('/')}`], data ?? undefined, {
         revalidate: false,
       }),
+    /**
+     * Returns debounced versions of invalidate/invalidateAll.
+     * Multiple calls within `ms` coalesce into a single invalidation.
+     * Call `flush` to force immediate invalidation (e.g. on register/remove).
+     */
+    debounced: (ms: number) => {
+      function getOrCreate(key: string, fn: () => void) {
+        let d = debouncers.get(key)
+        if (!d) {
+          d = createDebouncedAction(fn, ms)
+          debouncers.set(key, d)
+        }
+        return d
+      }
+      return {
+        invalidate: (...parts: string[]) =>
+          getOrCreate(parts.join('/'), () => cache.invalidate(...parts)).trigger(),
+        invalidateAll: () => getOrCreate('*', () => cache.invalidateAll()).trigger(),
+        flush: (...parts: string[]) => {
+          const key = parts.length ? parts.join('/') : '*'
+          const d = debouncers.get(key)
+          if (d) {
+            d.flush()
+            return
+          }
+          if (parts.length) cache.invalidate(...parts)
+          else cache.invalidateAll()
+        },
+      }
+    },
   }
+  return cache
 }


### PR DESCRIPTION
Upload progress was re-rendering the transfers list and counts on every progress tick — this batches those aggregate refreshes to once a second, while keeping per-file progress updates live.

