### PR TITLE
perf(core): abortable slot acquisition for download cancellation

### DIFF
--- a/.changeset/abortable-download-slots.md
+++ b/.changeset/abortable-download-slots.md
@@ -1,0 +1,5 @@
+---
+core: minor
+---
+
+SlotPool.acquire() and SlotPool.withSlot() accept an optional AbortSignal so cancelled waiters release their queue position immediately. downloads.downloadFile() now registers the entry synchronously before the first DB read so cancel() arriving during initial metadata lookup is honored.

--- a/packages/core/src/app/namespaces/downloads.ts
+++ b/packages/core/src/app/namespaces/downloads.ts
@@ -68,24 +68,28 @@ export function buildDownloadsNamespace(
   }
 
   async function execute(fileId: string): Promise<void> {
-    const file = await ops.readFile(db, fileId)
-    if (!file) throw new Error('File record not found')
-
-    const { value: size } = await fsIO.size(fileId, file.type)
-    if (size !== null) return
-
-    const sdk = getSdk()
-    if (!sdk) throw new Error('SDK not initialized')
-    const objects = await ops.queryObjectsForFile(db, fileId)
-    if (!objects.length) throw new Error('No object available for download')
-
-    register(fileId)
-    const release = await slotPool.acquire()
+    // Caller (downloadFile) registers synchronously before awaiting, so the
+    // controller is guaranteed to exist here. Capturing it first means a
+    // cancel() arriving during any await below properly aborts this run.
+    const controller = controllers.get(fileId)!
+    let release: (() => void) | undefined
     try {
-      update(fileId, { status: 'downloading' })
+      const file = await ops.readFile(db, fileId)
+      if (!file) throw new Error('File record not found')
 
-      const controller = controllers.get(fileId)
-      if (!controller) throw new Error('No controller for download')
+      const { value: size } = await fsIO.size(fileId, file.type)
+      if (size !== null) {
+        remove(fileId)
+        return
+      }
+
+      const sdk = getSdk()
+      if (!sdk) throw new Error('SDK not initialized')
+      const objects = await ops.queryObjectsForFile(db, fileId)
+      if (!objects.length) throw new Error('No object available for download')
+
+      release = await slotPool.acquire(controller.signal)
+      update(fileId, { status: 'downloading' })
 
       await downloadObject.download({
         file: { id: fileId, type: file.type, size: file.size },
@@ -105,14 +109,16 @@ export function buildDownloadsNamespace(
       })
       update(fileId, { status: 'done', progress: 1 })
     } catch (e) {
-      const controller = controllers.get(fileId)
-      if (!controller?.signal.aborted) {
+      if (e instanceof DOMException && e.name === 'AbortError') {
+        return
+      }
+      if (!controller.signal.aborted) {
         const message = e instanceof Error ? e.message : String(e)
         update(fileId, { status: 'error', error: message })
       }
       throw e
     } finally {
-      release()
+      release?.()
       inFlight.delete(fileId)
     }
   }
@@ -139,6 +145,7 @@ export function buildDownloadsNamespace(
     downloadFile: (fileId) => {
       const existing = inFlight.get(fileId)
       if (existing) return existing
+      register(fileId)
       const promise = execute(fileId).finally(() => {
         inFlight.delete(fileId)
       })

--- a/packages/core/src/lib/slotPool.test.ts
+++ b/packages/core/src/lib/slotPool.test.ts
@@ -1,0 +1,90 @@
+import { SlotPool } from './slotPool'
+
+describe('SlotPool', () => {
+  describe('acquire with signal', () => {
+    it('grants a slot immediately when available', async () => {
+      const pool = new SlotPool(2)
+      const controller = new AbortController()
+      const release = await pool.acquire(controller.signal)
+      expect(pool.getInUseCount()).toBe(1)
+      release()
+      expect(pool.getInUseCount()).toBe(0)
+    })
+
+    it('rejects immediately if signal is already aborted', async () => {
+      const pool = new SlotPool(1)
+      const controller = new AbortController()
+      controller.abort()
+      await expect(pool.acquire(controller.signal)).rejects.toThrow('The operation was aborted.')
+      expect(pool.getInUseCount()).toBe(0)
+      expect(pool.getQueueSize()).toBe(0)
+    })
+
+    it('removes waiter from queue when signal aborts', async () => {
+      const pool = new SlotPool(1)
+      // Fill the only slot.
+      const release1 = await pool.acquire()
+      expect(pool.getInUseCount()).toBe(1)
+
+      const controller = new AbortController()
+      const promise = pool.acquire(controller.signal)
+      expect(pool.getQueueSize()).toBe(1)
+
+      // Abort while queued.
+      controller.abort()
+      await expect(promise).rejects.toThrow('The operation was aborted.')
+      expect(pool.getQueueSize()).toBe(0)
+
+      // The slot is still held by release1, not consumed by the aborted waiter.
+      expect(pool.getInUseCount()).toBe(1)
+      release1()
+      expect(pool.getInUseCount()).toBe(0)
+    })
+
+    it('does not double-grant if abort fires after slot is granted', async () => {
+      const pool = new SlotPool(1)
+      const release1 = await pool.acquire()
+
+      const controller = new AbortController()
+      const promise = pool.acquire(controller.signal)
+      expect(pool.getQueueSize()).toBe(1)
+
+      // Release the slot — the queued waiter should be granted.
+      release1()
+      const release2 = await promise
+      expect(pool.getInUseCount()).toBe(1)
+
+      // Aborting after grant should have no effect.
+      controller.abort()
+      expect(pool.getInUseCount()).toBe(1)
+      expect(pool.getQueueSize()).toBe(0)
+
+      release2()
+      expect(pool.getInUseCount()).toBe(0)
+    })
+
+    it('allows next waiter to proceed when earlier waiter aborts', async () => {
+      const pool = new SlotPool(1)
+      const release1 = await pool.acquire()
+
+      const controller1 = new AbortController()
+      const promise1 = pool.acquire(controller1.signal)
+
+      const controller2 = new AbortController()
+      const promise2 = pool.acquire(controller2.signal)
+
+      expect(pool.getQueueSize()).toBe(2)
+
+      // Abort the first waiter.
+      controller1.abort()
+      await expect(promise1).rejects.toThrow('The operation was aborted.')
+      expect(pool.getQueueSize()).toBe(1)
+
+      // Release the slot — the second waiter should get it.
+      release1()
+      const release2 = await promise2
+      expect(pool.getInUseCount()).toBe(1)
+      release2()
+    })
+  })
+})

--- a/packages/core/src/lib/slotPool.ts
+++ b/packages/core/src/lib/slotPool.ts
@@ -1,3 +1,11 @@
+import { AbortError } from './errors'
+
+type WaitEntry = {
+  priority: number
+  grant: () => void
+  evict?: () => void
+}
+
 /**
  * A counting semaphore-style pool that limits the number of concurrent operations.
  * Use `withSlot` to run an async task while reserving one slot. Defaults to 5 slots.
@@ -5,7 +13,7 @@
 export class SlotPool {
   private maxSlots: number
   private inUseCount: number
-  private waitQueue: Array<() => void>
+  private waitQueue: WaitEntry[]
 
   constructor(maxSlots: number) {
     this.maxSlots = Math.max(1, Math.floor(maxSlots))
@@ -35,38 +43,57 @@ export class SlotPool {
     this.drain()
   }
 
-  /** Acquire a slot. Resolves with a release function to free the slot. */
-  async acquire(): Promise<() => void> {
-    if (this.inUseCount < this.maxSlots) {
-      this.inUseCount += 1
-      let released = false
-      return () => {
-        if (released) return
-        released = true
-        this.inUseCount -= 1
-        this.drain()
-      }
+  /**
+   * Acquire a slot. Resolves with a release function to free the slot.
+   * If an AbortSignal is provided and fires before a slot is granted, the
+   * waiter is removed from the queue and the promise rejects with an
+   * AbortError. Once a slot has been granted the signal is ignored — the
+   * caller must release the slot normally.
+   */
+  async acquire(signal?: AbortSignal): Promise<() => void> {
+    if (signal?.aborted) {
+      throw new AbortError()
     }
 
-    return await new Promise<() => void>((resolve) => {
-      const grant = () => {
-        this.inUseCount += 1
-        let released = false
-        const release = () => {
-          if (released) return
-          released = true
-          this.inUseCount -= 1
-          this.drain()
-        }
-        resolve(release)
+    if (this.inUseCount < this.maxSlots) {
+      this.inUseCount += 1
+      return this.makeRelease()
+    }
+
+    return await new Promise<() => void>((resolve, reject) => {
+      let settled = false
+
+      const entry: WaitEntry = {
+        priority: 0,
+        grant: () => {
+          if (settled) return
+          settled = true
+          if (signal) signal.removeEventListener('abort', onAbort)
+          this.inUseCount += 1
+          resolve(this.makeRelease())
+        },
       }
-      this.waitQueue.push(grant)
+
+      const onAbort = () => {
+        if (settled) return
+        settled = true
+        const idx = this.waitQueue.indexOf(entry)
+        if (idx !== -1) this.waitQueue.splice(idx, 1)
+        reject(new AbortError())
+      }
+
+      this.waitQueue.push(entry)
+      signal?.addEventListener('abort', onAbort, { once: true })
     })
   }
 
-  /** Run an async function while holding one slot. Always releases. */
-  async withSlot<T>(task: () => Promise<T>): Promise<T> {
-    const release = await this.acquire()
+  /**
+   * Run an async function while holding one slot. Always releases.
+   * If an AbortSignal is provided, it aborts the slot wait only (not the
+   * task itself); the task receives no signal from this method.
+   */
+  async withSlot<T>(task: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+    const release = await this.acquire(signal)
     try {
       return await task()
     } finally {
@@ -74,10 +101,20 @@ export class SlotPool {
     }
   }
 
+  private makeRelease(): () => void {
+    let released = false
+    return () => {
+      if (released) return
+      released = true
+      this.inUseCount -= 1
+      this.drain()
+    }
+  }
+
   private drain(): void {
     while (this.inUseCount < this.maxSlots && this.waitQueue.length > 0) {
       const next = this.waitQueue.shift()
-      if (next) next()
+      if (next) next.grant()
     }
   }
 }


### PR DESCRIPTION
When a user cancelled a download that was still waiting for an open slot, the cancel was ignored until the download got its slot and briefly started running. Wasteful, and slow to respond.

Now the cancel takes effect immediately and the download is removed from the queue without ever starting. Uses `AbortError` from `@siastorage/core/lib/errors`.