### PR TITLE
feat(core,mobile): make orphan scanner abortable for clean suspension drain

### DIFF
--- a/.changeset/abortable-orphan-scanner.md
+++ b/.changeset/abortable-orphan-scanner.md
@@ -1,0 +1,5 @@
+---
+core: minor
+---
+
+`runOrphanScanner` now accepts an `AbortSignal` and checks it between batches and between rows, so iOS suspension can drain the loop cleanly before the DB gate closes.

--- a/apps/mobile/src/managers/backgroundTasks.ts
+++ b/apps/mobile/src/managers/backgroundTasks.ts
@@ -307,7 +307,7 @@ async function runBackgroundWork(config: TaskConfig, state: TaskState) {
   // Skip one-shot scanners if the app is foregrounded — startup already
   // runs these. The upload polling loop below still runs regardless.
   if (AppState.currentState !== 'active') {
-    await runFsOrphanScanner()
+    await runFsOrphanScanner({ signal })
     if (signal.aborted) return
     await runFsEvictionScanner({ signal })
     if (signal.aborted) return

--- a/apps/mobile/src/managers/fsOrphanScanner.test.ts
+++ b/apps/mobile/src/managers/fsOrphanScanner.test.ts
@@ -1,7 +1,7 @@
 import { FS_ORPHAN_FREQUENCY } from '@siastorage/core/config'
 import { initializeDB, resetDb } from '../db'
 import { app } from '../stores/appService'
-import { runFsOrphanScanner } from './fsOrphanScanner'
+import { cancelFsOrphanScanner, runFsOrphanScanner } from './fsOrphanScanner'
 
 let listFilesSpy: jest.SpyInstance
 let removeFileSpy: jest.SpyInstance
@@ -205,6 +205,22 @@ describe('fsOrphanScanner', () => {
     const result = await runFsOrphanScanner()
 
     expect(result).toEqual({ removed: 60 })
+  })
+
+  it('does not advance lastRun when aborted mid-scan', async () => {
+    listFilesSpy.mockResolvedValue(['orphan-1.jpg'])
+    const findSpy = jest.spyOn(app().fs, 'findOrphanedFileIds').mockImplementationOnce(async () => {
+      cancelFsOrphanScanner()
+      return new Set<string>()
+    })
+
+    try {
+      const result = await runFsOrphanScanner()
+      expect(result).toEqual({ removed: 0 })
+      expect(Number(await app().storage.getItem('fsOrphanLastRun'))).toBe(0)
+    } finally {
+      findSpy.mockRestore()
+    }
   })
 
   it('coalesces concurrent calls into a single scan', async () => {

--- a/apps/mobile/src/managers/fsOrphanScanner.ts
+++ b/apps/mobile/src/managers/fsOrphanScanner.ts
@@ -7,6 +7,12 @@ import { app } from '../stores/appService'
 import { fsFileUriCache } from '../stores/fs'
 
 const flight = new SingleInit()
+let activeController: AbortController | null = null
+
+/** Aborts an in-flight orphan scan. No-op if nothing is running. */
+export function cancelFsOrphanScanner(): void {
+  activeController?.abort()
+}
 
 /**
  * fsOrphanScanner scans the file system for files that are not indexed in the database.
@@ -17,6 +23,7 @@ const flight = new SingleInit()
 export async function runFsOrphanScanner(options?: {
   onProgress?: (removed: number, total: number) => void
   force?: boolean
+  signal?: AbortSignal
 }): Promise<OrphanScannerResult | undefined> {
   if (!options?.force) {
     const lastRun = await app().settings.getFsOrphanLastRun()
@@ -26,14 +33,26 @@ export async function runFsOrphanScanner(options?: {
     }
   }
   return flight.run(async () => {
+    activeController = new AbortController()
+    const onExternalAbort = () => activeController?.abort()
+    options?.signal?.addEventListener('abort', onExternalAbort)
     try {
-      const result = await runOrphanScanner(app(), options?.onProgress)
+      const result = await runOrphanScanner(app(), options?.onProgress, activeController.signal)
       fsFileUriCache.invalidateAll()
-      await app().settings.setFsOrphanLastRun(Date.now())
+      // Don't advance lastRun on abort — the scan didn't complete, so the
+      // throttle gate should let the next attempt through instead of skipping it.
+      if (activeController.signal.aborted) {
+        logger.debug('fsOrphanScanner', 'aborted', { lastRunAdvanced: false })
+      } else {
+        await app().settings.setFsOrphanLastRun(Date.now())
+      }
       return result
     } catch (error) {
       logger.error('fsOrphanScanner', 'scan_error', { error: error as Error })
       return undefined
+    } finally {
+      options?.signal?.removeEventListener('abort', onExternalAbort)
+      activeController = null
     }
   })
 }

--- a/apps/mobile/src/managers/suspension.ts
+++ b/apps/mobile/src/managers/suspension.ts
@@ -24,6 +24,7 @@ import { setSWREnabled } from '../lib/swr'
 import { app } from '../stores/appService'
 import { resumeLogger } from '../stores/logs'
 import { cancelFsEvictionScanner, runFsEvictionScanner } from './fsEvictionScanner'
+import { cancelFsOrphanScanner } from './fsOrphanScanner'
 import { isArchiveWalkActive, pauseArchiveSync, resumeArchiveSync } from './syncPhotosArchive'
 import { getUploadManager } from './uploader'
 
@@ -97,6 +98,7 @@ const manager = createSuspensionManager({
       // keeps issuing catalogAssets writes otherwise).
       app().downloads.cancelAll()
       cancelFsEvictionScanner()
+      cancelFsOrphanScanner()
       pauseArchiveSync()
     },
     onAfterResume: () => {

--- a/packages/core/src/services/orphanScanner.ts
+++ b/packages/core/src/services/orphanScanner.ts
@@ -19,10 +19,16 @@ function extractFileIdFromName(name: string): string | null {
  * Scans the local file system for files not indexed in the database and deletes them.
  * Files may be orphaned from a different account, previous app version, or interrupted operations.
  * Processes in batches, yielding to the event loop between each.
+ *
+ * Suspension signal policy: accepts AbortSignal. DB + disk write loop —
+ * removes orphaned files and metadata in batches. Checks the signal at
+ * the batch boundary and per-row so a mid-scan abort releases promptly
+ * before the DB gate closes.
  */
 export async function runOrphanScanner(
   app: AppService,
   onProgress?: (removed: number, total: number) => void,
+  signal?: AbortSignal,
 ): Promise<OrphanScannerResult | undefined> {
   const files = await app.fs.listFiles()
   if (files.length === 0) return undefined
@@ -30,6 +36,7 @@ export async function runOrphanScanner(
   let removed = 0
 
   for (let i = 0; i < files.length; i += BATCH_SIZE) {
+    if (signal?.aborted) break
     const batch = files.slice(i, i + BATCH_SIZE)
 
     const entries = batch
@@ -39,6 +46,7 @@ export async function runOrphanScanner(
     const orphanedIds = await app.fs.findOrphanedFileIds(entries.map((e) => e.fileId))
 
     for (const entry of entries) {
+      if (signal?.aborted) break
       if (!orphanedIds.has(entry.fileId)) continue
       try {
         const type = getMimeTypeFromExtension(entry.name) ?? 'application/octet-stream'
@@ -64,6 +72,7 @@ export async function runOrphanScanner(
   logger.info('orphanScanner', 'summary', {
     removed,
     total: files.length,
+    aborted: signal?.aborted ?? false,
   })
   return { removed }
 }


### PR DESCRIPTION
runOrphanScanner now accepts an AbortSignal and checks it between batches and between rows. With the signal in place the suspension manager can drain the scanner cleanly before closing the database. When run frequently both fs scanners are unlikely to take much time to run, but this makes them fully consistent with our general abort pattern.
