### PR TITLE
fix(mobile): keep auto-downloading when local copy is gone

### DIFF
--- a/.changeset/fix-auto-download-after-cache-evict.md
+++ b/.changeset/fix-auto-download-after-cache-evict.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Fixed an issue where files imported on this device could get stuck on "Press to download" after their local cache copy was evicted.

--- a/apps/mobile/src/hooks/useAutoDownload.ts
+++ b/apps/mobile/src/hooks/useAutoDownload.ts
@@ -36,7 +36,6 @@ export function useAutoDownload(
     if (!status.data.isUploaded) return
     if (status.data.isDownloaded) return
     if (status.data.isDownloading) return
-    if (file.localId) return
     if (!shouldDownload(file)) return
     download()
   }, [isInitializing, isConnected, status.data, download, file, shouldDownload])


### PR DESCRIPTION
- Removes the file.localId guard from useAutoDownload that skipped network downloads for files originally imported on this device. In this scenario local copy could be gone and we always want to download our cache copy either way.
- When the local copy has been evicted from cache (or the source is otherwise unreachable), the viewer had no URI to display and no download would fire, stranding the file on "Press to download" indefinitely. The remaining guards (isDownloaded, isDownloading, isUploaded) already correctly skip downloads when a local URI is present.
