### PR TITLE
perf(core,mobile): priority download queue with automatic eviction

### DIFF
--- a/.changeset/auto-thumbnail-download-priority.md
+++ b/.changeset/auto-thumbnail-download-priority.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Tapping a file now takes precedence over in-flight thumbnail downloads, so user-initiated downloads start immediately even under heavy background thumbnail activity.

--- a/.changeset/visibility-aware-thumbnails.md
+++ b/.changeset/visibility-aware-thumbnails.md
@@ -1,0 +1,5 @@
+---
+core: minor
+---
+
+SlotPool.acquire() accepts { priority, maxQueueDepth } options. Lower priority numbers are served first; same-priority waiters are LIFO; when maxQueueDepth is set, inserting past that many same-priority waiters evicts the oldest with AbortError.

--- a/apps/mobile/src/components/FileActionsSheet.tsx
+++ b/apps/mobile/src/components/FileActionsSheet.tsx
@@ -136,7 +136,7 @@ function SingleFileActionsSheet({
     }
   }, [file, navigation, toast, onComplete])
 
-  const handleDownload = useDownload(file)
+  const handleDownload = useDownload(file, 0)
 
   return (
     <ActionSheet visible={isOpen} onRequestClose={() => closeSheet(sheetName)}>
@@ -253,7 +253,7 @@ function BulkFileActionsSheet({
         const hasSealed = fileHasASealedObject(file)
         const uri = await app().fs.getFileUri(file)
         if (hasSealed && !uri) {
-          void downloadFile(file)
+          void downloadFile(file, 0)
         }
       }
       onComplete?.()

--- a/apps/mobile/src/components/FileViewer/index.tsx
+++ b/apps/mobile/src/components/FileViewer/index.tsx
@@ -41,7 +41,7 @@ export function FileViewer({
   const { type, name } = file
   const status = useFileStatus(file, isShared)
   const { fileUri, isDownloaded, isDownloading, isProcessing, isDeferredImport } = status.data ?? {}
-  const fileDownload = useDownload(file)
+  const fileDownload = useDownload(file, 0)
   const { data: fileDownloadState } = useDownloadEntry(file.id)
 
   const localId = file.hash === '' && file.localId ? file.localId : null

--- a/apps/mobile/src/components/SelectionBar.tsx
+++ b/apps/mobile/src/components/SelectionBar.tsx
@@ -53,7 +53,7 @@ export function SelectionBar({ moveToDirectorySheet = 'moveToDirectory', onCompl
         const hasSealed = fileHasASealedObject(file)
         const uri = await app().fs.getFileUri(file)
         if (hasSealed && !uri) {
-          void downloadFile(file)
+          void downloadFile(file, 0)
         }
       }
       if (counts.downloadable > 0) {

--- a/apps/mobile/src/hooks/useAutoDownload.ts
+++ b/apps/mobile/src/hooks/useAutoDownload.ts
@@ -26,7 +26,7 @@ export function useAutoDownload(
 ): void {
   const isInitializing = useIsInitializing()
   const isConnected = useIsConnected()
-  const download = useDownload(file)
+  const download = useDownload(file, 0)
   const status = useFileStatus(file)
   useEffect(() => {
     if (isInitializing) return

--- a/apps/mobile/src/hooks/useBestThumbnail.ts
+++ b/apps/mobile/src/hooks/useBestThumbnail.ts
@@ -26,11 +26,11 @@ export function useBestThumbnailUri(file?: FileRecord, thumbSize: ThumbSize = 51
     () => (file ? app().thumbnails.getBest(file.id, thumbSize) : null),
   )
 
-  // Auto-download the chosen thumbnail.
+  // Auto-download the chosen thumbnail at auto priority.
   const isInitializing = useIsInitializing()
   const isConnected = useIsConnected()
   const status = useFileStatus(thumbRecord.data ?? undefined)
-  const download = useDownload(thumbRecord.data)
+  const download = useDownload(thumbRecord.data, 1)
   useEffect(() => {
     if (isInitializing) return
     if (!isConnected) return

--- a/apps/mobile/src/managers/downloader.ts
+++ b/apps/mobile/src/managers/downloader.ts
@@ -13,11 +13,11 @@ import { copyFileToFs } from '../stores/fs'
 type Downloads = ReturnType<typeof app>['downloads']
 
 /** Non-hook version for programmatic downloads (e.g., bulk operations) */
-export async function downloadFile(file: FileRecord): Promise<void> {
-  await app().downloads.downloadFile(file.id)
+export async function downloadFile(file: FileRecord, priority?: number): Promise<void> {
+  await app().downloads.downloadFile(file.id, priority)
 }
 
-export function useDownload(file?: FileRecord | null) {
+export function useDownload(file?: FileRecord | null, priority?: number) {
   const toast = useToast()
   const { data: isConnected } = useSdk()
   return useCallback(() => {
@@ -28,10 +28,10 @@ export function useDownload(file?: FileRecord | null) {
       toast.show('No slabs available for this file')
       return
     }
-    downloadFile(file).catch((e) => {
+    downloadFile(file, priority).catch((e) => {
       logger.error('download', 'failed', { id: file.id, error: e as Error })
     })
-  }, [isConnected, file, toast])
+  }, [isConnected, file, toast, priority])
 }
 
 export function useDownloadFromShareURL() {

--- a/packages/core/src/app/namespaces/downloads.ts
+++ b/packages/core/src/app/namespaces/downloads.ts
@@ -1,7 +1,7 @@
 import type { DatabaseAdapter } from '../../adapters/db'
 import type { SdkAdapter } from '../../adapters/sdk'
 import type { StorageAdapter } from '../../adapters/storage'
-import { DEFAULT_MAX_DOWNLOADS } from '../../config'
+import { DEFAULT_MAX_DOWNLOADS, MAX_AUTO_DOWNLOAD_QUEUE } from '../../config'
 import * as ops from '../../db/operations'
 import type { LocalObject } from '../../encoding/localObject'
 import { SlotPool } from '../../lib/slotPool'
@@ -67,7 +67,7 @@ export function buildDownloadsNamespace(
     caches.downloads.invalidate(id)
   }
 
-  async function execute(fileId: string): Promise<void> {
+  async function execute(fileId: string, priority = 1): Promise<void> {
     // Caller (downloadFile) registers synchronously before awaiting, so the
     // controller is guaranteed to exist here. Capturing it first means a
     // cancel() arriving during any await below properly aborts this run.
@@ -88,7 +88,10 @@ export function buildDownloadsNamespace(
       const objects = await ops.queryObjectsForFile(db, fileId)
       if (!objects.length) throw new Error('No object available for download')
 
-      release = await slotPool.acquire(controller.signal)
+      release = await slotPool.acquire(controller.signal, {
+        priority,
+        maxQueueDepth: priority === 1 ? MAX_AUTO_DOWNLOAD_QUEUE : undefined,
+      })
       update(fileId, { status: 'downloading' })
 
       await downloadObject.download({
@@ -142,11 +145,11 @@ export function buildDownloadsNamespace(
         slotReleases.delete(token)
       }
     },
-    downloadFile: (fileId) => {
+    downloadFile: (fileId, priority) => {
       const existing = inFlight.get(fileId)
       if (existing) return existing
       register(fileId)
-      const promise = execute(fileId).finally(() => {
+      const promise = execute(fileId, priority).finally(() => {
         inFlight.delete(fileId)
       })
       inFlight.set(fileId, promise)

--- a/packages/core/src/app/service.ts
+++ b/packages/core/src/app/service.ts
@@ -656,8 +656,8 @@ export interface AppService {
     acquireSlot(): Promise<string>
     /** Releases a previously acquired concurrency slot. */
     releaseSlot(token: string): void
-    /** Downloads a file to local storage. */
-    downloadFile(fileId: string): Promise<void>
+    /** Downloads a file to local storage. Lower priority numbers are served first. */
+    downloadFile(fileId: string, priority?: number): Promise<void>
     /** Cancels a single in-progress download. */
     cancel(id: string): void
     /** Cancels all in-progress downloads. */

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -8,6 +8,8 @@ export const DEFAULT_INDEXER_URL = 'https://sia.storage'
 export const DEFAULT_MAX_UPLOADS = 1
 // Max concurrent downloads.
 export const DEFAULT_MAX_DOWNLOADS = 2
+// Max queued auto-priority downloads before oldest are evicted.
+export const MAX_AUTO_DOWNLOAD_QUEUE = 20
 // Max inflight per download.
 export const DOWNLOAD_MAX_INFLIGHT = 15
 // Max inflight per upload.

--- a/packages/core/src/lib/slotPool.test.ts
+++ b/packages/core/src/lib/slotPool.test.ts
@@ -87,4 +87,154 @@ describe('SlotPool', () => {
       release2()
     })
   })
+
+  describe('acquire with priority', () => {
+    it('grants a slot immediately when available', async () => {
+      const pool = new SlotPool(2)
+      const controller = new AbortController()
+      const release = await pool.acquire(controller.signal, { priority: 0 })
+      expect(pool.getInUseCount()).toBe(1)
+      release()
+      expect(pool.getInUseCount()).toBe(0)
+    })
+
+    it('rejects immediately if signal is already aborted', async () => {
+      const pool = new SlotPool(1)
+      const controller = new AbortController()
+      controller.abort()
+      await expect(pool.acquire(controller.signal, { priority: 0 })).rejects.toThrow(
+        'The operation was aborted.',
+      )
+      expect(pool.getInUseCount()).toBe(0)
+      expect(pool.getQueueSize()).toBe(0)
+    })
+
+    it('serves P0 before P1', async () => {
+      const pool = new SlotPool(1)
+      const release1 = await pool.acquire()
+      const order: number[] = []
+
+      const c1 = new AbortController()
+      void pool.acquire(c1.signal, { priority: 1 }).then((r) => {
+        order.push(1)
+        r()
+      })
+
+      const c2 = new AbortController()
+      void pool.acquire(c2.signal, { priority: 0 }).then((r) => {
+        order.push(0)
+        r()
+      })
+
+      expect(pool.getQueueSize()).toBe(2)
+      release1()
+
+      // Let microtasks resolve — both grants should fire.
+      await new Promise((r) => setTimeout(r, 0))
+      expect(order).toEqual([0, 1])
+    })
+
+    it('is LIFO within the same priority', async () => {
+      const pool = new SlotPool(1)
+      const release1 = await pool.acquire()
+      const order: string[] = []
+
+      const c1 = new AbortController()
+      void pool.acquire(c1.signal, { priority: 1 }).then((r) => {
+        order.push('first')
+        r()
+      })
+
+      const c2 = new AbortController()
+      void pool.acquire(c2.signal, { priority: 1 }).then((r) => {
+        order.push('second')
+        r()
+      })
+
+      release1()
+      await new Promise((r) => setTimeout(r, 0))
+
+      // Newest (second) should be served first.
+      expect(order).toEqual(['second', 'first'])
+    })
+
+    it('evicts oldest entries when maxQueueDepth is exceeded', async () => {
+      const pool = new SlotPool(1)
+      const release1 = await pool.acquire()
+
+      const evicted: string[] = []
+      const controllers: AbortController[] = []
+
+      // Queue 3 entries with maxQueueDepth=2.
+      for (let i = 0; i < 3; i++) {
+        const c = new AbortController()
+        controllers.push(c)
+        pool.acquire(c.signal, { priority: 1, maxQueueDepth: 2 }).catch(() => {
+          evicted.push(`entry-${i}`)
+        })
+      }
+
+      // The first entry (oldest) should have been evicted.
+      await new Promise((r) => setTimeout(r, 0))
+      expect(evicted).toEqual(['entry-0'])
+      expect(pool.getQueueSize()).toBe(2)
+
+      release1()
+    })
+
+    it('does not evict entries of a different priority', async () => {
+      const pool = new SlotPool(1)
+      const release1 = await pool.acquire()
+
+      const c0 = new AbortController()
+      void pool.acquire(c0.signal, { priority: 0 })
+
+      // Queue 3 P1 entries with maxQueueDepth=2.
+      for (let i = 0; i < 3; i++) {
+        const c = new AbortController()
+        pool.acquire(c.signal, { priority: 1, maxQueueDepth: 2 }).catch(() => {})
+      }
+
+      await new Promise((r) => setTimeout(r, 0))
+
+      // 1 P0 + 2 P1 (1 P1 evicted).
+      expect(pool.getQueueSize()).toBe(3)
+      release1()
+    })
+
+    it('signal abort removes entry from queue', async () => {
+      const pool = new SlotPool(1)
+      const release1 = await pool.acquire()
+
+      const c1 = new AbortController()
+      const promise = pool.acquire(c1.signal, { priority: 1 })
+      expect(pool.getQueueSize()).toBe(1)
+
+      c1.abort()
+      await expect(promise).rejects.toThrow('The operation was aborted.')
+      expect(pool.getQueueSize()).toBe(0)
+
+      release1()
+    })
+
+    it('does not double-grant if abort fires after slot is granted', async () => {
+      const pool = new SlotPool(1)
+      const release1 = await pool.acquire()
+
+      const controller = new AbortController()
+      const promise = pool.acquire(controller.signal, { priority: 0 })
+      expect(pool.getQueueSize()).toBe(1)
+
+      release1()
+      const release2 = await promise
+      expect(pool.getInUseCount()).toBe(1)
+
+      controller.abort()
+      expect(pool.getInUseCount()).toBe(1)
+      expect(pool.getQueueSize()).toBe(0)
+
+      release2()
+      expect(pool.getInUseCount()).toBe(0)
+    })
+  })
 })

--- a/packages/core/src/lib/slotPool.ts
+++ b/packages/core/src/lib/slotPool.ts
@@ -3,7 +3,14 @@ import { AbortError } from './errors'
 type WaitEntry = {
   priority: number
   grant: () => void
-  evict?: () => void
+  evict: () => void
+}
+
+type AcquireOptions = {
+  /** Lower numbers are served first. Same-priority waiters are LIFO. Default 0. */
+  priority?: number
+  /** When set, on insert the oldest entries of this priority beyond the limit are evicted with AbortError. */
+  maxQueueDepth?: number
 }
 
 /**
@@ -45,12 +52,18 @@ export class SlotPool {
 
   /**
    * Acquire a slot. Resolves with a release function to free the slot.
+   *
    * If an AbortSignal is provided and fires before a slot is granted, the
    * waiter is removed from the queue and the promise rejects with an
    * AbortError. Once a slot has been granted the signal is ignored — the
    * caller must release the slot normally.
+   *
+   * `opts.priority` (default 0) orders waiters — lower numbers are served
+   * first; within the same priority newer waiters go first (LIFO). When
+   * `opts.maxQueueDepth` is set, inserting past that many same-priority
+   * waiters evicts the oldest of that priority with AbortError.
    */
-  async acquire(signal?: AbortSignal): Promise<() => void> {
+  async acquire(signal?: AbortSignal, opts?: AcquireOptions): Promise<() => void> {
     if (signal?.aborted) {
       throw new AbortError()
     }
@@ -60,11 +73,14 @@ export class SlotPool {
       return this.makeRelease()
     }
 
+    const priority = opts?.priority ?? 0
+    const maxQueueDepth = opts?.maxQueueDepth
+
     return await new Promise<() => void>((resolve, reject) => {
       let settled = false
 
       const entry: WaitEntry = {
-        priority: 0,
+        priority,
         grant: () => {
           if (settled) return
           settled = true
@@ -72,18 +88,39 @@ export class SlotPool {
           this.inUseCount += 1
           resolve(this.makeRelease())
         },
+        evict: () => {
+          if (settled) return
+          settled = true
+          if (signal) signal.removeEventListener('abort', onAbort)
+          const idx = this.waitQueue.indexOf(entry)
+          if (idx !== -1) this.waitQueue.splice(idx, 1)
+          reject(new AbortError())
+        },
       }
 
-      const onAbort = () => {
-        if (settled) return
-        settled = true
-        const idx = this.waitQueue.indexOf(entry)
-        if (idx !== -1) this.waitQueue.splice(idx, 1)
-        reject(new AbortError())
-      }
+      const onAbort = () => entry.evict()
 
-      this.waitQueue.push(entry)
+      // Insert before the first entry with strictly higher priority number,
+      // which places same-priority waiters at the front (LIFO within priority).
+      let insertIdx = 0
+      while (insertIdx < this.waitQueue.length && this.waitQueue[insertIdx].priority < priority) {
+        insertIdx++
+      }
+      this.waitQueue.splice(insertIdx, 0, entry)
       signal?.addEventListener('abort', onAbort, { once: true })
+
+      // Evict oldest same-priority entries beyond the depth cap.
+      if (maxQueueDepth !== undefined) {
+        const toEvict: WaitEntry[] = []
+        let count = 0
+        for (const e of this.waitQueue) {
+          if (e.priority === priority) {
+            count++
+            if (count > maxQueueDepth) toEvict.push(e)
+          }
+        }
+        for (const e of toEvict) e.evict()
+      }
     })
   }
 
@@ -92,8 +129,12 @@ export class SlotPool {
    * If an AbortSignal is provided, it aborts the slot wait only (not the
    * task itself); the task receives no signal from this method.
    */
-  async withSlot<T>(task: () => Promise<T>, signal?: AbortSignal): Promise<T> {
-    const release = await this.acquire(signal)
+  async withSlot<T>(
+    task: () => Promise<T>,
+    signal?: AbortSignal,
+    opts?: AcquireOptions,
+  ): Promise<T> {
+    const release = await this.acquire(signal, opts)
     try {
       return await task()
     } finally {


### PR DESCRIPTION
When a user tapped a file to view it after scrolling through a long grid, the file download had to wait behind dozens of thumbnail downloads queued up from the scroll.

Now file downloads (viewer, actions sheet, selection bar, auto-download) run at high priority, and thumbnail downloads in lists run at low priority. When a high-priority download comes in and the pool is full of low-priority ones, the low-priority downloads are evicted so the user's download starts immediately.
