### PR TITLE
fix(mobile): speed up android builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+          cache: 'gradle'
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -68,6 +68,7 @@ export default {
       'expo-secure-store',
       'expo-sqlite',
       ['./plugins/ios-target-16'],
+      './plugins/android-gradle-cache',
       'expo-video',
       './plugins/background-fetch',
       [

--- a/apps/mobile/plugins/android-gradle-cache.js
+++ b/apps/mobile/plugins/android-gradle-cache.js
@@ -1,0 +1,23 @@
+const { withGradleProperties } = require('@expo/config-plugins')
+
+function withAndroidGradleCache(config) {
+  return withGradleProperties(config, (innerConfig) => {
+    const { modResults } = innerConfig
+
+    setProperty(modResults, 'org.gradle.caching', 'true')
+    setProperty(modResults, 'reactNativeArchitectures', 'armeabi-v7a,arm64-v8a')
+
+    return innerConfig
+  })
+}
+
+function setProperty(modResults, key, value) {
+  const existing = modResults.find((item) => item.type === 'property' && item.key === key)
+  if (existing) {
+    existing.value = value
+  } else {
+    modResults.push({ type: 'property', key, value })
+  }
+}
+
+module.exports = withAndroidGradleCache


### PR DESCRIPTION
Every Android build was spending real time compiling x86 and x86_64 native code that nobody runs — all devs are on Apple Silicon, all phones are arm, and the Play Store delivers the right ABI from the AAB anyway.

Now we limit reactNativeArchitectures to arm only, enable Gradle's build cache, and cache ~/.gradle in the release workflow. Local rebuilds and CI should both get noticeably faster.
