### PR TITLE
fix(mobile): show settings redirect when camera or photo permissions are denied

### DIFF
--- a/.changeset/permission-denied-alert.md
+++ b/.changeset/permission-denied-alert.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Show an alert with an "Open Settings" button when camera or photo library permission is permanently denied.

--- a/apps/mobile/jest.setup.cjs
+++ b/apps/mobile/jest.setup.cjs
@@ -109,6 +109,11 @@ jest.mock('react-native', () => ({
     addEventListener: jest.fn(() => ({ remove: jest.fn() })),
     currentState: 'active',
   },
+  Alert: { alert: jest.fn() },
+  Linking: {
+    openSettings: jest.fn().mockResolvedValue(undefined),
+    openURL: jest.fn().mockResolvedValue(undefined),
+  },
 }))
 
 // jest-expo's ImageLoader.getSize mock uses a callback API that doesn't match

--- a/apps/mobile/src/hooks/useCameraCapture.ts
+++ b/apps/mobile/src/hooks/useCameraCapture.ts
@@ -3,6 +3,7 @@ import { logger } from '@siastorage/logger'
 import { useCallback, useRef } from 'react'
 import * as ImagePicker from 'react-native-image-picker'
 import { extFromMime, getMimeType } from '../lib/fileTypes'
+import { showPermissionDeniedAlert } from '../lib/permissionAlert'
 import { importFiles } from '../lib/processAssets'
 import { useToast } from '../lib/toastContext'
 
@@ -33,6 +34,13 @@ export function useCameraCapture() {
 
       if (result.didCancel) {
         logger.debug('cameraCapture', 'canceled')
+        return []
+      }
+      if (result.errorCode === 'permission') {
+        showPermissionDeniedAlert(
+          'Camera Access Required',
+          'To take photos and videos, allow camera access in Settings.',
+        )
         return []
       }
       if (result.errorCode) {

--- a/apps/mobile/src/hooks/useImagePicker.ts
+++ b/apps/mobile/src/hooks/useImagePicker.ts
@@ -2,6 +2,7 @@ import type { FileRecord } from '@siastorage/core/types'
 import { logger } from '@siastorage/logger'
 import { useCallback, useRef } from 'react'
 import * as ImagePicker from 'react-native-image-picker'
+import { showPermissionDeniedAlert } from '../lib/permissionAlert'
 import { importFiles } from '../lib/processAssets'
 
 export function useImagePicker() {
@@ -29,6 +30,13 @@ export function useImagePicker() {
 
       if (result.didCancel) {
         logger.debug('imagePicker', 'canceled')
+        return []
+      }
+      if (result.errorCode === 'permission') {
+        showPermissionDeniedAlert(
+          'Photo Access Required',
+          'To choose photos and videos, allow photo library access in Settings.',
+        )
         return []
       }
       if (result.errorCode) {

--- a/apps/mobile/src/lib/permissionAlert.test.ts
+++ b/apps/mobile/src/lib/permissionAlert.test.ts
@@ -1,0 +1,56 @@
+import { Alert, Linking, Platform } from 'react-native'
+import { showPermissionDeniedAlert } from './permissionAlert'
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('showPermissionDeniedAlert', () => {
+  it('calls Alert.alert with correct title, message, and two buttons', () => {
+    showPermissionDeniedAlert('Test Title', 'Test message.')
+
+    expect(Alert.alert).toHaveBeenCalledWith('Test Title', 'Test message.', [
+      { text: 'Cancel', style: 'cancel' },
+      expect.objectContaining({ text: 'Open Settings' }),
+    ])
+  })
+
+  it('opens app-settings URL on iOS', async () => {
+    ;(Platform as { OS: string }).OS = 'ios'
+
+    showPermissionDeniedAlert('Title', 'Msg')
+
+    const buttons = (Alert.alert as jest.Mock).mock.calls[0][2]
+    const openSettingsButton = buttons.find((b: { text: string }) => b.text === 'Open Settings')
+    await openSettingsButton.onPress()
+
+    expect(Linking.openURL).toHaveBeenCalledWith('app-settings:')
+  })
+
+  it('falls back to Linking.openSettings if openURL rejects on iOS', async () => {
+    ;(Platform as { OS: string }).OS = 'ios'
+    ;(Linking.openURL as jest.Mock).mockRejectedValueOnce(new Error('fail'))
+
+    showPermissionDeniedAlert('Title', 'Msg')
+
+    const buttons = (Alert.alert as jest.Mock).mock.calls[0][2]
+    const openSettingsButton = buttons.find((b: { text: string }) => b.text === 'Open Settings')
+    await openSettingsButton.onPress()
+
+    expect(Linking.openURL).toHaveBeenCalledWith('app-settings:')
+    expect(Linking.openSettings).toHaveBeenCalled()
+  })
+
+  it('calls Linking.openSettings directly on Android', async () => {
+    ;(Platform as { OS: string }).OS = 'android'
+
+    showPermissionDeniedAlert('Title', 'Msg')
+
+    const buttons = (Alert.alert as jest.Mock).mock.calls[0][2]
+    const openSettingsButton = buttons.find((b: { text: string }) => b.text === 'Open Settings')
+    await openSettingsButton.onPress()
+
+    expect(Linking.openURL).not.toHaveBeenCalled()
+    expect(Linking.openSettings).toHaveBeenCalled()
+  })
+})

--- a/apps/mobile/src/lib/permissionAlert.ts
+++ b/apps/mobile/src/lib/permissionAlert.ts
@@ -1,0 +1,19 @@
+import { Alert, Linking, Platform } from 'react-native'
+
+export function showPermissionDeniedAlert(title: string, message: string) {
+  Alert.alert(title, message, [
+    { text: 'Cancel', style: 'cancel' },
+    {
+      text: 'Open Settings',
+      onPress: () => {
+        if (Platform.OS === 'ios') {
+          Linking.openURL('app-settings:').catch(() => {
+            Linking.openSettings().catch(() => {})
+          })
+        } else {
+          Linking.openSettings().catch(() => {})
+        }
+      },
+    },
+  ])
+}


### PR DESCRIPTION
When a user permanently denies camera or photo library access, iOS and Android won't prompt them again — so tapping the upload or capture button just silently fails, and most users assume the app is broken.

Now we detect the permission error code from react-native-image-picker and show an alert that links directly to the app's Settings page so the user can re-enable access.
