### PR TITLE
perf(core): drop encrypted metadata columns from LocalObject meta reads

### DIFF
--- a/.changeset/skip-object-encrypted-columns.md
+++ b/.changeset/skip-object-encrypted-columns.md
@@ -1,0 +1,5 @@
+---
+core: patch
+---
+
+Exclude encrypted metadata and signature columns from default object queries; full objects are loaded on demand for upload and download paths.

--- a/apps/integration/test/app.ts
+++ b/apps/integration/test/app.ts
@@ -15,7 +15,7 @@ import type {
   Tag,
   TagWithCount,
 } from '@siastorage/core/db/operations'
-import type { LocalObject } from '@siastorage/core/encoding/localObject'
+import type { LocalObjectRef } from '@siastorage/core/encoding/localObject'
 import { createSuspensionManager } from '@siastorage/core/services/suspension'
 import { detectMimeType } from '@siastorage/core/lib/detectMimeType'
 import { ServiceScheduler } from '@siastorage/core/lib/serviceInterval'
@@ -222,7 +222,7 @@ export interface TestApp {
     update: Partial<FileRecordRow> & { id: string },
     opts?: { includeUpdatedAt?: boolean },
   ): Promise<void>
-  readLocalObjectsForFile(fileId: string): Promise<LocalObject[]>
+  readLocalObjectsForFile(fileId: string): Promise<LocalObjectRef[]>
 
   removeFsFile(fileId: string, type: string): Promise<void>
   listFsFiles(): Promise<string[]>
@@ -633,7 +633,7 @@ export function createTestApp(
 
     updateFileRecord: (update, opts) => appService.files.update(update, opts),
 
-    readLocalObjectsForFile: (fileId) => appService.localObjects.getForFile(fileId),
+    readLocalObjectsForFile: (fileId) => appService.localObjects.getRefsForFile(fileId),
 
     async removeFsFile(fileId, type) {
       await appService.fs.removeFile({ id: fileId, type })

--- a/apps/mobile/src/components/FileDetails/FileMap.tsx
+++ b/apps/mobile/src/components/FileDetails/FileMap.tsx
@@ -14,7 +14,7 @@ export function FileMap({ fileId }: { fileId: string }) {
   const hosts = useHosts()
 
   const { data: firstSlab } = useSWR<Slab | null>(['fileMap:firstSlab', fileId], async () => {
-    const objects = await app().localObjects.getForFileWithSlabs(fileId)
+    const objects = await app().localObjects.getForFile(fileId)
     return objects[0]?.slabs[0] ?? null
   })
 

--- a/apps/mobile/src/hooks/usePinnedObjects.tsx
+++ b/apps/mobile/src/hooks/usePinnedObjects.tsx
@@ -8,7 +8,7 @@ export function usePinnedObjects(fileId: string) {
   return useSWR<{ indexerURL: string; pinnedObject: PinnedObjectInterface }[]>(
     ['pinnedObjects', fileId],
     async () => {
-      const objects = await app().localObjects.getForFileWithSlabs(fileId)
+      const objects = await app().localObjects.getForFile(fileId)
       const results = await Promise.all(
         objects.map(async (so) => {
           const appKey = await getAppKeyForIndexer(so.indexerURL)

--- a/apps/mobile/src/hooks/useShareAction.tsx
+++ b/apps/mobile/src/hooks/useShareAction.tsx
@@ -21,7 +21,7 @@ export function useShareAction({ fileId }: { fileId: string }) {
     const sdk = internal().getSdk()
     if (!sdk) return
 
-    const objects = await app().localObjects.getForFileWithSlabs(file.id)
+    const objects = await app().localObjects.getForFile(file.id)
     if (!objects.length) return
     const obj = objects[0]
     const appKey = await getAppKeyForIndexer(obj.indexerURL)

--- a/apps/mobile/src/lib/file.ts
+++ b/apps/mobile/src/lib/file.ts
@@ -1,5 +1,5 @@
 import type { DownloadEntry } from '@siastorage/core/app'
-import type { LocalObject } from '@siastorage/core/encoding/localObject'
+import type { LocalObjectRef } from '@siastorage/core/encoding/localObject'
 import { useDownloadEntry } from '@siastorage/core/stores'
 import type { FileRecord } from '@siastorage/core/types'
 import { useMemo } from 'react'
@@ -181,8 +181,8 @@ export function getFileTypeName(
 }
 
 export function getOneObject(file: {
-  objects: Record<string, LocalObject> | null
-}): { indexerURL: string; object: LocalObject } | null {
+  objects: Record<string, LocalObjectRef> | null
+}): { indexerURL: string; object: LocalObjectRef } | null {
   const entries = Object.entries(file.objects ?? {})
   if (entries.length === 0) return null
   const [indexerURL, object] = entries[0]

--- a/apps/mobile/src/lib/localObjects.ts
+++ b/apps/mobile/src/lib/localObjects.ts
@@ -1,4 +1,4 @@
-import type { LocalObjectWithSlabs } from '@siastorage/core/encoding/localObject'
+import type { LocalObject } from '@siastorage/core/encoding/localObject'
 import { sealPinnedObject } from '@siastorage/core/lib/localObjects'
 import type { PinnedObjectInterface } from 'react-native-sia'
 import { getAppKeyForIndexer } from '../stores/appKey'
@@ -7,7 +7,7 @@ export async function pinnedObjectToLocalObject(
   fileId: string,
   indexerURL: string,
   pinnedObject: PinnedObjectInterface,
-): Promise<LocalObjectWithSlabs> {
+): Promise<LocalObject> {
   const appKey = await getAppKeyForIndexer(indexerURL)
   if (!appKey) {
     throw new Error(`No AppKey found for indexer: ${indexerURL}`)

--- a/apps/mobile/src/managers/fsEvictionScanner.test.ts
+++ b/apps/mobile/src/managers/fsEvictionScanner.test.ts
@@ -1,5 +1,5 @@
 import { daysInMs } from '@siastorage/core'
-import type { LocalObjectWithSlabs } from '@siastorage/core/encoding/localObject'
+import type { LocalObject } from '@siastorage/core/encoding/localObject'
 import type { FileRecord } from '@siastorage/core/types'
 import { initializeDB, resetDb } from '../db'
 import { app } from '../stores/appService'
@@ -165,7 +165,7 @@ function makeLocalObject(params: {
   indexerURL: string
   createdAt: number
   updatedAt: number
-}): LocalObjectWithSlabs {
+}): LocalObject {
   return {
     id: params.objectId,
     fileId: params.fileId,

--- a/apps/mobile/src/managers/syncDownEvents.test.ts
+++ b/apps/mobile/src/managers/syncDownEvents.test.ts
@@ -1,5 +1,5 @@
 import { encodeFileMetadata } from '@siastorage/core/encoding/fileMetadata'
-import type { LocalObjectWithSlabs } from '@siastorage/core/encoding/localObject'
+import type { LocalObject } from '@siastorage/core/encoding/localObject'
 import type { FileMetadata, FileRecord } from '@siastorage/core/types'
 import type { ObjectEvent, PinnedObjectInterface } from 'react-native-sia'
 import { initializeDB, resetDb } from '../db'
@@ -12,7 +12,7 @@ function makeLocalObject(params: {
   indexerURL: string
   createdAt: number
   updatedAt: number
-}): LocalObjectWithSlabs {
+}): LocalObject {
   return {
     id: params.objectId,
     fileId: params.fileId,

--- a/apps/mobile/src/managers/syncUpMetadata.test.ts
+++ b/apps/mobile/src/managers/syncUpMetadata.test.ts
@@ -1,4 +1,4 @@
-import type { LocalObjectWithSlabs } from '@siastorage/core/encoding/localObject'
+import type { LocalObject } from '@siastorage/core/encoding/localObject'
 import type { FileRecord } from '@siastorage/core/types'
 import { initializeDB, resetDb } from '../db'
 import { app, internal } from '../stores/appService'
@@ -15,7 +15,7 @@ function makeLocalObject(params: {
   indexerURL: string
   createdAt: number
   updatedAt: number
-}): LocalObjectWithSlabs {
+}): LocalObject {
   return {
     id: params.objectId,
     fileId: params.fileId,

--- a/packages/core/src/app/namespaces/db.ts
+++ b/packages/core/src/app/namespaces/db.ts
@@ -479,9 +479,9 @@ export function buildDbNamespaces(
       },
     },
     localObjects: {
-      getForFile: (fileId) => ops.queryObjectMetasForFile(db, fileId),
-      getForFiles: (fileIds) => ops.queryObjectMetasForFiles(db, fileIds),
-      getForFileWithSlabs: (fileId) => ops.queryObjectsForFileWithSlabs(db, fileId),
+      getRefsForFile: (fileId) => ops.queryObjectRefsForFile(db, fileId),
+      getRefsForFiles: (fileIds) => ops.queryObjectRefsForFiles(db, fileIds),
+      getForFile: (fileId) => ops.queryObjectsForFile(db, fileId),
       upsert: async (object, opts) => {
         await ops.insertObject(db, object)
         if (!opts?.skipInvalidation) {

--- a/packages/core/src/app/namespaces/downloads.ts
+++ b/packages/core/src/app/namespaces/downloads.ts
@@ -3,7 +3,7 @@ import type { SdkAdapter } from '../../adapters/sdk'
 import type { StorageAdapter } from '../../adapters/storage'
 import { DEFAULT_MAX_DOWNLOADS } from '../../config'
 import * as ops from '../../db/operations'
-import type { LocalObjectWithSlabs } from '../../encoding/localObject'
+import type { LocalObject } from '../../encoding/localObject'
 import { SlotPool } from '../../lib/slotPool'
 import type { FsIOAdapter } from '../../services/fsFileUri'
 import type { AppCaches, AppService } from '../service'
@@ -13,7 +13,7 @@ import type { DownloadsState } from '../stores'
 export type DownloadObjectAdapter = {
   download(params: {
     file: { id: string; type: string; size: number }
-    object: LocalObjectWithSlabs
+    object: LocalObject
     sdk: SdkAdapter
     onProgress: (progress: number) => void
     signal: AbortSignal
@@ -76,7 +76,7 @@ export function buildDownloadsNamespace(
 
     const sdk = getSdk()
     if (!sdk) throw new Error('SDK not initialized')
-    const objects = await ops.queryObjectsForFileWithSlabs(db, fileId)
+    const objects = await ops.queryObjectsForFile(db, fileId)
     if (!objects.length) throw new Error('No object available for download')
 
     register(fileId)

--- a/packages/core/src/app/service.ts
+++ b/packages/core/src/app/service.ts
@@ -9,7 +9,7 @@ import type {
   TagWithCount,
   UploadStats,
 } from '../db/operations'
-import type { LocalObject, LocalObjectWithSlabs } from '../encoding/localObject'
+import type { LocalObject, LocalObjectRef } from '../encoding/localObject'
 import type { SyncUpCursor } from '../services/syncUpMetadata'
 import type { FileMetadata, FileRecord, FileRecordRow, ThumbSize } from '../types/files'
 import type {
@@ -154,7 +154,7 @@ export interface AppService {
     /** Creates a file, optionally with a local object. */
     create(
       record: Omit<FileRecord, 'objects'>,
-      localObject?: LocalObjectWithSlabs,
+      localObject?: LocalObject,
       opts?: { skipInvalidation?: boolean; skipCurrentRecalc?: boolean },
     ): Promise<void>
     /** Creates multiple files. */
@@ -195,7 +195,7 @@ export interface AppService {
     /** Updates a file and upserts its local object. */
     updateWithLocalObject(
       update: Partial<FileRecordRow> & { id: string },
-      localObject: LocalObjectWithSlabs,
+      localObject: LocalObject,
       opts?: { includeUpdatedAt?: boolean; skipInvalidation?: boolean },
     ): Promise<void>
     /** Hard-deletes a file by ID. */
@@ -348,14 +348,14 @@ export interface AppService {
   }
   /** Local object (remote reference) CRUD for file-to-indexer mappings. */
   localObjects: {
-    /** Returns local objects for a file (without slabs). */
+    /** Returns lightweight object refs for a file. */
+    getRefsForFile(fileId: string): Promise<LocalObjectRef[]>
+    /** Returns lightweight object refs for multiple files. */
+    getRefsForFiles(fileIds: string[]): Promise<Record<string, LocalObjectRef[]>>
+    /** Returns full local objects for a file. */
     getForFile(fileId: string): Promise<LocalObject[]>
-    /** Returns local objects for multiple files (without slabs). */
-    getForFiles(fileIds: string[]): Promise<Record<string, LocalObject[]>>
-    /** Returns local objects for a file with full slab data. */
-    getForFileWithSlabs(fileId: string): Promise<LocalObjectWithSlabs[]>
     /** Creates or updates a local object. */
-    upsert(object: LocalObjectWithSlabs, opts?: { skipInvalidation?: boolean }): Promise<void>
+    upsert(object: LocalObject, opts?: { skipInvalidation?: boolean }): Promise<void>
     /** Deletes a local object by object ID and indexer URL. */
     delete(
       objectId: string,
@@ -367,10 +367,7 @@ export interface AppService {
     /** Deletes all local objects for multiple files. */
     deleteManyForFiles(fileIds: string[]): Promise<void>
     /** Creates or updates multiple local objects. */
-    upsertMany(
-      objects: LocalObjectWithSlabs[],
-      opts?: { skipInvalidation?: boolean },
-    ): Promise<void>
+    upsertMany(objects: LocalObject[], opts?: { skipInvalidation?: boolean }): Promise<void>
     /** Returns the count of local objects for a file. */
     countForFile(fileId: string): Promise<number>
     /** Deletes local objects by object IDs for a given indexer. */

--- a/packages/core/src/db/operations/files.test.ts
+++ b/packages/core/src/db/operations/files.test.ts
@@ -15,7 +15,7 @@ import {
   queryFileStats,
   queryLostFiles,
   readFile,
-  readFileWithSlabs,
+  readFileWithObjects,
   readFilesByIds,
   updateFile,
   updateManyFiles,
@@ -99,11 +99,11 @@ describe('readFile', () => {
   })
 })
 
-describe('readFileWithSlabs', () => {
+describe('readFileWithObjects', () => {
   it('includes slabs in objects', async () => {
     await insertFile(db(), makeFileRecord('file-1'))
     await insertObject(db(), makeLocalObject('file-1'))
-    const result = await readFileWithSlabs(db(), 'file-1')
+    const result = await readFileWithObjects(db(), 'file-1')
     expect(result).not.toBeNull()
     const obj = result!.objects['https://indexer.example.com']
     expect(obj).toBeDefined()

--- a/packages/core/src/db/operations/files.ts
+++ b/packages/core/src/db/operations/files.ts
@@ -1,12 +1,12 @@
 import { logger } from '@siastorage/logger'
 import type { DatabaseAdapter } from '../../adapters/db'
-import type { LocalObject, LocalObjectRow, LocalObjectWithSlabs } from '../../encoding/localObject'
-import { localObjectFromStorageRow } from '../../encoding/localObject'
+import type { LocalObject, LocalObjectRef, LocalObjectRefRow } from '../../encoding/localObject'
+import { localObjectRefFromStorageRow } from '../../encoding/localObject'
 import { naturalSortKey } from '../../lib/naturalSortKey'
 import type { FileRecord, FileRecordRow } from '../../types/files'
 import * as sql from '../sql'
 import { buildActiveFileFilter, buildActiveFilter } from './library'
-import { insertObject, queryObjectMetasForFile, queryObjectsForFileWithSlabs } from './localObjects'
+import { insertObject, queryObjectRefsForFile, queryObjectsForFile } from './localObjects'
 import { trashFilesAndThumbnails } from './trash'
 
 export async function recalculateCurrentForGroup(
@@ -125,7 +125,7 @@ export async function queryFilesByObjectIds(
   return result
 }
 
-export function transformRow<T extends LocalObject = LocalObject>(
+export function transformRow<T extends LocalObjectRef = LocalObjectRef>(
   row: FileRecordRow,
   objects?: T[],
 ): FileRecordRow & { objects: Record<string, T> } {
@@ -336,7 +336,7 @@ export async function queryFiles(db: DatabaseAdapter, opts: FileQueryOpts): Prom
 
   const joined = await db.getAllAsync<
     FileRecordRow &
-      LocalObjectRow & {
+      LocalObjectRefRow & {
         objectId: string
         objectCreatedAt: number
         objectUpdatedAt: number
@@ -344,9 +344,7 @@ export async function queryFiles(db: DatabaseAdapter, opts: FileQueryOpts): Prom
   >(
     `SELECT f.id, f.name, f.size, f.createdAt, f.updatedAt, f.type, f.kind, f.localId, f.hash, f.addedAt, f.thumbForId, f.thumbSize, f.trashedAt, f.deletedAt, f.lostReason,
             o.fileId as fileId, o.indexerURL as indexerURL, o.id as objectId,
-            o.encryptedDataKey as encryptedDataKey, o.encryptedMetadataKey as encryptedMetadataKey,
-            o.encryptedMetadata as encryptedMetadata, o.dataSignature as dataSignature,
-            o.metadataSignature as metadataSignature, o.createdAt as objectCreatedAt, o.updatedAt as objectUpdatedAt
+            o.createdAt as objectCreatedAt, o.updatedAt as objectUpdatedAt
      FROM files f
      LEFT JOIN objects o ON o.fileId = f.id
      ${where}
@@ -355,7 +353,7 @@ export async function queryFiles(db: DatabaseAdapter, opts: FileQueryOpts): Prom
   )
 
   const byId: Map<string, FileRecordRow> = new Map()
-  const objectsById: Map<string, LocalObject[]> = new Map()
+  const objectsById: Map<string, LocalObjectRef[]> = new Map()
 
   for (const r of joined) {
     if (!byId.has(r.id)) {
@@ -364,7 +362,7 @@ export async function queryFiles(db: DatabaseAdapter, opts: FileQueryOpts): Prom
     if (r.fileId && r.indexerURL) {
       const arr = objectsById.get(r.id) || []
       arr.push(
-        localObjectFromStorageRow({
+        localObjectRefFromStorageRow({
           ...r,
           id: r.objectId,
           createdAt: r.objectCreatedAt,
@@ -597,17 +595,17 @@ export async function deleteAllFiles(db: DatabaseAdapter): Promise<void> {
 export async function readFile(db: DatabaseAdapter, id: string): Promise<FileRecord | null> {
   const row = await queryFileById(db, id)
   if (!row) return null
-  const objects = await queryObjectMetasForFile(db, id)
+  const objects = await queryObjectRefsForFile(db, id)
   return transformRow(row, objects)
 }
 
-export async function readFileWithSlabs(
+export async function readFileWithObjects(
   db: DatabaseAdapter,
   id: string,
-): Promise<(FileRecordRow & { objects: Record<string, LocalObjectWithSlabs> }) | null> {
+): Promise<(FileRecordRow & { objects: Record<string, LocalObject> }) | null> {
   const row = await queryFileById(db, id)
   if (!row) return null
-  const objects = await queryObjectsForFileWithSlabs(db, id)
+  const objects = await queryObjectsForFile(db, id)
   return transformRow(row, objects)
 }
 
@@ -618,7 +616,7 @@ export async function readFileByObjectId(
 ): Promise<FileRecord | null> {
   const row = await queryFileByObjectId(db, objectId, indexerURL)
   if (!row) return null
-  const objects = await queryObjectMetasForFile(db, row.id)
+  const objects = await queryObjectRefsForFile(db, row.id)
   return transformRow(row, objects)
 }
 
@@ -628,7 +626,7 @@ export async function readFileByContentHash(
 ): Promise<FileRecord | null> {
   const row = await queryFileByContentHash(db, hash)
   if (!row) return null
-  const objects = await queryObjectMetasForFile(db, row.id)
+  const objects = await queryObjectRefsForFile(db, row.id)
   return transformRow(row, objects)
 }
 
@@ -674,7 +672,7 @@ export async function queryLocalOnlyFiles(
 export async function createFileWithLocalObject(
   db: DatabaseAdapter,
   record: Omit<FileRecord, 'objects'>,
-  localObject: LocalObjectWithSlabs,
+  localObject: LocalObject,
 ): Promise<void> {
   await db.withTransactionAsync(async () => {
     await insertFile(db, record)
@@ -685,7 +683,7 @@ export async function createFileWithLocalObject(
 export async function updateFileWithLocalObject(
   db: DatabaseAdapter,
   update: Partial<FileRecordRow> & { id: string },
-  localObject: LocalObjectWithSlabs,
+  localObject: LocalObject,
   options?: { includeUpdatedAt?: boolean },
 ): Promise<void> {
   await db.withTransactionAsync(async () => {
@@ -775,12 +773,12 @@ export async function readFilesByIds(db: DatabaseAdapter, ids: string[]): Promis
   if (ids.length === 0) return []
 
   const byId: Map<string, FileRecordRow> = new Map()
-  const objectsById: Map<string, LocalObject[]> = new Map()
+  const objectsById: Map<string, LocalObjectRef[]> = new Map()
 
   const ph = ids.map(() => '?').join(',')
   const joined = await db.getAllAsync<
     FileRecordRow &
-      LocalObjectRow & {
+      LocalObjectRefRow & {
         objectId: string
         objectCreatedAt: number
         objectUpdatedAt: number
@@ -788,9 +786,7 @@ export async function readFilesByIds(db: DatabaseAdapter, ids: string[]): Promis
   >(
     `SELECT f.id, f.name, f.size, f.createdAt, f.updatedAt, f.type, f.kind, f.localId, f.hash, f.addedAt, f.thumbForId, f.thumbSize, f.trashedAt, f.deletedAt, f.lostReason,
             o.fileId as fileId, o.indexerURL as indexerURL, o.id as objectId,
-            o.encryptedDataKey as encryptedDataKey, o.encryptedMetadataKey as encryptedMetadataKey,
-            o.encryptedMetadata as encryptedMetadata, o.dataSignature as dataSignature,
-            o.metadataSignature as metadataSignature, o.createdAt as objectCreatedAt, o.updatedAt as objectUpdatedAt
+            o.createdAt as objectCreatedAt, o.updatedAt as objectUpdatedAt
      FROM files f
      LEFT JOIN objects o ON o.fileId = f.id
      WHERE f.id IN (${ph})`,
@@ -804,7 +800,7 @@ export async function readFilesByIds(db: DatabaseAdapter, ids: string[]): Promis
     if (r.fileId && r.indexerURL) {
       const arr = objectsById.get(r.id) || []
       arr.push(
-        localObjectFromStorageRow({
+        localObjectRefFromStorageRow({
           ...r,
           id: r.objectId,
           createdAt: r.objectCreatedAt,
@@ -970,7 +966,7 @@ export async function readFileByName(
 ): Promise<FileRecord | null> {
   const row = await queryFileByName(db, name)
   if (!row) return null
-  const objects = await queryObjectMetasForFile(db, row.id)
+  const objects = await queryObjectRefsForFile(db, row.id)
   return transformRow(row, objects)
 }
 

--- a/packages/core/src/db/operations/index.ts
+++ b/packages/core/src/db/operations/index.ts
@@ -67,7 +67,7 @@ export {
   readFileByContentHash,
   readFileByName,
   readFileByObjectId,
-  readFileWithSlabs,
+  readFileWithObjects,
   readFilesByContentHashes,
   readFilesByIds,
   readFilesByLocalIds,
@@ -126,10 +126,10 @@ export {
   insertObject,
   insertManyObjects,
   queryFilesWithNoObjects,
-  queryObjectMetasForFile,
-  queryObjectMetasForFiles,
-  queryObjectsForFileWithSlabs,
-  queryObjectsForFilesWithSlabs,
+  queryObjectRefsForFile,
+  queryObjectRefsForFiles,
+  queryObjectsForFile,
+  queryObjectsForFiles,
 } from './localObjects'
 export {
   deleteAllLogs,

--- a/packages/core/src/db/operations/localObjects.test.ts
+++ b/packages/core/src/db/operations/localObjects.test.ts
@@ -5,10 +5,10 @@ import {
   deleteObjectsForFile,
   deleteManyObjectsForFiles,
   insertObject,
-  queryObjectMetasForFile,
-  queryObjectMetasForFiles,
-  queryObjectsForFileWithSlabs,
-  queryObjectsForFilesWithSlabs,
+  queryObjectRefsForFile,
+  queryObjectRefsForFiles,
+  queryObjectsForFile,
+  queryObjectsForFiles,
 } from './localObjects'
 import { db, setupTestDb, teardownTestDb } from './test-setup'
 
@@ -55,7 +55,7 @@ describe('insertObject', () => {
     const obj = makeLocalObject('f1', 'https://idx.example.com', 'obj1')
     await insertObject(db(), obj)
 
-    const results = await queryObjectMetasForFile(db(), 'f1')
+    const results = await queryObjectRefsForFile(db(), 'f1')
     expect(results).toHaveLength(1)
     expect(results[0].id).toBe('obj1')
     expect(results[0].fileId).toBe('f1')
@@ -63,45 +63,45 @@ describe('insertObject', () => {
   })
 })
 
-describe('queryObjectMetasForFile', () => {
-  it('returns objects without slabs', async () => {
+describe('queryObjectRefsForFile', () => {
+  it('returns refs without slabs or encrypted fields', async () => {
     await createTestFile('f1')
     await insertObject(db(), makeLocalObject('f1', 'https://a.com', 'obj1'))
     await insertObject(db(), makeLocalObject('f1', 'https://b.com', 'obj2'))
 
-    const results = await queryObjectMetasForFile(db(), 'f1')
+    const results = await queryObjectRefsForFile(db(), 'f1')
     expect(results).toHaveLength(2)
     expect(results[0]).not.toHaveProperty('slabs')
+    expect(results[0]).not.toHaveProperty('encryptedDataKey')
     expect(results[0].id).toBeDefined()
-    expect(results[0].encryptedDataKey).toBeInstanceOf(ArrayBuffer)
   })
 
   it('returns empty for non-existent file', async () => {
-    const results = await queryObjectMetasForFile(db(), 'nonexistent')
+    const results = await queryObjectRefsForFile(db(), 'nonexistent')
     expect(results).toEqual([])
   })
 })
 
-describe('queryObjectsForFileWithSlabs', () => {
-  it('returns objects with slabs', async () => {
+describe('queryObjectsForFile', () => {
+  it('returns full objects with slabs', async () => {
     await createTestFile('f1')
     await insertObject(db(), makeLocalObject('f1', 'https://a.com', 'obj1'))
 
-    const results = await queryObjectsForFileWithSlabs(db(), 'f1')
+    const results = await queryObjectsForFile(db(), 'f1')
     expect(results).toHaveLength(1)
     expect(results[0]).toHaveProperty('slabs')
     expect(results[0].slabs).toEqual([])
   })
 })
 
-describe('queryObjectMetasForFiles', () => {
+describe('queryObjectRefsForFiles', () => {
   it('returns map keyed by fileId without slabs', async () => {
     await createTestFile('f1')
     await createTestFile('f2')
     await insertObject(db(), makeLocalObject('f1', 'https://a.com', 'obj1'))
     await insertObject(db(), makeLocalObject('f2', 'https://a.com', 'obj2'))
 
-    const map = await queryObjectMetasForFiles(db(), ['f1', 'f2'])
+    const map = await queryObjectRefsForFiles(db(), ['f1', 'f2'])
     expect(map.f1).toHaveLength(1)
     expect(map.f1[0].id).toBe('obj1')
     expect(map.f1[0]).not.toHaveProperty('slabs')
@@ -110,17 +110,17 @@ describe('queryObjectMetasForFiles', () => {
   })
 
   it('returns empty object for empty input', async () => {
-    const map = await queryObjectMetasForFiles(db(), [])
+    const map = await queryObjectRefsForFiles(db(), [])
     expect(map).toEqual({})
   })
 })
 
-describe('queryObjectsForFilesWithSlabs', () => {
+describe('queryObjectsForFiles', () => {
   it('returns map with slabs included', async () => {
     await createTestFile('f1')
     await insertObject(db(), makeLocalObject('f1', 'https://a.com', 'obj1'))
 
-    const map = await queryObjectsForFilesWithSlabs(db(), ['f1'])
+    const map = await queryObjectsForFiles(db(), ['f1'])
     expect(map.f1).toHaveLength(1)
     expect(map.f1[0]).toHaveProperty('slabs')
   })
@@ -151,7 +151,7 @@ describe('deleteObject', () => {
 
     await deleteObject(db(), 'obj1', 'https://a.com')
 
-    const results = await queryObjectMetasForFile(db(), 'f1')
+    const results = await queryObjectRefsForFile(db(), 'f1')
     expect(results).toHaveLength(1)
     expect(results[0].id).toBe('obj2')
   })
@@ -165,7 +165,7 @@ describe('deleteObjectsForFile', () => {
 
     await deleteObjectsForFile(db(), 'f1')
 
-    const results = await queryObjectMetasForFile(db(), 'f1')
+    const results = await queryObjectRefsForFile(db(), 'f1')
     expect(results).toEqual([])
   })
 })
@@ -181,9 +181,9 @@ describe('deleteManyObjectsForFiles', () => {
 
     await deleteManyObjectsForFiles(db(), ['f1', 'f2'])
 
-    expect(await queryObjectMetasForFile(db(), 'f1')).toEqual([])
-    expect(await queryObjectMetasForFile(db(), 'f2')).toEqual([])
-    expect(await queryObjectMetasForFile(db(), 'f3')).toHaveLength(1)
+    expect(await queryObjectRefsForFile(db(), 'f1')).toEqual([])
+    expect(await queryObjectRefsForFile(db(), 'f2')).toEqual([])
+    expect(await queryObjectRefsForFile(db(), 'f3')).toHaveLength(1)
   })
 
   it('handles empty array', async () => {

--- a/packages/core/src/db/operations/localObjects.ts
+++ b/packages/core/src/db/operations/localObjects.ts
@@ -1,49 +1,45 @@
 import type { DatabaseAdapter } from '../../adapters/db'
 import type {
   LocalObject,
+  LocalObjectRef,
+  LocalObjectRefRow,
   LocalObjectRow,
-  LocalObjectRowWithSlabs,
-  LocalObjectWithSlabs,
 } from '../../encoding/localObject'
 import {
   localObjectFromStorageRow,
-  localObjectWithSlabsFromStorageRow,
-  localObjectWithSlabsToStorageRow,
+  localObjectRefFromStorageRow,
+  localObjectToStorageRow,
 } from '../../encoding/localObject'
 import * as sql from '../sql'
 
-const OBJECT_META_COLUMNS =
-  'id, fileId, indexerURL, encryptedDataKey, encryptedMetadataKey, encryptedMetadata, dataSignature, metadataSignature, createdAt, updatedAt'
+const OBJECT_REF_COLUMNS = 'id, fileId, indexerURL, createdAt, updatedAt'
 
-const OBJECT_ALL_COLUMNS = `${OBJECT_META_COLUMNS}, slabs`
+const OBJECT_ALL_COLUMNS = `${OBJECT_REF_COLUMNS}, encryptedDataKey, encryptedMetadataKey, encryptedMetadata, dataSignature, metadataSignature, slabs`
 
-export async function queryObjectMetasForFile(
+export async function queryObjectRefsForFile(
+  db: DatabaseAdapter,
+  fileId: string,
+): Promise<LocalObjectRef[]> {
+  const rows = await db.getAllAsync<LocalObjectRefRow>(
+    `SELECT ${OBJECT_REF_COLUMNS} FROM objects WHERE fileId = ?`,
+    fileId,
+  )
+  return rows.map(localObjectRefFromStorageRow)
+}
+
+export async function queryObjectsForFile(
   db: DatabaseAdapter,
   fileId: string,
 ): Promise<LocalObject[]> {
   const rows = await db.getAllAsync<LocalObjectRow>(
-    `SELECT ${OBJECT_META_COLUMNS} FROM objects WHERE fileId = ?`,
+    `SELECT ${OBJECT_ALL_COLUMNS} FROM objects WHERE fileId = ?`,
     fileId,
   )
   return rows.map(localObjectFromStorageRow)
 }
 
-export async function queryObjectsForFileWithSlabs(
-  db: DatabaseAdapter,
-  fileId: string,
-): Promise<LocalObjectWithSlabs[]> {
-  const rows = await db.getAllAsync<LocalObjectRowWithSlabs>(
-    `SELECT ${OBJECT_ALL_COLUMNS} FROM objects WHERE fileId = ?`,
-    fileId,
-  )
-  return rows.map(localObjectWithSlabsFromStorageRow)
-}
-
-export async function insertObject(
-  db: DatabaseAdapter,
-  object: LocalObjectWithSlabs,
-): Promise<void> {
-  const e = localObjectWithSlabsToStorageRow(object)
+export async function insertObject(db: DatabaseAdapter, object: LocalObject): Promise<void> {
+  const e = localObjectToStorageRow(object)
   await sql.insert(
     db,
     'objects',
@@ -84,14 +80,33 @@ export async function deleteObjectsForFile(db: DatabaseAdapter, fileId: string):
   await sql.del(db, 'objects', { fileId })
 }
 
-export async function queryObjectMetasForFiles(
+export async function queryObjectRefsForFiles(
+  db: DatabaseAdapter,
+  fileIds: string[],
+): Promise<Record<string, LocalObjectRef[]>> {
+  if (fileIds.length === 0) return {}
+  const ph = fileIds.map(() => '?').join(',')
+  const rows = await db.getAllAsync<LocalObjectRefRow>(
+    `SELECT ${OBJECT_REF_COLUMNS} FROM objects WHERE fileId IN (${ph})`,
+    ...fileIds,
+  )
+  const map: Record<string, LocalObjectRef[]> = {}
+  for (const r of rows) {
+    const lo = localObjectRefFromStorageRow(r)
+    if (!map[r.fileId]) map[r.fileId] = []
+    map[r.fileId].push(lo)
+  }
+  return map
+}
+
+export async function queryObjectsForFiles(
   db: DatabaseAdapter,
   fileIds: string[],
 ): Promise<Record<string, LocalObject[]>> {
   if (fileIds.length === 0) return {}
   const ph = fileIds.map(() => '?').join(',')
   const rows = await db.getAllAsync<LocalObjectRow>(
-    `SELECT ${OBJECT_META_COLUMNS} FROM objects WHERE fileId IN (${ph})`,
+    `SELECT ${OBJECT_ALL_COLUMNS} FROM objects WHERE fileId IN (${ph})`,
     ...fileIds,
   )
   const map: Record<string, LocalObject[]> = {}
@@ -103,32 +118,13 @@ export async function queryObjectMetasForFiles(
   return map
 }
 
-export async function queryObjectsForFilesWithSlabs(
-  db: DatabaseAdapter,
-  fileIds: string[],
-): Promise<Record<string, LocalObjectWithSlabs[]>> {
-  if (fileIds.length === 0) return {}
-  const ph = fileIds.map(() => '?').join(',')
-  const rows = await db.getAllAsync<LocalObjectRowWithSlabs>(
-    `SELECT ${OBJECT_ALL_COLUMNS} FROM objects WHERE fileId IN (${ph})`,
-    ...fileIds,
-  )
-  const map: Record<string, LocalObjectWithSlabs[]> = {}
-  for (const r of rows) {
-    const lo = localObjectWithSlabsFromStorageRow(r)
-    if (!map[r.fileId]) map[r.fileId] = []
-    map[r.fileId].push(lo)
-  }
-  return map
-}
-
 export async function insertManyObjects(
   db: DatabaseAdapter,
-  objects: LocalObjectWithSlabs[],
+  objects: LocalObject[],
 ): Promise<void> {
   if (objects.length === 0) return
   const rows = objects.map((o) => {
-    const e = localObjectWithSlabsToStorageRow(o)
+    const e = localObjectToStorageRow(o)
     return {
       fileId: e.fileId,
       indexerURL: e.indexerURL,

--- a/packages/core/src/db/operations/thumbnails.ts
+++ b/packages/core/src/db/operations/thumbnails.ts
@@ -3,7 +3,7 @@ import type { FileRecord, FileRecordRow, ThumbSize } from '../../types/files'
 import { ThumbSizes } from '../../types/files'
 import { transformRow } from './files'
 import { buildActiveFileFilter, buildActiveFilter } from './library'
-import { queryObjectMetasForFile } from './localObjects'
+import { queryObjectRefsForFile } from './localObjects'
 
 export type ThumbnailCandidateRow = {
   id: string
@@ -71,7 +71,7 @@ export async function queryBestThumbnailByFileId(
     requiredSize,
   )
   if (!row) return null
-  const objects = await queryObjectMetasForFile(db, row.id)
+  const objects = await queryObjectRefsForFile(db, row.id)
   return transformRow(row, objects)
 }
 
@@ -100,7 +100,7 @@ export async function queryThumbnailByFileIdAndSize(
     size,
   )
   if (!row) return null
-  const objects = await queryObjectMetasForFile(db, row.id)
+  const objects = await queryObjectRefsForFile(db, row.id)
   return transformRow(row, objects)
 }
 

--- a/packages/core/src/encoding/localObject.ts
+++ b/packages/core/src/encoding/localObject.ts
@@ -60,10 +60,18 @@ const localObjectStorageCodec = z.codec(
   },
 )
 
-export type LocalObjectWithSlabs = ReturnType<typeof localObjectStorageCodec.decode>
-export type LocalObject = Omit<LocalObjectWithSlabs, 'slabs'>
+export type LocalObject = ReturnType<typeof localObjectStorageCodec.decode>
+export type LocalObjectRef = Omit<
+  LocalObject,
+  | 'slabs'
+  | 'encryptedDataKey'
+  | 'encryptedMetadataKey'
+  | 'encryptedMetadata'
+  | 'dataSignature'
+  | 'metadataSignature'
+>
 
-export type LocalObjectRowWithSlabs = {
+export type LocalObjectRow = {
   id: string
   fileId: string
   indexerURL: string
@@ -77,11 +85,17 @@ export type LocalObjectRowWithSlabs = {
   updatedAt: number
 }
 
-export type LocalObjectRow = Omit<LocalObjectRowWithSlabs, 'slabs'>
+export type LocalObjectRefRow = Omit<
+  LocalObjectRow,
+  | 'slabs'
+  | 'encryptedDataKey'
+  | 'encryptedMetadataKey'
+  | 'encryptedMetadata'
+  | 'dataSignature'
+  | 'metadataSignature'
+>
 
-export function localObjectWithSlabsToStorageRow(
-  lo: LocalObjectWithSlabs,
-): LocalObjectRowWithSlabs {
+export function localObjectToStorageRow(lo: LocalObject): LocalObjectRow {
   const e = localObjectStorageCodec.encode({
     id: lo.id,
     fileId: lo.fileId,
@@ -110,9 +124,7 @@ export function localObjectWithSlabsToStorageRow(
   }
 }
 
-export function localObjectWithSlabsFromStorageRow(
-  row: LocalObjectRowWithSlabs,
-): LocalObjectWithSlabs {
+export function localObjectFromStorageRow(row: LocalObjectRow): LocalObject {
   return localObjectStorageCodec.decode({
     id: row.id,
     fileId: row.fileId,
@@ -128,16 +140,11 @@ export function localObjectWithSlabsFromStorageRow(
   })
 }
 
-export function localObjectFromStorageRow(row: LocalObjectRow): LocalObject {
+export function localObjectRefFromStorageRow(row: LocalObjectRefRow): LocalObjectRef {
   return {
     id: row.id,
     fileId: row.fileId,
     indexerURL: row.indexerURL,
-    encryptedDataKey: hexArrayBufferCodec.decode(row.encryptedDataKey),
-    encryptedMetadataKey: hexArrayBufferCodec.decode(row.encryptedMetadataKey),
-    encryptedMetadata: hexArrayBufferCodec.decode(row.encryptedMetadata),
-    dataSignature: hexArrayBufferCodec.decode(row.dataSignature),
-    metadataSignature: hexArrayBufferCodec.decode(row.metadataSignature),
     createdAt: isoToEpochCodec.decode(row.createdAt),
     updatedAt: isoToEpochCodec.decode(row.updatedAt),
   }

--- a/packages/core/src/lib/localObjects.ts
+++ b/packages/core/src/lib/localObjects.ts
@@ -1,12 +1,12 @@
 import type { AppKeyRef, PinnedObjectRef } from '../adapters/sdk'
-import type { LocalObjectWithSlabs } from '../encoding/localObject'
+import type { LocalObject } from '../encoding/localObject'
 
 export function sealPinnedObject(
   fileId: string,
   indexerURL: string,
   pinnedObject: PinnedObjectRef,
   appKey: AppKeyRef,
-): LocalObjectWithSlabs {
+): LocalObject {
   const sealed = pinnedObject.seal(appKey)
   return {
     ...sealed,

--- a/packages/core/src/services/syncDownEvents.ts
+++ b/packages/core/src/services/syncDownEvents.ts
@@ -7,7 +7,7 @@ import {
   hasCompleteFileMetadata,
   hasCompleteThumbnailMetadata,
 } from '../encoding/fileMetadata'
-import type { LocalObjectWithSlabs } from '../encoding/localObject'
+import type { LocalObject } from '../encoding/localObject'
 import { sealPinnedObject } from '../lib/localObjects'
 import type { FileMetadata, FileRecordRow } from '../types/files'
 
@@ -33,7 +33,7 @@ type Counts = {
 type PreparedCreate = {
   kind: 'create'
   fileRecord: FileRecordRow
-  localObject: LocalObjectWithSlabs
+  localObject: LocalObject
   tags?: string[]
   directory?: string
   isFile: boolean
@@ -43,7 +43,7 @@ type PreparedCreate = {
 type PreparedUpdate = {
   kind: 'update'
   fileRecord: FileRecordRow
-  localObject: LocalObjectWithSlabs
+  localObject: LocalObject
   fileId: string
   tags?: string[]
   directory?: string

--- a/packages/core/src/services/uploader.ts
+++ b/packages/core/src/services/uploader.ts
@@ -18,7 +18,7 @@ import {
   UPLOAD_PARITY_SHARDS,
 } from '../config'
 import { encodeFileMetadata } from '../encoding/fileMetadata'
-import type { LocalObjectWithSlabs } from '../encoding/localObject'
+import type { LocalObject } from '../encoding/localObject'
 import { sealPinnedObject } from '../lib/localObjects'
 import { retry } from '../lib/retry'
 import { SlotPool } from '../lib/slotPool'
@@ -1037,7 +1037,7 @@ export class UploadManager {
           type: 'success'
           fileId: string
           size: number
-          localObject: LocalObjectWithSlabs
+          localObject: LocalObject
         }
       | { type: 'deleted'; fileId: string }
       | { type: 'error'; fileId: string }

--- a/packages/core/src/stores/library.ts
+++ b/packages/core/src/stores/library.ts
@@ -70,7 +70,7 @@ export function useFileList(params: FileListParams) {
     })
 
     const fileIds = rows.map((r) => r.id)
-    const objectsByFile = await app.localObjects.getForFiles(fileIds)
+    const objectsByFile = await app.localObjects.getRefsForFiles(fileIds)
     return rows.map((row) => transformRow(row, objectsByFile[row.id]))
   }
 

--- a/packages/core/src/types/files.ts
+++ b/packages/core/src/types/files.ts
@@ -1,4 +1,4 @@
-import type { LocalObject } from '../encoding/localObject'
+import type { LocalObjectRef } from '../encoding/localObject'
 import { keysOf } from '../lib/types'
 
 /** Valid thumbnail sizes in pixels. */
@@ -63,5 +63,5 @@ export const fileRecordRowKeys = keysOf<Omit<FileRecordRow, 'tags'>>()([
 ])
 
 export type FileRecord = FileRecordRow & {
-  objects: Record<string, LocalObject>
+  objects: Record<string, LocalObjectRef>
 }


### PR DESCRIPTION
Every file list and metadata query was loading and decoding the encrypted blob columns, even though only upload and download actually use them.

Splits the reads in two: a slim ref-only path for everything else, and a full path for upload/download. Faster queries across the app, less memory churn.
