### PR TITLE
feat(core): make imported files evictable as soon as they're uploaded

### DIFF
--- a/.changeset/imported-files-evict-promptly.md
+++ b/.changeset/imported-files-evict-promptly.md
@@ -1,0 +1,5 @@
+---
+core: minor
+---
+
+Imported files are evictable from the local cache as soon as they're uploaded, instead of after the standard 1-day LRU grace.

--- a/packages/core/src/app/namespaces/db.ts
+++ b/packages/core/src/app/namespaces/db.ts
@@ -83,14 +83,14 @@ export function buildDbNamespaces(
     findOrphanedFileIds: (fileIds) => ops.queryOrphanedFileIds(db, fileIds),
     getFileUri: (file) => getFsFileUri(db, file, fsIO),
     removeFile,
-    copyFile: async (file, sourceUri) => {
+    copyFile: async (file, sourceUri, opts) => {
       const result = await fsIO.copy(file, sourceUri)
       const previous = await ops.readFsMeta(db, file.id)
       await ops.upsertFsMeta(db, {
         fileId: file.id,
         size: result.size,
         addedAt: previous?.addedAt ?? Date.now(),
-        usedAt: Date.now(),
+        usedAt: opts?.usedAt ?? Date.now(),
       })
       return result.uri
     },

--- a/packages/core/src/app/service.ts
+++ b/packages/core/src/app/service.ts
@@ -412,7 +412,11 @@ export interface AppService {
     /** Removes a local file from disk. */
     removeFile(file: { id: string; type: string }): Promise<void>
     /** Copies a file from the source URI into managed storage; returns the new URI. */
-    copyFile(file: { id: string; type: string }, sourceUri: string): Promise<string>
+    copyFile(
+      file: { id: string; type: string },
+      sourceUri: string,
+      opts?: { usedAt?: number },
+    ): Promise<string>
     /** Writes file data to managed storage, computes hash, and upserts metadata. */
     writeFileData(
       file: { id: string; type: string },

--- a/packages/core/src/services/importScanner.test.ts
+++ b/packages/core/src/services/importScanner.test.ts
@@ -199,6 +199,7 @@ describe('ImportScanner', () => {
       expect(mock.app.fs.copyFile).toHaveBeenCalledWith(
         { id: 'f4', type: 'image/jpeg' },
         'file:///photo.jpg',
+        { usedAt: 0 },
       )
     })
 

--- a/packages/core/src/services/importScanner.ts
+++ b/packages/core/src/services/importScanner.ts
@@ -257,7 +257,10 @@ export class ImportScanner {
               try {
                 // Exit early on suspension before starting file copy + hash.
                 if (signal?.aborted) break
-                const uri = await app.fs.copyFile({ id: file.id, type: file.type }, resolved.uri)
+                // usedAt: 0 — imported files are evictable as soon as they're uploaded.
+                const uri = await app.fs.copyFile({ id: file.id, type: file.type }, resolved.uri, {
+                  usedAt: 0,
+                })
                 if (signal?.aborted) break
                 const outcome = await this.hashExistingFile(file, uri)
                 if (outcome.action === 'finalized') {


### PR DESCRIPTION
Imported files used to wait the full 1-day LRU grace window before becoming eligible for cache eviction, even after they had successfully uploaded to the indexer. Now they're evictable as soon as the upload completes — they can always be re-fetched, so holding the local copy is just consuming space.
