### PR TITLE
refactor(core): replace buildActive*Filter helpers with buildRecordFilter

### DIFF
--- a/.changeset/record-filter-consolidation.md
+++ b/.changeset/record-filter-consolidation.md
@@ -1,0 +1,5 @@
+---
+core: patch
+---
+
+Consolidate active-record filter helpers into a single `buildRecordFilter` with explicit opt-in flags; no behavior change.

--- a/apps/integration/test/app.ts
+++ b/apps/integration/test/app.ts
@@ -454,7 +454,13 @@ export function createTestApp(
     },
 
     async getFiles() {
-      return appService.files.query({ order: 'ASC' })
+      return appService.files.query({
+        order: 'ASC',
+        includeThumbnails: true,
+        includeOldVersions: true,
+        includeTrashed: true,
+        includeDeleted: true,
+      })
     },
 
     async getFileById(id) {
@@ -462,13 +468,20 @@ export function createTestApp(
     },
 
     async waitForFileCount(count, timeout = 15_000) {
+      const queryOpts = {
+        order: 'ASC',
+        includeThumbnails: true,
+        includeOldVersions: true,
+        includeTrashed: true,
+        includeDeleted: true,
+      } as const
       const start = Date.now()
       while (Date.now() - start < timeout) {
-        const files = await appService.files.query({ order: 'ASC' })
+        const files = await appService.files.query(queryOpts)
         if (files.length === count) return
         await new Promise((r) => setTimeout(r, 50))
       }
-      const final = await appService.files.query({ order: 'ASC' })
+      const final = await appService.files.query(queryOpts)
       throw new Error(`Expected ${count} files but got ${final.length} within ${timeout}ms`)
     },
 
@@ -494,6 +507,10 @@ export function createTestApp(
             order: 'ASC',
             pinned: { indexerURL: INDEXER_URL, isPinned: false },
             fileExistsLocally: true,
+            includeThumbnails: true,
+            includeOldVersions: true,
+            includeTrashed: true,
+            includeDeleted: true,
           })
           return pending.length === 0
         },

--- a/apps/integration/test/trash-restore.test.ts
+++ b/apps/integration/test/trash-restore.test.ts
@@ -14,7 +14,7 @@ describe('Trash and Restore', () => {
   })
 
   async function getActiveFiles() {
-    return app.app.files.query({ order: 'ASC', activeOnly: true })
+    return app.app.files.query({ order: 'ASC', includeThumbnails: true, includeOldVersions: true })
   }
 
   it('trash excludes files from library queries', async () => {

--- a/apps/mobile/src/managers/importScanner.ts
+++ b/apps/mobile/src/managers/importScanner.ts
@@ -26,7 +26,8 @@ async function computeMaxDeferred(): Promise<number> {
     order: 'ASC',
     pinned: { indexerURL, isPinned: false },
     fileExistsLocally: true,
-    activeOnly: true,
+    includeThumbnails: true,
+    includeOldVersions: true,
     hashNotEmpty: true,
   })
   const maxDeferred =

--- a/apps/mobile/src/managers/thumbnailScanner.test.ts
+++ b/apps/mobile/src/managers/thumbnailScanner.test.ts
@@ -54,7 +54,16 @@ describe('thumbnailScanner', () => {
     getFsFileUriMock.mockResolvedValue(null)
     const result = await runThumbnailScanner()
     expect(result.skippedNoSource).toEqual([{ fileId: 'file1', hash: 'hash1' }])
-    expect(await app().files.queryCount({ limit: 100, order: 'ASC' })).toBe(1)
+    expect(
+      await app().files.queryCount({
+        limit: 100,
+        order: 'ASC',
+        includeThumbnails: true,
+        includeOldVersions: true,
+        includeTrashed: true,
+        includeDeleted: true,
+      }),
+    ).toBe(1)
   })
 
   it('skips files that already have all thumbnail sizes', async () => {
@@ -96,7 +105,16 @@ describe('thumbnailScanner', () => {
     expect(result.produced).toHaveLength(0)
     expect(result.attempts).toHaveLength(0)
     expect(result.skippedFullyCovered).toHaveLength(0)
-    expect(await app().files.queryCount({ limit: 100, order: 'ASC' })).toBe(3)
+    expect(
+      await app().files.queryCount({
+        limit: 100,
+        order: 'ASC',
+        includeThumbnails: true,
+        includeOldVersions: true,
+        includeTrashed: true,
+        includeDeleted: true,
+      }),
+    ).toBe(3)
   })
 
   it('generates a missing thumbnail (64px)', async () => {
@@ -143,7 +161,16 @@ describe('thumbnailScanner', () => {
     expect(producedSizes).toEqual([64])
     const sizes = await app().thumbnails.getSizesForFile('file1')
     expect(sizes).toEqual([...ThumbSizes].sort((a, b) => a - b))
-    expect(await app().files.queryCount({ limit: 100, order: 'ASC' })).toBe(3)
+    expect(
+      await app().files.queryCount({
+        limit: 100,
+        order: 'ASC',
+        includeThumbnails: true,
+        includeOldVersions: true,
+        includeTrashed: true,
+        includeDeleted: true,
+      }),
+    ).toBe(3)
   })
 
   it('pages past skipped candidates to find eligible originals', async () => {
@@ -271,7 +298,16 @@ describe('thumbnailScanner', () => {
     getFsFileUriMock.mockResolvedValue('file://test.jpg')
     const result = await runThumbnailScanner()
     expect(result.produced.filter((p) => p.size === 64)).toHaveLength(0)
-    expect(await app().files.queryCount({ limit: 100, order: 'ASC' })).toBe(3)
+    expect(
+      await app().files.queryCount({
+        limit: 100,
+        order: 'ASC',
+        includeThumbnails: true,
+        includeOldVersions: true,
+        includeTrashed: true,
+        includeDeleted: true,
+      }),
+    ).toBe(3)
   })
 
   it('generates thumbnails for video files using captured frames', async () => {

--- a/apps/mobile/src/stores/files.ts
+++ b/apps/mobile/src/stores/files.ts
@@ -26,7 +26,8 @@ export async function getFilesLocalOnly(params: {
       isPinned: false,
     },
     fileExistsLocally: true,
-    activeOnly: true,
+    includeThumbnails: true,
+    includeOldVersions: true,
   })
 }
 
@@ -69,7 +70,8 @@ export async function getFileCountLocal(params: { localOnly: boolean }) {
       isPinned: !params.localOnly,
     },
     fileExistsLocally: true,
-    activeOnly: true,
+    includeThumbnails: true,
+    includeOldVersions: true,
   })
 }
 
@@ -87,7 +89,8 @@ export async function getFileStatsLocal(params: { localOnly: boolean }) {
       isPinned: !params.localOnly,
     },
     fileExistsLocally: true,
-    activeOnly: true,
+    includeThumbnails: true,
+    includeOldVersions: true,
   })
 }
 

--- a/packages/core/src/db/operations/directories.ts
+++ b/packages/core/src/db/operations/directories.ts
@@ -4,7 +4,7 @@ import { uniqueId } from '../../lib/uniqueId'
 import type { FileRecordRow } from '../../types/files'
 import * as sql from '../sql'
 import { recalculateCurrentForGroup, recalculateCurrentForGroups } from './files'
-import { buildActiveFileFilter, buildActiveFilter } from './library'
+import { buildRecordFilter } from './library'
 import { trashFilesAndThumbnails } from './trash'
 
 export type Directory = {
@@ -202,7 +202,7 @@ export async function queryDirectoryChildren(
   if (parentPath === null) {
     rows = await db.getAllAsync<Row>(
       `SELECT d.id, d.path, d.createdAt,
-        (SELECT COUNT(*) FROM files f WHERE f.directoryId = d.id AND ${buildActiveFileFilter('f')}) as fileCount,
+        (SELECT COUNT(*) FROM files f WHERE f.directoryId = d.id AND ${buildRecordFilter('f')}) as fileCount,
         (SELECT COUNT(*) FROM directories c WHERE c.path LIKE ${sqlEscapeLike('d.path')} || '/%' ESCAPE '\\' AND c.path NOT LIKE ${sqlEscapeLike('d.path')} || '/%/%' ESCAPE '\\') as subdirectoryCount
        FROM directories d
        WHERE d.path NOT LIKE '%/%' ESCAPE '\\'
@@ -212,7 +212,7 @@ export async function queryDirectoryChildren(
     const escaped = escapeLikePattern(parentPath)
     rows = await db.getAllAsync<Row>(
       `SELECT d.id, d.path, d.createdAt,
-        (SELECT COUNT(*) FROM files f WHERE f.directoryId = d.id AND ${buildActiveFileFilter('f')}) as fileCount,
+        (SELECT COUNT(*) FROM files f WHERE f.directoryId = d.id AND ${buildRecordFilter('f')}) as fileCount,
         (SELECT COUNT(*) FROM directories c WHERE c.path LIKE ${sqlEscapeLike('d.path')} || '/%' ESCAPE '\\' AND c.path NOT LIKE ${sqlEscapeLike('d.path')} || '/%/%' ESCAPE '\\') as subdirectoryCount
        FROM directories d
        WHERE d.path LIKE ? || '/%' ESCAPE '\\' AND d.path NOT LIKE ? || '/%/%' ESCAPE '\\'
@@ -236,7 +236,7 @@ export async function queryAllDirectoriesWithCounts(
 
   const rows = await db.getAllAsync<Row>(
     `SELECT d.id, d.path, d.createdAt,
-      (SELECT COUNT(*) FROM files f WHERE f.directoryId = d.id AND ${buildActiveFileFilter('f')}) as fileCount,
+      (SELECT COUNT(*) FROM files f WHERE f.directoryId = d.id AND ${buildRecordFilter('f')}) as fileCount,
       (SELECT COUNT(*) FROM directories c WHERE c.path LIKE ${sqlEscapeLike('d.path')} || '/%' ESCAPE '\\' AND c.path NOT LIKE ${sqlEscapeLike('d.path')} || '/%/%' ESCAPE '\\') as subdirectoryCount
      FROM directories d
      ORDER BY d.nameSortKey`,
@@ -414,7 +414,7 @@ export async function deleteDirectoryAndTrashFiles(
     `SELECT f.id FROM files f
      INNER JOIN directories d ON f.directoryId = d.id
      WHERE (d.path = ? OR d.path LIKE ? || '/%' ESCAPE '\\')
-       AND f.kind = 'file' AND ${buildActiveFilter('f')}`,
+       AND f.kind = 'file' AND ${buildRecordFilter('f', { includeOldVersions: true })}`,
     [dir.path, escaped],
     500,
     async (rows) => {
@@ -441,7 +441,7 @@ export async function queryCountFilesWithDirectories(
   if (fileIds.length === 0) return 0
   const ph = fileIds.map(() => '?').join(',')
   const row = await db.getFirstAsync<{ count: number }>(
-    `SELECT COUNT(*) as count FROM files f WHERE f.id IN (${ph}) AND f.directoryId IS NOT NULL AND ${buildActiveFileFilter('f')}`,
+    `SELECT COUNT(*) as count FROM files f WHERE f.id IN (${ph}) AND f.directoryId IS NOT NULL AND ${buildRecordFilter('f')}`,
     ...fileIds,
   )
   return row?.count ?? 0
@@ -458,7 +458,7 @@ export async function queryFileByNameInDirectory(
             f.localId, f.hash, f.addedAt, f.thumbForId, f.thumbSize, f.trashedAt, f.deletedAt
      FROM files f
      INNER JOIN directories d ON f.directoryId = d.id
-     WHERE f.name = ? AND ${buildActiveFileFilter('f')}
+     WHERE f.name = ? AND ${buildRecordFilter('f')}
        AND d.path = ?
      ORDER BY f.updatedAt DESC, f.id DESC
      LIMIT 1`,
@@ -476,7 +476,7 @@ export async function queryFilesByDirectoryPath(
             f.localId, f.hash, f.addedAt, f.thumbForId, f.thumbSize, f.trashedAt, f.deletedAt
      FROM files f
      INNER JOIN directories d ON f.directoryId = d.id
-     WHERE d.path = ? AND ${buildActiveFileFilter('f')}
+     WHERE d.path = ? AND ${buildRecordFilter('f')}
      ORDER BY f.nameSortKey`,
     directoryPath,
   )

--- a/packages/core/src/db/operations/fileStats.ts
+++ b/packages/core/src/db/operations/fileStats.ts
@@ -1,5 +1,5 @@
 import type { DatabaseAdapter } from '../../adapters/db'
-import { buildActiveFileFilter, buildActiveFilter } from './library'
+import { buildRecordFilter } from './library'
 
 export type UploadCategoryStats = {
   total: number
@@ -89,7 +89,7 @@ export async function queryUploadStats(
 ): Promise<UploadStats> {
   // Include all active files. Importing files (hash = '') have size = 0,
   // so byte totals remain accurate while counts reflect the full library.
-  const activeFile = buildActiveFileFilter('f')
+  const activeFile = buildRecordFilter('f')
   const q = (where: string) => queryStatsForWhere(db, where, indexerURL)
 
   const [photos, videos, audio, docs, other, thumbnails, importingRow] = await Promise.all([
@@ -100,7 +100,9 @@ export async function queryUploadStats(
     q(
       `${activeFile} AND f.type NOT LIKE 'image/%' AND f.type NOT LIKE 'video/%' AND f.type NOT LIKE 'audio/%' AND f.type NOT LIKE 'text/%' AND f.type NOT LIKE 'application/%'`,
     ),
-    q(`f.kind = 'thumb' AND ${buildActiveFilter('f')}`),
+    q(
+      `f.kind = 'thumb' AND ${buildRecordFilter('f', { includeThumbnails: true, includeOldVersions: true })}`,
+    ),
     db.getFirstAsync<{ count: number }>(
       `SELECT COUNT(*) as count FROM files f WHERE ${activeFile} AND f.hash = ''`,
     ),

--- a/packages/core/src/db/operations/files.test.ts
+++ b/packages/core/src/db/operations/files.test.ts
@@ -365,13 +365,14 @@ describe('queryFiles', () => {
     expect(results[1].id).toBe('file-3')
   })
 
-  it('filters by activeOnly', async () => {
+  it('filters out trashed and deleted records', async () => {
     await insertFile(db(), makeFileRecord('active'))
     await insertFile(db(), makeFileRecord('trashed', { trashedAt: 2000 }))
     await insertFile(db(), makeFileRecord('deleted', { deletedAt: 3000 }))
     const results = await queryFiles(db(), {
       order: 'ASC',
-      activeOnly: true,
+      includeThumbnails: true,
+      includeOldVersions: true,
     })
     expect(results).toHaveLength(1)
     expect(results[0].id).toBe('active')
@@ -432,16 +433,23 @@ describe('queryFiles', () => {
     expect(results.map((r) => r.id)).toEqual(['f2', 'f3'])
   })
 
-  it('activeOnly excludes trashed separately from deleted', async () => {
+  it('excludes trashed separately from deleted', async () => {
     await insertFile(db(), makeFileRecord('active'))
     await insertFile(db(), makeFileRecord('trashed', { trashedAt: 2000 }))
     await insertFile(db(), makeFileRecord('deleted', { deletedAt: 3000, trashedAt: 3000 }))
     const active = await queryFiles(db(), {
       order: 'ASC',
-      activeOnly: true,
+      includeThumbnails: true,
+      includeOldVersions: true,
     })
     expect(active.map((r) => r.id)).toEqual(['active'])
-    const all = await queryFiles(db(), { order: 'ASC' })
+    const all = await queryFiles(db(), {
+      order: 'ASC',
+      includeThumbnails: true,
+      includeOldVersions: true,
+      includeTrashed: true,
+      includeDeleted: true,
+    })
     expect(all).toHaveLength(3)
   })
 })
@@ -471,7 +479,8 @@ describe('queryFileCount', () => {
     await insertFile(db(), makeFileRecord('f3', { trashedAt: 2000 }))
     const count = await queryFileCount(db(), {
       order: 'ASC',
-      activeOnly: true,
+      includeThumbnails: true,
+      includeOldVersions: true,
     })
     expect(count).toBe(2)
   })
@@ -479,7 +488,8 @@ describe('queryFileCount', () => {
   it('returns 0 when no records match', async () => {
     const count = await queryFileCount(db(), {
       order: 'ASC',
-      activeOnly: true,
+      includeThumbnails: true,
+      includeOldVersions: true,
     })
     expect(count).toBe(0)
   })
@@ -497,7 +507,8 @@ describe('queryFileStats', () => {
   it('returns zeros when no records match', async () => {
     const stats = await queryFileStats(db(), {
       order: 'ASC',
-      activeOnly: true,
+      includeThumbnails: true,
+      includeOldVersions: true,
     })
     expect(stats.count).toBe(0)
     expect(stats.totalBytes).toBe(0)

--- a/packages/core/src/db/operations/files.ts
+++ b/packages/core/src/db/operations/files.ts
@@ -5,7 +5,7 @@ import { localObjectRefFromStorageRow } from '../../encoding/localObject'
 import { naturalSortKey } from '../../lib/naturalSortKey'
 import type { FileRecord, FileRecordRow } from '../../types/files'
 import * as sql from '../sql'
-import { buildActiveFileFilter, buildActiveFilter } from './library'
+import { buildRecordFilter } from './library'
 import { insertObject, queryObjectRefsForFile, queryObjectsForFile } from './localObjects'
 import { trashFilesAndThumbnails } from './trash'
 
@@ -215,7 +215,14 @@ export type FileQueryOpts = {
   }
   fileExistsLocally?: boolean
   excludeIds?: string[]
-  activeOnly?: boolean
+  /** Include kind='thumb' rows. Default: only kind='file'. */
+  includeThumbnails?: boolean
+  /** Include superseded versions (current=0). Default: current version only. */
+  includeOldVersions?: boolean
+  /** Include trashed rows. Default: excluded. */
+  includeTrashed?: boolean
+  /** Include tombstoned rows. Default: excluded. */
+  includeDeleted?: boolean
   hashEmpty?: boolean
   hashNotEmpty?: boolean
 }
@@ -237,7 +244,10 @@ function buildFileRecordsQuery(
     orderBy,
     fileExistsLocally,
     excludeIds,
-    activeOnly,
+    includeThumbnails,
+    includeOldVersions,
+    includeTrashed,
+    includeDeleted,
     hashEmpty,
     hashNotEmpty,
   } = opts
@@ -245,12 +255,14 @@ function buildFileRecordsQuery(
 
   const params: (string | number)[] = []
 
-  const whereClauses: string[] = []
-
-  if (activeOnly) {
-    whereClauses.push(`${tableAlias}.trashedAt IS NULL`)
-    whereClauses.push(`${tableAlias}.deletedAt IS NULL`)
-  }
+  const whereClauses: string[] = [
+    buildRecordFilter(tableAlias, {
+      includeThumbnails,
+      includeOldVersions,
+      includeTrashed,
+      includeDeleted,
+    }),
+  ]
 
   if (hashEmpty) {
     whereClauses.push(`${tableAlias}.hash = ''`)
@@ -665,7 +677,8 @@ export async function queryLocalOnlyFiles(
     pinned: { indexerURL, isPinned: false },
     fileExistsLocally: true,
     excludeIds: opts.excludeIds,
-    activeOnly: true,
+    includeThumbnails: true,
+    includeOldVersions: true,
   })
 }
 
@@ -695,7 +708,7 @@ export async function updateFileWithLocalObject(
 export async function queryLostFileCount(db: DatabaseAdapter, indexerURL: string): Promise<number> {
   const row = await db.getFirstAsync<{ count: number }>(
     `SELECT COUNT(*) as count FROM files f
-     WHERE ${buildActiveFileFilter('f')}
+     WHERE ${buildRecordFilter('f')}
      AND (
        (NOT EXISTS (SELECT 1 FROM objects s WHERE s.fileId = f.id AND s.indexerURL = ?)
         AND NOT EXISTS (SELECT 1 FROM fs fsMeta WHERE fsMeta.fileId = f.id)
@@ -713,7 +726,7 @@ export async function queryLostFileStats(
 ): Promise<{ count: number; totalBytes: number }> {
   const row = await db.getFirstAsync<{ count: number; totalBytes: number }>(
     `SELECT COUNT(*) as count, COALESCE(SUM(size), 0) as totalBytes FROM files f
-     WHERE ${buildActiveFileFilter('f')}
+     WHERE ${buildRecordFilter('f')}
      AND (
        (NOT EXISTS (SELECT 1 FROM objects s WHERE s.fileId = f.id AND s.indexerURL = ?)
         AND NOT EXISTS (SELECT 1 FROM fs fsMeta WHERE fsMeta.fileId = f.id)
@@ -731,7 +744,7 @@ export async function queryLostFiles(
 ): Promise<FileRecordRow[]> {
   return db.getAllAsync<FileRecordRow>(
     `SELECT ${FILE_ROW_COLUMNS} FROM files f
-     WHERE ${buildActiveFileFilter('f')}
+     WHERE ${buildRecordFilter('f')}
      AND (
        f.lostReason IS NOT NULL
        OR (NOT EXISTS (SELECT 1 FROM objects s WHERE s.fileId = f.id AND s.indexerURL = ?)
@@ -752,7 +765,8 @@ export async function queryLocalFileCount(
     order: 'ASC',
     pinned: { indexerURL, isPinned: !localOnly },
     fileExistsLocally: true,
-    activeOnly: true,
+    includeThumbnails: true,
+    includeOldVersions: true,
   })
 }
 
@@ -765,7 +779,8 @@ export async function queryLocalFileStats(
     order: 'ASC',
     pinned: { indexerURL, isPinned: !localOnly },
     fileExistsLocally: true,
-    activeOnly: true,
+    includeThumbnails: true,
+    includeOldVersions: true,
   })
 }
 
@@ -954,7 +969,7 @@ export async function queryFileByName(
 ): Promise<FileRecordRow | null> {
   return db.getFirstAsync<FileRecordRow>(
     `SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize, trashedAt, deletedAt, lostReason
-     FROM files f WHERE f.name = ? AND ${buildActiveFileFilter('f')}
+     FROM files f WHERE f.name = ? AND ${buildRecordFilter('f')}
      ORDER BY f.updatedAt DESC, f.id DESC`,
     name,
   )
@@ -973,7 +988,7 @@ export async function readFileByName(
 export async function queryUnuploadedFileCount(db: DatabaseAdapter): Promise<number> {
   const row = await db.getFirstAsync<{ count: number }>(
     `SELECT COUNT(*) as count FROM files f
-     WHERE ${buildActiveFileFilter('f')}
+     WHERE ${buildRecordFilter('f')}
        AND NOT EXISTS (SELECT 1 FROM objects o WHERE o.fileId = f.id)`,
   )
   return row?.count ?? 0
@@ -989,7 +1004,7 @@ export async function queryUnuploadedFiles(
     size: number
   }>(
     `SELECT f.id, f.name, f.type, f.size FROM files f
-     WHERE ${buildActiveFileFilter('f')}
+     WHERE ${buildRecordFilter('f')}
        AND NOT EXISTS (SELECT 1 FROM objects o WHERE o.fileId = f.id)
      ORDER BY f.addedAt DESC`,
   )
@@ -1003,7 +1018,7 @@ export async function queryActiveFileSummaries(
     kind: string
     type: string
     size: number
-  }>(`SELECT f.id, f.kind, f.type, f.size FROM files f WHERE ${buildActiveFileFilter('f')}`)
+  }>(`SELECT f.id, f.kind, f.type, f.size FROM files f WHERE ${buildRecordFilter('f')}`)
 }
 
 export async function queryUploadedFileIds(
@@ -1024,7 +1039,7 @@ export async function deleteLostFilesAndThumbnails(
   return sql.processInBatches<{ id: string }>(
     db,
     `SELECT f.id FROM files f
-     WHERE f.kind = 'file' AND ${buildActiveFilter('f')}
+     WHERE f.kind = 'file' AND ${buildRecordFilter('f', { includeOldVersions: true })}
      AND (
        (NOT EXISTS (SELECT 1 FROM objects s WHERE s.fileId = f.id AND s.indexerURL = ?)
         AND NOT EXISTS (SELECT 1 FROM fs fsMeta WHERE fsMeta.fileId = f.id)

--- a/packages/core/src/db/operations/index.ts
+++ b/packages/core/src/db/operations/index.ts
@@ -97,9 +97,9 @@ export {
 } from './fs'
 export {
   ALL_CATEGORIES,
-  buildActiveFileFilter,
-  buildActiveFilter,
   buildLatestVersionFilter,
+  buildRecordFilter,
+  type RecordFilterOpts,
   buildLibraryQueryParts,
   type Category,
   type LibraryQueryParams,

--- a/packages/core/src/db/operations/library.test.ts
+++ b/packages/core/src/db/operations/library.test.ts
@@ -1,6 +1,7 @@
 import { insertFile } from './files'
 import {
   buildLibraryQueryParts,
+  buildRecordFilter,
   queryDirectoryFileCount,
   queryFileCountWithFilters,
   queryFilePositionInSortedList,
@@ -653,5 +654,69 @@ describe('querySortedFileIds', () => {
 
     const ids = await querySortedFileIds(db(), { sortBy: 'NAME', sortDir: 'DESC' }, 5, 0)
     expect(ids).toEqual(['f20', 'f10', 'f3', 'f2', 'f1'])
+  })
+})
+
+describe('buildRecordFilter', () => {
+  test('default: kind=file AND current=1, non-trashed, non-deleted', () => {
+    expect(buildRecordFilter('f')).toBe(
+      "f.kind = 'file' AND f.current = 1 AND f.trashedAt IS NULL AND f.deletedAt IS NULL",
+    )
+  })
+
+  test('includeTrashed drops trashedAt clause', () => {
+    expect(buildRecordFilter('f', { includeTrashed: true })).toBe(
+      "f.kind = 'file' AND f.current = 1 AND f.deletedAt IS NULL",
+    )
+  })
+
+  test('includeOldVersions alone drops current clause', () => {
+    expect(buildRecordFilter('f', { includeOldVersions: true })).toBe(
+      "f.kind = 'file' AND f.trashedAt IS NULL AND f.deletedAt IS NULL",
+    )
+  })
+
+  test('includeThumbnails + includeOldVersions: all rows, just trashed/deleted guarded', () => {
+    expect(buildRecordFilter('f', { includeThumbnails: true, includeOldVersions: true })).toBe(
+      'f.trashedAt IS NULL AND f.deletedAt IS NULL',
+    )
+  })
+
+  test('includeThumbnails alone: current files + thumbs of current, non-trashed, non-deleted originals', () => {
+    const filter = buildRecordFilter('f', { includeThumbnails: true })
+    expect(filter).toContain("f.kind = 'file' AND f.current = 1")
+    expect(filter).toContain("f.kind = 'thumb' AND EXISTS")
+    expect(filter).toContain(
+      'o.id = f.thumbForId AND o.current = 1 AND o.trashedAt IS NULL AND o.deletedAt IS NULL',
+    )
+    expect(filter).toContain('f.trashedAt IS NULL')
+    expect(filter).toContain('f.deletedAt IS NULL')
+  })
+
+  test('includeThumbnails + includeTrashed: thumbs of trashed originals also pass', () => {
+    const filter = buildRecordFilter('f', { includeThumbnails: true, includeTrashed: true })
+    expect(filter).toContain('o.id = f.thumbForId AND o.current = 1 AND o.deletedAt IS NULL')
+    expect(filter).not.toContain('o.trashedAt IS NULL')
+    expect(filter).not.toContain('f.trashedAt IS NULL')
+    expect(filter).toContain('f.deletedAt IS NULL')
+  })
+
+  test('includeThumbnails + includeDeleted: thumbs of deleted originals also pass', () => {
+    const filter = buildRecordFilter('f', { includeThumbnails: true, includeDeleted: true })
+    expect(filter).toContain('o.id = f.thumbForId AND o.current = 1 AND o.trashedAt IS NULL')
+    expect(filter).not.toContain('o.deletedAt IS NULL')
+    expect(filter).toContain('f.trashedAt IS NULL')
+    expect(filter).not.toContain('f.deletedAt IS NULL')
+  })
+
+  test('all include flags produce 1=1', () => {
+    expect(
+      buildRecordFilter('f', {
+        includeThumbnails: true,
+        includeOldVersions: true,
+        includeTrashed: true,
+        includeDeleted: true,
+      }),
+    ).toBe('1=1')
   })
 })

--- a/packages/core/src/db/operations/library.ts
+++ b/packages/core/src/db/operations/library.ts
@@ -24,21 +24,45 @@ export function buildLatestVersionFilter(alias: string): string {
   return `${alias}.current = 1`
 }
 
-/**
- * Filters to active, user-visible file records: non-trashed, non-deleted,
- * kind = 'file', latest version only. Do NOT use for thumbnail queries
- * (thumbnails don't maintain the `current` column).
- */
-export function buildActiveFileFilter(alias: string): string {
-  return `${alias}.kind = 'file' AND ${alias}.trashedAt IS NULL AND ${alias}.deletedAt IS NULL AND ${alias}.current = 1`
+export type RecordFilterOpts = {
+  /** Include kind='thumb' rows. Default: only kind='file'. */
+  includeThumbnails?: boolean
+  /** Include superseded file versions (current=0) and thumbnails whose original is superseded. Default: current only. */
+  includeOldVersions?: boolean
+  /** Include trashed rows (trashedAt IS NOT NULL). Default: excluded. */
+  includeTrashed?: boolean
+  /** Include tombstoned rows (deletedAt IS NOT NULL). Default: excluded. */
+  includeDeleted?: boolean
 }
 
 /**
- * Filters to non-trashed, non-deleted records of any kind.
- * Use for thumbnail queries or when kind/version filtering is handled separately.
+ * Canonical WHERE fragment for "visible library record".
+ * Default: kind='file' AND current=1 AND trashedAt IS NULL AND deletedAt IS NULL.
+ *
+ * Thumbnails don't carry `current` directly — their currency is inherited
+ * from their original via `thumbForId`. With `includeThumbnails: true` and
+ * `includeOldVersions: false` (default), only thumbs whose original is
+ * current=1 pass. `includeOldVersions: true` widens both files and thumbs
+ * to every version.
  */
-export function buildActiveFilter(alias: string): string {
-  return `${alias}.trashedAt IS NULL AND ${alias}.deletedAt IS NULL`
+export function buildRecordFilter(alias: string, opts: RecordFilterOpts = {}): string {
+  const clauses: string[] = []
+  if (!opts.includeThumbnails) clauses.push(`${alias}.kind = 'file'`)
+  if (!opts.includeOldVersions) {
+    if (opts.includeThumbnails) {
+      const originalClauses = [`o.id = ${alias}.thumbForId`, `o.current = 1`]
+      if (!opts.includeTrashed) originalClauses.push(`o.trashedAt IS NULL`)
+      if (!opts.includeDeleted) originalClauses.push(`o.deletedAt IS NULL`)
+      clauses.push(
+        `((${alias}.kind = 'file' AND ${alias}.current = 1) OR (${alias}.kind = 'thumb' AND EXISTS (SELECT 1 FROM files o WHERE ${originalClauses.join(' AND ')})))`,
+      )
+    } else {
+      clauses.push(`${alias}.current = 1`)
+    }
+  }
+  if (!opts.includeTrashed) clauses.push(`${alias}.trashedAt IS NULL`)
+  if (!opts.includeDeleted) clauses.push(`${alias}.deletedAt IS NULL`)
+  return clauses.length === 0 ? '1=1' : clauses.join(' AND ')
 }
 
 export function buildLibraryQueryParts(
@@ -75,7 +99,7 @@ export function buildLibraryQueryParts(
 
   const whereParts: string[] = []
   const params: (string | number)[] = []
-  whereParts.push(buildActiveFileFilter(tableAlias))
+  whereParts.push(buildRecordFilter(tableAlias))
 
   if (!allSelected && (mediaCategories.length > 0 || includesFiles)) {
     const categoryConditions: string[] = []
@@ -150,7 +174,7 @@ export type LibraryQueryParams = {
 
 export async function queryLibraryFileCount(db: DatabaseAdapter): Promise<number> {
   const row = await db.getFirstAsync<{ count: number }>(
-    `SELECT COUNT(*) as count FROM files f WHERE ${buildActiveFileFilter('f')}`,
+    `SELECT COUNT(*) as count FROM files f WHERE ${buildRecordFilter('f')}`,
   )
   return row?.count ?? 0
 }
@@ -158,7 +182,7 @@ export async function queryLibraryFileCount(db: DatabaseAdapter): Promise<number
 export async function queryMediaFileCount(db: DatabaseAdapter): Promise<number> {
   const row = await db.getFirstAsync<{ count: number }>(
     `SELECT COUNT(*) as count FROM files f
-     WHERE ${buildActiveFileFilter('f')}
+     WHERE ${buildRecordFilter('f')}
        AND (f.type LIKE 'image/%' OR f.type LIKE 'video/%' OR f.type LIKE 'audio/%')`,
   )
   return row?.count ?? 0
@@ -168,7 +192,7 @@ export async function queryTagFileCount(db: DatabaseAdapter, tagId: string): Pro
   const row = await db.getFirstAsync<{ count: number }>(
     `SELECT COUNT(*) as count FROM files f
      INNER JOIN file_tags ft ON ft.fileId = f.id
-     WHERE ft.tagId = ? AND ${buildActiveFileFilter('f')}`,
+     WHERE ft.tagId = ? AND ${buildRecordFilter('f')}`,
     tagId,
   )
   return row?.count ?? 0
@@ -183,7 +207,7 @@ export async function queryDirectoryFileCount(
   }
   const row = await db.getFirstAsync<{ count: number }>(
     `SELECT COUNT(*) as count FROM files f
-     WHERE f.directoryId = ? AND ${buildActiveFileFilter('f')}`,
+     WHERE f.directoryId = ? AND ${buildRecordFilter('f')}`,
     directoryId,
   )
   return row?.count ?? 0
@@ -192,7 +216,7 @@ export async function queryDirectoryFileCount(
 export async function queryUnfiledFileCount(db: DatabaseAdapter): Promise<number> {
   const row = await db.getFirstAsync<{ count: number }>(
     `SELECT COUNT(*) as count FROM files f
-     WHERE f.directoryId IS NULL AND ${buildActiveFileFilter('f')}`,
+     WHERE f.directoryId IS NULL AND ${buildRecordFilter('f')}`,
   )
   return row?.count ?? 0
 }

--- a/packages/core/src/db/operations/tags.ts
+++ b/packages/core/src/db/operations/tags.ts
@@ -1,7 +1,7 @@
 import type { DatabaseAdapter } from '../../adapters/db'
 import { uniqueId } from '../../lib/uniqueId'
 import * as sql from '../sql'
-import { buildActiveFileFilter } from './library'
+import { buildRecordFilter } from './library'
 
 export const SYSTEM_TAGS = {
   favorites: { id: 'sys:favorites', name: 'Favorites' },
@@ -112,7 +112,7 @@ export async function queryAllTagsWithCounts(db: DatabaseAdapter): Promise<TagWi
     `SELECT t.id, t.name, t.createdAt, t.usedAt, t.system, COUNT(f.id) as fileCount
      FROM tags t
      LEFT JOIN file_tags ft ON ft.tagId = t.id
-     LEFT JOIN files f ON f.id = ft.fileId AND ${buildActiveFileFilter('f')}
+     LEFT JOIN files f ON f.id = ft.fileId AND ${buildRecordFilter('f')}
      GROUP BY t.id
      ORDER BY t.system DESC, t.name`,
   )

--- a/packages/core/src/db/operations/thumbnails.ts
+++ b/packages/core/src/db/operations/thumbnails.ts
@@ -2,7 +2,7 @@ import type { DatabaseAdapter } from '../../adapters/db'
 import type { FileRecord, FileRecordRow, ThumbSize } from '../../types/files'
 import { ThumbSizes } from '../../types/files'
 import { transformRow } from './files'
-import { buildActiveFileFilter, buildActiveFilter } from './library'
+import { buildRecordFilter } from './library'
 import { queryObjectRefsForFile } from './localObjects'
 
 export type ThumbnailCandidateRow = {
@@ -124,7 +124,7 @@ export async function queryThumbnailCandidatePage(
       AND t.thumbSize IN (${ThumbSizes.join(',')})
      WHERE (f.type LIKE 'image/%' OR f.type LIKE 'video/%')
        AND f.type != 'image/tiff'
-       AND ${buildActiveFileFilter('f')}
+       AND ${buildRecordFilter('f')}
        AND f.hash != ''
        ${cursorClause}
      GROUP BY f.id
@@ -139,10 +139,10 @@ export async function queryThumbnailScanProgress(
   db: DatabaseAdapter,
 ): Promise<{ originals: number; thumbs: number }> {
   const originalsRow = await db.getFirstAsync<{ count: number }>(
-    `SELECT COUNT(*) as count FROM files f WHERE (f.type LIKE 'image/%' OR f.type LIKE 'video/%') AND ${buildActiveFileFilter('f')}`,
+    `SELECT COUNT(*) as count FROM files f WHERE (f.type LIKE 'image/%' OR f.type LIKE 'video/%') AND ${buildRecordFilter('f')}`,
   )
   const thumbsRow = await db.getFirstAsync<{ count: number }>(
-    `SELECT COUNT(*) as count FROM files f WHERE f.kind = 'thumb' AND ${buildActiveFilter('f')} AND f.thumbSize IN (${ThumbSizes.join(',')})`,
+    `SELECT COUNT(*) as count FROM files f WHERE f.kind = 'thumb' AND ${buildRecordFilter('f', { includeThumbnails: true, includeOldVersions: true })} AND f.thumbSize IN (${ThumbSizes.join(',')})`,
   )
   return {
     originals: originalsRow?.count ?? 0,

--- a/packages/core/src/services/importScanner.test.ts
+++ b/packages/core/src/services/importScanner.test.ts
@@ -28,7 +28,8 @@ function createMockApp(): MockHelper {
         const results: any[] = []
         for (const [, file] of fileRecords) {
           if (excludeSet.has(file.id)) continue
-          if (opts.activeOnly && (file.trashedAt || file.deletedAt)) continue
+          if (!opts.includeTrashed && file.trashedAt) continue
+          if (!opts.includeDeleted && file.deletedAt) continue
           if (opts.hashEmpty && file.hash !== '') continue
           if (opts.fileExistsLocally === true && !fsFiles.has(file.id)) continue
           if (opts.fileExistsLocally === false && fsFiles.has(file.id)) continue
@@ -174,7 +175,8 @@ describe('ImportScanner', () => {
         expect.objectContaining({
           hashEmpty: true,
           fileExistsLocally: true,
-          activeOnly: true,
+          includeThumbnails: true,
+          includeOldVersions: true,
         }),
       )
     })
@@ -252,7 +254,8 @@ describe('ImportScanner', () => {
         expect.objectContaining({
           hashEmpty: true,
           fileExistsLocally: false,
-          activeOnly: true,
+          includeThumbnails: true,
+          includeOldVersions: true,
         }),
       )
     })

--- a/packages/core/src/services/importScanner.ts
+++ b/packages/core/src/services/importScanner.ts
@@ -136,7 +136,8 @@ export class ImportScanner {
         const localCandidates = await app.files.query({
           hashEmpty: true,
           fileExistsLocally: true,
-          activeOnly: true,
+          includeThumbnails: true,
+          includeOldVersions: true,
           limit: MAX_PER_TICK,
           order: 'DESC',
           orderBy: 'addedAt',
@@ -206,7 +207,8 @@ export class ImportScanner {
         const deferredCandidates = await app.files.query({
           hashEmpty: true,
           fileExistsLocally: false,
-          activeOnly: true,
+          includeThumbnails: true,
+          includeOldVersions: true,
           limit: deferredLimit,
           order: 'DESC',
           orderBy: 'addedAt',

--- a/packages/core/src/services/syncUpMetadata.ts
+++ b/packages/core/src/services/syncUpMetadata.ts
@@ -101,6 +101,10 @@ export async function syncUpMetadataBatch(
           id: after.id,
         }
       : undefined,
+    includeThumbnails: true,
+    includeOldVersions: true,
+    includeTrashed: true,
+    includeDeleted: true,
   })
   if (batch.length === 0) {
     logger.debug('syncUpMetadata', 'no_updates')
@@ -117,6 +121,10 @@ export async function syncUpMetadataBatch(
       orderBy: 'updatedAt',
       pinned: { indexerURL, isPinned: true },
       after: after ? { value: after.updatedAt, id: after.id } : undefined,
+      includeThumbnails: true,
+      includeOldVersions: true,
+      includeTrashed: true,
+      includeDeleted: true,
     }
     const total = await app.files.queryCount(queryOpts)
     app.sync.setState({

--- a/packages/core/src/services/uploader.ts
+++ b/packages/core/src/services/uploader.ts
@@ -884,7 +884,8 @@ export class UploadManager {
         fileExistsLocally: true,
         hashNotEmpty: true,
         excludeIds: activeIds.length > 0 ? activeIds : undefined,
-        activeOnly: true,
+        includeThumbnails: true,
+        includeOldVersions: true,
       })
 
       const newEntries: FileEntry[] = []

--- a/packages/core/src/stores/files.ts
+++ b/packages/core/src/stores/files.ts
@@ -15,7 +15,8 @@ export function useFileCountAll() {
       limit: undefined,
       after: undefined,
       order: 'ASC',
-      activeOnly: true,
+      includeThumbnails: true,
+      includeOldVersions: true,
     }),
   )
 }
@@ -28,7 +29,8 @@ export function useFileStatsAll() {
       limit: undefined,
       after: undefined,
       order: 'ASC',
-      activeOnly: true,
+      includeThumbnails: true,
+      includeOldVersions: true,
     }),
   )
 }


### PR DESCRIPTION
Three near-identical query helpers (`buildActiveFileFilter`, `buildActiveFilter`) collapse into one `buildRecordFilter` with explicit opt-in flags (`includeThumbnails`, `includeOldVersions`, `includeTrashed`, `includeDeleted`) that widen the filter from its default.

The new default is "visible library record" — `kind='file' AND current=1 AND trashedAt IS NULL AND deletedAt IS NULL` — which is narrower than the previous unfiltered default. Every existing caller has been updated to pass the flags needed to preserve its prior behavior, so there is no functional change. This sets the table for the eviction passes downstream that need finer-grained control over what counts as visible.