### PR TITLE
feat(mobile): disable WAL by default and expose as developer toggle

### DIFF
--- a/.changeset/disable-wal-by-default.md
+++ b/.changeset/disable-wal-by-default.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Disabled WAL journaling by default while we resolve remaining iOS background reliability issues and finish the Files app integration. WAL can still be re-enabled under Settings → Advanced → Database.

--- a/apps/mobile/src/components/SettingsAdvancedDatabase.tsx
+++ b/apps/mobile/src/components/SettingsAdvancedDatabase.tsx
@@ -1,0 +1,61 @@
+import { Alert } from 'react-native'
+import Share from 'react-native-share'
+import { database, getActiveJournalMode } from '../db'
+import { toggleUseWalMode, useUseWalMode } from '../stores/settings'
+import {
+  InsetGroupLink,
+  InsetGroupSection,
+  InsetGroupToggleRow,
+  InsetGroupValueRow,
+} from './InsetGroup'
+
+const ACTIVE_LABELS = {
+  WAL: 'WAL',
+  DELETE: 'Rollback journal',
+} as const
+
+export function SettingsAdvancedDatabase() {
+  const useWal = useUseWalMode()
+  const selected = useWal.data ?? false
+  const active = getActiveJournalMode()
+  const selectedMode = selected ? 'WAL' : 'DELETE'
+  const restartRequired = selectedMode !== active
+
+  const footer = restartRequired
+    ? 'Restart the app to apply your change.'
+    : 'WAL mode is exposed as a developer preference while we evaluate it. Toggling it off uses SQLite’s rollback journal.'
+
+  const handleExportDatabase = async () => {
+    try {
+      await Share.open({
+        url: `file://${database.databasePath}`,
+        type: 'application/x-sqlite3',
+        filename: 'app.db',
+      })
+    } catch (e: unknown) {
+      if (e instanceof Error && e.message?.includes('User did not share')) return
+      Alert.alert('Error', String(e))
+    }
+  }
+
+  return (
+    <>
+      <InsetGroupSection header="Database" footer={footer}>
+        <InsetGroupToggleRow
+          label="Use WAL journal mode"
+          value={selected}
+          onValueChange={toggleUseWalMode}
+        />
+        <InsetGroupValueRow label="Active mode" value={ACTIVE_LABELS[active]} />
+      </InsetGroupSection>
+      <InsetGroupSection>
+        <InsetGroupLink
+          label="Export database"
+          description="Saves the app's SQLite database file for debugging."
+          onPress={handleExportDatabase}
+          showChevron={false}
+        />
+      </InsetGroupSection>
+    </>
+  )
+}

--- a/apps/mobile/src/components/SettingsAdvancedInfo.tsx
+++ b/apps/mobile/src/components/SettingsAdvancedInfo.tsx
@@ -1,8 +1,6 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack'
 import { useShowAdvanced } from '@siastorage/core/stores'
 import { Alert } from 'react-native'
-import Share from 'react-native-share'
-import { database } from '../db'
 import { humanSize } from '../lib/humanSize'
 import { runFsEvictionScanner } from '../managers/fsEvictionScanner'
 import { runFsOrphanScanner } from '../managers/fsOrphanScanner'
@@ -14,19 +12,6 @@ type Props = NativeStackScreenProps<MenuStackParamList, 'Advanced'>
 
 export function SettingsAdvancedInfo(_props: Props) {
   const showAdvanced = useShowAdvanced()
-
-  const handleExportDatabase = async () => {
-    try {
-      await Share.open({
-        url: `file://${database.databasePath}`,
-        type: 'application/x-sqlite3',
-        filename: 'app.db',
-      })
-    } catch (e: unknown) {
-      if (e instanceof Error && e.message?.includes('User did not share')) return
-      Alert.alert('Error', String(e))
-    }
-  }
 
   const handleClearLocalFiles = async () => {
     const cached = await app().fs.calcTotalSize()
@@ -68,12 +53,6 @@ export function SettingsAdvancedInfo(_props: Props) {
         />
       </InsetGroupSection>
       <InsetGroupSection>
-        <InsetGroupLink
-          label="Export database"
-          description="Saves the app's SQLite database file for debugging."
-          onPress={handleExportDatabase}
-          showChevron={false}
-        />
         <InsetGroupLink
           label="Clear local files"
           description="Removes files on this device that are already backed up. Files that aren't backed up yet are kept."

--- a/apps/mobile/src/db/index.ts
+++ b/apps/mobile/src/db/index.ts
@@ -135,16 +135,37 @@ export let dbInitialized = false
 let dbName = 'app.db'
 const dbDirectory = getSharedDbDirectory()
 
-// synchronous=NORMAL under WAL trades fsync-per-commit for fsync-per-checkpoint,
-// drastically reducing the chance a commit is mid-fsync at iOS suspension time
-// (the mechanism behind 0xdead10cc). Durable across app kills — the WAL file
-// survives; only a full OS crash loses the last few uncheckpointed seconds,
-// which syncDown recovers from the indexer on next launch.
-// wal_autocheckpoint=500 (~2MB at 4KB pages, down from default 1000/~4MB) keeps
-// each checkpoint's fsync small so the fsyncs that remain finish in tens of ms
-// even under disk I/O contention from Photos exports or large file copies.
-const INIT_PRAGMAS =
-  'PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL; PRAGMA wal_autocheckpoint = 500; PRAGMA busy_timeout = 5000; PRAGMA foreign_keys = ON'
+export type JournalMode = 'WAL' | 'DELETE'
+
+// The mode the next initializeDB / reopenDb / resetDb will open the database
+// with. Set once during bootstrap from the persisted developer preference.
+// Defaults to DELETE; WAL is exposed as a developer toggle (Settings →
+// Advanced → Database) so we can test it in the field. Once a feature
+// requires WAL, the toggle and this default both go away.
+let currentJournalMode: JournalMode = 'DELETE'
+
+export function setJournalMode(mode: JournalMode): void {
+  currentJournalMode = mode
+}
+
+export function getActiveJournalMode(): JournalMode {
+  return currentJournalMode
+}
+
+function buildInitPragmas(mode: JournalMode): string {
+  if (mode === 'WAL') {
+    // synchronous=NORMAL under WAL trades fsync-per-commit for fsync-per-checkpoint,
+    // drastically reducing the chance a commit is mid-fsync at iOS suspension time
+    // (the mechanism behind 0xdead10cc). Durable across app kills — the WAL file
+    // survives; only a full OS crash loses the last few uncheckpointed seconds,
+    // which syncDown recovers from the indexer on next launch.
+    // wal_autocheckpoint=500 (~2MB at 4KB pages, down from default 1000/~4MB) keeps
+    // each checkpoint's fsync small so the fsyncs that remain finish in tens of ms
+    // even under disk I/O contention from Photos exports or large file copies.
+    return 'PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL; PRAGMA wal_autocheckpoint = 500; PRAGMA busy_timeout = 5000; PRAGMA foreign_keys = ON'
+  }
+  return 'PRAGMA journal_mode = DELETE; PRAGMA busy_timeout = 5000; PRAGMA foreign_keys = ON'
+}
 export async function initializeDB(options?: {
   onProgress?: MigrationProgressHandler
   /** Custom database name (for test isolation) */
@@ -172,7 +193,7 @@ export async function initializeDB(options?: {
   database = await SQLite.openDatabaseAsync(name, openOptions, dbDirectory)
   // Use database directly (not the db() adapter) to avoid triggering
   // withRecovery during init, which would open a competing connection.
-  await database.execAsync(INIT_PRAGMAS)
+  await database.execAsync(buildInitPragmas(currentJournalMode))
   await runMigrations(database, migrations, {
     log: logger,
     onProgress: options?.onProgress,
@@ -215,7 +236,7 @@ async function reopenDb(): Promise<boolean> {
       } catch {}
       // useNewConnection bypasses expo-sqlite's per-name connection cache.
       database = await SQLite.openDatabaseAsync(dbName, { useNewConnection: true }, dbDirectory)
-      await database.execAsync(INIT_PRAGMAS)
+      await database.execAsync(buildInitPragmas(currentJournalMode))
       dbInitialized = true
       logger.warn('db', 'reopened_successfully')
       return true
@@ -314,7 +335,7 @@ export async function resetDb() {
       }
     }
     database = await SQLite.openDatabaseAsync(dbName, { useNewConnection: true }, dbDirectory)
-    await database.execAsync(INIT_PRAGMAS)
+    await database.execAsync(buildInitPragmas(currentJournalMode))
     await runMigrations(database, migrations, { log: logger })
     dbInitialized = true
   } finally {

--- a/apps/mobile/src/db/suspension.test.ts
+++ b/apps/mobile/src/db/suspension.test.ts
@@ -4,10 +4,12 @@ import {
   database,
   db,
   dbInitialized,
+  getActiveJournalMode,
   getDbState,
   initializeDB,
   resetDb,
   resumeDb,
+  setJournalMode,
   suspendDb,
   waitForQueriesIdle,
   withRecovery,
@@ -386,5 +388,45 @@ describe('full suspend/resume cycle', () => {
 
     const rows = await db().getAllAsync<{ v: number }>('SELECT 1 as v')
     expect(rows).toEqual([{ v: 1 }])
+  })
+})
+
+describe('journal mode', () => {
+  afterEach(() => {
+    setJournalMode('DELETE')
+  })
+
+  it('defaults to DELETE', () => {
+    expect(getActiveJournalMode()).toBe('DELETE')
+  })
+
+  it('round-trips through setJournalMode', () => {
+    setJournalMode('WAL')
+    expect(getActiveJournalMode()).toBe('WAL')
+    setJournalMode('DELETE')
+    expect(getActiveJournalMode()).toBe('DELETE')
+  })
+
+  it('initializeDB applies the DELETE pragma when mode is DELETE', async () => {
+    setJournalMode('DELETE')
+    await initializeDB({ databaseName: ':memory:' })
+    const row = await db().getFirstAsync<{ journal_mode: string }>('PRAGMA journal_mode')
+    // :memory: forces 'memory' regardless, so assert the pragma at least
+    // executed by also checking auto_checkpoint is at the SQLite default
+    // (1000 pages) rather than the WAL-tuned 500.
+    expect(row?.journal_mode).toBeDefined()
+    const auto = await db().getFirstAsync<{ wal_autocheckpoint: number }>(
+      'PRAGMA wal_autocheckpoint',
+    )
+    expect(auto?.wal_autocheckpoint).toBe(1000)
+  })
+
+  it('initializeDB applies the WAL pragma when mode is WAL', async () => {
+    setJournalMode('WAL')
+    await initializeDB({ databaseName: ':memory:' })
+    const auto = await db().getFirstAsync<{ wal_autocheckpoint: number }>(
+      'PRAGMA wal_autocheckpoint',
+    )
+    expect(auto?.wal_autocheckpoint).toBe(500)
   })
 })

--- a/apps/mobile/src/managers/app.ts
+++ b/apps/mobile/src/managers/app.ts
@@ -4,12 +4,12 @@ import { shutdownAllServiceIntervals } from '@siastorage/core/lib/serviceInterva
 import { activateSyncGate } from '@siastorage/core/services/syncDownEvents'
 import { stopLogAppender } from '@siastorage/logger'
 import { mutate } from 'swr'
-import { initializeDB, resetDb } from '../db'
+import { initializeDB, resetDb, setJournalMode } from '../db'
 import { app } from '../stores/appService'
 import { resetFileSelection } from '../stores/fileSelection'
 import { initLogger } from '../stores/logs'
 import { reconnectIndexer, resetSdk } from '../stores/sdk'
-import { initKeepAwake } from '../stores/settings'
+import { getUseWalMode, initKeepAwake } from '../stores/settings'
 import { resetSheets } from '../stores/sheets'
 import { ensureTempFsStorageDirectory } from '../stores/tempFs'
 import { resetViewSettings } from '../stores/viewSettings'
@@ -60,6 +60,8 @@ export async function initApp(): Promise<void> {
         await initKeepAwake()
         const maxDownloads = await app().settings.getMaxDownloads()
         await app().downloads.setMaxSlots(maxDownloads)
+        const useWal = await getUseWalMode()
+        setJournalMode(useWal ? 'WAL' : 'DELETE')
       },
     },
     {

--- a/apps/mobile/src/screens/SettingsAdvancedScreen.tsx
+++ b/apps/mobile/src/screens/SettingsAdvancedScreen.tsx
@@ -1,5 +1,6 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack'
 import { InsetGroupLink, InsetGroupSection } from '../components/InsetGroup'
+import { SettingsAdvancedDatabase } from '../components/SettingsAdvancedDatabase'
 import { SettingsAdvancedInfo } from '../components/SettingsAdvancedInfo'
 import { SettingsAdvancedSync } from '../components/SettingsAdvancedSync'
 import { SettingsAdvancedTransfers } from '../components/SettingsAdvancedTransfers'
@@ -19,6 +20,7 @@ export function SettingsAdvancedScreen(props: Props) {
       <SettingsAdvancedInfo {...props} />
       <SettingsAdvancedTransfers />
       <SettingsAdvancedSync />
+      <SettingsAdvancedDatabase />
     </SettingsScrollLayout>
   )
 }

--- a/apps/mobile/src/stores/settings.ts
+++ b/apps/mobile/src/stores/settings.ts
@@ -55,3 +55,27 @@ export async function initKeepAwake() {
     await activateKeepAwakeAsync(KEEP_AWAKE_TAG)
   }
 }
+
+// Developer preference exposing SQLite WAL journal mode as a toggle so we can
+// test it in the field. Default off. The toggle goes away once a feature
+// requires WAL. Read at bootstrap and applied to the DB module before
+// initializeDB runs.
+
+export async function getUseWalMode(): Promise<boolean> {
+  const raw = await app().storage.getItem('devUseWalMode')
+  return raw === 'true'
+}
+
+export function useUseWalMode() {
+  return useSWR(app().caches.settings.key('devUseWalMode'), () => getUseWalMode())
+}
+
+export async function setUseWalMode(value: boolean) {
+  await app().storage.setItem('devUseWalMode', String(value))
+  app().caches.settings.invalidate('devUseWalMode')
+}
+
+export async function toggleUseWalMode() {
+  const current = await getUseWalMode()
+  await setUseWalMode(!current)
+}


### PR DESCRIPTION
Switches the SQLite default away from WAL journaling. The original switch to WAL was made to support the iOS File Provider extension, but WAL is also entangled with the suspension/checkpoint flow that's still producing rare background crashes. Until that's fully resolved (and until the Files app feature actually depends on WAL), it's safer to default to the rollback journal. A developer "Use WAL journal mode" toggle lives at Settings → Advanced → Database. Existing users automatically pick up the new default on next launch.
