### PR TITLE
refactor(core,mobile): move share-URL download into downloads namespace

### DIFF
--- a/.changeset/downloads-share-url-facade.md
+++ b/.changeset/downloads-share-url-facade.md
@@ -1,0 +1,5 @@
+---
+core: minor
+---
+
+Added downloads.downloadFromShareUrl(id, url) and removed register, update, remove, acquireSlot, releaseSlot from the public downloads API — the share-URL flow now runs entirely inside the downloads namespace with the same cancel() / cancelAll() semantics and abortable slot-queue waits as downloadFile().

--- a/.changeset/share-url-download-cancel.md
+++ b/.changeset/share-url-download-cancel.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Cancelling a share-link download now stops it reliably, matching the behavior of regular file downloads.

--- a/apps/integration/test/app.ts
+++ b/apps/integration/test/app.ts
@@ -292,6 +292,9 @@ export function createTestApp(
         if (!fsIO.writeFile) throw new Error('writeFile not implemented')
         await fsIO.writeFile(file, data)
       },
+      async downloadFromShareUrl() {
+        throw new Error('downloadFromShareUrl not implemented in integration tests')
+      },
     },
     uploader: createTestUploaderAdapters(),
     sdkAuth: {

--- a/apps/integration/test/downloads.test.ts
+++ b/apps/integration/test/downloads.test.ts
@@ -135,58 +135,12 @@ describe('Downloads', () => {
     await expect(app.app.downloads.downloadFile(file.id)).rejects.toThrow('SDK not initialized')
   })
 
-  it('cancel removes a download entry', () => {
-    app.app.downloads.register('dl-1')
-    expect(app.app.downloads.getEntry('dl-1')).toBeDefined()
-
-    app.app.downloads.cancel('dl-1')
-    expect(app.app.downloads.getEntry('dl-1')).toBeUndefined()
-    expect(app.app.downloads.getState().downloads).toEqual({})
-  })
-
-  it('cancelAll clears all download entries', () => {
-    app.app.downloads.register('dl-1')
-    app.app.downloads.register('dl-2')
-    expect(Object.keys(app.app.downloads.getState().downloads)).toHaveLength(2)
-
-    app.app.downloads.cancelAll()
-    expect(app.app.downloads.getState().downloads).toEqual({})
-  })
-
   it('setMaxSlots persists and applies', async () => {
     await app.app.downloads.setMaxSlots(5)
     expect(await app.app.settings.getMaxDownloads()).toBe(5)
 
     await app.app.downloads.setMaxSlots(0)
     expect(await app.app.settings.getMaxDownloads()).toBe(1)
-  })
-
-  it('acquireSlot / releaseSlot', async () => {
-    const token = await app.app.downloads.acquireSlot()
-    expect(typeof token).toBe('string')
-
-    app.app.downloads.releaseSlot(token)
-    app.app.downloads.releaseSlot(token)
-  })
-
-  it('register / update / remove / getEntry / getState', () => {
-    app.app.downloads.register('x')
-    expect(app.app.downloads.getEntry('x')).toEqual({
-      id: 'x',
-      status: 'queued',
-      progress: 0,
-    })
-
-    app.app.downloads.update('x', { status: 'downloading', progress: 0.5 })
-    expect(app.app.downloads.getEntry('x')).toEqual({
-      id: 'x',
-      status: 'downloading',
-      progress: 0.5,
-    })
-
-    app.app.downloads.remove('x')
-    expect(app.app.downloads.getEntry('x')).toBeUndefined()
-    expect(app.app.downloads.getState().downloads).toEqual({})
   })
 
   it('progress reports file.size-based progress', async () => {

--- a/apps/mobile/src/adapters/downloadObject.ts
+++ b/apps/mobile/src/adapters/downloadObject.ts
@@ -29,5 +29,25 @@ export function createDownloadAdapter(): DownloadObjectAdapter {
         onProgress,
       })
     },
+    async downloadFromShareUrl({ file, url, sdk, onProgress, signal }) {
+      const sharedObject = await sdk.sharedObject(url)
+      const totalSize = Number(sharedObject.size())
+      const dl = await sdk.download(sharedObject, {
+        maxInflight: DOWNLOAD_MAX_INFLIGHT,
+        offset: BigInt(0),
+        length: undefined,
+      })
+
+      await streamToCache({
+        file,
+        totalSize,
+        dl,
+        signal,
+        onAfterClose: async (targetFile) => {
+          await copyFileToFs(file, targetFile.uri)
+        },
+        onProgress,
+      })
+    },
   }
 }

--- a/apps/mobile/src/managers/downloader.ts
+++ b/apps/mobile/src/managers/downloader.ts
@@ -5,12 +5,8 @@ import type { FileRecord } from '@siastorage/core/types'
 import { logger } from '@siastorage/logger'
 import { useCallback } from 'react'
 import { getOneObject } from '../lib/file'
-import { streamToCache } from '../lib/streamToCache'
 import { useToast } from '../lib/toastContext'
-import { app, internal } from '../stores/appService'
-import { copyFileToFs } from '../stores/fs'
-
-type Downloads = ReturnType<typeof app>['downloads']
+import { app } from '../stores/appService'
 
 /** Non-hook version for programmatic downloads (e.g., bulk operations) */
 export async function downloadFile(file: FileRecord, priority?: number): Promise<void> {
@@ -36,44 +32,7 @@ export function useDownload(file?: FileRecord | null, priority?: number) {
 
 export function useDownloadFromShareURL() {
   return useCallback(async (id: string, sharedUrl: string) => {
-    const downloads: Downloads = app().downloads
-    const sdk = internal().requireSdk()
-    const sharedObject = await sdk.sharedObject(sharedUrl)
-    const totalSize = Number(sharedObject.size())
-
-    const file = {
-      id,
-      type: 'application/octet-stream',
-    }
-
-    downloads.register(id)
-    const slotToken = await downloads.acquireSlot()
-    try {
-      downloads.update(id, { status: 'downloading' })
-      const dl = await sdk.download(sharedObject, {
-        maxInflight: DOWNLOAD_MAX_INFLIGHT,
-        offset: BigInt(0),
-        length: undefined,
-      })
-      await streamToCache({
-        file,
-        totalSize,
-        dl,
-        onAfterClose: async (targetFile) => {
-          await copyFileToFs(file, targetFile.uri)
-        },
-        onProgress: (progress) => {
-          downloads.update(id, { progress: Math.min(1, progress) })
-        },
-      })
-      downloads.remove(id)
-    } catch (e) {
-      const message = e instanceof Error ? e.message : String(e)
-      downloads.update(id, { status: 'error', error: message })
-      throw e
-    } finally {
-      downloads.releaseSlot(slotToken)
-    }
+    await app().downloads.downloadFromShareUrl(id, sharedUrl)
     return id
   }, [])
 }

--- a/packages/core/src/app/namespaces/downloads.ts
+++ b/packages/core/src/app/namespaces/downloads.ts
@@ -18,6 +18,14 @@ export type DownloadObjectAdapter = {
     onProgress: (progress: number) => void
     signal: AbortSignal
   }): Promise<void>
+  /** Resolves a share URL via the SDK and streams its contents to local storage. */
+  downloadFromShareUrl(params: {
+    file: { id: string; type: string }
+    url: string
+    sdk: SdkAdapter
+    onProgress: (progress: number) => void
+    signal: AbortSignal
+  }): Promise<void>
 }
 
 /** Builds the downloads namespace: queue, track, cancel, and download files. */
@@ -33,8 +41,6 @@ export function buildDownloadsNamespace(
   const controllers = new Map<string, AbortController>()
   const slotPool = new SlotPool(DEFAULT_MAX_DOWNLOADS)
   const inFlight = new Map<string, Promise<void>>()
-  const slotReleases = new Map<string, () => void>()
-  let slotTokenCounter = 0
 
   function register(id: string) {
     const controller = new AbortController()
@@ -126,25 +132,45 @@ export function buildDownloadsNamespace(
     }
   }
 
+  async function executeShareUrl(id: string, url: string): Promise<void> {
+    // Caller (downloadFromShareUrl) registers synchronously before awaiting.
+    const controller = controllers.get(id)!
+    let release: (() => void) | undefined
+    try {
+      const sdk = getSdk()
+      if (!sdk) throw new Error('SDK not initialized')
+
+      release = await slotPool.acquire(controller.signal)
+      update(id, { status: 'downloading' })
+
+      await downloadObject.downloadFromShareUrl({
+        file: { id, type: 'application/octet-stream' },
+        url,
+        sdk,
+        onProgress: (progress) => update(id, { progress: Math.min(1, progress) }),
+        signal: controller.signal,
+      })
+
+      if (controller.signal.aborted) return
+      remove(id)
+    } catch (e) {
+      if (e instanceof DOMException && e.name === 'AbortError') {
+        return
+      }
+      if (!controller.signal.aborted) {
+        const message = e instanceof Error ? e.message : String(e)
+        update(id, { status: 'error', error: message })
+      }
+      throw e
+    } finally {
+      release?.()
+      inFlight.delete(id)
+    }
+  }
+
   return {
     getState: () => ({ ...state }),
     getEntry: (id) => state.downloads[id],
-    register: (id) => register(id),
-    update: (id, patch) => update(id, patch),
-    remove: (id) => remove(id),
-    acquireSlot: async () => {
-      const release = await slotPool.acquire()
-      const token = String(++slotTokenCounter)
-      slotReleases.set(token, release)
-      return token
-    },
-    releaseSlot: (token) => {
-      const release = slotReleases.get(token)
-      if (release) {
-        release()
-        slotReleases.delete(token)
-      }
-    },
     downloadFile: (fileId, priority) => {
       const existing = inFlight.get(fileId)
       if (existing) return existing
@@ -153,6 +179,16 @@ export function buildDownloadsNamespace(
         inFlight.delete(fileId)
       })
       inFlight.set(fileId, promise)
+      return promise
+    },
+    downloadFromShareUrl: (id, url) => {
+      const existing = inFlight.get(id)
+      if (existing) return existing
+      register(id)
+      const promise = executeShareUrl(id, url).finally(() => {
+        inFlight.delete(id)
+      })
+      inFlight.set(id, promise)
       return promise
     },
     cancel: (id) => {

--- a/packages/core/src/app/service.ts
+++ b/packages/core/src/app/service.ts
@@ -646,18 +646,10 @@ export interface AppService {
     getState(): DownloadsState
     /** Returns a single download entry by ID. */
     getEntry(id: string): DownloadEntry | undefined
-    /** Registers a queued download entry. */
-    register(id: string): void
-    /** Updates a download entry with a partial patch. */
-    update(id: string, patch: Partial<DownloadEntry>): void
-    /** Removes a completed or failed download entry. */
-    remove(id: string): void
-    /** Acquires a concurrency slot; resolves with an opaque token to pass to releaseSlot. */
-    acquireSlot(): Promise<string>
-    /** Releases a previously acquired concurrency slot. */
-    releaseSlot(token: string): void
     /** Downloads a file to local storage. Lower priority numbers are served first. */
     downloadFile(fileId: string, priority?: number): Promise<void>
+    /** Resolves a share URL via the SDK and downloads its contents to local storage. */
+    downloadFromShareUrl(id: string, url: string): Promise<void>
     /** Cancels a single in-progress download. */
     cancel(id: string): void
     /** Cancels all in-progress downloads. */


### PR DESCRIPTION
The share-URL download path built its own AbortController inside the mobile downloader and exposed a bunch of low-level methods (register, update, remove, acquireSlot, releaseSlot) on the public downloads facade. That leaked internals and meant share-URL downloads didn't respect cancel(id) or cancelAll().

Now there's a single downloads.downloadFromShareUrl(id, url) method, and the low-level primitives are gone from the public API. Share-URL downloads go through the same lifecycle as everything else and respect cancellation.
