### PR TITLE
feat(mobile): add developer setting to clear local file cache

### DIFF
--- a/.changeset/settings-clear-cache.md
+++ b/.changeset/settings-clear-cache.md
@@ -1,0 +1,5 @@
+---
+mobile: minor
+---
+
+Added a developer setting to clear the local file cache.

--- a/apps/mobile/src/components/SettingsAdvancedInfo.tsx
+++ b/apps/mobile/src/components/SettingsAdvancedInfo.tsx
@@ -3,6 +3,9 @@ import { useShowAdvanced } from '@siastorage/core/stores'
 import { Alert } from 'react-native'
 import Share from 'react-native-share'
 import { database } from '../db'
+import { humanSize } from '../lib/humanSize'
+import { runFsEvictionScanner } from '../managers/fsEvictionScanner'
+import { runFsOrphanScanner } from '../managers/fsOrphanScanner'
 import type { MenuStackParamList } from '../stacks/types'
 import { app } from '../stores/appService'
 import { InsetGroupLink, InsetGroupSection, InsetGroupToggleRow } from './InsetGroup'
@@ -25,6 +28,33 @@ export function SettingsAdvancedInfo(_props: Props) {
     }
   }
 
+  const handleClearLocalFiles = async () => {
+    const cached = await app().fs.calcTotalSize()
+    Alert.alert(
+      'Clear local files',
+      `Removes up to ${humanSize(cached) ?? '0 B'} of files from this device. Files that aren't backed up yet are kept.`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Clear',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              const before = await app().fs.calcTotalSize()
+              await runFsOrphanScanner({ force: true })
+              await runFsEvictionScanner({ force: true })
+              const after = await app().fs.calcTotalSize()
+              const freed = Math.max(0, before - after)
+              Alert.alert('Local files cleared', `Freed ${humanSize(freed) ?? '0 B'}.`)
+            } catch (e: unknown) {
+              Alert.alert('Error', String(e))
+            }
+          },
+        },
+      ],
+    )
+  }
+
   return (
     <>
       <InsetGroupSection
@@ -43,6 +73,13 @@ export function SettingsAdvancedInfo(_props: Props) {
           description="Saves the app's SQLite database file for debugging."
           onPress={handleExportDatabase}
           showChevron={false}
+        />
+        <InsetGroupLink
+          label="Clear local files"
+          description="Removes files on this device that are already backed up. Files that aren't backed up yet are kept."
+          onPress={handleClearLocalFiles}
+          showChevron={false}
+          destructive
         />
       </InsetGroupSection>
     </>

--- a/apps/mobile/src/managers/fsEvictionScanner.test.ts
+++ b/apps/mobile/src/managers/fsEvictionScanner.test.ts
@@ -78,6 +78,22 @@ describe('fsEvictionScanner', () => {
     expect(await app().fs.readMeta('file-t')).toBeNull()
   })
 
+  it('force bypasses the throttle check', async () => {
+    await createRemoteFile({
+      id: 'file-x',
+      size: 200,
+      usedAt: now - daysInMs(1000),
+    })
+    await app().storage.setItem('fsEvictionLastRun', String(now - 1_000))
+
+    const skipped = await runFsEvictionScanner()
+    expect(skipped).toBeUndefined()
+
+    const forced = await runFsEvictionScanner({ force: true })
+    expect(forced).toBeDefined()
+    expect(Number(await app().storage.getItem('fsEvictionLastRun'))).toBe(now)
+  })
+
   it('evicts oldest remote files until under limit', async () => {
     // Keep
     await createLocalOnlyFile({

--- a/apps/mobile/src/managers/fsEvictionScanner.ts
+++ b/apps/mobile/src/managers/fsEvictionScanner.ts
@@ -14,12 +14,14 @@ const flight = new SingleInit()
  * - Only evict a specific file if it is older than FS_EVICTABLE_MIN_AGE.
  */
 export async function runFsEvictionScanner(
-  opts: { signal?: AbortSignal } = {},
+  opts: { force?: boolean; signal?: AbortSignal } = {},
 ): Promise<CacheEvictionResult | undefined> {
-  const lastRun = await app().settings.getFsEvictionLastRun()
-  if (Date.now() - lastRun < FS_EVICTION_FREQUENCY) {
-    logger.debug('fsEvictionScanner', 'skipped', { reason: 'too_recent' })
-    return
+  if (!opts.force) {
+    const lastRun = await app().settings.getFsEvictionLastRun()
+    if (Date.now() - lastRun < FS_EVICTION_FREQUENCY) {
+      logger.debug('fsEvictionScanner', 'skipped', { reason: 'too_recent' })
+      return
+    }
   }
   return flight.run(async () => {
     try {

--- a/apps/mobile/src/managers/fsOrphanScanner.test.ts
+++ b/apps/mobile/src/managers/fsOrphanScanner.test.ts
@@ -36,6 +36,15 @@ describe('fsOrphanScanner', () => {
     expect(result).toBeUndefined()
   })
 
+  it('force bypasses the throttle check', async () => {
+    await app().storage.setItem('fsOrphanLastRun', String(now - FS_ORPHAN_FREQUENCY / 2))
+
+    await runFsOrphanScanner({ force: true })
+
+    expect(listFilesSpy).toHaveBeenCalled()
+    expect(Number(await app().storage.getItem('fsOrphanLastRun'))).toBe(now)
+  })
+
   it('records timestamp even when there are no files', async () => {
     const result = await runFsOrphanScanner()
 

--- a/apps/mobile/src/managers/fsOrphanScanner.ts
+++ b/apps/mobile/src/managers/fsOrphanScanner.ts
@@ -16,11 +16,14 @@ const flight = new SingleInit()
  */
 export async function runFsOrphanScanner(options?: {
   onProgress?: (removed: number, total: number) => void
+  force?: boolean
 }): Promise<OrphanScannerResult | undefined> {
-  const lastRun = await app().settings.getFsOrphanLastRun()
-  if (Date.now() - lastRun < FS_ORPHAN_FREQUENCY) {
-    logger.debug('fsOrphanScanner', 'skipped', { reason: 'too_recent' })
-    return
+  if (!options?.force) {
+    const lastRun = await app().settings.getFsOrphanLastRun()
+    if (Date.now() - lastRun < FS_ORPHAN_FREQUENCY) {
+      logger.debug('fsOrphanScanner', 'skipped', { reason: 'too_recent' })
+      return
+    }
   }
   return flight.run(async () => {
     try {


### PR DESCRIPTION
Adds a "Clear local files" action under Settings → Advanced. Removes everything that's already backed up; files not yet uploaded are kept. Useful when a tester needs to reclaim space or verify on-demand re-download.
