### PR TITLE
feat(mobile,core): add import status settings screen

### DIFF
--- a/.changeset/settings-import-screen.md
+++ b/.changeset/settings-import-screen.md
@@ -1,0 +1,6 @@
+---
+mobile: minor
+core: minor
+---
+
+Add import status screen showing files in retry backoff and permanently lost files.

--- a/apps/mobile/src/components/LibraryStatusSheet.tsx
+++ b/apps/mobile/src/components/LibraryStatusSheet.tsx
@@ -1,20 +1,22 @@
+import { type NavigationProp, useNavigation } from '@react-navigation/native'
 import type { UploadCategoryStats, UploadStats } from '@siastorage/core/db/operations'
 import { useSyncState } from '@siastorage/core/stores'
 import { TriangleAlertIcon } from 'lucide-react-native'
 import { useCallback } from 'react'
-import { Alert, Platform, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native'
+import { Platform, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native'
 import useSWR from 'swr'
 import { useIsOnline } from '../hooks/useIsOnline'
 import { humanSize } from '../lib/humanSize'
 import { humanUploadPercent } from '../lib/uploadPercent'
+import { getImportBackoffEntries } from '../managers/importScanner'
+import type { RootTabParamList } from '../stacks/types'
 import { app } from '../stores/appService'
-import { deleteLostFilesAndThumbnails, useFileStatsLocal, useFileStatsLost } from '../stores/files'
+import { useFileStatsLocal, useFileStatsLost } from '../stores/files'
 import { useIsConnected } from '../stores/sdk'
 import { useStatusDisplayMode } from '../stores/settings'
 import { closeSheet, useSheetOpen } from '../stores/sheets'
 import { getActiveUploads } from '../stores/uploads'
 import { palette, whiteA } from '../styles/colors'
-import { Button } from './Button'
 import { RowGroup, RowSubGroup } from './Group'
 import { InfoCard } from './InfoCard'
 import { LabeledValueRow } from './LabeledValueRow'
@@ -73,6 +75,19 @@ export function LibraryStatusSheet() {
   const onDevice = useFileStatsLocal({ localOnly: false }, { refreshInterval })
   const pendingBackup = useFileStatsLocal({ localOnly: true }, { refreshInterval })
   const lost = useFileStatsLost({ refreshInterval })
+  const importErrors = useSWR(
+    ['import-errors', isOpen ?? null],
+    () => getImportBackoffEntries().length,
+    { refreshInterval },
+  )
+  const navigation = useNavigation<NavigationProp<RootTabParamList>>()
+  const openImportSettings = useCallback(
+    (tab: 'retrying' | 'lost') => {
+      closeSheet()
+      navigation.navigate('MenuTab', { screen: 'Import', params: { tab }, initial: false })
+    },
+    [navigation],
+  )
   const batch = useSWR(
     ['active-batch', isOpen ?? null],
     () => {
@@ -224,6 +239,26 @@ export function LibraryStatusSheet() {
                   canCopy={false}
                   showDividerTop
                 />
+              )}
+              {(importErrors.data ?? 0) > 0 && (
+                <Pressable onPress={() => openImportSettings('retrying')}>
+                  <LabeledValueRow
+                    label="Import errors"
+                    labelStyle={styles.indentedLabel}
+                    labelWidth={120}
+                    value={
+                      <View style={styles.valueRight}>
+                        <Text style={styles.valueText}>
+                          {`${(importErrors.data ?? 0).toLocaleString()} files`}
+                        </Text>
+                        <View style={styles.dotOffline} />
+                      </View>
+                    }
+                    align="right"
+                    canCopy={false}
+                    showDividerTop
+                  />
+                </Pressable>
               )}
             </InfoCard>
           </RowSubGroup>
@@ -446,63 +481,26 @@ export function LibraryStatusSheet() {
                 canCopy={false}
                 showDividerTop
               />
-              <LabeledValueRow
-                label="Lost"
-                labelWidth={120}
-                value={
-                  <View style={styles.valueRight}>
-                    <Text style={styles.valueText}>
-                      {formatDeviceValue(lost.data, stats.data?.files, displayMode)}
-                    </Text>
-                    <Text style={styles.valuePercent}>
-                      {humanUploadPercent(devicePercent(lost.data, stats.data?.files))}
-                    </Text>
-                  </View>
-                }
-                align="right"
-                canCopy={false}
-                showDividerTop
-              />
+              <Pressable onPress={() => openImportSettings('lost')}>
+                <LabeledValueRow
+                  label="Lost"
+                  labelWidth={120}
+                  value={
+                    <View style={styles.valueRight}>
+                      <Text style={styles.valueText}>
+                        {formatDeviceValue(lost.data, stats.data?.files, displayMode)}
+                      </Text>
+                      <Text style={styles.valuePercent}>
+                        {humanUploadPercent(devicePercent(lost.data, stats.data?.files))}
+                      </Text>
+                    </View>
+                  }
+                  align="right"
+                  canCopy={false}
+                  showDividerTop
+                />
+              </Pressable>
             </InfoCard>
-            {(lost.data?.count ?? 0) > 0 && (
-              <View style={styles.deleteLostContainer}>
-                <Button
-                  variant="secondary"
-                  style={styles.deleteLostButton}
-                  onPress={() => {
-                    Alert.alert(
-                      'Delete Lost Files',
-                      `This will delete ${(lost.data?.count ?? 0).toLocaleString()} file records that are not on the network or this device. This cannot be undone.`,
-                      [
-                        { text: 'Cancel', style: 'cancel' },
-                        {
-                          text: 'Delete',
-                          style: 'destructive',
-                          onPress: async () => {
-                            try {
-                              await deleteLostFilesAndThumbnails()
-                              Alert.alert(
-                                'Lost files deleted',
-                                'Lost file records were successfully deleted.',
-                              )
-                            } catch (error) {
-                              Alert.alert(
-                                'Error deleting lost files',
-                                error instanceof Error
-                                  ? error.message
-                                  : 'An unexpected error occurred while deleting lost files.',
-                              )
-                            }
-                          },
-                        },
-                      ],
-                    )
-                  }}
-                >
-                  Delete lost files
-                </Button>
-              </View>
-            )}
           </RowSubGroup>
         </RowGroup>
       </ScrollView>
@@ -594,13 +592,5 @@ const styles = StyleSheet.create({
     height: 8,
     borderRadius: 4,
     backgroundColor: palette.yellow[400],
-  },
-  deleteLostContainer: {
-    marginTop: 8,
-    alignItems: 'flex-end',
-  },
-  deleteLostButton: {
-    paddingVertical: 8,
-    paddingHorizontal: 16,
   },
 })

--- a/apps/mobile/src/managers/importScanner.ts
+++ b/apps/mobile/src/managers/importScanner.ts
@@ -45,6 +45,10 @@ export async function runImportScanner(signal?: AbortSignal): Promise<ImportScan
   return scanner.runScan(signal, getMediaLibraryUri, maxDeferred)
 }
 
+export function getImportBackoffEntries() {
+  return scanner.getBackoffEntries()
+}
+
 export const { init: initImportScanner, triggerNow: triggerImportScanner } = createServiceInterval({
   name: 'importScanner',
   worker: async (signal) => {
@@ -52,3 +56,13 @@ export const { init: initImportScanner, triggerNow: triggerImportScanner } = cre
   },
   interval: IMPORT_SCANNER_INTERVAL,
 })
+
+export function retryImportFile(id: string): void {
+  scanner.clearBackoff(id)
+  triggerImportScanner()
+}
+
+export function retryAllImportFiles(): void {
+  scanner.clearAllBackoff()
+  triggerImportScanner()
+}

--- a/apps/mobile/src/screens/MenuScreen.tsx
+++ b/apps/mobile/src/screens/MenuScreen.tsx
@@ -45,6 +45,7 @@ export function MenuScreen({ navigation }: Props) {
       <MenuSection title="Settings">
         <MenuItem label="Indexer" onPress={() => navigation.navigate('Indexer')} />
         <MenuItem label="Sync" onPress={() => navigation.navigate('Sync')} />
+        <MenuItem label="Import" onPress={() => navigation.navigate('Import')} />
         <MenuItem label="Hosts" onPress={() => navigation.navigate('Hosts')} />
         <MenuItem label="Advanced" onPress={() => navigation.navigate('Advanced')} />
         <MenuItem label="Logs" onPress={() => navigation.navigate('Logs')} />

--- a/apps/mobile/src/screens/SettingsImportScreen.tsx
+++ b/apps/mobile/src/screens/SettingsImportScreen.tsx
@@ -1,0 +1,334 @@
+import type { NativeStackScreenProps } from '@react-navigation/native-stack'
+import type { BackoffEntry } from '@siastorage/core/lib/backoffTracker'
+import type { FileRecordRow } from '@siastorage/core/types/files'
+import { useCallback, useEffect, useState } from 'react'
+import { Alert, FlatList, Pressable, StyleSheet, Text, View } from 'react-native'
+import {
+  getImportBackoffEntries,
+  retryAllImportFiles,
+  retryImportFile,
+} from '../managers/importScanner'
+import { app } from '../stores/appService'
+import type { MenuStackParamList } from '../stacks/types'
+import { colors, palette } from '../styles/colors'
+
+type Props = NativeStackScreenProps<MenuStackParamList, 'Import'>
+type Tab = 'retrying' | 'lost'
+
+function useImportBackoff() {
+  const [entries, setEntries] = useState<BackoffEntry[]>([])
+  const refresh = useCallback(() => setEntries(getImportBackoffEntries()), [])
+  useEffect(() => {
+    refresh()
+    const id = setInterval(refresh, 3000)
+    return () => clearInterval(id)
+  }, [refresh])
+  return { entries, refresh }
+}
+
+function useLostFiles() {
+  const [files, setFiles] = useState<FileRecordRow[]>([])
+  const [loading, setLoading] = useState(true)
+  const reload = useCallback(async () => {
+    try {
+      const indexerURL = await app().settings.getIndexerURL()
+      const result = await app().files.getLost(indexerURL)
+      setFiles(result)
+    } catch {
+      setFiles([])
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+  useEffect(() => {
+    reload()
+  }, [reload])
+  return { files, loading, reload }
+}
+
+function formatRetryIn(retryAfter: number): string {
+  const remaining = retryAfter - Date.now()
+  if (remaining <= 0) return 'Retrying...'
+  const minutes = Math.ceil(remaining / 60_000)
+  if (minutes >= 60) return `Retry in ${Math.round(minutes / 60)}h`
+  return `Retry in ${minutes}m`
+}
+
+function RetryingTab() {
+  const { entries, refresh } = useImportBackoff()
+
+  const retryAll = useCallback(() => {
+    retryAllImportFiles()
+    refresh()
+  }, [refresh])
+
+  const retryOne = useCallback(
+    (id: string) => {
+      retryImportFile(id)
+      refresh()
+    },
+    [refresh],
+  )
+
+  if (entries.length === 0) {
+    return (
+      <View style={styles.empty}>
+        <Text style={styles.emptyText}>No files retrying</Text>
+      </View>
+    )
+  }
+
+  return (
+    <View style={styles.flex}>
+      <View style={styles.listHeader}>
+        <Text style={styles.listHeaderCount}>{entries.length.toLocaleString()} retrying</Text>
+        <Pressable onPress={retryAll}>
+          <Text style={styles.retryAllText}>Retry all</Text>
+        </Pressable>
+      </View>
+      <FlatList
+        data={entries}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={styles.listContent}
+        renderItem={({ item }) => (
+          <View style={styles.row}>
+            <View style={styles.rowContent}>
+              <Text style={styles.rowId} numberOfLines={1}>
+                {item.id}
+              </Text>
+              <Text style={styles.rowReason} numberOfLines={1}>
+                {item.reason ?? 'Unknown'}
+              </Text>
+              <Text style={styles.rowMeta}>
+                {formatRetryIn(item.retryAfter)} · Attempt {item.attempts}
+              </Text>
+            </View>
+            <Pressable onPress={() => retryOne(item.id)} style={styles.retryButton}>
+              <Text style={styles.retryButtonText}>Retry</Text>
+            </Pressable>
+          </View>
+        )}
+      />
+    </View>
+  )
+}
+
+function LostTab() {
+  const { files, loading, reload } = useLostFiles()
+
+  const removeAll = useCallback(() => {
+    Alert.alert(
+      'Remove all lost files',
+      'This will permanently remove all lost files from this library. This cannot be undone. Continue?',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Remove all',
+          style: 'destructive',
+          onPress: async () => {
+            const indexerURL = await app().settings.getIndexerURL()
+            await app().files.deleteLost(indexerURL)
+            reload()
+          },
+        },
+      ],
+    )
+  }, [reload])
+
+  const removeOne = useCallback(
+    async (id: string) => {
+      await app().files.deleteWithThumbnails(id)
+      reload()
+    },
+    [reload],
+  )
+
+  if (loading) {
+    return (
+      <View style={styles.empty}>
+        <Text style={styles.emptyText}>Loading...</Text>
+      </View>
+    )
+  }
+
+  if (files.length === 0) {
+    return (
+      <View style={styles.empty}>
+        <Text style={styles.emptyText}>No lost files</Text>
+      </View>
+    )
+  }
+
+  return (
+    <View style={styles.flex}>
+      <View style={styles.listHeader}>
+        <Text style={styles.listHeaderCount}>{files.length.toLocaleString()} lost</Text>
+        <Pressable onPress={removeAll}>
+          <Text style={styles.removeAllText}>Remove all</Text>
+        </Pressable>
+      </View>
+      <FlatList
+        data={files}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={styles.listContent}
+        renderItem={({ item }) => (
+          <View style={styles.row}>
+            <View style={styles.rowContent}>
+              <Text style={styles.rowName} numberOfLines={1}>
+                {item.name}
+              </Text>
+              <Text style={styles.rowReason} numberOfLines={1}>
+                {item.lostReason ?? 'Local file missing, not uploaded'}
+              </Text>
+            </View>
+            <Pressable onPress={() => removeOne(item.id)} style={styles.removeButton}>
+              <Text style={styles.removeButtonText}>Remove</Text>
+            </Pressable>
+          </View>
+        )}
+      />
+    </View>
+  )
+}
+
+export function SettingsImportScreen({ route }: Props) {
+  const [activeTab, setActiveTab] = useState<Tab>(route.params?.tab ?? 'retrying')
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.tabs}>
+        <Pressable
+          style={[styles.tab, activeTab === 'retrying' && styles.tabActive]}
+          onPress={() => setActiveTab('retrying')}
+        >
+          <Text style={[styles.tabText, activeTab === 'retrying' && styles.tabTextActive]}>
+            Retrying
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[styles.tab, activeTab === 'lost' && styles.tabActive]}
+          onPress={() => setActiveTab('lost')}
+        >
+          <Text style={[styles.tabText, activeTab === 'lost' && styles.tabTextActive]}>Lost</Text>
+        </Pressable>
+      </View>
+      {activeTab === 'retrying' ? <RetryingTab /> : <LostTab />}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.bgCanvas,
+  },
+  flex: {
+    flex: 1,
+  },
+  tabs: {
+    flexDirection: 'row',
+    borderBottomColor: colors.borderSubtle,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  tab: {
+    flex: 1,
+    paddingVertical: 12,
+    alignItems: 'center',
+  },
+  tabActive: {
+    borderBottomColor: palette.blue[400],
+    borderBottomWidth: 2,
+  },
+  tabText: {
+    color: palette.gray[400],
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  tabTextActive: {
+    color: palette.gray[50],
+  },
+  empty: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingTop: 64,
+  },
+  emptyText: {
+    color: palette.gray[400],
+    fontSize: 15,
+  },
+  listHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  listHeaderCount: {
+    color: palette.gray[300],
+    fontSize: 14,
+  },
+  removeAllText: {
+    color: palette.red[500],
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  listContent: {
+    paddingBottom: 64,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomColor: colors.borderSubtle,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  rowContent: {
+    flex: 1,
+  },
+  rowId: {
+    color: palette.gray[100],
+    fontSize: 13,
+    fontFamily: 'monospace',
+  },
+  rowName: {
+    color: palette.gray[100],
+    fontSize: 15,
+  },
+  rowReason: {
+    color: palette.gray[400],
+    fontSize: 13,
+    marginTop: 2,
+  },
+  rowMeta: {
+    color: palette.gray[500],
+    fontSize: 12,
+    marginTop: 2,
+  },
+  removeButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    marginLeft: 8,
+  },
+  removeButtonText: {
+    color: palette.red[500],
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  retryAllText: {
+    color: palette.blue[400],
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  retryButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    marginLeft: 8,
+  },
+  retryButtonText: {
+    color: palette.blue[400],
+    fontSize: 13,
+    fontWeight: '600',
+  },
+})

--- a/apps/mobile/src/stacks/MenuStack.tsx
+++ b/apps/mobile/src/stacks/MenuStack.tsx
@@ -8,6 +8,7 @@ import { LearnRecoveryPhraseScreen } from '../screens/learn/LearnRecoveryPhraseS
 import { LearnSiaNetworkScreen } from '../screens/learn/LearnSiaNetworkScreen'
 import { MenuScreen } from '../screens/MenuScreen'
 import { SettingsAdvancedScreen } from '../screens/SettingsAdvancedScreen'
+import { SettingsImportScreen } from '../screens/SettingsImportScreen'
 import { SettingsIndexerScreen } from '../screens/SettingsIndexerScreen'
 import { SettingsLogsScreen } from '../screens/SettingsLogsScreen'
 import { SettingsSyncScreen } from '../screens/SettingsSyncScreen'
@@ -34,6 +35,7 @@ export function MenuStack() {
         options={{ title: 'Indexer' }}
       />
       <Stack.Screen name="Sync" component={SettingsSyncScreen} options={{ title: 'Sync' }} />
+      <Stack.Screen name="Import" component={SettingsImportScreen} options={{ title: 'Import' }} />
       <Stack.Screen name="Logs" component={SettingsLogsScreen} options={{ title: 'Logs' }} />
       <Stack.Screen name="Hosts" component={HostListScreen} options={{ title: 'Hosts' }} />
       <Stack.Screen

--- a/apps/mobile/src/stacks/types.ts
+++ b/apps/mobile/src/stacks/types.ts
@@ -24,6 +24,7 @@ export type MenuStackParamList = {
   Indexer: undefined
   SwitchIndexer: NavigatorScreenParams<SwitchIndexerStackParamList> | undefined
   Sync: undefined
+  Import: { tab?: 'retrying' | 'lost' } | undefined
   Logs: undefined
   Advanced: undefined
   LearnRecoveryPhrase: undefined

--- a/packages/core/src/app/namespaces/db.ts
+++ b/packages/core/src/app/namespaces/db.ts
@@ -313,6 +313,7 @@ export function buildDbNamespaces(
       },
       getLostCount: (indexerURL) => ops.queryLostFileCount(db, indexerURL),
       getLostStats: (indexerURL) => ops.queryLostFileStats(db, indexerURL),
+      getLost: (indexerURL) => ops.queryLostFiles(db, indexerURL),
       getUnuploadedCount: () => ops.queryUnuploadedFileCount(db),
       getUnuploaded: () => ops.queryUnuploadedFiles(db),
       getActiveSummaries: () => ops.queryActiveFileSummaries(db),

--- a/packages/core/src/app/service.ts
+++ b/packages/core/src/app/service.ts
@@ -236,6 +236,8 @@ export interface AppService {
     getLostCount(indexerURL: string): Promise<number>
     /** Returns count and total size of lost files for an indexer. */
     getLostStats(indexerURL: string): Promise<{ count: number; totalBytes: number }>
+    /** Returns lost files for an indexer. */
+    getLost(indexerURL: string): Promise<FileRecordRow[]>
     /** Returns all versions of a file, ordered by updatedAt DESC. */
     getVersionHistory(name: string, directoryId: string | null): Promise<FileRecord[]>
     /** Renames all versions of a file. */

--- a/packages/core/src/db/operations/files.test.ts
+++ b/packages/core/src/db/operations/files.test.ts
@@ -13,6 +13,7 @@ import {
   queryFilesByLocalIds,
   queryFileCount,
   queryFileStats,
+  queryLostFiles,
   readFile,
   readFileWithSlabs,
   readFilesByIds,
@@ -279,6 +280,53 @@ describe('deleteLostFilesAndThumbnails', () => {
     await insertObject(db(), makeLocalObject('pinned', { indexerURL }))
     const deletedCount = await deleteLostFilesAndThumbnails(db(), indexerURL)
     expect(deletedCount).toBe(0)
+  })
+})
+
+describe('queryLostFiles', () => {
+  const indexerURL = 'https://indexer.example.com'
+
+  it('returns files with an explicit lostReason even when pinned or local', async () => {
+    await insertFile(db(), makeFileRecord('explicit-pinned', { lostReason: 'Corrupted' }))
+    await insertObject(db(), makeLocalObject('explicit-pinned', { indexerURL }))
+    await insertFile(db(), makeFileRecord('explicit-local', { lostReason: 'Unreadable' }))
+    await upsertFsMeta(db(), {
+      fileId: 'explicit-local',
+      size: 100,
+      addedAt: 1000,
+      usedAt: 1000,
+    })
+    const results = await queryLostFiles(db(), indexerURL)
+    const ids = results.map((r) => r.id).sort()
+    expect(ids).toEqual(['explicit-local', 'explicit-pinned'])
+  })
+
+  it('returns files that are hashed but missing from both objects and fs', async () => {
+    await insertFile(db(), makeFileRecord('implicit-lost'))
+    const results = await queryLostFiles(db(), indexerURL)
+    expect(results.map((r) => r.id)).toEqual(['implicit-lost'])
+  })
+
+  it('excludes pinned, local-only, and empty-hash files', async () => {
+    await insertFile(db(), makeFileRecord('pinned'))
+    await insertObject(db(), makeLocalObject('pinned', { indexerURL }))
+    await insertFile(db(), makeFileRecord('local-only'))
+    await upsertFsMeta(db(), {
+      fileId: 'local-only',
+      size: 100,
+      addedAt: 1000,
+      usedAt: 1000,
+    })
+    await insertFile(db(), makeFileRecord('no-hash', { hash: '' }))
+    const results = await queryLostFiles(db(), indexerURL)
+    expect(results).toHaveLength(0)
+  })
+
+  it('orders results by addedAt DESC', async () => {
+    await insertFile(db(), makeFileRecord('older', { addedAt: 1000 }))
+    await insertFile(db(), makeFileRecord('newer', { addedAt: 2000 }))
+    const results = await queryLostFiles(db(), indexerURL)
+    expect(results.map((r) => r.id)).toEqual(['newer', 'older'])
   })
 })
 

--- a/packages/core/src/db/operations/files.ts
+++ b/packages/core/src/db/operations/files.ts
@@ -727,6 +727,24 @@ export async function queryLostFileStats(
   return { count: row?.count ?? 0, totalBytes: row?.totalBytes ?? 0 }
 }
 
+export async function queryLostFiles(
+  db: DatabaseAdapter,
+  indexerURL: string,
+): Promise<FileRecordRow[]> {
+  return db.getAllAsync<FileRecordRow>(
+    `SELECT ${FILE_ROW_COLUMNS} FROM files f
+     WHERE ${buildActiveFileFilter('f')}
+     AND (
+       f.lostReason IS NOT NULL
+       OR (NOT EXISTS (SELECT 1 FROM objects s WHERE s.fileId = f.id AND s.indexerURL = ?)
+           AND NOT EXISTS (SELECT 1 FROM fs fsMeta WHERE fsMeta.fileId = f.id)
+           AND f.hash != '')
+     )
+     ORDER BY f.addedAt DESC`,
+    indexerURL,
+  )
+}
+
 export async function queryLocalFileCount(
   db: DatabaseAdapter,
   indexerURL: string,

--- a/packages/core/src/db/operations/index.ts
+++ b/packages/core/src/db/operations/index.ts
@@ -58,6 +58,7 @@ export {
   queryLocalFileStats,
   queryLocalOnlyFiles,
   queryLostFileCount,
+  queryLostFiles,
   queryLostFileStats,
   queryUnuploadedFileCount,
   queryUnuploadedFiles,

--- a/packages/core/src/lib/backoffTracker.test.ts
+++ b/packages/core/src/lib/backoffTracker.test.ts
@@ -104,6 +104,33 @@ describe('BackoffTracker', () => {
     expect(tracker.getExcludeIds()).toEqual([])
   })
 
+  it('stores reason with entry', () => {
+    tracker.recordSkip('a', 'Content temporarily unavailable')
+    const entries = tracker.getEntries()
+    expect(entries).toHaveLength(1)
+    expect(entries[0].id).toBe('a')
+    expect(entries[0].reason).toBe('Content temporarily unavailable')
+  })
+
+  it('getEntries returns all entries with metadata', () => {
+    tracker.recordSkip('a', 'Unavailable')
+    tracker.recordSkip('b', 'Copy failed')
+    const entries = tracker.getEntries()
+    expect(entries).toHaveLength(2)
+    expect(entries.map((e) => e.id).sort()).toEqual(['a', 'b'])
+    expect(entries.find((e) => e.id === 'a')?.reason).toBe('Unavailable')
+    expect(entries.find((e) => e.id === 'b')?.reason).toBe('Copy failed')
+    expect(entries.every((e) => e.attempts === 1)).toBe(true)
+  })
+
+  it('getEntries includes expired entries', () => {
+    tracker.recordSkip('a')
+    jest.advanceTimersByTime(5 * 60 * 1000)
+    const entries = tracker.getEntries()
+    expect(entries).toHaveLength(1)
+    expect(entries[0].id).toBe('a')
+  })
+
   it('tracks independent backoff per ID', () => {
     tracker.recordSkip('a')
     jest.advanceTimersByTime(3 * 60 * 1000)

--- a/packages/core/src/lib/backoffTracker.ts
+++ b/packages/core/src/lib/backoffTracker.ts
@@ -3,7 +3,9 @@ import { minutesInMs } from './time'
 const BASE_MS = minutesInMs(5)
 const MAX_MS = minutesInMs(60)
 
-type Entry = { attempts: number; retryAfter: number }
+type Entry = { attempts: number; retryAfter: number; reason?: string }
+
+export type BackoffEntry = { id: string; attempts: number; retryAfter: number; reason?: string }
 
 /**
  * In-memory backoff tracker for temporarily-failing items.
@@ -23,11 +25,11 @@ export class BackoffTracker {
   }
 
   /** Record a skip, incrementing attempts and setting the next retry time. */
-  recordSkip(id: string): void {
+  recordSkip(id: string, reason?: string): void {
     const existing = this.entries.get(id)
     const attempts = (existing?.attempts ?? 0) + 1
     const delay = Math.min(BASE_MS * Math.pow(3, attempts - 1), MAX_MS)
-    this.entries.set(id, { attempts, retryAfter: Date.now() + delay })
+    this.entries.set(id, { attempts, retryAfter: Date.now() + delay, reason })
   }
 
   /** All IDs currently in backoff (not yet expired). */
@@ -45,6 +47,15 @@ export class BackoffTracker {
   /** Remove an ID from tracking (item succeeded). */
   clear(id: string): void {
     this.entries.delete(id)
+  }
+
+  /** All entries with metadata (both active and expired). */
+  getEntries(): BackoffEntry[] {
+    const result: BackoffEntry[] = []
+    for (const [id, entry] of this.entries) {
+      result.push({ id, ...entry })
+    }
+    return result
   }
 
   /** Clear all entries (shutdown/reset). */

--- a/packages/core/src/services/importScanner.ts
+++ b/packages/core/src/services/importScanner.ts
@@ -1,6 +1,6 @@
 import { logger } from '@siastorage/logger'
 import type { AppService } from '../app/service'
-import { BackoffTracker } from '../lib/backoffTracker'
+import { type BackoffEntry, BackoffTracker } from '../lib/backoffTracker'
 
 const MAX_PER_TICK = 20
 
@@ -50,6 +50,21 @@ export class ImportScanner {
 
   isFileBeingProcessed(fileId: string): boolean {
     return this.processingFiles.has(fileId)
+  }
+
+  /** Returns all backoff entries for UI display. */
+  getBackoffEntries(): BackoffEntry[] {
+    return this.backoff.getEntries()
+  }
+
+  /** Removes a single ID from backoff so it's re-eligible on the next tick. */
+  clearBackoff(id: string): void {
+    this.backoff.clear(id)
+  }
+
+  /** Removes all IDs from backoff so all retrying files are re-eligible. */
+  clearAllBackoff(): void {
+    this.backoff.reset()
   }
 
   private getApp(): AppService {
@@ -153,7 +168,7 @@ export class ImportScanner {
               result.finalized++
               this.backoff.clear(file.id)
             } else {
-              this.backoff.recordSkip(file.id)
+              this.backoff.recordSkip(file.id, 'Hash computation failed')
               result.failed++
             }
           } catch (e) {
@@ -161,7 +176,7 @@ export class ImportScanner {
               fileId: file.id,
               error: e as Error,
             })
-            this.backoff.recordSkip(file.id)
+            this.backoff.recordSkip(file.id, 'Processing error')
             result.failed++
           } finally {
             this.processingFiles.delete(file.id)
@@ -221,7 +236,7 @@ export class ImportScanner {
                   fileId: file.id,
                   localId: file.localId,
                 })
-                this.backoff.recordSkip(file.id)
+                this.backoff.recordSkip(file.id, 'Content temporarily unavailable')
                 result.skipped++
                 continue
               }
@@ -242,7 +257,7 @@ export class ImportScanner {
                   result.finalized++
                   this.backoff.clear(file.id)
                 } else {
-                  this.backoff.recordSkip(file.id)
+                  this.backoff.recordSkip(file.id, 'Hash computation failed')
                   result.failed++
                 }
               } catch (e) {
@@ -250,7 +265,7 @@ export class ImportScanner {
                   fileId: file.id,
                   error: e as Error,
                 })
-                this.backoff.recordSkip(file.id)
+                this.backoff.recordSkip(file.id, 'Failed to copy from device')
                 result.failed++
               }
               continue
@@ -260,7 +275,7 @@ export class ImportScanner {
               logger.debug('importScanner', 'skipped_no_resolver', {
                 fileId: file.id,
               })
-              this.backoff.recordSkip(file.id)
+              this.backoff.recordSkip(file.id, 'No resolver available')
               result.skipped++
               continue
             }
@@ -276,7 +291,7 @@ export class ImportScanner {
               fileId: file.id,
               error: e as Error,
             })
-            this.backoff.recordSkip(file.id)
+            this.backoff.recordSkip(file.id, 'Processing error')
             result.failed++
           } finally {
             this.processingFiles.delete(file.id)


### PR DESCRIPTION
Add a settings screen with two tabs showing import scanner state:
- Retrying: files in backoff with reason, attempt count, and time until next retry, plus retry actions (individual or bulk)
- Lost: permanently lost files with reason and remove actions (individual or bulk), including both explicit lostReason and implicit lost files (hashed but missing from disk and network)

Other changes:
- BackoffTracker now stores a reason string with each entry and exposes getEntries() for UI consumption.
- Import scanner passes descriptive reasons for each skip type and exposes clearBackoff/clearAllBackoff so the UI can re-admit retrying files.
