### PR TITLE
fix(core,mobile): stats count current thumbs only, excluding orphans

### DIFF
--- a/.changeset/stats-current-thumbs-only.md
+++ b/.changeset/stats-current-thumbs-only.md
@@ -1,0 +1,6 @@
+---
+core: patch
+mobile: patch
+---
+
+Library and device stat counts now match the visible library, excluding superseded file versions and thumbnails of files no longer in the library.

--- a/apps/mobile/src/stores/files.ts
+++ b/apps/mobile/src/stores/files.ts
@@ -71,7 +71,6 @@ export async function getFileCountLocal(params: { localOnly: boolean }) {
     },
     fileExistsLocally: true,
     includeThumbnails: true,
-    includeOldVersions: true,
   })
 }
 
@@ -90,7 +89,6 @@ export async function getFileStatsLocal(params: { localOnly: boolean }) {
     },
     fileExistsLocally: true,
     includeThumbnails: true,
-    includeOldVersions: true,
   })
 }
 

--- a/packages/core/src/db/operations/fileStats.ts
+++ b/packages/core/src/db/operations/fileStats.ts
@@ -100,9 +100,7 @@ export async function queryUploadStats(
     q(
       `${activeFile} AND f.type NOT LIKE 'image/%' AND f.type NOT LIKE 'video/%' AND f.type NOT LIKE 'audio/%' AND f.type NOT LIKE 'text/%' AND f.type NOT LIKE 'application/%'`,
     ),
-    q(
-      `f.kind = 'thumb' AND ${buildRecordFilter('f', { includeThumbnails: true, includeOldVersions: true })}`,
-    ),
+    q(`f.kind = 'thumb' AND ${buildRecordFilter('f', { includeThumbnails: true })}`),
     db.getFirstAsync<{ count: number }>(
       `SELECT COUNT(*) as count FROM files f WHERE ${activeFile} AND f.hash = ''`,
     ),

--- a/packages/core/src/stores/files.ts
+++ b/packages/core/src/stores/files.ts
@@ -16,7 +16,6 @@ export function useFileCountAll() {
       after: undefined,
       order: 'ASC',
       includeThumbnails: true,
-      includeOldVersions: true,
     }),
   )
 }
@@ -30,7 +29,6 @@ export function useFileStatsAll() {
       after: undefined,
       order: 'ASC',
       includeThumbnails: true,
-      includeOldVersions: true,
     }),
   )
 }


### PR DESCRIPTION
Library and device stat counts were including superseded versions and orphaned thumbnails, so the numbers users saw didn't match the library they could see. Now stats count only the current set, matching the visible library.
