### PR TITLE
feat(mobile): redesign library status sheet with attention banner and unified row pattern

### DIFF
--- a/.changeset/mobile-status-sheet-redesign.md
+++ b/.changeset/mobile-status-sheet-redesign.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Redesigned the library status sheet: library size and counts now lead, connectivity issues surface as a top banner only when offline or unreachable, and sync metadata moved to the bottom. Renamed "Lost" files to "Unavailable" in both the sheet and the Import screen.

--- a/apps/mobile/src/components/LibraryStatusSheet.tsx
+++ b/apps/mobile/src/components/LibraryStatusSheet.tsx
@@ -1,55 +1,64 @@
 import { type NavigationProp, useNavigation } from '@react-navigation/native'
 import type { UploadCategoryStats, UploadStats } from '@siastorage/core/db/operations'
-import { useSyncState } from '@siastorage/core/stores'
-import { TriangleAlertIcon } from 'lucide-react-native'
+import { useAccount, useStatusDisplayMode, useSyncState } from '@siastorage/core/stores'
 import { useCallback } from 'react'
-import { Platform, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native'
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native'
 import useSWR from 'swr'
 import { useIsOnline } from '../hooks/useIsOnline'
 import { humanSize } from '../lib/humanSize'
-import { humanUploadPercent } from '../lib/uploadPercent'
 import { getImportBackoffEntries } from '../managers/importScanner'
 import type { RootTabParamList } from '../stacks/types'
 import { app } from '../stores/appService'
 import { useFileStatsLocal, useFileStatsLost } from '../stores/files'
-import { useIsConnected } from '../stores/sdk'
-import { useStatusDisplayMode } from '../stores/settings'
+import { reconnectIndexer, useIsConnected } from '../stores/sdk'
 import { closeSheet, useSheetOpen } from '../stores/sheets'
 import { getActiveUploads } from '../stores/uploads'
 import { palette, whiteA } from '../styles/colors'
-import { RowGroup, RowSubGroup } from './Group'
-import { InfoCard } from './InfoCard'
-import { LabeledValueRow } from './LabeledValueRow'
+import { InsetGroupLink, InsetGroupSection, InsetGroupValueRow } from './InsetGroup'
 import { ModalSheet } from './ModalSheet'
+import { StatusBanner } from './StatusBanner'
 
 const refreshInterval = 5_000
+type Mode = 'count' | 'size'
 
-function formatDeviceValue(
-  data: { count: number; totalBytes: number } | undefined,
-  overall: { total: number; totalBytes: number } | undefined,
-  mode: 'count' | 'size',
-): string {
-  if (!data || !overall) return mode === 'count' ? '0 / 0' : '0 B / 0 B'
-  if (mode === 'size') {
-    return `${humanSize(data.totalBytes) ?? '0 B'} / ${humanSize(overall.totalBytes) ?? '0 B'}`
-  }
-  return `${data.count.toLocaleString()} / ${overall.total.toLocaleString()}`
+function formatCount(count: number): string {
+  return `${count.toLocaleString()} file${count === 1 ? '' : 's'}`
 }
 
-function devicePercent(
-  data: { count: number; totalBytes: number } | undefined,
-  overall: { totalBytes: number } | undefined,
-): number | undefined {
-  if (!data || !overall || !overall.totalBytes) return undefined
-  return data.totalBytes / overall.totalBytes
+function formatSize(bytes: number | undefined): string {
+  if (bytes === undefined || bytes <= 0) return '0 B'
+  return humanSize(bytes) ?? '0 B'
 }
 
-function formatCategoryValue(cat: UploadCategoryStats | undefined, mode: 'count' | 'size'): string {
-  if (!cat) return mode === 'count' ? '0 / 0' : '0 B / 0 B'
-  if (mode === 'size') {
-    return `${humanSize(cat.uploadedBytes) ?? '0 B'} / ${humanSize(cat.totalBytes) ?? '0 B'}`
+/** Single-value display for non-progress rows (Library totals, Device). */
+function formatModeValue(mode: Mode, count: number, bytes: number | undefined): string {
+  return mode === 'count' ? formatCount(count) : formatSize(bytes)
+}
+
+/**
+ * Trailing value for an upload-progress row. Completed rows collapse to a
+ * single value; in-progress rows show the ratio in the current mode. The
+ * ratio itself conveys progress, so no separate percent is shown.
+ */
+function categoryValue(mode: Mode, cat: UploadCategoryStats | undefined): string | undefined {
+  if (!cat || cat.total === 0) return undefined
+  const complete = cat.uploaded === cat.total
+  if (mode === 'count') {
+    return complete
+      ? formatCount(cat.total)
+      : `${cat.uploaded.toLocaleString()} / ${cat.total.toLocaleString()} files`
   }
-  return `${cat.uploaded.toLocaleString()} / ${cat.total.toLocaleString()}`
+  return complete
+    ? formatSize(cat.totalBytes)
+    : `${formatSize(cat.uploadedBytes)} / ${formatSize(cat.totalBytes)}`
+}
+
+function humanLimit(maxPinnedData: bigint | string | undefined): string {
+  if (maxPinnedData === undefined) return '—'
+  const n = Number(maxPinnedData)
+  if (!Number.isFinite(n)) return '—'
+  if (n >= 2 ** 62) return 'No app limit'
+  return humanSize(n) ?? '—'
 }
 
 export function LibraryStatusSheet() {
@@ -61,16 +70,16 @@ export function LibraryStatusSheet() {
   const syncUpProcessed = syncState?.syncUpProcessed ?? 0
   const syncUpTotal = syncState?.syncUpTotal ?? 0
   const isOpen = useSheetOpen('libraryStatus')
-  const { data: displayMode = 'count' } = useStatusDisplayMode()
+  const { data: rawMode = 'count' } = useStatusDisplayMode()
+  const mode: Mode = rawMode === 'size' ? 'size' : 'count'
+  const account = useAccount()
   const stats = useSWR(
     ['upload-stats', isOpen ?? null],
     async (): Promise<UploadStats> => {
       const indexerURL = await app().settings.getIndexerURL()
       return app().stats.uploadStats(indexerURL)
     },
-    {
-      refreshInterval,
-    },
+    { refreshInterval },
   )
   const onDevice = useFileStatsLocal({ localOnly: false }, { refreshInterval })
   const pendingBackup = useFileStatsLocal({ localOnly: true }, { refreshInterval })
@@ -94,9 +103,7 @@ export function LibraryStatusSheet() {
       const uploads = getActiveUploads()
       const count = uploads.length
       const totalBytes = uploads.reduce((s, u) => s + u.size, 0)
-      const uploadedBytes = uploads.reduce((s, u) => s + u.progress * u.size, 0)
-      const percent = totalBytes ? `${((uploadedBytes / totalBytes) * 100).toFixed(1)}%` : ''
-      return { count, totalBytes, percent }
+      return { count, totalBytes }
     },
     { refreshInterval },
   )
@@ -105,404 +112,141 @@ export function LibraryStatusSheet() {
     closeSheet()
   }, [])
 
-  const toggle = (
-    <View style={styles.toggleTrack}>
-      {(['count', 'size'] as const).map((mode) => (
-        <Pressable
-          key={mode}
-          style={[styles.toggleSegment, displayMode === mode && styles.toggleSegmentSelected]}
-          onPress={() => app().settings.setStatusDisplayMode(mode)}
-        >
-          <Text style={[styles.toggleLabel, displayMode === mode && styles.toggleLabelSelected]}>
-            {mode === 'count' ? 'Count' : 'Size'}
-          </Text>
-        </Pressable>
-      ))}
-    </View>
-  )
+  const handleReconnect = useCallback(() => {
+    void reconnectIndexer()
+  }, [])
+
+  const offline = isOnline.data === false
+  const indexerDown = isOnline.data === true && !isConnected
+
+  const importingCount = stats.data?.importingCount ?? 0
+  const importErrorCount = importErrors.data ?? 0
+  const activeBatchCount = batch.data?.count ?? 0
+
+  const totalCount = stats.data?.files.total ?? 0
+  const totalBytes = account.data ? Number(account.data.pinnedData) : undefined
+  const availableBytes = account.data ? Number(account.data.remainingStorage) : undefined
+
+  const categories: Array<[string, UploadCategoryStats | undefined]> = [
+    ['Files', stats.data?.files],
+    ['Photos', stats.data?.photos],
+    ['Videos', stats.data?.videos],
+    ['Audio', stats.data?.audio],
+    ['Docs', stats.data?.docs],
+    ['Other', stats.data?.other],
+    ['Thumbnails', stats.data?.thumbnails],
+  ]
 
   return (
     <ModalSheet visible={isOpen} onRequestClose={handleClose} title="Status">
       <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
-        <RowGroup title="Connectivity" style={styles.groupSpacing}>
-          <InfoCard>
-            <LabeledValueRow
-              label="Internet"
-              align="right"
-              value={
-                <View style={styles.valueRight}>
-                  <View style={{ flex: 1 }} />
-                  <Text style={styles.valueText}>
-                    {typeof isOnline.data === 'boolean'
-                      ? isOnline.data
-                        ? 'Online'
-                        : 'Offline'
-                      : '—'}
-                  </Text>
-                  <View style={isOnline.data ? styles.dotOnline : styles.dotOffline} />
-                </View>
-              }
-              canCopy={false}
-            />
-            <LabeledValueRow
-              label="Indexer"
-              value={
-                <View style={styles.valueRight}>
-                  <View style={{ flex: 1 }} />
-                  <Text style={styles.valueText}>{isConnected ? 'Connected' : 'Disconnected'}</Text>
-                  <View style={isConnected ? styles.dotOnline : styles.dotOffline} />
-                </View>
-              }
-              showDividerTop
-              canCopy={false}
-            />
-          </InfoCard>
-        </RowGroup>
+        <StatusBanner active={offline} message="No internet connection." />
+        <StatusBanner
+          active={indexerDown}
+          message="Can't reach indexer."
+          actionLabel="Reconnect"
+          onAction={handleReconnect}
+        />
 
-        <RowGroup title="Sync metadata" style={styles.groupSpacing}>
-          <InfoCard>
-            <LabeledValueRow
-              label="Remote down"
-              labelWidth={120}
-              value={
-                <View style={styles.valueRight}>
-                  <View style={{ flex: 1 }} />
-                  <Text style={styles.valueText}>{isSyncingDown ? 'Syncing...' : 'Synced'}</Text>
-                  <View style={isSyncingDown ? styles.dotSyncing : styles.dotOnline} />
-                </View>
-              }
-              align="right"
-              canCopy={false}
-            />
-            <LabeledValueRow
-              label="Local up"
-              labelWidth={120}
-              value={
-                <View style={styles.valueRight}>
-                  <View style={{ flex: 1 }} />
-                  <Text style={styles.valueText}>
-                    {isSyncingUpMetadata
-                      ? `${syncUpProcessed.toLocaleString()} / ${syncUpTotal.toLocaleString()}`
-                      : 'Synced'}
-                  </Text>
-                  <View style={isSyncingUpMetadata ? styles.dotSyncing : styles.dotOnline} />
-                </View>
-              }
-              align="right"
-              showDividerTop
-              canCopy={false}
-            />
-          </InfoCard>
-        </RowGroup>
-
-        <RowGroup title="Files" indicator={toggle} style={styles.groupSpacing}>
-          {displayMode === 'size' && (stats.data?.importingCount ?? 0) > 0 && (
-            <View style={styles.warningRow}>
-              <TriangleAlertIcon color={palette.yellow[400]} size={14} />
-              <Text style={styles.warningText}>
-                Sizes do not include {(stats.data?.importingCount ?? 0).toLocaleString()} file
-                {stats.data?.importingCount === 1 ? '' : 's'} pending import.
-              </Text>
-            </View>
-          )}
-          <RowSubGroup title="Library" style={styles.subGroupSpacing}>
-            <Text style={styles.sectionDesc}>All files tracked in the library.</Text>
-            <InfoCard>
-              <LabeledValueRow
-                label="Total"
-                labelStyle={styles.boldLabel}
-                labelWidth={120}
-                value={
-                  <View style={styles.valueRight}>
-                    <Text style={styles.valueText}>
-                      {`${(stats.data?.files.total ?? 0).toLocaleString()} files`}
-                    </Text>
-                  </View>
-                }
-                align="right"
-                canCopy={false}
-              />
-              {(stats.data?.importingCount ?? 0) > 0 && (
-                <LabeledValueRow
-                  label="Pending import"
-                  labelStyle={styles.indentedLabel}
-                  labelWidth={120}
-                  value={
-                    <View style={styles.valueRight}>
-                      <Text style={styles.valueText}>
-                        {`${(stats.data?.importingCount ?? 0).toLocaleString()} files`}
-                      </Text>
-                      <View style={styles.dotSyncing} />
-                    </View>
-                  }
-                  align="right"
-                  canCopy={false}
-                  showDividerTop
-                />
-              )}
-              {(importErrors.data ?? 0) > 0 && (
-                <Pressable onPress={() => openImportSettings('retrying')}>
-                  <LabeledValueRow
-                    label="Import errors"
-                    labelStyle={styles.indentedLabel}
-                    labelWidth={120}
-                    value={
-                      <View style={styles.valueRight}>
-                        <Text style={styles.valueText}>
-                          {`${(importErrors.data ?? 0).toLocaleString()} files`}
-                        </Text>
-                        <View style={styles.dotOffline} />
-                      </View>
-                    }
-                    align="right"
-                    canCopy={false}
-                    showDividerTop
-                  />
-                </Pressable>
-              )}
-            </InfoCard>
-          </RowSubGroup>
-          <RowSubGroup title="Sync" style={styles.subGroupSpacing}>
-            <Text style={styles.sectionDesc}>Upload progress across all files in the library.</Text>
-            {(batch.data?.count ?? 0) > 0 && (
-              <InfoCard>
-                <LabeledValueRow
-                  label="Active uploads"
-                  labelWidth={120}
-                  value={
-                    <View style={styles.valueRight}>
-                      <Text style={styles.valueText}>
-                        {displayMode === 'size'
-                          ? (humanSize(batch.data?.totalBytes ?? 0) ?? '0 B')
-                          : `${(batch.data?.count ?? 0).toLocaleString()} files`}
-                      </Text>
-                      <Text style={styles.valuePercent}>{batch.data?.percent}</Text>
-                      <View style={styles.dotSyncing} />
-                    </View>
-                  }
-                  align="right"
-                  canCopy={false}
-                />
-              </InfoCard>
-            )}
-            {(batch.data?.count ?? 0) > 0 && <View style={styles.networkGroupGap} />}
-            <InfoCard>
-              <LabeledValueRow
-                label="Files"
-                labelStyle={styles.boldLabel}
-                value={
-                  <View style={styles.valueRight}>
-                    <Text style={styles.valueText}>
-                      {formatCategoryValue(stats.data?.files, displayMode)}
-                    </Text>
-                    <Text style={styles.valuePercent}>
-                      {humanUploadPercent(
-                        stats.data?.files.percentDecimal,
-                        stats.data?.files.percent,
-                      )}
-                    </Text>
-                  </View>
-                }
-                align="right"
-                canCopy={false}
-              />
-              <LabeledValueRow
-                label="  Photos"
-                value={
-                  <View style={styles.valueRight}>
-                    <Text style={styles.valueText}>
-                      {formatCategoryValue(stats.data?.photos, displayMode)}
-                    </Text>
-                    <Text style={styles.valuePercent}>
-                      {humanUploadPercent(
-                        stats.data?.photos.percentDecimal,
-                        stats.data?.photos.percent,
-                      )}
-                    </Text>
-                  </View>
-                }
-                align="right"
-                canCopy={false}
-                showDividerTop
-              />
-              <LabeledValueRow
-                label="  Videos"
-                value={
-                  <View style={styles.valueRight}>
-                    <Text style={styles.valueText}>
-                      {formatCategoryValue(stats.data?.videos, displayMode)}
-                    </Text>
-                    <Text style={styles.valuePercent}>
-                      {humanUploadPercent(
-                        stats.data?.videos.percentDecimal,
-                        stats.data?.videos.percent,
-                      )}
-                    </Text>
-                  </View>
-                }
-                align="right"
-                canCopy={false}
-                showDividerTop
-              />
-              <LabeledValueRow
-                label="  Audio"
-                value={
-                  <View style={styles.valueRight}>
-                    <Text style={styles.valueText}>
-                      {formatCategoryValue(stats.data?.audio, displayMode)}
-                    </Text>
-                    <Text style={styles.valuePercent}>
-                      {humanUploadPercent(
-                        stats.data?.audio.percentDecimal,
-                        stats.data?.audio.percent,
-                      )}
-                    </Text>
-                  </View>
-                }
-                align="right"
-                canCopy={false}
-                showDividerTop
-              />
-              <LabeledValueRow
-                label="  Docs"
-                value={
-                  <View style={styles.valueRight}>
-                    <Text style={styles.valueText}>
-                      {formatCategoryValue(stats.data?.docs, displayMode)}
-                    </Text>
-                    <Text style={styles.valuePercent}>
-                      {humanUploadPercent(
-                        stats.data?.docs.percentDecimal,
-                        stats.data?.docs.percent,
-                      )}
-                    </Text>
-                  </View>
-                }
-                align="right"
-                canCopy={false}
-                showDividerTop
-              />
-              <LabeledValueRow
-                label="  Other"
-                value={
-                  <View style={styles.valueRight}>
-                    <Text style={styles.valueText}>
-                      {formatCategoryValue(stats.data?.other, displayMode)}
-                    </Text>
-                    <Text style={styles.valuePercent}>
-                      {humanUploadPercent(
-                        stats.data?.other.percentDecimal,
-                        stats.data?.other.percent,
-                      )}
-                    </Text>
-                  </View>
-                }
-                align="right"
-                canCopy={false}
-                showDividerTop
-              />
-            </InfoCard>
-            <View style={styles.networkGroupGap} />
-            <InfoCard>
-              <LabeledValueRow
-                label="Thumbnails"
-                value={
-                  <View style={styles.valueRight}>
-                    <Text style={styles.valueText}>
-                      {formatCategoryValue(stats.data?.thumbnails, displayMode)}
-                    </Text>
-                    <Text style={styles.valuePercent}>
-                      {humanUploadPercent(
-                        stats.data?.thumbnails.percentDecimal,
-                        stats.data?.thumbnails.percent,
-                      )}
-                    </Text>
-                  </View>
-                }
-                align="right"
-                canCopy={false}
-              />
-            </InfoCard>
-            <View style={styles.networkGroupGap} />
-            <InfoCard>
-              <LabeledValueRow
-                label="All"
-                value={
-                  <View style={styles.valueRight}>
-                    <Text style={styles.valueText}>
-                      {formatCategoryValue(stats.data?.overall, displayMode)}
-                    </Text>
-                    <Text style={styles.valuePercent}>
-                      {humanUploadPercent(
-                        stats.data?.overall.percentDecimal,
-                        stats.data?.overall.percent,
-                      )}
-                    </Text>
-                  </View>
-                }
-                align="right"
-                canCopy={false}
-              />
-            </InfoCard>
-          </RowSubGroup>
-          <RowSubGroup title="Device" style={styles.subGroupSpacing}>
-            <Text style={styles.sectionDesc}>Files cached on this device.</Text>
-            <InfoCard>
-              <LabeledValueRow
-                label="On device"
-                labelWidth={120}
-                value={
-                  <View style={styles.valueRight}>
-                    <Text style={styles.valueText}>
-                      {formatDeviceValue(onDevice.data, stats.data?.files, displayMode)}
-                    </Text>
-                    <Text style={styles.valuePercent}>
-                      {humanUploadPercent(devicePercent(onDevice.data, stats.data?.files))}
-                    </Text>
-                  </View>
-                }
-                align="right"
-                canCopy={false}
-              />
-              <LabeledValueRow
-                label="Pending backup"
-                labelWidth={120}
-                value={
-                  <View style={styles.valueRight}>
-                    <Text style={styles.valueText}>
-                      {formatDeviceValue(pendingBackup.data, stats.data?.files, displayMode)}
-                    </Text>
-                    <Text style={styles.valuePercent}>
-                      {humanUploadPercent(devicePercent(pendingBackup.data, stats.data?.files))}
-                    </Text>
-                  </View>
-                }
-                align="right"
-                canCopy={false}
-                showDividerTop
-              />
-              <Pressable onPress={() => openImportSettings('lost')}>
-                <LabeledValueRow
-                  label="Lost"
-                  labelWidth={120}
-                  value={
-                    <View style={styles.valueRight}>
-                      <Text style={styles.valueText}>
-                        {formatDeviceValue(lost.data, stats.data?.files, displayMode)}
-                      </Text>
-                      <Text style={styles.valuePercent}>
-                        {humanUploadPercent(devicePercent(lost.data, stats.data?.files))}
-                      </Text>
-                    </View>
-                  }
-                  align="right"
-                  canCopy={false}
-                  showDividerTop
-                />
+        <View style={styles.toolbar}>
+          <View style={styles.toggleTrack}>
+            {(['count', 'size'] as const).map((m) => (
+              <Pressable
+                key={m}
+                style={[styles.toggleSegment, mode === m && styles.toggleSegmentSelected]}
+                onPress={() => app().settings.setStatusDisplayMode(m)}
+              >
+                <Text style={[styles.toggleLabel, mode === m && styles.toggleLabelSelected]}>
+                  {m === 'count' ? 'Count' : 'Size'}
+                </Text>
               </Pressable>
-            </InfoCard>
-          </RowSubGroup>
-        </RowGroup>
+            ))}
+          </View>
+        </View>
+
+        <InsetGroupSection header="Library">
+          <InsetGroupValueRow label="Total" value={formatModeValue(mode, totalCount, totalBytes)} />
+          <InsetGroupValueRow
+            label="Available"
+            value={availableBytes !== undefined ? (humanSize(availableBytes) ?? '—') : '—'}
+          />
+          <InsetGroupValueRow
+            label="Storage limit"
+            value={humanLimit(account.data?.maxPinnedData)}
+          />
+          {importingCount > 0 ? (
+            <InsetGroupValueRow label="Pending import" value={formatCount(importingCount)} />
+          ) : null}
+          {importErrorCount > 0 ? (
+            <InsetGroupLink
+              label="Import errors"
+              onPress={() => openImportSettings('retrying')}
+              value={formatCount(importErrorCount)}
+            />
+          ) : null}
+        </InsetGroupSection>
+
+        {activeBatchCount > 0 ? (
+          <InsetGroupSection header="Active upload">
+            <InsetGroupValueRow
+              label="This batch"
+              value={
+                mode === 'count'
+                  ? formatCount(activeBatchCount)
+                  : formatSize(batch.data?.totalBytes)
+              }
+            />
+          </InsetGroupSection>
+        ) : null}
+
+        <InsetGroupSection
+          header="Upload progress"
+          footer="Upload progress across all files in the library."
+        >
+          {categories.map(([label, cat]) => {
+            const value = categoryValue(mode, cat)
+            if (!value) return null
+            return <InsetGroupValueRow key={label} label={label} value={value} />
+          })}
+        </InsetGroupSection>
+
+        <InsetGroupSection header="Device">
+          <InsetGroupValueRow
+            label="On device"
+            description="Files cached locally for instant access."
+            value={formatModeValue(mode, onDevice.data?.count ?? 0, onDevice.data?.totalBytes)}
+          />
+          <InsetGroupValueRow
+            label="Pending backup"
+            description="On this device but not yet uploaded."
+            value={formatModeValue(
+              mode,
+              pendingBackup.data?.count ?? 0,
+              pendingBackup.data?.totalBytes,
+            )}
+          />
+          <InsetGroupLink
+            label="Unavailable"
+            description="Files that were unavailable during import."
+            onPress={() => openImportSettings('lost')}
+            value={formatModeValue(mode, lost.data?.count ?? 0, lost.data?.totalBytes)}
+          />
+        </InsetGroupSection>
+
+        <InsetGroupSection
+          header="Sync metadata"
+          footer="Background metadata sync with other devices."
+        >
+          <InsetGroupValueRow label="Remote down" value={isSyncingDown ? 'Syncing…' : 'Synced'} />
+          <InsetGroupValueRow
+            label="Local up"
+            value={
+              isSyncingUpMetadata
+                ? `${syncUpProcessed.toLocaleString()} / ${syncUpTotal.toLocaleString()}`
+                : 'Synced'
+            }
+          />
+        </InsetGroupSection>
       </ScrollView>
     </ModalSheet>
   )
@@ -510,31 +254,15 @@ export function LibraryStatusSheet() {
 
 const styles = StyleSheet.create({
   scrollContent: {
-    paddingHorizontal: 12,
     paddingBottom: 48,
-    gap: 14,
   },
-  groupSpacing: { marginTop: 8 },
-  subGroupSpacing: { marginTop: 12 },
-  sectionDesc: {
-    color: palette.gray[400],
-    fontSize: 12,
-    marginBottom: 8,
-  },
-  warningRow: {
+  toolbar: {
     flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-    marginBottom: 8,
+    justifyContent: 'flex-end',
+    paddingHorizontal: 16,
+    paddingTop: 8,
+    paddingBottom: 16,
   },
-  warningText: {
-    color: palette.yellow[400],
-    fontSize: 12,
-    flex: 1,
-  },
-  networkGroupGap: { height: 8 },
-  boldLabel: { fontWeight: '700' },
-  indentedLabel: { paddingLeft: 12 },
   toggleTrack: {
     flexDirection: 'row',
     backgroundColor: whiteA.a08,
@@ -556,41 +284,5 @@ const styles = StyleSheet.create({
   },
   toggleLabelSelected: {
     color: palette.gray[50],
-  },
-  valueRight: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-    justifyContent: 'flex-end',
-    width: '100%',
-    flex: 1,
-  },
-  valueText: {
-    color: palette.gray[100],
-    fontFamily: Platform.select({ ios: 'Menlo', android: 'monospace' }),
-    fontSize: 13,
-  },
-  valuePercent: {
-    color: palette.gray[400],
-    fontFamily: Platform.select({ ios: 'Menlo', android: 'monospace' }),
-    fontSize: 13,
-  },
-  dotOnline: {
-    width: 8,
-    height: 8,
-    borderRadius: 4,
-    backgroundColor: palette.green[500],
-  },
-  dotOffline: {
-    width: 8,
-    height: 8,
-    borderRadius: 4,
-    backgroundColor: palette.red[500],
-  },
-  dotSyncing: {
-    width: 8,
-    height: 8,
-    borderRadius: 4,
-    backgroundColor: palette.yellow[400],
   },
 })

--- a/apps/mobile/src/components/StatusBanner.tsx
+++ b/apps/mobile/src/components/StatusBanner.tsx
@@ -1,0 +1,81 @@
+import { TriangleAlertIcon } from 'lucide-react-native'
+import { useEffect, useState } from 'react'
+import { Pressable, StyleSheet, Text, View } from 'react-native'
+import { colors, palette } from '../styles/colors'
+
+type Props = {
+  /**
+   * When true, the banner is scheduled to appear. Visibility is delayed by
+   * `appearDelayMs` so brief transient failures don't flash a banner.
+   */
+  active: boolean
+  message: string
+  actionLabel?: string
+  onAction?: () => void
+  appearDelayMs?: number
+}
+
+/**
+ * Attention banner, rendered at the top of a surface when a non-fatal
+ * issue needs the user's attention. Follows the iOS "iCloud: Sign-in
+ * required" pattern — silent when things are fine, visible with a clear
+ * message when something needs action.
+ */
+export function StatusBanner({
+  active,
+  message,
+  actionLabel,
+  onAction,
+  appearDelayMs = 3000,
+}: Props) {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    if (active) {
+      const id = setTimeout(() => setVisible(true), appearDelayMs)
+      return () => clearTimeout(id)
+    }
+    setVisible(false)
+    return undefined
+  }, [active, appearDelayMs])
+
+  if (!visible) return null
+
+  return (
+    <View style={styles.banner}>
+      <TriangleAlertIcon size={16} color={palette.yellow[400]} />
+      <Text style={styles.message}>{message}</Text>
+      {actionLabel && onAction ? (
+        <Pressable onPress={onAction} hitSlop={6}>
+          <Text style={styles.action}>{actionLabel}</Text>
+        </Pressable>
+      ) : null}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  banner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    marginHorizontal: 16,
+    marginBottom: 12,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    backgroundColor: colors.bgPanel,
+    borderLeftWidth: 3,
+    borderLeftColor: palette.yellow[400],
+    borderRadius: 8,
+  },
+  message: {
+    flex: 1,
+    color: palette.gray[100],
+    fontSize: 14,
+  },
+  action: {
+    color: palette.blue[400],
+    fontSize: 14,
+    fontWeight: '600',
+  },
+})

--- a/apps/mobile/src/screens/SettingsImportScreen.tsx
+++ b/apps/mobile/src/screens/SettingsImportScreen.tsx
@@ -118,8 +118,8 @@ function LostTab() {
 
   const removeAll = useCallback(() => {
     Alert.alert(
-      'Remove all lost files',
-      'This will permanently remove all lost files from this library. This cannot be undone. Continue?',
+      'Remove all unavailable files',
+      'This will permanently remove all unavailable files from this library. This cannot be undone. Continue?',
       [
         { text: 'Cancel', style: 'cancel' },
         {
@@ -154,7 +154,7 @@ function LostTab() {
   if (files.length === 0) {
     return (
       <View style={styles.empty}>
-        <Text style={styles.emptyText}>No lost files</Text>
+        <Text style={styles.emptyText}>No unavailable files</Text>
       </View>
     )
   }
@@ -162,7 +162,7 @@ function LostTab() {
   return (
     <View style={styles.flex}>
       <View style={styles.listHeader}>
-        <Text style={styles.listHeaderCount}>{files.length.toLocaleString()} lost</Text>
+        <Text style={styles.listHeaderCount}>{files.length.toLocaleString()} unavailable</Text>
         <Pressable onPress={removeAll}>
           <Text style={styles.removeAllText}>Remove all</Text>
         </Pressable>
@@ -209,7 +209,9 @@ export function SettingsImportScreen({ route }: Props) {
           style={[styles.tab, activeTab === 'lost' && styles.tabActive]}
           onPress={() => setActiveTab('lost')}
         >
-          <Text style={[styles.tabText, activeTab === 'lost' && styles.tabTextActive]}>Lost</Text>
+          <Text style={[styles.tabText, activeTab === 'lost' && styles.tabTextActive]}>
+            Unavailable
+          </Text>
         </Pressable>
       </View>
       {activeTab === 'retrying' ? <RetryingTab /> : <LostTab />}

--- a/apps/mobile/src/stores/settings.ts
+++ b/apps/mobile/src/stores/settings.ts
@@ -2,15 +2,7 @@ import { activateKeepAwakeAsync, deactivateKeepAwake } from 'expo-keep-awake'
 import useSWR from 'swr'
 import { app } from './appService'
 
-export type StatusDisplayMode = 'count' | 'size'
 export type ActiveLibraryTab = 'files' | 'tags' | 'media'
-
-export function useStatusDisplayMode() {
-  return useSWR(
-    app().caches.settings.key('statusDisplayMode'),
-    () => app().settings.getStatusDisplayMode() as Promise<StatusDisplayMode>,
-  )
-}
 
 export function useActiveLibraryTab() {
   return useSWR(


### PR DESCRIPTION
- This PR applies consistent menus and streamlines the data display in the app status sheet.

![Screenshot 2026-04-24 at 10.04.34.png](https://app.graphite.com/user-attachments/assets/61db1fe8-ce7c-4b7e-acc4-63172c2525d5.png)

