### PR TITLE
fix(mobile,core): scope AbortSignal to drain DB-holding workers cleanly at iOS suspension

### DIFF
--- a/.changeset/ios-suspension-scan-download-crash.md
+++ b/.changeset/ios-suspension-scan-download-crash.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Reduced iOS crashes that could occur while a photo scan or download was running when the app was suspended.

--- a/.changeset/suspension-signal-plumbing.md
+++ b/.changeset/suspension-signal-plumbing.md
@@ -1,0 +1,5 @@
+---
+core: patch
+---
+
+Scheduler-driven services that hold a DB handle now accept an AbortSignal so workers exit at loop boundaries before the suspension gate closes.

--- a/apps/mobile/src/lib/contentHash.ts
+++ b/apps/mobile/src/lib/contentHash.ts
@@ -6,6 +6,12 @@ export type HashResult = `sha256:${string}`
 /**
  * Calculate a content hash for a file.
  * - Raw byte SHA-256 for exact file identity.
+ *
+ * Suspension signal policy: does NOT accept a signal. Wraps a single
+ * native RNFS.hash call that runs to completion on a native thread and
+ * can't be cancelled from JS. On iOS suspension the native thread
+ * freezes with the process and thaws on resume. Callers that loop over
+ * many files should check their signal at the loop boundary.
  */
 export async function calculateContentHash(uri: string): Promise<HashResult | null> {
   if (!uri || uri === '') {

--- a/apps/mobile/src/lib/mediaLibrary.ts
+++ b/apps/mobile/src/lib/mediaLibrary.ts
@@ -30,6 +30,12 @@ const unavailable: ResolveLocalIdResult = { status: 'unavailable' }
  * - unavailable: file exists but can't be accessed right now, skip
  *   without marking as lost (retry on next scan)
  * - deleted: file is gone from the device, mark as lost
+ *
+ * Suspension signal policy: does NOT accept a signal. Wraps a single
+ * native MediaLibrary.getAssetInfoAsync call (which itself may invoke
+ * an iCloud download on iOS). The native work runs to completion and
+ * can't be cancelled from JS. Callers that loop should check their
+ * signal at the loop boundary before invoking.
  */
 export async function getMediaLibraryUri(localId: string | null): Promise<ResolveLocalIdResult> {
   if (!localId) return deleted

--- a/apps/mobile/src/lib/processAssets.ts
+++ b/apps/mobile/src/lib/processAssets.ts
@@ -15,6 +15,16 @@
 //   placeholder records in bulk via INSERT OR IGNORE (no copy, no hash).
 //   The import scanner finalizes these in the background with
 //   backpressure based on the upload backlog.
+//
+// Suspension signal policy:
+//   processInBatches and processFileContent accept a signal and check at
+//   loop boundaries / step boundaries. The signal is NOT plumbed into
+//   the per-file leaves (copyFileToFs, calculateContentHash,
+//   getMediaLibraryUri) because those wrap single native calls that
+//   can't be cancelled mid-flight in JS. Leaf-level checks would only
+//   duplicate the loop-level skip one statement earlier. copyImportedFiles
+//   is fire-and-forget: the user-initiated import path doesn't block
+//   shutdown, and native copies ride the iOS freeze/thaw naturally.
 
 import { uniqueId } from '@siastorage/core/lib/uniqueId'
 import { yieldToEventLoop } from '@siastorage/core/lib/yieldToEventLoop'
@@ -35,8 +45,10 @@ async function processInBatches<T>(
   items: T[],
   batchSize: number,
   processor: (item: T) => Promise<void>,
+  signal?: AbortSignal,
 ): Promise<void> {
   for (let i = 0; i < items.length; i += batchSize) {
+    if (signal?.aborted) return
     const batch = items.slice(i, i + batchSize)
     await Promise.all(batch.map(processor))
     await yieldToEventLoop()
@@ -65,15 +77,19 @@ type FileContentResult = {
 async function processFileContent(
   file: { id: string; name: string; type: string },
   sourceUri: string,
+  signal?: AbortSignal,
 ): Promise<FileContentResult | null> {
+  if (signal?.aborted) return null
   let type = file.type
   if (type === 'application/octet-stream') {
     type = await getMimeType({ name: file.name, uri: sourceUri })
   }
 
+  if (signal?.aborted) return null
   const fileUri = await copyFileToFs(file, sourceUri)
   if (!fileUri) return null
 
+  if (signal?.aborted) return null
   const hash = await calculateContentHash(fileUri)
   if (!hash) return null
 
@@ -154,6 +170,7 @@ export async function syncAssets(
   assets: Asset[] | undefined,
   defaultFileName: string = 'file',
   { addToImportDirectory = false, skipExistingUpdates = false }: SyncAssetsOptions = {},
+  signal?: AbortSignal,
 ) {
   const candidateFiles: CandidateFileRecord[] = await Promise.all(
     (assets ?? []).map(async (a) => {
@@ -199,7 +216,7 @@ export async function syncAssets(
         return
       }
 
-      const result = await processFileContent(f, bestUri)
+      const result = await processFileContent(f, bestUri, signal)
       if (!result) {
         f.status = 'incomplete'
         f.statusDetails = 'processingFailed'
@@ -210,7 +227,12 @@ export async function syncAssets(
       f.hash = result.hash
       f.size = result.size
     },
+    signal,
   )
+
+  if (signal?.aborted) {
+    return { files: [], updatedFiles: [], warnings: [] }
+  }
 
   const existingContentHashes = await app().files.getByContentHashes(
     candidateFiles.filter((f) => f.status === 'new' && f.hash !== null).map((f) => f.hash!),
@@ -278,6 +300,10 @@ export async function syncAssets(
     await moveMediaToImportDirectory(newFiles)
   }
 
+  if (signal?.aborted) {
+    return { files: newFiles, updatedFiles: existingFiles, warnings }
+  }
+
   logger.debug('syncAssets', 'generating_thumbnails', {
     count: newFiles.length,
   })
@@ -307,6 +333,7 @@ export async function catalogAssets(
   assets: Asset[] | undefined,
   defaultFileName: string = 'file',
   { addToImportDirectory = false }: CatalogAssetsOptions = {},
+  signal?: AbortSignal,
 ) {
   const candidates: FileRecord[] = await Promise.all(
     (assets ?? []).map(async (a) => {
@@ -326,6 +353,8 @@ export async function catalogAssets(
     }),
   )
 
+  if (signal?.aborted) return { newCount: 0, existingCount: 0 }
+
   const localIds = candidates.filter((f) => f.localId).map((f) => f.localId!)
   const existingFiles = localIds.length > 0 ? await app().files.getByLocalIds(localIds) : []
   const existingLocalIds = new Set(existingFiles.map((f) => f.localId))
@@ -337,6 +366,8 @@ export async function catalogAssets(
     newCount,
     existingCount,
   })
+
+  if (signal?.aborted) return { newCount: 0, existingCount: 0 }
 
   await app().files.createMany(candidates, { conflictClause: 'OR IGNORE' })
   await app().optimize()
@@ -406,11 +437,12 @@ export async function importFiles(
     await app().optimize()
   }
 
-  // Fire-and-forget: sourceURIs are ephemeral (document picker content://
-  // URIs, share intent file:// paths) and must be copied promptly. The
-  // copy runs without blocking the caller so the UI shows placeholders
-  // immediately. If interrupted, files with localId are recovered by the
-  // scanner via media library.
+  // Fire-and-forget: each copy dispatches to a native RNFS thread that
+  // holds the source URI open once it starts reading, so ephemeral
+  // picker/share URIs are captured by the native call before the caller
+  // can do anything else. The native thread freezes with the process on
+  // iOS suspension and thaws on resume. If iOS terminates (rather than
+  // suspends) the import is lost — same as before.
   void copyImportedFiles(pendingCopies)
 
   triggerImportScanner()

--- a/apps/mobile/src/managers/dbOptimize.ts
+++ b/apps/mobile/src/managers/dbOptimize.ts
@@ -1,10 +1,21 @@
+// Periodic PRAGMA optimize + WAL checkpoint to keep query plans fresh
+// and the WAL file trimmed.
+//
+// Suspension signal policy: accepts AbortSignal. Touches the DB but
+// completes in <10ms in the typical case, so the signal check is
+// cheap insurance against starting a checkpoint after the gate has
+// closed. Pattern consistency with other scheduler-driven workers.
+
 import { DB_OPTIMIZE_INTERVAL } from '@siastorage/core/config'
 import { createServiceInterval } from '@siastorage/core/lib/serviceInterval'
 import { app } from '../stores/appService'
 
 const { init: initDbOptimize } = createServiceInterval({
   name: 'dbOptimize',
-  worker: () => app().optimize(),
+  worker: async (signal) => {
+    if (signal?.aborted) return
+    await app().optimize()
+  },
   interval: DB_OPTIMIZE_INTERVAL,
 })
 

--- a/apps/mobile/src/managers/logRotation.ts
+++ b/apps/mobile/src/managers/logRotation.ts
@@ -1,3 +1,9 @@
+// Periodically rotates old log records out of the DB to bound storage.
+//
+// Suspension signal policy: accepts AbortSignal. Touches the DB
+// (deletes old log records) but the work is fast and idempotent. The
+// signal check is cheap insurance and pattern consistency.
+
 import { createServiceInterval } from '@siastorage/core/lib/serviceInterval'
 import { LOG_ROTATION_INTERVAL, runLogRotation } from '@siastorage/core/services'
 import { app } from '../stores/appService'
@@ -7,7 +13,8 @@ export async function initLogRotation(): Promise<void> {
   initLogRotationInterval()
 }
 
-async function run(): Promise<void> {
+async function run(signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return
   await runLogRotation(app())
 }
 

--- a/apps/mobile/src/managers/perfMonitor.ts
+++ b/apps/mobile/src/managers/perfMonitor.ts
@@ -1,9 +1,16 @@
+// Periodic sampler for CPU, memory, and FPS counters into the log.
+//
+// Suspension signal policy: accepts AbortSignal. Doesn't touch the DB
+// directly, just reads native counters and logs. The signal check
+// avoids logging a useless tick during the suspension drain window.
+
 import { PERF_MONITOR_INTERVAL } from '@siastorage/core/config'
 import { createServiceInterval } from '@siastorage/core/lib/serviceInterval'
 import { logger } from '@siastorage/logger'
 import { getCpuUsage, getJsFps, getMemoryUsage, getUiFps } from 'react-native-performance-toolkit'
 
-function run(): void {
+function run(signal?: AbortSignal): void {
+  if (signal?.aborted) return
   const cpu = getCpuUsage()
   const mem = getMemoryUsage()
   const jsFps = getJsFps()

--- a/apps/mobile/src/managers/suspension.ts
+++ b/apps/mobile/src/managers/suspension.ts
@@ -17,8 +17,10 @@ import {
   waitForQueriesIdle,
 } from '../db'
 import { setSWREnabled } from '../lib/swr'
+import { app } from '../stores/appService'
 import { resumeLogger } from '../stores/logs'
 import { getIsBackgroundTaskRunning } from './backgroundTasks'
+import { pauseArchiveSync, resumeArchiveSync } from './syncPhotosArchive'
 import { getUploadManager } from './uploader'
 
 // Hard deadline for service drain. iOS gives ~30s via beginBackgroundTask
@@ -52,10 +54,18 @@ const manager = createSuspensionManager({
     onBeforeSuspend: async () => {
       await stopLogAppender()
       setSWREnabled(false)
+      // Cancel in-flight downloads (disk I/O contention with SQLite fsync
+      // is a known 0xdead10cc trigger) and pause the photo-archive walk
+      // (an independent loop not driven by the service scheduler, so it
+      // keeps issuing catalogAssets writes otherwise).
+      app().downloads.cancelAll()
+      pauseArchiveSync()
     },
     onAfterResume: () => {
       setSWREnabled(true)
       resumeLogger()
+      // Resume archive walk from the same cursor if it wasn't complete.
+      void resumeArchiveSync()
     },
   },
   hardDeadlineMs: HARD_DEADLINE_MS,

--- a/apps/mobile/src/managers/syncNewPhotos.test.ts
+++ b/apps/mobile/src/managers/syncNewPhotos.test.ts
@@ -120,6 +120,7 @@ describe('syncNewPhotos', () => {
       ],
       'file',
       { addToImportDirectory: true, skipExistingUpdates: true },
+      undefined,
     )
   })
 

--- a/apps/mobile/src/managers/syncNewPhotos.ts
+++ b/apps/mobile/src/managers/syncNewPhotos.ts
@@ -78,6 +78,7 @@ export async function run(signal?: AbortSignal): Promise<void> {
       })),
       'file',
       { addToImportDirectory: true, skipExistingUpdates: true },
+      signal,
     )
     if (files.length > 0) {
       await app().caches.library.invalidateAll()

--- a/apps/mobile/src/managers/syncPhotosArchive.test.ts
+++ b/apps/mobile/src/managers/syncPhotosArchive.test.ts
@@ -214,6 +214,7 @@ describe('syncPhotosArchive', () => {
       ],
       'file',
       { addToImportDirectory: true },
+      undefined,
     )
   })
 
@@ -238,6 +239,7 @@ describe('syncPhotosArchive', () => {
       ],
       'file',
       { addToImportDirectory: true },
+      undefined,
     )
   })
 
@@ -346,6 +348,7 @@ describe('syncPhotosArchive', () => {
         [expect.objectContaining({ id: 'a1' }), expect.objectContaining({ id: 'a2' })],
         'file',
         { addToImportDirectory: true },
+        undefined,
       )
     })
   })

--- a/apps/mobile/src/managers/syncPhotosArchive.ts
+++ b/apps/mobile/src/managers/syncPhotosArchive.ts
@@ -26,6 +26,12 @@
  * Catches: the full historical tail plus periodic re-scans of the
  * recent window for cross-device synced photos.
  * Misses: newly taken photos (covered by syncNewPhotos).
+ *
+ * Suspension signal policy: accepts AbortSignal. DB-holding walk loop
+ * — writes via catalogAssets on each page. NOT driven by the service
+ * scheduler; uses its own module-level walkAbortController managed
+ * by pauseArchiveSync() / resumeArchiveSync() hooks wired into the
+ * suspension manager's onBeforeSuspend / onAfterResume.
  */
 
 import { useApp } from '@siastorage/core/app'
@@ -71,17 +77,36 @@ export async function stopArchiveSync(): Promise<void> {
   await setPhotosArchiveCursor(CURSOR_DONE)
 }
 
+/** Abort the in-flight walk without clearing cursor so it resumes from the same page. */
+export function pauseArchiveSync(): void {
+  walkAbortController?.abort()
+}
+
+/** Restart the walk from where it left off if cursor isn't DONE. */
+export async function resumeArchiveSync(): Promise<void> {
+  if (activeWalk) return
+  const cursor = await getPhotosArchiveCursor()
+  if (cursor === CURSOR_DONE) return
+  walkAbortController = new AbortController()
+  activeWalk = runArchiveWalk(walkAbortController.signal)
+  activeWalk.finally(() => {
+    activeWalk = null
+    walkAbortController = null
+  })
+}
+
 async function runArchiveWalk(signal: AbortSignal): Promise<void> {
   while (!signal.aborted) {
     const cursor = await getPhotosArchiveCursor()
     if (cursor === CURSOR_DONE) break
-    await run()
+    await run(signal)
     await yieldToEventLoop()
   }
 }
 
-export async function run() {
+export async function run(signal?: AbortSignal) {
   logger.debug('syncPhotosArchive', 'tick')
+  if (signal?.aborted) return
   if (!(await getMediaLibraryPermissions())) {
     logger.debug('syncPhotosArchive', 'skipped', { reason: 'no_permission' })
     return
@@ -92,6 +117,7 @@ export async function run() {
     return
   }
 
+  if (signal?.aborted) return
   logger.info('syncPhotosArchive', 'query', {
     cursor: cursor === CURSOR_START ? 'start' : cursor,
   })
@@ -103,6 +129,7 @@ export async function run() {
       sortBy: [[MediaLibrary.SortBy.modificationTime, false]],
       mediaType: [MediaLibrary.MediaType.photo, MediaLibrary.MediaType.video],
     })
+    if (signal?.aborted) return
     if (page.assets.length === 0) {
       if (cursor !== CURSOR_START) {
         logger.info('syncPhotosArchive', 'cursor_reached_end', {
@@ -138,6 +165,7 @@ export async function run() {
       })),
       'file',
       { addToImportDirectory: true },
+      signal,
     )
     photosAddedCount += assets.length
     photosExistingCount += existingCount

--- a/apps/mobile/src/stores/fs.ts
+++ b/apps/mobile/src/stores/fs.ts
@@ -16,6 +16,14 @@ export async function removeFsFile(file: FsFileInfo): Promise<void> {
   await fsFileUriCache.set(null, file.id)
 }
 
+/**
+ * Copy a file into app storage.
+ *
+ * Suspension signal policy: does NOT accept a signal. Wraps a single
+ * native RNFS.copyFile call that can't be cancelled mid-flight in JS.
+ * Callers that loop over many copies should check their signal at the
+ * loop boundary before invoking.
+ */
 export async function copyFileToFs(file: FsFileInfo, sourceUri: string): Promise<string> {
   logger.debug('fs', 'copy_file', { fileId: file.id, sourceUri })
   const uri = await app().fs.copyFile(file, sourceUri)

--- a/packages/core/src/services/importScanner.ts
+++ b/packages/core/src/services/importScanner.ts
@@ -19,6 +19,17 @@ export type ResolveLocalId = (localId: string) => Promise<ResolveLocalIdResult>
 export type CalculateContentHash = (uri: string) => Promise<string | null>
 export type GetMimeType = (opts: { name?: string; uri?: string }) => Promise<string>
 
+/**
+ * Finalizes placeholder file records by hashing local files (phase 1)
+ * or copying from the media library via resolveLocalId (phase 2).
+ * Phase 2 is throttled via maxDeferred to backpressure against upload.
+ *
+ * Suspension signal policy: accepts AbortSignal. DB-holding loop —
+ * each tick processes placeholder files (hash: '') by hashing local
+ * files or copying from media library. Checks signal at loop boundaries
+ * (phase 1 file loop, phase 2 deferred loop) so workers exit before the
+ * DB gate closes.
+ */
 export class ImportScanner {
   private app: AppService | null = null
   private processingFiles = new Set<string>()

--- a/packages/core/src/services/syncDownEvents.ts
+++ b/packages/core/src/services/syncDownEvents.ts
@@ -70,6 +70,11 @@ type PreparedEvent = PreparedCreate | PreparedUpdate | PreparedDelete
  *
  * Returns 0 when multiple events were fetched (run again immediately),
  * or void to use the default interval.
+ *
+ * Suspension signal policy: accepts AbortSignal. DB-holding loop —
+ * fetches event batches from the indexer and writes objects to the
+ * local DB in a transaction. Checks signal at every exit point so a
+ * mid-batch abort releases the transaction before the DB gate closes.
  */
 export async function syncDownEventsBatch(
   signal: AbortSignal,

--- a/packages/core/src/services/syncUpMetadata.ts
+++ b/packages/core/src/services/syncUpMetadata.ts
@@ -64,6 +64,10 @@ async function tryWithLog<T>(
  * cleanup service should scan for tombstoned files that still have object
  * rows on non-current indexers. Alternatively, the cursor could be reset
  * or stored per-indexer when multi-indexer support is added.
+ *
+ * Suspension signal policy: accepts AbortSignal. DB-holding loop —
+ * reads remote metadata and writes local DB. Checks signal at exit
+ * points so a mid-batch abort doesn't issue queries after the gate.
  */
 export async function syncUpMetadataBatch(
   batchSize: number,

--- a/packages/core/src/services/thumbnailScanner.ts
+++ b/packages/core/src/services/thumbnailScanner.ts
@@ -85,6 +85,15 @@ export function computeTargetDimensions(
   return { targetWidth: size, targetHeight: undefined }
 }
 
+/**
+ * Generates and stores thumbnails for files lacking them, prioritized
+ * by recency and bounded per tick to avoid starving other services.
+ *
+ * Suspension signal policy: accepts AbortSignal. DB-holding loop — each
+ * tick queries candidate files and writes thumbnails via app().files /
+ * app().thumbs. Checks signal at loop boundaries so straggler workers
+ * don't issue queries after the gate and hit DatabaseSuspendedError.
+ */
 export class ThumbnailScanner {
   private app: AppService | null = null
   private processingFiles = new Set<string>()

--- a/packages/core/src/services/uploader.ts
+++ b/packages/core/src/services/uploader.ts
@@ -131,6 +131,12 @@ export type FlushRecord = {
  * in the order they were added to the library. Photos arrive before their
  * thumbnails (which are generated asynchronously), naturally mixing large
  * and small files for efficient slab packing.
+ *
+ * Suspension signal policy: does NOT use the scheduler abort signal.
+ * Coordinates with native packer state via internal _suspended flag and
+ * dedicated suspend()/resume() methods that preserve batch state across
+ * suspension. The scheduler signal would only stop the JS loop — it
+ * couldn't reach the in-flight network I/O inside the packer.
  */
 export class UploadManager {
   private app!: AppService


### PR DESCRIPTION
When iOS suspends the app, anything still touching SQLite or writing to disk during the WAL fsync is a known trigger for the 0xdead10cc watchdog crash. Several scheduler-driven workers and the photo archive walk weren't honoring the suspension AbortSignal, so they kept running into the gate.

Wires the suspension signal into every worker that holds a DB handle or does write I/O — thumbnail/import scanners, sync-down/up, dbOptimize, log rotation, perf monitor, photo import — and adds pauseArchiveSync/resumeArchiveSync hooks for the non-scheduler archive walk. Active downloads are also cancelled on suspend. Leaf functions wrapping a single uncancellable native call deliberately don't take a signal — JS can't interrupt the native thread there. Each touched file documents its signal policy so the contract stays explicit.
