### PR TITLE
feat(mobile): add Delete Account entry linking to the managing indexer

### DIFF
--- a/.changeset/delete-account-link.md
+++ b/.changeset/delete-account-link.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Added a Delete Account entry in the Menu that opens the sia.storage account page where account deletion is performed.

--- a/.changeset/menu-help-section.md
+++ b/.changeset/menu-help-section.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Added a Help section in the Menu with links to Support, Report Content, Terms of Service, and Privacy Policy on sia.storage.

--- a/apps/mobile/src/lib/inAppBrowser.ts
+++ b/apps/mobile/src/lib/inAppBrowser.ts
@@ -1,0 +1,32 @@
+import { Linking } from 'react-native'
+import InAppBrowser from 'react-native-inappbrowser-reborn'
+import { palette } from '../styles/colors'
+
+export const IN_APP_BROWSER_OPTIONS = {
+  dismissButtonStyle: 'done',
+  preferredBarTintColor: palette.gray[950],
+  preferredControlTintColor: 'white',
+  modalPresentationStyle: 'fullScreen',
+  modalTransitionStyle: 'coverVertical',
+  modalEnabled: true,
+  animated: true,
+  showTitle: true,
+  toolbarColor: palette.gray[950],
+  navigationBarColor: palette.gray[950],
+} as const
+
+/**
+ * Opens a URL in the in-app browser, falling back to the system browser if the
+ * in-app browser is unavailable or fails to open.
+ */
+export async function openExternalURL(url: string): Promise<void> {
+  try {
+    if (await InAppBrowser.isAvailable()) {
+      await InAppBrowser.open(url, IN_APP_BROWSER_OPTIONS)
+      return
+    }
+  } catch {
+    // fall through to system browser
+  }
+  await Linking.openURL(url)
+}

--- a/apps/mobile/src/lib/openAuthUrl.ts
+++ b/apps/mobile/src/lib/openAuthUrl.ts
@@ -1,6 +1,6 @@
 import { Linking, Platform } from 'react-native'
 import InAppBrowser from 'react-native-inappbrowser-reborn'
-import { palette } from '../styles/colors'
+import { IN_APP_BROWSER_OPTIONS } from './inAppBrowser'
 
 /**
  * Opens the auth URL in the system browser.
@@ -24,18 +24,7 @@ export async function openAuthURL(authURL: string): Promise<boolean> {
   })
 
   try {
-    await InAppBrowser.open(authURL, {
-      dismissButtonStyle: 'done',
-      preferredBarTintColor: palette.gray[950],
-      preferredControlTintColor: 'white',
-      modalPresentationStyle: 'fullScreen',
-      modalTransitionStyle: 'coverVertical',
-      modalEnabled: true,
-      animated: true,
-      showTitle: true,
-      toolbarColor: palette.gray[950],
-      navigationBarColor: palette.gray[950],
-    })
+    await InAppBrowser.open(authURL, IN_APP_BROWSER_OPTIONS)
 
     if (Platform.OS === 'android') {
       await new Promise((resolve) => setTimeout(resolve, 100))

--- a/apps/mobile/src/screens/MenuScreen.tsx
+++ b/apps/mobile/src/screens/MenuScreen.tsx
@@ -1,10 +1,42 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack'
+import { DEFAULT_INDEXER_URL } from '@siastorage/core/config'
+import { useIndexerURL } from '@siastorage/core/stores'
 import type React from 'react'
-import { Pressable, StyleSheet, Text, View } from 'react-native'
+import { useCallback } from 'react'
+import { Alert, Pressable, StyleSheet, Text, View } from 'react-native'
 import { SettingsScrollLayout } from '../components/SettingsLayout'
 import { useMenuHeader } from '../hooks/useMenuHeader'
+import { openExternalURL } from '../lib/inAppBrowser'
 import type { MenuStackParamList } from '../stacks/types'
 import { colors, palette } from '../styles/colors'
+
+const SIA_STORAGE_HOST = 'sia.storage'
+const SIA_STORAGE_DELETE_URL = 'https://sia.storage/dashboard/account'
+const SIA_STORAGE_SUPPORT_URL = 'https://sia.storage/resources/support'
+const SIA_STORAGE_REPORT_URL = 'https://sia.storage/resources/report'
+const SIA_STORAGE_TERMS_URL = 'https://sia.storage/resources/terms'
+const SIA_STORAGE_PRIVACY_URL = 'https://sia.storage/resources/privacy'
+
+function isSiaStorageIndexer(indexerURL: string): boolean {
+  try {
+    return new URL(indexerURL).hostname === SIA_STORAGE_HOST
+  } catch {
+    return false
+  }
+}
+
+function promptDeleteAccount(indexerURL: string) {
+  const isSiaStorage = isSiaStorageIndexer(indexerURL)
+  const targetURL = isSiaStorage ? SIA_STORAGE_DELETE_URL : indexerURL
+  const message = isSiaStorage
+    ? 'Your Sia Storage account is managed on the sia.storage website. Tap Continue to sign in and permanently delete your account and all data stored with Sia Storage.'
+    : `Your account is managed by your indexer at ${indexerURL}. Tap Continue to sign in and permanently delete your account and all your data.`
+
+  Alert.alert('Delete Account', message, [
+    { text: 'Cancel', style: 'cancel' },
+    { text: 'Continue to Website', onPress: () => void openExternalURL(targetURL) },
+  ])
+}
 
 type Props = NativeStackScreenProps<MenuStackParamList, 'MenuHome'>
 
@@ -40,6 +72,10 @@ function MenuItem({ label, onPress }: MenuItemProps) {
 
 export function MenuScreen({ navigation }: Props) {
   useMenuHeader()
+  const indexerURL = useIndexerURL()
+  const handleDeleteAccount = useCallback(() => {
+    promptDeleteAccount(indexerURL.data ?? DEFAULT_INDEXER_URL)
+  }, [indexerURL.data])
   return (
     <SettingsScrollLayout>
       <MenuSection title="Settings">
@@ -62,6 +98,26 @@ export function MenuScreen({ navigation }: Props) {
         />
         <MenuItem label="What is an Indexer?" onPress={() => navigation.navigate('LearnIndexer')} />
         <MenuItem label="The Sia Network" onPress={() => navigation.navigate('LearnSiaNetwork')} />
+      </MenuSection>
+
+      <MenuSection title="Help">
+        <MenuItem label="Support" onPress={() => void openExternalURL(SIA_STORAGE_SUPPORT_URL)} />
+        <MenuItem
+          label="Report Content"
+          onPress={() => void openExternalURL(SIA_STORAGE_REPORT_URL)}
+        />
+        <MenuItem
+          label="Terms of Service"
+          onPress={() => void openExternalURL(SIA_STORAGE_TERMS_URL)}
+        />
+        <MenuItem
+          label="Privacy Policy"
+          onPress={() => void openExternalURL(SIA_STORAGE_PRIVACY_URL)}
+        />
+      </MenuSection>
+
+      <MenuSection title="Account">
+        <MenuItem label="Delete Account" onPress={handleDeleteAccount} />
       </MenuSection>
     </SettingsScrollLayout>
   )


### PR DESCRIPTION
- Adds a Delete Account entry under a new Account section that opens the sia.storage account page in an in-app browser (SFSafariViewController), satisfying App Store guideline 5.1.1(v). Custom indexer URLs open the configured indexer with adjusted copy.
- Adds a Help section with links to Support, Report Content, Terms of Service, and Privacy Policy on sia.storage, giving users an in-app path to moderation and legal pages.
