### PR TITLE
refactor(core,mobile): add shares namespace to AppService facade

### DIFF
--- a/.changeset/shares-namespace.md
+++ b/.changeset/shares-namespace.md
@@ -1,0 +1,5 @@
+---
+core: minor
+---
+
+Add shares namespace to AppService facade for resolving, previewing, pinning, and creating share URLs.

--- a/apps/benchmark/src/main.ts
+++ b/apps/benchmark/src/main.ts
@@ -36,6 +36,9 @@ function createStubAppService(db: any) {
       async download() {
         throw new Error('not implemented')
       },
+      async downloadFromShareUrl() {
+        throw new Error('not implemented')
+      },
     },
     uploader: {
       calculateContentHash: async () => '',

--- a/apps/integration/test/adapters/upload.ts
+++ b/apps/integration/test/adapters/upload.ts
@@ -14,6 +14,8 @@ export function buildTestSdkAdapter(sdk: MockSdk, appKey: AppKeyRef): SdkAdapter
     getPinnedObject: (id) => sdk.getPinnedObject(id),
     sharedObject: (url) => sdk.sharedObject(url),
     shareObject: () => '',
+    openAppKey: (bytes) => sdk.openAppKey(bytes),
+    openPinnedObject: (key, object) => sdk.openPinnedObject(key, object),
     appKey: () => appKey,
     downloadByObjectId: (id) => sdk.downloadByObjectId(id),
     hosts: async () => [],

--- a/apps/mobile/src/adapters/sdk.ts
+++ b/apps/mobile/src/adapters/sdk.ts
@@ -11,6 +11,8 @@ import type {
   SdkAdapter,
   UploadOptions,
 } from '@siastorage/core/adapters'
+import type { LocalObject } from '@siastorage/core/encoding/localObject'
+import { AppKey, type AppKeyInterface, PinnedObject } from 'react-native-sia'
 import type { SdkInterface } from 'react-native-sia'
 
 export class MobileSdkAdapter implements SdkAdapter {
@@ -84,6 +86,14 @@ export class MobileSdkAdapter implements SdkAdapter {
 
   shareObject(object: PinnedObjectRef, validUntil: Date): string {
     return this.sdk.shareObject(object, validUntil)
+  }
+
+  openAppKey(bytes: Uint8Array): AppKeyRef {
+    return new AppKey(bytes.buffer as ArrayBuffer) as AppKeyRef
+  }
+
+  openPinnedObject(appKey: AppKeyRef, object: LocalObject): PinnedObjectRef {
+    return PinnedObject.open(appKey as AppKeyInterface, object) as PinnedObjectRef
   }
 
   appKey(): AppKeyRef {

--- a/packages/core/src/adapters/sdk.ts
+++ b/packages/core/src/adapters/sdk.ts
@@ -1,3 +1,4 @@
+import type { LocalObject } from '../encoding/localObject'
 import type { Reader } from './fs'
 
 export interface ObjectsCursor {
@@ -156,6 +157,10 @@ export interface SdkAdapter {
   getPinnedObject(objectId: string): Promise<PinnedObjectRef>
   sharedObject(url: string): Promise<PinnedObjectRef>
   shareObject(object: PinnedObjectRef, validUntil: Date): string
+  /** Reconstructs a live AppKeyRef from stored key bytes. */
+  openAppKey(bytes: Uint8Array): AppKeyRef
+  /** Reconstructs a live PinnedObjectRef from a stored LocalObject. */
+  openPinnedObject(appKey: AppKeyRef, object: LocalObject): PinnedObjectRef
   appKey(): AppKeyRef
   downloadByObjectId(objectId: string): Promise<ArrayBuffer>
   hosts(): Promise<Host[]>

--- a/packages/core/src/app/namespaces/db.ts
+++ b/packages/core/src/app/namespaces/db.ts
@@ -50,6 +50,7 @@ export function buildDbNamespaces(
   | 'sync'
   | 'uploads'
   | 'downloads'
+  | 'shares'
   | 'connection'
   | 'init'
   | 'uploader'

--- a/packages/core/src/app/namespaces/index.ts
+++ b/packages/core/src/app/namespaces/index.ts
@@ -15,6 +15,7 @@ import { buildAuthNamespace } from './auth'
 import { buildDbNamespaces } from './db'
 import { buildDownloadsNamespace, type DownloadObjectAdapter } from './downloads'
 import { buildSettingsNamespace } from './settings'
+import { buildSharesNamespace } from './shares'
 import { buildUploaderNamespace, initUploader } from './uploader'
 import { buildUploadsNamespace } from './uploads'
 
@@ -108,6 +109,16 @@ export function createAppService(adapters: AppServiceAdapters): AppServiceResult
     () => sdkRef,
   )
 
+  const settingsNamespace = buildSettingsNamespace(adapters.storage, caches)
+  const authNamespace = buildAuthNamespace(adapters.secrets, adapters.crypto, adapters.sdkAuth)
+
+  const sharesNamespace = buildSharesNamespace(
+    adapters.db,
+    () => sdkRef,
+    () => settingsNamespace.getIndexerURL(),
+    (indexerURL) => authNamespace.getAppKey(indexerURL),
+  )
+
   const service: AppService = {
     // PRAGMA optimize refreshes query planner stats for tables flagged as
     // having stale sqlite_stat*. WAL trimming is delegated to SQLite's own
@@ -123,7 +134,7 @@ export function createAppService(adapters: AppServiceAdapters): AppServiceResult
       thumbnail: adapters.thumbnail,
       detectMimeType: adapters.detectMimeType,
     }),
-    settings: buildSettingsNamespace(adapters.storage, caches),
+    settings: settingsNamespace,
     storage: {
       getItem: (k) => adapters.storage.getItem(k),
       setItem: (k, v) => adapters.storage.setItem(k, v),
@@ -134,7 +145,7 @@ export function createAppService(adapters: AppServiceAdapters): AppServiceResult
       setItem: (k, v) => adapters.secrets.setItem(k, v),
       deleteItem: (k) => adapters.secrets.deleteItem(k),
     },
-    auth: buildAuthNamespace(adapters.secrets, adapters.crypto, adapters.sdkAuth),
+    auth: authNamespace,
     sync: {
       getState: () => ({ ...syncState }),
       setState: (patch) => {
@@ -175,6 +186,7 @@ export function createAppService(adapters: AppServiceAdapters): AppServiceResult
     },
     uploads: uploadsNamespace,
     downloads: downloadsNamespace,
+    shares: sharesNamespace,
     connection: {
       getState: () => ({ ...connectionState }),
       setState: (patch) => {

--- a/packages/core/src/app/namespaces/shares.ts
+++ b/packages/core/src/app/namespaces/shares.ts
@@ -1,0 +1,84 @@
+import type { DatabaseAdapter } from '../../adapters/db'
+import type { SdkAdapter } from '../../adapters/sdk'
+import { DOWNLOAD_MAX_INFLIGHT } from '../../config'
+import * as ops from '../../db/operations'
+import { sealPinnedObject } from '../../lib/localObjects'
+import type { AppService } from '../service'
+
+export function buildSharesNamespace(
+  db: DatabaseAdapter,
+  getSdk: () => SdkAdapter | null,
+  getIndexerURL: () => Promise<string>,
+  getAppKeyBytes: (indexerURL: string) => Promise<Uint8Array | null>,
+): AppService['shares'] {
+  function requireSdk(): SdkAdapter {
+    const sdk = getSdk()
+    if (!sdk) throw new Error('SDK not initialized')
+    return sdk
+  }
+
+  async function loadAppKey(sdk: SdkAdapter, indexerURL: string) {
+    const bytes = await getAppKeyBytes(indexerURL)
+    if (!bytes) throw new Error(`No AppKey found for indexer: ${indexerURL}`)
+    return sdk.openAppKey(bytes)
+  }
+
+  return {
+    getMetadata: async (url) => {
+      const sdk = requireSdk()
+      const obj = await sdk.sharedObject(url)
+      return { size: Number(obj.size()) }
+    },
+
+    downloadFirstBytes: async (url, byteCount) => {
+      const sdk = requireSdk()
+      const obj = await sdk.sharedObject(url)
+      const dl = await sdk.download(obj, {
+        maxInflight: DOWNLOAD_MAX_INFLIGHT,
+        offset: BigInt(0),
+        length: BigInt(byteCount),
+      })
+      const chunks: Uint8Array[] = []
+      let total = 0
+      try {
+        while (total < byteCount) {
+          const chunk = await dl.read()
+          if (chunk.byteLength === 0) break
+          const buf = new Uint8Array(chunk)
+          chunks.push(buf)
+          total += buf.length
+        }
+      } finally {
+        await dl.cancel().catch(() => {})
+      }
+      const out = new Uint8Array(Math.min(total, byteCount))
+      let offset = 0
+      for (const chunk of chunks) {
+        const n = Math.min(chunk.length, byteCount - offset)
+        out.set(chunk.slice(0, n), offset)
+        offset += n
+        if (offset >= byteCount) break
+      }
+      return out
+    },
+
+    pin: async (url, fileId) => {
+      const sdk = requireSdk()
+      const indexerURL = await getIndexerURL()
+      const appKey = await loadAppKey(sdk, indexerURL)
+      const obj = await sdk.sharedObject(url)
+      await sdk.pinObject(obj)
+      return sealPinnedObject(fileId, indexerURL, obj, appKey)
+    },
+
+    create: async (fileId, validUntil) => {
+      const sdk = requireSdk()
+      const objects = await ops.queryObjectsForFile(db, fileId)
+      if (objects.length === 0) throw new Error('No local object for file')
+      const object = objects[0]
+      const appKey = await loadAppKey(sdk, object.indexerURL)
+      const pinned = sdk.openPinnedObject(appKey, object)
+      return sdk.shareObject(pinned, validUntil)
+    },
+  }
+}

--- a/packages/core/src/app/service.ts
+++ b/packages/core/src/app/service.ts
@@ -657,6 +657,17 @@ export interface AppService {
     /** Sets the maximum concurrent download slots and persists the value. */
     setMaxSlots(n: number): Promise<void>
   }
+  /** Share URL operations: resolve, preview, pin, and create share links. */
+  shares: {
+    /** Returns serializable metadata (size) for a share URL. */
+    getMetadata(url: string): Promise<{ size: number }>
+    /** Downloads the first N bytes of a shared object for MIME sniffing. */
+    downloadFirstBytes(url: string, byteCount: number): Promise<Uint8Array>
+    /** Pins a shared URL to the current indexer and returns the new local object. */
+    pin(url: string, fileId: string): Promise<LocalObject>
+    /** Creates a share URL for a file, valid until the given date. */
+    create(fileId: string, validUntil: Date): Promise<string>
+  }
   /** Connection state: tracks whether the app is connected to an indexer. */
   connection: {
     /** Returns the current connection state snapshot. */

--- a/packages/sdk-mock/src/index.ts
+++ b/packages/sdk-mock/src/index.ts
@@ -15,6 +15,7 @@ import type {
 } from '@siastorage/core/adapters'
 import { SECTOR_SIZE } from '@siastorage/core/config'
 import { decodeFileMetadata, encodeFileMetadata } from '@siastorage/core/encoding/fileMetadata'
+import type { LocalObject } from '@siastorage/core/encoding/localObject'
 import type { FileMetadata } from '@siastorage/core/types'
 
 export type StoredObject = {
@@ -338,6 +339,16 @@ export class MockSdk implements SdkAdapter {
 
   shareObject(_object: PinnedObjectRef, _validUntil: Date): string {
     return 'https://mock-share-url.com'
+  }
+
+  openAppKey(_bytes: Uint8Array): AppKeyRef {
+    return this.appKey()
+  }
+
+  openPinnedObject(_appKey: AppKeyRef, object: LocalObject): PinnedObjectRef {
+    const stored = this.storage.objects.get(object.id)
+    if (!stored) throw new Error(`Object not found: ${object.id}`)
+    return createMockPinnedObject(stored)
   }
 
   async hosts(): Promise<Host[]> {


### PR DESCRIPTION
- Hoists the share methods into the AppService with all other APIs. These methods were calling the SDK which should only occur inside the AppService. The next PR fixes a few issues with the share flow.
