### PR TITLE
feat(mobile): run cache eviction on resume from suspension

### DIFF
--- a/.changeset/eviction-on-resume.md
+++ b/.changeset/eviction-on-resume.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Cache eviction now runs when the app resumes from suspension, in addition to cold launch and background fetch.

--- a/apps/mobile/src/managers/fsEvictionScanner.test.ts
+++ b/apps/mobile/src/managers/fsEvictionScanner.test.ts
@@ -3,7 +3,7 @@ import type { LocalObject } from '@siastorage/core/encoding/localObject'
 import type { FileRecord } from '@siastorage/core/types'
 import { initializeDB, resetDb } from '../db'
 import { app } from '../stores/appService'
-import { runFsEvictionScanner } from './fsEvictionScanner'
+import { cancelFsEvictionScanner, runFsEvictionScanner } from './fsEvictionScanner'
 
 jest.mock('@siastorage/core/config', () => {
   const { daysInMs } = jest.requireActual('@siastorage/core')
@@ -92,6 +92,29 @@ describe('fsEvictionScanner', () => {
     const forced = await runFsEvictionScanner({ force: true })
     expect(forced).toBeDefined()
     expect(Number(await app().storage.getItem('fsEvictionLastRun'))).toBe(now)
+  })
+
+  it('does not advance lastRun when aborted mid-scan', async () => {
+    await createRemoteFile({
+      id: 'file-abort',
+      size: 2_000,
+      usedAt: now - daysInMs(1000),
+    })
+
+    const trashedSpy = jest
+      .spyOn(app().fs, 'trashedCachedFiles')
+      .mockImplementationOnce(async () => {
+        cancelFsEvictionScanner()
+        return []
+      })
+
+    try {
+      const result = await runFsEvictionScanner()
+      expect(result).toBeDefined()
+      expect(Number(await app().storage.getItem('fsEvictionLastRun'))).toBe(0)
+    } finally {
+      trashedSpy.mockRestore()
+    }
   })
 
   it('evicts oldest remote files until under limit', async () => {

--- a/apps/mobile/src/managers/fsEvictionScanner.ts
+++ b/apps/mobile/src/managers/fsEvictionScanner.ts
@@ -6,6 +6,12 @@ import { logger } from '@siastorage/logger'
 import { app } from '../stores/appService'
 
 const flight = new SingleInit()
+let activeController: AbortController | null = null
+
+/** Aborts an in-flight eviction run. No-op if nothing is running. */
+export function cancelFsEvictionScanner(): void {
+  activeController?.abort()
+}
 
 /**
  * fsEvictionScanner evicts stale files from the file system under the following rules:
@@ -24,13 +30,25 @@ export async function runFsEvictionScanner(
     }
   }
   return flight.run(async () => {
+    activeController = new AbortController()
+    const onExternalAbort = () => activeController?.abort()
+    opts.signal?.addEventListener('abort', onExternalAbort)
     try {
-      const result = await runCacheEviction(app(), undefined, opts.signal)
-      await app().settings.setFsEvictionLastRun(Date.now())
+      const result = await runCacheEviction(app(), undefined, activeController.signal)
+      // Don't advance lastRun on abort — the scan didn't complete, so the
+      // throttle gate should let the next attempt through instead of skipping it.
+      if (activeController.signal.aborted) {
+        logger.debug('fsEvictionScanner', 'aborted', { lastRunAdvanced: false })
+      } else {
+        await app().settings.setFsEvictionLastRun(Date.now())
+      }
       return result
     } catch (error) {
       logger.error('fsEvictionScanner', 'scan_error', { error: error as Error })
       return undefined
+    } finally {
+      opts.signal?.removeEventListener('abort', onExternalAbort)
+      activeController = null
     }
   })
 }

--- a/apps/mobile/src/managers/suspension.ts
+++ b/apps/mobile/src/managers/suspension.ts
@@ -23,6 +23,7 @@ import {
 import { setSWREnabled } from '../lib/swr'
 import { app } from '../stores/appService'
 import { resumeLogger } from '../stores/logs'
+import { cancelFsEvictionScanner, runFsEvictionScanner } from './fsEvictionScanner'
 import { isArchiveWalkActive, pauseArchiveSync, resumeArchiveSync } from './syncPhotosArchive'
 import { getUploadManager } from './uploader'
 
@@ -95,6 +96,7 @@ const manager = createSuspensionManager({
       // (an independent loop not driven by the service scheduler, so it
       // keeps issuing catalogAssets writes otherwise).
       app().downloads.cancelAll()
+      cancelFsEvictionScanner()
       pauseArchiveSync()
     },
     onAfterResume: () => {
@@ -109,6 +111,9 @@ const manager = createSuspensionManager({
       void swrGlobalMutate(() => true)
       // Resume archive walk from the same cursor if it wasn't complete.
       void resumeArchiveSync()
+      // Eviction's frequency gate short-circuits when it ran recently, so a
+      // quick app-switch is cheap; a long suspension triggers a real pass.
+      void runFsEvictionScanner()
     },
   },
   hardDeadlineMs: HARD_DEADLINE_MS,


### PR DESCRIPTION
Cache eviction previously ran on cold launch and background fetch, which meant a long foreground session could keep accumulating without a sweep. Now it also runs when the app resumes from suspension, so eviction happens proportional to actual use.
