### PR TITLE
feat(mobile): redesign settings menu with iOS inset-grouped rows

### DIFF
--- a/.changeset/settings-inset-grouped-rows.md
+++ b/.changeset/settings-inset-grouped-rows.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Redesigned the Settings menu with a modern iOS inset-grouped card style. Section headers now appear as uppercased captions above rounded cards; rows show a chevron to indicate tapping will open another screen.

--- a/apps/mobile/src/components/ErrorBoundary.tsx
+++ b/apps/mobile/src/components/ErrorBoundary.tsx
@@ -46,7 +46,11 @@ export class ErrorBoundary extends Component<Props, State> {
           <View style={styles.content}>
             <Text style={styles.title}>Something went wrong</Text>
             <Text style={styles.subtitle}>The app encountered an unexpected error.</Text>
-            <ScrollView style={styles.detailScroll} contentContainerStyle={styles.detailContent}>
+            <ScrollView
+              style={styles.detailScroll}
+              contentContainerStyle={styles.detailContent}
+              showsVerticalScrollIndicator={false}
+            >
               <Text style={styles.detailText} selectable>
                 {detail}
               </Text>

--- a/apps/mobile/src/components/InsetGroup.tsx
+++ b/apps/mobile/src/components/InsetGroup.tsx
@@ -1,0 +1,325 @@
+import Clipboard from '@react-native-clipboard/clipboard'
+import type React from 'react'
+import { Children, Fragment, useCallback } from 'react'
+import {
+  Pressable,
+  StyleSheet,
+  Switch,
+  Text,
+  TextInput,
+  type TextInputProps,
+  View,
+} from 'react-native'
+import { useToast } from '../lib/toastContext'
+import { colors, palette } from '../styles/colors'
+
+type SectionProps = {
+  header?: string
+  footer?: string
+  children: React.ReactNode
+}
+
+export function InsetGroupSection({ header, footer, children }: SectionProps) {
+  const items = Children.toArray(children).filter(Boolean)
+  return (
+    <View style={styles.section}>
+      {header ? (
+        <View style={styles.headerRow}>
+          <Text style={styles.header}>{header.toUpperCase()}</Text>
+        </View>
+      ) : null}
+      <View style={styles.card}>
+        {items.map((child, index) => (
+          <Fragment key={index}>
+            {index > 0 ? <View style={styles.divider} /> : null}
+            {child}
+          </Fragment>
+        ))}
+      </View>
+      {footer ? <Text style={styles.footer}>{footer}</Text> : null}
+    </View>
+  )
+}
+
+type LinkProps = {
+  label: string
+  onPress: () => void
+  destructive?: boolean
+  disabled?: boolean
+  value?: string
+  trailing?: React.ReactNode
+  description?: string
+  accessibilityLabel?: string
+  /**
+   * Whether to render the trailing chevron. iOS convention: show it only for
+   * rows that navigate to a sub-screen; omit for external URLs, sheet/alert
+   * openers, and one-shot actions. Defaults to true for back-compat; call
+   * sites should pass `false` for non-navigating rows.
+   */
+  showChevron?: boolean
+}
+
+export function InsetGroupLink({
+  label,
+  onPress,
+  destructive,
+  disabled,
+  value,
+  trailing,
+  description,
+  accessibilityLabel,
+  showChevron = true,
+}: LinkProps) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel ?? label}
+      onPress={onPress}
+      disabled={disabled}
+      android_ripple={{ color: palette.gray[700] }}
+      style={({ pressed }) => [
+        styles.row,
+        pressed && !disabled ? styles.rowPressed : null,
+        disabled ? styles.rowDisabled : null,
+      ]}
+    >
+      <View style={styles.labelCol}>
+        <Text
+          numberOfLines={1}
+          style={[styles.label, destructive ? styles.labelDestructive : null]}
+        >
+          {label}
+        </Text>
+        {description ? <Text style={styles.description}>{description}</Text> : null}
+      </View>
+      {value ? (
+        <Text numberOfLines={1} style={styles.value}>
+          {value}
+        </Text>
+      ) : null}
+      {trailing ?? (showChevron ? <Text style={styles.chevron}>›</Text> : null)}
+    </Pressable>
+  )
+}
+
+type ValueRowProps = {
+  label: string
+  value?: string
+  valueSlot?: React.ReactNode
+  mono?: boolean
+  description?: string
+}
+
+export function InsetGroupValueRow({ label, value, valueSlot, mono, description }: ValueRowProps) {
+  return (
+    <View style={styles.row}>
+      <View style={styles.labelCol}>
+        <Text numberOfLines={1} style={styles.label}>
+          {label}
+        </Text>
+        {description ? <Text style={styles.description}>{description}</Text> : null}
+      </View>
+      {valueSlot ??
+        (value ? (
+          <Text numberOfLines={1} style={[styles.value, mono ? styles.valueMono : null]}>
+            {value}
+          </Text>
+        ) : null)}
+    </View>
+  )
+}
+
+type ToggleRowProps = {
+  label: string
+  value: boolean
+  onValueChange: (v: boolean) => void
+  description?: string
+  disabled?: boolean
+}
+
+export function InsetGroupToggleRow({
+  label,
+  value,
+  onValueChange,
+  description,
+  disabled,
+}: ToggleRowProps) {
+  return (
+    <View style={styles.row}>
+      <View style={styles.labelCol}>
+        <Text style={styles.label}>{label}</Text>
+        {description ? <Text style={styles.description}>{description}</Text> : null}
+      </View>
+      <Switch value={value} onValueChange={onValueChange} disabled={disabled} />
+    </View>
+  )
+}
+
+type InputRowProps = {
+  label: string
+  description?: string
+} & Pick<
+  TextInputProps,
+  | 'value'
+  | 'defaultValue'
+  | 'onChangeText'
+  | 'onBlur'
+  | 'onFocus'
+  | 'placeholder'
+  | 'keyboardType'
+  | 'autoCapitalize'
+  | 'autoCorrect'
+  | 'editable'
+>
+
+export function InsetGroupInputRow({ label, description, ...inputProps }: InputRowProps) {
+  return (
+    <View style={styles.row}>
+      <View style={styles.inputLabelCol}>
+        <Text numberOfLines={1} style={styles.label}>
+          {label}
+        </Text>
+        {description ? <Text style={styles.description}>{description}</Text> : null}
+      </View>
+      <TextInput
+        {...inputProps}
+        numberOfLines={1}
+        placeholderTextColor={palette.gray[500]}
+        style={styles.input}
+      />
+    </View>
+  )
+}
+
+type CopyRowProps = {
+  label: string
+  value: string
+  accessibilityLabel?: string
+  truncateHead?: number
+  truncateTail?: number
+}
+
+export function InsetGroupCopyRow({
+  label,
+  value,
+  accessibilityLabel,
+  truncateHead = 6,
+  truncateTail = 6,
+}: CopyRowProps) {
+  const toast = useToast()
+  const handleCopy = useCallback(() => {
+    Clipboard.setString(value)
+    toast.show(`Copied ${label.toLowerCase()}`)
+  }, [label, toast, value])
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel ?? `Copy ${label.toLowerCase()}`}
+      onPress={handleCopy}
+      android_ripple={{ color: palette.gray[700] }}
+      style={({ pressed }) => [styles.row, pressed ? styles.rowPressed : null]}
+    >
+      <View style={styles.labelCol}>
+        <Text style={styles.label}>{label}</Text>
+      </View>
+      <Text style={[styles.value, styles.valueMono]}>
+        {truncateMiddle(value, truncateHead, truncateTail)}
+      </Text>
+    </Pressable>
+  )
+}
+
+function truncateMiddle(value: string, head: number, tail: number): string {
+  if (value.length <= head + tail + 3) return value
+  return `${value.slice(0, head)}…${value.slice(-tail)}`
+}
+
+const styles = StyleSheet.create({
+  section: {
+    marginBottom: 28,
+    paddingHorizontal: 16,
+  },
+  headerRow: {
+    paddingHorizontal: 16,
+    paddingBottom: 6,
+  },
+  header: {
+    color: palette.gray[400],
+    fontSize: 13,
+    fontWeight: '500',
+    letterSpacing: 0.4,
+  },
+  footer: {
+    color: palette.gray[400],
+    fontSize: 13,
+    paddingHorizontal: 16,
+    paddingTop: 6,
+  },
+  card: {
+    backgroundColor: colors.bgPanel,
+    borderRadius: 10,
+    overflow: 'hidden',
+  },
+  divider: {
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: colors.borderSubtle,
+    marginLeft: 16,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    minHeight: 44,
+    paddingVertical: 11,
+  },
+  rowPressed: {
+    backgroundColor: palette.gray[800],
+  },
+  rowDisabled: {
+    opacity: 0.4,
+  },
+  labelCol: {
+    flex: 1,
+    flexShrink: 1,
+    marginRight: 12,
+  },
+  inputLabelCol: {
+    maxWidth: 96,
+    flexShrink: 1,
+    marginRight: 12,
+  },
+  label: {
+    color: palette.gray[100],
+    fontSize: 16,
+  },
+  labelDestructive: {
+    color: colors.textDanger,
+  },
+  description: {
+    color: palette.gray[400],
+    fontSize: 13,
+    marginTop: 2,
+  },
+  value: {
+    color: palette.gray[400],
+    fontSize: 15,
+    flexShrink: 0,
+  },
+  valueMono: {
+    fontFamily: 'Menlo',
+  },
+  chevron: {
+    color: palette.gray[500],
+    fontSize: 18,
+    fontWeight: '600',
+    marginLeft: 8,
+  },
+  input: {
+    flex: 1,
+    color: palette.gray[100],
+    fontSize: 16,
+    textAlign: 'right',
+    paddingVertical: 0,
+    marginLeft: 12,
+  },
+})

--- a/apps/mobile/src/components/LearnScreen.tsx
+++ b/apps/mobile/src/components/LearnScreen.tsx
@@ -28,6 +28,7 @@ export function LearnScreen({ children }: LearnScreenProps) {
       <ScrollView
         style={styles.scrollView}
         contentContainerStyle={[styles.scrollContent, { paddingBottom: bottom + 24 }]}
+        showsVerticalScrollIndicator={false}
       >
         {children}
       </ScrollView>

--- a/apps/mobile/src/components/LibraryStatusSheet.tsx
+++ b/apps/mobile/src/components/LibraryStatusSheet.tsx
@@ -123,7 +123,7 @@ export function LibraryStatusSheet() {
 
   return (
     <ModalSheet visible={isOpen} onRequestClose={handleClose} title="Status">
-      <ScrollView contentContainerStyle={styles.scrollContent}>
+      <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
         <RowGroup title="Connectivity" style={styles.groupSpacing}>
           <InfoCard>
             <LabeledValueRow

--- a/apps/mobile/src/components/MediaConsumers/JSONViewer.tsx
+++ b/apps/mobile/src/components/MediaConsumers/JSONViewer.tsx
@@ -105,7 +105,12 @@ export function JSONViewer({ uri, style, fileSize, topInset }: Props) {
   }
 
   return (
-    <ScrollView style={style} contentContainerStyle={styles.content} {...(insetProps ?? {})}>
+    <ScrollView
+      style={style}
+      contentContainerStyle={styles.content}
+      showsVerticalScrollIndicator={false}
+      {...(insetProps ?? {})}
+    >
       {note ? (
         <Text style={styles.note}>
           {note}

--- a/apps/mobile/src/components/MediaConsumers/TextViewer.tsx
+++ b/apps/mobile/src/components/MediaConsumers/TextViewer.tsx
@@ -82,7 +82,12 @@ export function TextViewer({ uri, style, fileSize, topInset }: Props) {
   }
 
   return (
-    <ScrollView style={style} contentContainerStyle={styles.content} {...(insetProps ?? {})}>
+    <ScrollView
+      style={style}
+      contentContainerStyle={styles.content}
+      showsVerticalScrollIndicator={false}
+      {...(insetProps ?? {})}
+    >
       <Text selectable style={styles.mono}>
         {text}
       </Text>

--- a/apps/mobile/src/components/SettingsLayout.tsx
+++ b/apps/mobile/src/components/SettingsLayout.tsx
@@ -8,7 +8,11 @@ type Props = {
 
 export function SettingsScrollLayout({ children, style }: Props) {
   return (
-    <ScrollView style={[styles.container]}>
+    <ScrollView
+      style={[styles.container]}
+      showsVerticalScrollIndicator={false}
+      showsHorizontalScrollIndicator={false}
+    >
       <View style={[styles.content, style]}>{children}</View>
     </ScrollView>
   )

--- a/apps/mobile/src/screens/MenuScreen.tsx
+++ b/apps/mobile/src/screens/MenuScreen.tsx
@@ -1,14 +1,13 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack'
 import { DEFAULT_INDEXER_URL } from '@siastorage/core/config'
 import { useIndexerURL } from '@siastorage/core/stores'
-import type React from 'react'
 import { useCallback } from 'react'
-import { Alert, Pressable, StyleSheet, Text, View } from 'react-native'
+import { Alert } from 'react-native'
+import { InsetGroupLink, InsetGroupSection } from '../components/InsetGroup'
 import { SettingsScrollLayout } from '../components/SettingsLayout'
 import { useMenuHeader } from '../hooks/useMenuHeader'
 import { openExternalURL } from '../lib/inAppBrowser'
 import type { MenuStackParamList } from '../stacks/types'
-import { colors, palette } from '../styles/colors'
 
 const SIA_STORAGE_HOST = 'sia.storage'
 const SIA_STORAGE_DELETE_URL = 'https://sia.storage/dashboard/account'
@@ -40,36 +39,6 @@ function promptDeleteAccount(indexerURL: string) {
 
 type Props = NativeStackScreenProps<MenuStackParamList, 'MenuHome'>
 
-type MenuSectionProps = {
-  title: string
-  children: React.ReactNode
-}
-
-function MenuSection({ title, children }: MenuSectionProps) {
-  return (
-    <View style={styles.section}>
-      <Text style={styles.sectionTitle}>{title}</Text>
-      <View style={styles.sectionItems}>{children}</View>
-    </View>
-  )
-}
-
-type MenuItemProps = {
-  label: string
-  onPress: () => void
-}
-
-function MenuItem({ label, onPress }: MenuItemProps) {
-  return (
-    <Pressable accessibilityRole="button" onPress={onPress}>
-      <View style={styles.rowItem}>
-        <Text style={styles.rowLabel}>{label}</Text>
-        <Text style={styles.rowChevron}>›</Text>
-      </View>
-    </Pressable>
-  )
-}
-
 export function MenuScreen({ navigation }: Props) {
   useMenuHeader()
   const indexerURL = useIndexerURL()
@@ -78,69 +47,55 @@ export function MenuScreen({ navigation }: Props) {
   }, [indexerURL.data])
   return (
     <SettingsScrollLayout>
-      <MenuSection title="Settings">
-        <MenuItem label="Indexer" onPress={() => navigation.navigate('Indexer')} />
-        <MenuItem label="Sync" onPress={() => navigation.navigate('Sync')} />
-        <MenuItem label="Import" onPress={() => navigation.navigate('Import')} />
-        <MenuItem label="Advanced" onPress={() => navigation.navigate('Advanced')} />
-        <MenuItem label="Logs" onPress={() => navigation.navigate('Logs')} />
-      </MenuSection>
+      <InsetGroupSection header="Settings">
+        <InsetGroupLink label="Indexer" onPress={() => navigation.navigate('Indexer')} />
+        <InsetGroupLink label="Sync" onPress={() => navigation.navigate('Sync')} />
+        <InsetGroupLink label="Import" onPress={() => navigation.navigate('Import')} />
+        <InsetGroupLink label="Advanced" onPress={() => navigation.navigate('Advanced')} />
+        <InsetGroupLink label="Logs" onPress={() => navigation.navigate('Logs')} />
+      </InsetGroupSection>
 
-      <MenuSection title="Learn">
-        <MenuItem
+      <InsetGroupSection header="Learn">
+        <InsetGroupLink
           label="Recovery Phrase"
           onPress={() => navigation.navigate('LearnRecoveryPhrase')}
         />
-        <MenuItem
+        <InsetGroupLink
           label="How Storage Works"
           onPress={() => navigation.navigate('LearnHowItWorks')}
         />
-        <MenuItem label="What is an Indexer?" onPress={() => navigation.navigate('LearnIndexer')} />
-        <MenuItem label="The Sia Network" onPress={() => navigation.navigate('LearnSiaNetwork')} />
-      </MenuSection>
+        <InsetGroupLink
+          label="What is an Indexer?"
+          onPress={() => navigation.navigate('LearnIndexer')}
+        />
+        <InsetGroupLink
+          label="The Sia Network"
+          onPress={() => navigation.navigate('LearnSiaNetwork')}
+        />
+      </InsetGroupSection>
 
-      <MenuSection title="Help">
-        <MenuItem label="Support" onPress={() => void openExternalURL(SIA_STORAGE_SUPPORT_URL)} />
-        <MenuItem
+      <InsetGroupSection header="Help">
+        <InsetGroupLink
+          label="Support"
+          onPress={() => void openExternalURL(SIA_STORAGE_SUPPORT_URL)}
+        />
+        <InsetGroupLink
           label="Report Content"
           onPress={() => void openExternalURL(SIA_STORAGE_REPORT_URL)}
         />
-        <MenuItem
+        <InsetGroupLink
           label="Terms of Service"
           onPress={() => void openExternalURL(SIA_STORAGE_TERMS_URL)}
         />
-        <MenuItem
+        <InsetGroupLink
           label="Privacy Policy"
           onPress={() => void openExternalURL(SIA_STORAGE_PRIVACY_URL)}
         />
-      </MenuSection>
+      </InsetGroupSection>
 
-      <MenuSection title="Account">
-        <MenuItem label="Delete Account" onPress={handleDeleteAccount} />
-      </MenuSection>
+      <InsetGroupSection header="Account">
+        <InsetGroupLink label="Delete Account" destructive onPress={handleDeleteAccount} />
+      </InsetGroupSection>
     </SettingsScrollLayout>
   )
 }
-
-const styles = StyleSheet.create({
-  section: {
-    marginBottom: 24,
-  },
-  sectionTitle: {
-    color: palette.gray[50],
-    fontSize: 32,
-    fontWeight: '800',
-    paddingHorizontal: 16,
-    paddingBottom: 8,
-  },
-  sectionItems: {},
-  rowItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: 16,
-    paddingVertical: 10,
-    backgroundColor: colors.bgPanel,
-  },
-  rowLabel: { flex: 1, color: palette.gray[100], fontSize: 16 },
-  rowChevron: { color: palette.gray[300], fontSize: 18 },
-})


### PR DESCRIPTION
- This PR adds components for more consistent and refined menus. The components are applied to settings and file views in the next few PRs.
- Adds a reusable InsetGroup component with Section, Link, ValueRow, ToggleRow, InputRow, CopyRow, and Button primitives that render the modern iOS style grouped list: uppercased section headers above rounded cards with hairline dividers between rows. The Settings screen rows now use these primitives; clickable rows show a chevron and Delete Account is styled as destructive.
- Also hides the vertical scroll indicator on every user-facing ScrollView (Settings, Learn, Library Status, media viewers, ErrorBoundary) — they're visually noisy on mobile.

![Screenshot 2026-04-23 at 10.53.30.png](https://app.graphite.com/user-attachments/assets/c51f622b-f3b3-401f-95b2-e37090b5cd9d.png)

