### PR TITLE
fix(core): add raceWithTimeout helper, fix suspension phase 4 timer leak

### DIFF
--- a/.changeset/race-with-timeout-helper.md
+++ b/.changeset/race-with-timeout-helper.md
@@ -1,0 +1,5 @@
+---
+core: patch
+---
+
+Add raceWithTimeout helper and fix a pending-timer leak in the suspension manager's phase 4 DB drain.

--- a/apps/mobile/src/stores/sdk.ts
+++ b/apps/mobile/src/stores/sdk.ts
@@ -19,7 +19,7 @@
 
 import { err, ok, type Result, uint8ToHex } from '@siastorage/core'
 import { APP_KEY } from '@siastorage/core/config'
-import { withTimeout } from '@siastorage/core/lib/timeout'
+import { raceWithTimeout, withTimeout } from '@siastorage/core/lib/timeout'
 import { useConnectionState } from '@siastorage/core/stores'
 import { logger } from '@siastorage/logger'
 import { AppState, Platform } from 'react-native'
@@ -396,13 +396,10 @@ async function waitForUserApproval(responseUrl: string): Promise<Result<void, Au
       approvalPromise = startApprovalPoll()
     }
 
-    const grace = await Promise.race([
-      approvalPromise.then(() => 'approved' as const),
-      new Promise<'timeout'>((r) => setTimeout(() => r('timeout'), BROWSER_CLOSE_GRACE_MS)),
-    ])
+    const grace = await raceWithTimeout(approvalPromise, BROWSER_CLOSE_GRACE_MS)
 
-    if (grace === 'approved') {
-      const outcome = await approvalPromise
+    if (grace.ok) {
+      const outcome = grace.value
       if (outcome.ok) return ok(undefined)
       if (outcome.error.name === 'AbortError') return err({ type: 'cancelled' })
       return err({ type: 'error', message: outcome.error.message })

--- a/packages/core/src/lib/timeout.test.ts
+++ b/packages/core/src/lib/timeout.test.ts
@@ -1,0 +1,37 @@
+import { raceWithTimeout } from './timeout'
+
+describe('raceWithTimeout', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('resolves with the value when the promise settles first', async () => {
+    const promise = Promise.resolve('done')
+    const result = await raceWithTimeout(promise, 1000)
+    expect(result).toEqual({ ok: true, value: 'done' })
+  })
+
+  it('resolves with ok:false when the timeout fires first', async () => {
+    const promise = new Promise<string>(() => {})
+    const racePromise = raceWithTimeout(promise, 1000)
+    jest.advanceTimersByTime(1000)
+    await expect(racePromise).resolves.toEqual({ ok: false })
+  })
+
+  it('clears the timer when the promise wins so no handle leaks', async () => {
+    const before = jest.getTimerCount()
+    const result = await raceWithTimeout(Promise.resolve(42), 5000)
+    expect(result).toEqual({ ok: true, value: 42 })
+    expect(jest.getTimerCount()).toBe(before)
+  })
+
+  it('clears the timer when the promise rejects', async () => {
+    const before = jest.getTimerCount()
+    await expect(raceWithTimeout(Promise.reject(new Error('boom')), 5000)).rejects.toThrow('boom')
+    expect(jest.getTimerCount()).toBe(before)
+  })
+})

--- a/packages/core/src/lib/timeout.ts
+++ b/packages/core/src/lib/timeout.ts
@@ -21,3 +21,35 @@ export function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
     )
   })
 }
+
+/**
+ * Races a promise against a timeout without throwing on timeout. Resolves
+ * to `{ ok: true, value }` if the promise fulfills first, or `{ ok: false }`
+ * when the timer wins. If the input promise rejects before the timeout,
+ * that rejection propagates. The timer is cleared in both branches so no
+ * pending setTimeout handle leaks into the JS event loop (which can keep
+ * Node alive and cause jest "worker failed to exit gracefully" warnings).
+ */
+export async function raceWithTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+): Promise<{ ok: true; value: T } | { ok: false }> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    const result = await Promise.race([
+      promise.then((value) => ({ ok: true as const, value })),
+      new Promise<{ ok: false }>((resolve) => {
+        timer = setTimeout(() => resolve({ ok: false }), ms)
+      }),
+    ])
+    // If the timeout won, the original promise is still running.
+    // Promise.race doesn't cancel it, so a later rejection would
+    // become unhandled. Attach a no-op catch to swallow it.
+    if (!result.ok) {
+      promise.catch(() => {})
+    }
+    return result
+  } finally {
+    if (timer !== undefined) clearTimeout(timer)
+  }
+}

--- a/packages/core/src/services/suspension.ts
+++ b/packages/core/src/services/suspension.ts
@@ -1,4 +1,5 @@
 import { CoalescingQueue } from '../lib/coalescingQueue'
+import { raceWithTimeout } from '../lib/timeout'
 import { logger } from '@siastorage/logger'
 
 export type SuspensionAdapters = {
@@ -61,18 +62,9 @@ export function createSuspensionManager(adapters: SuspensionAdapters) {
       // workers can complete their current unit of work (DB writes, cursor
       // updates) without hitting DatabaseSuspendedError.
       const drainStart = Date.now()
-      let deadlineTimer: ReturnType<typeof setTimeout>
-      const deadlinePromise = new Promise<false>((r) => {
-        deadlineTimer = setTimeout(() => r(false), hardDeadlineMs)
-      })
-      let drained: boolean
-      try {
-        drained = await Promise.race([scheduler.waitForIdle().then(() => true), deadlinePromise])
-      } finally {
-        clearTimeout(deadlineTimer!)
-      }
+      const drained = await raceWithTimeout(scheduler.waitForIdle(), hardDeadlineMs)
 
-      if (drained) {
+      if (drained.ok) {
         logger.debug('suspension', 'services_drained', {
           drainMs: Date.now() - drainStart,
         })
@@ -92,11 +84,8 @@ export function createSuspensionManager(adapters: SuspensionAdapters) {
       // can't block suspension indefinitely.
       const elapsedMs = Date.now() - drainStart
       const remainingMs = Math.max(hardDeadlineMs - elapsedMs, 1000)
-      const dbDrained = await Promise.race([
-        db.waitForIdle().then(() => true),
-        new Promise<false>((r) => setTimeout(() => r(false), remainingMs)),
-      ])
-      if (!dbDrained) {
+      const dbDrainResult = await raceWithTimeout(db.waitForIdle(), remainingMs)
+      if (!dbDrainResult.ok) {
         logger.warn('suspension', 'db_drain_timeout', {
           remainingMs,
         })


### PR DESCRIPTION
We had three copies of the same Promise.race + setTimeout pattern scattered across suspension phases and the mobile auth flow, and one of them (phase 4) was missing the clearTimeout that the others had — which leaked a timer every iOS suspend.

This adds a raceWithTimeout helper in core/lib/timeout.ts that always clears its timer regardless of which side wins, and swaps all three callsites over. Phase 4 stops leaking, and there's only one place to get this right going forward.
