### PR TITLE
chore(mobile,core): upgrade sdk

### DIFF
--- a/.changeset/native-streaming-uploads.md
+++ b/.changeset/native-streaming-uploads.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Mobile uploads now use the platform's native `ReadableStream` with a BYOB file reader instead of a JS polyfill.

--- a/.changeset/sdk-upgrade-0-13-21.md
+++ b/.changeset/sdk-upgrade-0-13-21.md
@@ -1,0 +1,6 @@
+---
+core: minor
+mobile: patch
+---
+
+Upgraded react-native-sia to 0.13.21: shard-based upload progress and a pull-based SDK download handle.

--- a/apps/integration/test/adapters/upload.ts
+++ b/apps/integration/test/adapters/upload.ts
@@ -7,7 +7,7 @@ export function buildTestSdkAdapter(sdk: MockSdk, appKey: AppKeyRef): SdkAdapter
   return {
     objectEvents: (cursor, limit) => sdk.objectEvents(cursor, limit),
     updateObjectMetadata: (po) => sdk.updateObjectMetadata(po),
-    download: async () => {},
+    download: (po, opts) => sdk.download(po, opts),
     uploadPacked: (opts) => sdk.uploadPacked(opts),
     pinObject: (po) => sdk.pinObject(po),
     deleteObject: (id) => sdk.deleteObject(id),

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -87,12 +87,11 @@
     "react-native-safe-area-context": "5.6.2",
     "react-native-screens": "4.23.0",
     "react-native-share": "12.2.5",
-    "react-native-sia": "0.13.18",
+    "react-native-sia": "0.13.21",
     "react-native-svg": "15.15.3",
     "react-native-webview": "13.16.0",
     "react-native-worklets": "0.7.2",
     "swr": "2.4.1",
-    "web-streams-polyfill": "4.2.0",
     "zod": "4.3.6"
   },
   "devDependencies": {

--- a/apps/mobile/polyfills.ts
+++ b/apps/mobile/polyfills.ts
@@ -1,10 +1,8 @@
 /* eslint-disable import/order */
 
-// Use a WHATWG-compliant ReadableStream for File.stream().
-import { ReadableStream } from 'web-streams-polyfill'
-
-// @ts-expect-error - globalThis.ReadableStream type mismatch with polyfill
-globalThis.ReadableStream = ReadableStream
+// Expo SDK 55 ships a native ReadableStream/WritableStream/TransformStream,
+// so we no longer polyfill with web-streams-polyfill (which was ~34% of
+// upload CPU via its per-chunk structuredClone).
 
 import '@azure/core-asynciterator-polyfill'
 

--- a/apps/mobile/src/adapters/downloadObject.ts
+++ b/apps/mobile/src/adapters/downloadObject.ts
@@ -12,21 +12,17 @@ export function createDownloadAdapter(): DownloadObjectAdapter {
       if (!appKey) throw new Error(`No AppKey found for indexer: ${object.indexerURL}`)
 
       const pinnedObject = PinnedObject.open(appKey, object)
+      const dl = await sdk.download(pinnedObject, {
+        maxInflight: DOWNLOAD_MAX_INFLIGHT,
+        offset: BigInt(0),
+        length: undefined,
+      })
 
       await streamToCache({
         file,
         totalSize: file.size,
-        download: (writer) =>
-          sdk.download(
-            writer,
-            pinnedObject,
-            {
-              maxInflight: DOWNLOAD_MAX_INFLIGHT,
-              offset: BigInt(0),
-              length: undefined,
-            },
-            { signal },
-          ),
+        dl,
+        signal,
         onAfterClose: async (targetFile) => {
           await copyFileToFs(file, targetFile.uri)
         },

--- a/apps/mobile/src/adapters/sdk.ts
+++ b/apps/mobile/src/adapters/sdk.ts
@@ -1,6 +1,7 @@
 import type {
   Account,
   AppKeyRef,
+  DownloadLikeRef,
   DownloadOptions,
   Host,
   ObjectEvent,
@@ -9,7 +10,6 @@ import type {
   PinnedObjectRef,
   SdkAdapter,
   UploadOptions,
-  Writer,
 } from '@siastorage/core/adapters'
 import type { SdkInterface } from 'react-native-sia'
 
@@ -29,27 +29,29 @@ export class MobileSdkAdapter implements SdkAdapter {
   }
 
   async download(
-    writer: Writer,
     pinnedObject: PinnedObjectRef,
     options: DownloadOptions,
-    control?: { signal: AbortSignal },
-  ): Promise<void> {
-    await this.sdk.download(writer, pinnedObject, options, control)
+  ): Promise<DownloadLikeRef> {
+    return this.sdk.download(pinnedObject, options)
   }
 
   async downloadByObjectId(objectId: string): Promise<ArrayBuffer> {
     const obj = await this.sdk.object(objectId)
-    const chunks: ArrayBuffer[] = []
-    const writer: Writer = {
-      write: async (data: ArrayBuffer) => {
-        chunks.push(data)
-      },
-    }
-    await this.sdk.download(writer, obj as PinnedObjectRef, {
+    const dl = this.sdk.download(obj, {
       maxInflight: 1,
       offset: 0n,
       length: undefined,
     })
+    const chunks: ArrayBuffer[] = []
+    try {
+      while (true) {
+        const chunk = await dl.read()
+        if (chunk.byteLength === 0) break
+        chunks.push(chunk)
+      }
+    } finally {
+      await dl.cancel().catch(() => {})
+    }
     const totalLength = chunks.reduce((sum, c) => sum + c.byteLength, 0)
     const combined = new Uint8Array(totalLength)
     let offset = 0

--- a/apps/mobile/src/lib/fileReader.ts
+++ b/apps/mobile/src/lib/fileReader.ts
@@ -1,36 +1,41 @@
-// oxlint-disable-next-line no-restricted-imports -- File constructor + .open() (sync native reads)
+// oxlint-disable-next-line no-restricted-imports -- File constructor + .stream() (async)
 import { File } from 'expo-file-system'
 import type { Reader } from 'react-native-sia'
 
-// Read 256KB at a time. The previous stream-based approach used 1KB chunks
-// (expo-file-system's default), meaning ~40,000 reads per 40MB file.
 const CHUNK_SIZE = 256 * 1024
 
 /**
- * Creates a Reader interface that reads file data for the SDK's packed upload
- * API using direct FileHandle.readBytes() instead of File.stream().
+ * Creates a Reader that streams a file via `File.stream()` with a BYOB
+ * reader pulling `CHUNK_SIZE`-byte chunks directly into our buffer.
  *
- * Why not streams: File.stream() goes through web-streams-polyfill which calls
- * structuredClone (@ungap/structured-clone → pair()) on every chunk enqueued
- * to the ReadableStream. With 1KB default chunks, that's ~40k clones per 40MB
- * file — profiling showed pair() consuming ~34% of total JS CPU during uploads.
+ * Why BYOB: expo-file-system's default ReadableStream pull size is 1KB
+ * (see node_modules/expo-file-system/src/streams.ts). A BYOB reader lets
+ * us dictate the chunk size — we pass a 256KB view and `pull` reads into
+ * it, so we get one native file read per 256KB (vs ~40k per 40MB file).
  *
- * Direct readBytes() is synchronous but at 256KB chunks it's negligible per
- * call and eliminates the polyfill overhead entirely. Profiled result: file
- * reading dropped from 34% CPU to <1.5%.
+ * Why not File.open() + handle.readBytes(): synchronous JSI call — panics
+ * the SDK's Rust upload task post-0.13.20 (UploadError.Closed before the
+ * body runs). Any reader that makes a fresh native read per invocation
+ * hits the same panic. File.stream() works because its chunks are
+ * pre-buffered into JS memory via the stream machinery before our
+ * `read()` returns.
+ *
+ * Why not File.bytes(): loads the whole file into memory, bad for videos.
  */
 export function createFileReader(fileUri: string): Reader {
-  const file = new File(fileUri)
-  const handle = file.open()
-
+  const stream = new File(fileUri).stream()
+  const streamReader = stream.getReader({ mode: 'byob' })
   return {
     async read(): Promise<ArrayBuffer> {
-      const bytes = handle.readBytes(CHUNK_SIZE)
-      if (bytes.length === 0) {
-        handle.close()
-        return new ArrayBuffer(0)
-      }
-      return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+      const view = new Uint8Array(CHUNK_SIZE)
+      const { value, done } = await streamReader.read(view)
+      if (done || !value || value.byteLength === 0) return new ArrayBuffer(0)
+      // Copy into a fresh JS-owned Uint8Array before handing to uniffi.
+      // value's buffer is the one we passed in (after transfer); slicing
+      // creates a clean, exact-sized JS-owned ArrayBuffer.
+      const owned = new Uint8Array(value.byteLength)
+      owned.set(value)
+      return owned.buffer
     },
   }
 }

--- a/apps/mobile/src/lib/streamToCache.ts
+++ b/apps/mobile/src/lib/streamToCache.ts
@@ -1,24 +1,41 @@
+import type { DownloadLikeRef } from '@siastorage/core/adapters'
 import { logger } from '@siastorage/logger'
 // oxlint-disable-next-line no-restricted-imports -- type-only import for .writableStream() (async)
 import type { File } from 'expo-file-system'
-import type { Writer } from 'react-native-sia'
 import { getOrCreateTempDownloadFile } from '../stores/tempFs'
 
-function createFileWriter(params: {
-  writer: WritableStreamDefaultWriter<Uint8Array>
+/**
+ * Streams a pull-based download handle into a temp cache file. Reads
+ * chunks from `dl.read()` and writes each to the target file's
+ * writableStream until EOF.
+ */
+export async function streamToCache(params: {
+  file: { id: string; type: string }
   totalSize?: number
+  dl: DownloadLikeRef
+  signal?: AbortSignal
+  onAfterClose?: (targetFile: File) => Promise<void>
   onProgress?: (progress: number) => void
-}): Writer {
-  const { writer, totalSize, onProgress } = params
+}): Promise<void> {
+  const { file, totalSize, dl, signal, onAfterClose, onProgress } = params
+  const targetFile = await getOrCreateTempDownloadFile({
+    ...file,
+    localId: null,
+  })
+  logger.debug('streamToCache', 'write_start', { uri: targetFile.uri })
+
+  const fileWriter = targetFile.writableStream().getWriter()
   let bytesWritten = 0
   let chunks = 0
 
-  return {
-    async write(data: ArrayBuffer): Promise<void> {
-      const buf = new Uint8Array(data)
+  try {
+    while (true) {
+      const chunk = await dl.read(signal ? { signal } : undefined)
+      if (chunk.byteLength === 0) break
+      const buf = new Uint8Array(chunk)
+      await fileWriter.write(buf)
       bytesWritten += buf.byteLength
       chunks += 1
-      await writer.write(buf)
 
       if (onProgress) {
         if (typeof totalSize === 'number' && totalSize > 0) {
@@ -31,39 +48,12 @@ function createFileWriter(params: {
       if (chunks % 10 === 0) {
         logger.debug('streamToCache', 'progress', { bytesWritten })
       }
-    },
-  }
-}
-
-export async function streamToCache(params: {
-  file: { id: string; type: string }
-  totalSize?: number
-  download: (writer: Writer) => Promise<void>
-  onAfterClose?: (targetFile: File) => Promise<void>
-  onProgress?: (progress: number) => void
-}): Promise<void> {
-  const { file, totalSize, download, onAfterClose, onProgress } = params
-  const targetFile = await getOrCreateTempDownloadFile({
-    ...file,
-    localId: null,
-  })
-  logger.debug('streamToCache', 'write_start', { uri: targetFile.uri })
-
-  const fileWriter = targetFile.writableStream().getWriter()
-
-  try {
-    const writer = createFileWriter({
-      writer: fileWriter,
-      totalSize,
-      onProgress,
-    })
-
-    await download(writer)
-
+    }
     logger.debug('streamToCache', 'stream_ended')
   } finally {
     await fileWriter.close()
     logger.debug('streamToCache', 'writer_closed')
+    await dl.cancel().catch(() => {})
   }
 
   if (onAfterClose) {

--- a/apps/mobile/src/managers/downloader.ts
+++ b/apps/mobile/src/managers/downloader.ts
@@ -4,7 +4,6 @@ import { useSdk } from '@siastorage/core/stores'
 import type { FileRecord } from '@siastorage/core/types'
 import { logger } from '@siastorage/logger'
 import { useCallback } from 'react'
-import type { Writer } from 'react-native-sia'
 import { getOneObject } from '../lib/file'
 import { streamToCache } from '../lib/streamToCache'
 import { useToast } from '../lib/toastContext'
@@ -51,20 +50,15 @@ export function useDownloadFromShareURL() {
     const slotToken = await downloads.acquireSlot()
     try {
       downloads.update(id, { status: 'downloading' })
+      const dl = await sdk.download(sharedObject, {
+        maxInflight: DOWNLOAD_MAX_INFLIGHT,
+        offset: BigInt(0),
+        length: undefined,
+      })
       await streamToCache({
         file,
         totalSize,
-        download: (writer) =>
-          sdk.download(
-            writer,
-            sharedObject,
-            {
-              maxInflight: DOWNLOAD_MAX_INFLIGHT,
-              offset: BigInt(0),
-              length: undefined,
-            },
-            { signal: new AbortController().signal },
-          ),
+        dl,
         onAfterClose: async (targetFile) => {
           await copyFileToFs(file, targetFile.uri)
         },
@@ -99,37 +93,23 @@ export async function downloadFirstBytesFromShared(
 
   logger.debug('downloadFirstBytesFromShared', 'downloading', { byteCount })
 
+  const dl = await sdk.download(sharedObject, {
+    maxInflight: DOWNLOAD_MAX_INFLIGHT,
+    offset: BigInt(0),
+    length: BigInt(byteCount),
+  })
   const chunks: Uint8Array[] = []
   let totalBytes = 0
-  const abortController = new AbortController()
-
-  const writer: Writer = {
-    async write(data: ArrayBuffer): Promise<void> {
-      const buf = new Uint8Array(data)
+  try {
+    while (totalBytes < byteCount) {
+      const chunk = await dl.read()
+      if (chunk.byteLength === 0) break
+      const buf = new Uint8Array(chunk)
       chunks.push(buf)
       totalBytes += buf.length
-
-      if (totalBytes >= byteCount) {
-        abortController.abort()
-      }
-    },
-  }
-
-  try {
-    await sdk.download(
-      writer,
-      sharedObject,
-      {
-        maxInflight: DOWNLOAD_MAX_INFLIGHT,
-        offset: BigInt(0),
-        length: BigInt(byteCount),
-      },
-      { signal: abortController.signal },
-    )
-  } catch (e) {
-    if (e instanceof Error && e.name !== 'AbortError') {
-      throw e
     }
+  } finally {
+    await dl.cancel().catch(() => {})
   }
 
   const bytes = new Uint8Array(Math.min(totalBytes, byteCount))

--- a/apps/mobile/src/managers/uploader.test.ts
+++ b/apps/mobile/src/managers/uploader.test.ts
@@ -29,6 +29,7 @@ import {
   UPLOAD_MAX_INFLIGHT,
   UPLOAD_PARITY_SHARDS,
 } from '@siastorage/core/config'
+import type { ShardProgress } from '@siastorage/core/adapters'
 import { type UploaderAdapters, UploadManager } from '@siastorage/core/services/uploader'
 import type { PackedUploadInterface, PinnedObjectInterface, SdkInterface } from 'react-native-sia'
 import { initializeDB, resetDb } from '../db'
@@ -238,7 +239,7 @@ describe('UploadManager', () => {
         maxInflight: UPLOAD_MAX_INFLIGHT,
         dataShards: UPLOAD_DATA_SHARDS,
         parityShards: UPLOAD_PARITY_SHARDS,
-        progressCallback: expect.any(Object),
+        shardUploaded: expect.any(Object),
       })
     })
 
@@ -709,7 +710,7 @@ describe('UploadManager', () => {
   })
 
   describe('progress callback', () => {
-    it('updates progress in upload store when reported', async () => {
+    it('updates progress in upload store when a shard finishes', async () => {
       manager.initialize(app(), internal(), {
         createFileReader: jest.fn(() => ({
           read: jest.fn().mockResolvedValue(new ArrayBuffer(0)),
@@ -717,29 +718,35 @@ describe('UploadManager', () => {
         progressScheduler: (cb) => cb(),
       })
 
-      let progressCallback: ((uploaded: bigint, total: bigint) => void) | null = null
+      let shardProgress: ((p: ShardProgress) => void) | null = null
       mockSdk.uploadPacked.mockImplementation(async (opts: any) => {
-        progressCallback = opts.progressCallback.progress
+        shardProgress = opts.shardUploaded.progress
         return mockPacker
       })
 
       await manager.__testProcessFiles([createFileEntry('file1', 100)])
 
-      expect(progressCallback).not.toBeNull()
+      expect(shardProgress).not.toBeNull()
 
       // Initial progress should be 0
       const uploadBefore = app().uploads.getEntry('file1')
       expect(uploadBefore?.progress).toBe(0)
 
-      // Simulate progress update (50%)
-      progressCallback!(BigInt(50), BigInt(100))
+      // Simulate one shard uploaded (the SDK reports per-shard, not cumulative bytes)
+      shardProgress!({
+        hostKey: 'host-0',
+        shardSize: BigInt(50),
+        shardIndex: 0,
+        slabIndex: 0,
+        elapsedMs: BigInt(10),
+      })
 
       // Progress should be updated in store (progressScheduler applies synchronously)
       const uploadAfter = app().uploads.getEntry('file1')
       expect(uploadAfter?.progress).toBeGreaterThan(0)
     })
 
-    it('progress never decreases when SDK encoded total grows at slab boundaries', async () => {
+    it('progress is monotonic across successive shard events', async () => {
       const fileSize = Math.floor(SLAB_SIZE * 1.5)
       manager.initialize(app(), internal(), {
         createFileReader: jest.fn(() => ({
@@ -748,32 +755,28 @@ describe('UploadManager', () => {
         progressScheduler: (cb) => cb(),
       })
 
-      let progressCallback: ((uploaded: bigint, total: bigint) => void) | null = null
+      let shardProgress: ((p: ShardProgress) => void) | null = null
       mockSdk.uploadPacked.mockImplementation(async (opts: any) => {
-        progressCallback = opts.progressCallback.progress
+        shardProgress = opts.shardUploaded.progress
         return mockPacker
       })
 
       await manager.__testProcessFiles([createFileEntry('multi-slab', fileSize)])
-      expect(progressCallback).not.toBeNull()
+      expect(shardProgress).not.toBeNull()
 
-      // Our stable denominator: ceil(1.5 slabs) = 2 slabs worth of encoded sectors
-      const expectedEncoded = 2 * (UPLOAD_DATA_SHARDS + UPLOAD_PARITY_SHARDS) * SECTOR_SIZE
-
-      // Simulate SDK sawtooth: first slab uploads with total = 1 slab of sectors,
-      // then second slab starts and total jumps to 2 slabs of sectors.
-      const oneSlab = (UPLOAD_DATA_SHARDS + UPLOAD_PARITY_SHARDS) * SECTOR_SIZE
-
-      const calls: [bigint, bigint][] = [
-        [BigInt(oneSlab / 2), BigInt(oneSlab)], // 50% of first slab
-        [BigInt(oneSlab), BigInt(oneSlab)], // first slab done (SDK: 100%)
-        [BigInt(oneSlab), BigInt(expectedEncoded)], // SDK total jumps (SDK: 50% — sawtooth!)
-        [BigInt(oneSlab * 1.5), BigInt(expectedEncoded)], // more progress
+      // Simulate four shards completing over two slabs. Each shard adds to the
+      // running uploadedShardBytes — batch progress should never decrease.
+      const shardSize = BigInt(SECTOR_SIZE)
+      const shards: ShardProgress[] = [
+        { hostKey: 'h-0', shardSize, shardIndex: 0, slabIndex: 0, elapsedMs: BigInt(5) },
+        { hostKey: 'h-1', shardSize, shardIndex: 1, slabIndex: 0, elapsedMs: BigInt(5) },
+        { hostKey: 'h-0', shardSize, shardIndex: 0, slabIndex: 1, elapsedMs: BigInt(5) },
+        { hostKey: 'h-1', shardSize, shardIndex: 1, slabIndex: 1, elapsedMs: BigInt(5) },
       ]
 
       let prevProgress = 0
-      for (const [uploaded, total] of calls) {
-        progressCallback!(uploaded, total)
+      for (const s of shards) {
+        shardProgress!(s)
         const entry = app().uploads.getEntry('multi-slab')
         expect(entry?.progress).toBeGreaterThanOrEqual(prevProgress)
         prevProgress = entry?.progress ?? 0

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "siastorage",
@@ -103,12 +102,11 @@
         "react-native-safe-area-context": "5.6.2",
         "react-native-screens": "4.23.0",
         "react-native-share": "12.2.5",
-        "react-native-sia": "0.13.18",
+        "react-native-sia": "0.13.21",
         "react-native-svg": "15.15.3",
         "react-native-webview": "13.16.0",
         "react-native-worklets": "0.7.2",
         "swr": "2.4.1",
-        "web-streams-polyfill": "4.2.0",
         "zod": "4.3.6",
       },
       "devDependencies": {
@@ -1859,7 +1857,7 @@
 
     "react-native-share": ["react-native-share@12.2.5", "", {}, "sha512-2uwd/PdlUyvpsSBfL7OMiL4sD0Ja51wu5m62JSIXjrtlF+uSTUOGsMrE49ncIRYziqAfYUeI195WwhpvqXB0ww=="],
 
-    "react-native-sia": ["react-native-sia@0.13.18", "", { "dependencies": { "uniffi-bindgen-react-native": "^0.29.3-1" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-vmO4WZpebKNKY01ofexdgSJ6mVxRvl94eYJC2Jjv6EZ7szapwa3cx9vXPLv94c2fqa0qEwgGEoVCgguIYFpg4A=="],
+    "react-native-sia": ["react-native-sia@0.13.21", "", { "dependencies": { "uniffi-bindgen-react-native": "0.31.0-2" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-o8xV1+l2xLKNLvXbJiqODG5Ilm+L2VwXRWCHNs4H0z8e+OaL7rhbvDgEyFr/XL4Nl3IBtqT41uFFo+h6+sAi5A=="],
 
     "react-native-svg": ["react-native-svg@15.15.3", "", { "dependencies": { "css-select": "^5.1.0", "css-tree": "^1.1.3", "warn-once": "0.1.1" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-/k4KYwPBLGcx2f5d4FjE+vCScK7QOX14cl2lIASJ28u4slHHtIhL0SZKU7u9qmRBHxTCKPoPBtN6haT1NENJNA=="],
 
@@ -2081,7 +2079,7 @@
 
     "unicode-property-aliases-ecmascript": ["unicode-property-aliases-ecmascript@2.2.0", "", {}, "sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ=="],
 
-    "uniffi-bindgen-react-native": ["uniffi-bindgen-react-native@0.29.3-1", "", { "bin": { "ubrn": "bin/cli.cjs", "uniffi-bindgen-react-native": "bin/cli.cjs" } }, "sha512-o6gXZsAh55yuvhwF2WSFdIHV4phyfWcCmg4DuyfJWJ7CvUz1UcIz2S4u9SmXAz1jsuqvu6Xc9hexrRBB0a5osg=="],
+    "uniffi-bindgen-react-native": ["uniffi-bindgen-react-native@0.31.0-2", "", { "bin": { "ubrn": "bin/cli.cjs", "uniffi-bindgen-react-native": "bin/cli.cjs" } }, "sha512-kcmW4/ayEEQH3mg4r3wJAgDoBd7Ix7Y/4E2npS51ydUKuHMzLsTU+lgzanZVAwC+yQsDduEK63TFXq54imJWsA=="],
 
     "universalify": ["universalify@0.2.0", "", {}, "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="],
 
@@ -2122,8 +2120,6 @@
     "warn-once": ["warn-once@0.1.1", "", {}, "sha512-VkQZJbO8zVImzYFteBXvBOZEl1qL175WH8VmZcxF2fZAoudNhNDvHi+doCaAEdU2l2vtcIwa2zn0QK5+I1HQ3Q=="],
 
     "wcwidth": ["wcwidth@1.0.1", "", { "dependencies": { "defaults": "^1.0.3" } }, "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg=="],
-
-    "web-streams-polyfill": ["web-streams-polyfill@4.2.0", "", {}, "sha512-0rYDzGOh9EZpig92umN5g5D/9A1Kff7k0/mzPSSCY8jEQeYkgRMoY7LhbXtUCWzLCMX0TUE9aoHkjFNB7D9pfA=="],
 
     "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
 

--- a/packages/core/src/adapters/index.ts
+++ b/packages/core/src/adapters/index.ts
@@ -6,6 +6,7 @@ export type {
   Account,
   AccountApp,
   AppKeyRef,
+  DownloadLikeRef,
   DownloadOptions,
   Host,
   NetAddress,
@@ -15,6 +16,7 @@ export type {
   PinnedObjectRef,
   SdkAdapter,
   SealedObjectRef,
+  ShardProgress,
   UploadOptions,
 } from './sdk'
 export { AddressProtocol } from './sdk'

--- a/packages/core/src/adapters/sdk.ts
+++ b/packages/core/src/adapters/sdk.ts
@@ -1,4 +1,4 @@
-import type { Reader, Writer } from './fs'
+import type { Reader } from './fs'
 
 export interface ObjectsCursor {
   id: string
@@ -57,15 +57,26 @@ export interface PackedUploadRef {
   slabs(): bigint
 }
 
+/**
+ * Progress information emitted by the SDK for each successfully uploaded
+ * or downloaded shard. Matches the shape of `react-native-sia`'s
+ * `ShardProgress` record.
+ */
+export interface ShardProgress {
+  hostKey: string
+  shardSize: bigint
+  shardIndex: number
+  slabIndex: number
+  elapsedMs: bigint
+}
+
 export interface UploadOptions {
   maxInflight: number
   dataShards: number
   parityShards: number
-  progressCallback:
-    | {
-        progress: (uploaded: bigint, total: bigint) => void
-      }
-    | undefined
+  shardUploaded?: {
+    progress: (p: ShardProgress) => void
+  }
 }
 
 export interface DownloadOptions {
@@ -117,15 +128,28 @@ export interface Account {
   lastUsed: Date
 }
 
+/**
+ * Pull-based download handle. Call `read()` repeatedly to receive decoded
+ * chunks; an empty ArrayBuffer signals end of stream. Call `cancel()` to
+ * abort in-flight chunk recovery (subsequent reads resolve with an empty
+ * buffer or throw `DownloadError::Cancelled`). Matches the shape of
+ * uniffi-generated `DownloadLike` across platforms.
+ */
+export interface DownloadLikeRef {
+  /**
+   * Resolves to the next decoded chunk, or an empty `ArrayBuffer` on
+   * end of stream. Also resolves with an empty buffer (or rejects with
+   * `DownloadError::Cancelled`) once `cancel()` has been called.
+   * Callers loop until `byteLength === 0` or an exception propagates.
+   */
+  read(control?: { signal: AbortSignal }): Promise<ArrayBuffer>
+  cancel(): Promise<void>
+}
+
 export interface SdkAdapter {
   objectEvents(cursor: ObjectsCursor | undefined, limit: number): Promise<ObjectEvent[]>
   updateObjectMetadata(pinnedObject: PinnedObjectRef): Promise<void>
-  download(
-    writer: Writer,
-    pinnedObject: PinnedObjectRef,
-    options: DownloadOptions,
-    control?: { signal: AbortSignal },
-  ): Promise<void>
+  download(pinnedObject: PinnedObjectRef, options: DownloadOptions): Promise<DownloadLikeRef>
   uploadPacked(options: UploadOptions): Promise<PackedUploadRef>
   pinObject(pinnedObject: PinnedObjectRef): Promise<void>
   deleteObject(objectId: string): Promise<void>

--- a/packages/core/src/services/uploader.ts
+++ b/packages/core/src/services/uploader.ts
@@ -1,6 +1,6 @@
 import { logger } from '@siastorage/logger'
 import type { Reader } from '../adapters/fs'
-import type { PackedUploadRef, PinnedObjectRef } from '../adapters/sdk'
+import type { PackedUploadRef, PinnedObjectRef, ShardProgress } from '../adapters/sdk'
 import type { AppService, AppServiceInternal } from '../app/service'
 import {
   PACKER_IDLE_TIMEOUT,
@@ -95,6 +95,12 @@ type BatchState = {
   totalAddMs: number
   /** Number of packer.add() calls that triggered a slab upload (slabs increased). */
   slabUploadAdds: number
+  /**
+   * Running sum of uploaded-shard byte counts reported by the SDK's
+   * per-shard progress callback. Divided by expected encoded size to
+   * compute batch-level progress.
+   */
+  uploadedShardBytes: number
 }
 
 /** Recorded after each flush for efficiency analysis and testing. */
@@ -579,14 +585,15 @@ export class UploadManager {
           suspendedMs: 0,
           totalAddMs: 0,
           slabUploadAdds: 0,
+          uploadedShardBytes: 0,
         }
         this.batch = batch
         this.packer = await sdk.uploadPacked({
           maxInflight: UPLOAD_MAX_INFLIGHT,
           dataShards: UPLOAD_DATA_SHARDS,
           parityShards: UPLOAD_PARITY_SHARDS,
-          progressCallback: {
-            progress: (uploaded, total) => this.onProgress(batch, uploaded, total),
+          shardUploaded: {
+            progress: (p) => this.onShardUploaded(batch, p),
           },
         })
       }
@@ -640,6 +647,9 @@ export class UploadManager {
         error: e as Error,
       })
       this.app.uploads.setError(entry.fileId, message)
+      // Keep this.packer / this.batch alive — the SDK leaves the packer
+      // usable after add() errors, so subsequent entries continue in the
+      // same batch instead of orphaning already-successful adds.
     }
   }
 
@@ -756,6 +766,13 @@ export class UploadManager {
           error: e as Error,
         })
         this.app.uploads.setError(entry.fileId, message)
+        // Abandon the rest of this window on first error; the loop below
+        // attaches .catch so skipped in-flight promises don't surface as
+        // unhandled rejections. Keep this.packer / this.batch alive — the
+        // SDK leaves the packer usable after add() errors, so the next
+        // entry continues in the same batch instead of orphaning its
+        // already-successful adds.
+        break
       }
     }
 
@@ -933,11 +950,18 @@ export class UploadManager {
     return (this.batch.totalSize % SLAB_SIZE) / SLAB_SIZE
   }
 
-  /** Distribute batch upload progress across individual files by size weight. */
-  private onProgress(batch: BatchState, uploaded: bigint, _encodedTotal: bigint): void {
+  /**
+   * Per-shard progress from the SDK. Each callback reports one uploaded
+   * shard's size; we accumulate into batch.uploadedShardBytes and divide
+   * by the expected encoded size (slabs × (data+parity) shards × SECTOR_SIZE)
+   * to produce a batch-level progress fraction, then distribute across
+   * files by size weight.
+   */
+  private onShardUploaded(batch: BatchState, p: ShardProgress): void {
+    batch.uploadedShardBytes += Number(p.shardSize)
     const slabs = Math.ceil(batch.totalSize / SLAB_SIZE)
     const expectedEncoded = slabs * (UPLOAD_DATA_SHARDS + UPLOAD_PARITY_SHARDS) * SECTOR_SIZE
-    const batchProgress = expectedEncoded > 0 ? Number(uploaded) / expectedEncoded : 0
+    const batchProgress = expectedEncoded > 0 ? batch.uploadedShardBytes / expectedEncoded : 0
 
     const batchInfo: BatchInfo = {
       files: batch.files.map((f) => ({

--- a/packages/sdk-mock/src/index.ts
+++ b/packages/sdk-mock/src/index.ts
@@ -1,6 +1,7 @@
 import type {
   Account,
   AppKeyRef,
+  DownloadLikeRef,
   DownloadOptions,
   Host,
   ObjectEvent,
@@ -11,8 +12,8 @@ import type {
   SdkAdapter,
   SealedObjectRef,
   UploadOptions,
-  Writer,
 } from '@siastorage/core/adapters'
+import { SECTOR_SIZE } from '@siastorage/core/config'
 import { decodeFileMetadata, encodeFileMetadata } from '@siastorage/core/encoding/fileMetadata'
 import type { FileMetadata } from '@siastorage/core/types'
 
@@ -84,19 +85,12 @@ function createMockPinnedObject(stored: StoredObject): PinnedObjectRef {
 
 class MockPacker implements PackedUploadRef {
   private storage: MockIndexerStorage
-  private options: {
-    progressCallback?: { progress: (uploaded: bigint, total: bigint) => void }
-  }
+  private options: UploadOptions
   private files: Array<{ data: Uint8Array; size: bigint }> = []
   private totalSize = 0n
   private slabSize = 120n * 1024n * 1024n
 
-  constructor(
-    storage: MockIndexerStorage,
-    options: {
-      progressCallback?: { progress: (uploaded: bigint, total: bigint) => void }
-    },
-  ) {
+  constructor(storage: MockIndexerStorage, options: UploadOptions) {
     this.storage = storage
     this.options = options
   }
@@ -145,16 +139,37 @@ class MockPacker implements PackedUploadRef {
     const results: PinnedObjectRef[] = []
     const totalBytes = this.totalSize
 
-    const progressSteps = [0.0, 0.25, 0.5, 0.75, 1.0]
-    const delayPerStep = 50
+    // Simulate per-shard progress: emit one event per (slab × shard)
+    // with SECTOR_SIZE-sized shards, matching the real SDK's emission.
+    // A batch of totalBytes spans ceil(totalBytes / slabBytes) slabs,
+    // each containing (dataShards + parityShards) shards of SECTOR_SIZE.
+    // Summing reported shardSize across all events equals the batch's
+    // expectedEncoded = slabs × totalShards × SECTOR_SIZE, so consumers
+    // computing progress from shard events reach exactly 1.0 at end.
+    const dataShards = this.options.dataShards
+    const parityShards = this.options.parityShards
+    const totalShards = dataShards + parityShards
+    const slabBytes = BigInt(SECTOR_SIZE) * BigInt(dataShards)
+    const slabCount =
+      totalBytes > 0n && slabBytes > 0n ? Number((totalBytes + slabBytes - 1n) / slabBytes) : 0
+    const shardSize = BigInt(SECTOR_SIZE)
+    const delayPerShard = 50
 
-    for (const progress of progressSteps) {
-      if (this.options.progressCallback && totalBytes > 0n) {
-        const uploaded = BigInt(Math.floor(Number(totalBytes) * progress))
-        this.options.progressCallback.progress(uploaded, totalBytes)
-      }
-      if (progress < 1.0) {
-        await this.sleep(delayPerStep)
+    for (let slab = 0; slab < slabCount; slab++) {
+      for (let shard = 0; shard < totalShards; shard++) {
+        if (this.options.shardUploaded) {
+          this.options.shardUploaded.progress({
+            hostKey: `mock-host-${slab}-${shard}`,
+            shardSize,
+            shardIndex: shard,
+            slabIndex: slab,
+            elapsedMs: BigInt(delayPerShard),
+          })
+        }
+        const isLast = slab === slabCount - 1 && shard === totalShards - 1
+        if (!isLast) {
+          await this.sleep(delayPerShard)
+        }
       }
     }
 
@@ -242,11 +257,9 @@ export class MockSdk implements SdkAdapter {
   }
 
   async download(
-    _writer: Writer,
     _pinnedObject: PinnedObjectRef,
     _options: DownloadOptions,
-    _control?: { signal: AbortSignal },
-  ): Promise<void> {
+  ): Promise<DownloadLikeRef> {
     throw new Error('Not implemented in mock')
   }
 


### PR DESCRIPTION
- Migrate to the new SDK's pull-based download API: UploadOptions.progressCallback → shardUploaded (per-shard ShardProgress), and sdk.download now returns a DownloadLikeRef (read/cancel) instead of taking a Writer callback. streamToCache, downloadObject, and downloadFirstBytesFromShared pull directly; sdk-mock mirrors the new shapes.
- Recover from dead packers: null this.packer/this.batch after packer.add() throws so the next entry opens a fresh packer instead of tight-looping on a closed buffer.
- Switch the upload file reader from File.open() + handle.readBytes() to File.stream() with a BYOB reader (256 KB chunks) — the sync JSI path was returning a Uint8Array that panicked at the uniffi boundary (UploadError.Closed).
- Drop web-streams-polyfill: Expo SDK 55 ships native ReadableStream/WritableStream/TransformStream, and the polyfill's per-chunk structuredClone was costing ~34% of upload CPU.

