### PR TITLE
fix(mobile): tighten startup and sync screen copy

### DIFF
--- a/.changeset/startup-sync-copy.md
+++ b/.changeset/startup-sync-copy.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Clearer startup and sync progress copy; sync screen shows only the percent bar without a file-count line.

--- a/apps/mobile/src/components/AppSplash.tsx
+++ b/apps/mobile/src/components/AppSplash.tsx
@@ -17,7 +17,6 @@ import { Button } from './Button'
 function useSyncProgress() {
   const { data } = useSyncState()
   return {
-    count: data?.syncDownCount ?? 0,
     progress: data?.syncDownProgress ?? 0,
   }
 }
@@ -26,7 +25,7 @@ export function AppSplash() {
   const currentStep = useCurrentInitStep()
   const initializationError = useInitializationError()
   const syncGateStatus = useSyncGateStatus()
-  const { count, progress } = useSyncProgress()
+  const { progress } = useSyncProgress()
   const { top, bottom } = useSafeAreaInsets()
   useSyncGateGuard()
 
@@ -80,11 +79,8 @@ export function AppSplash() {
               <>
                 <View style={styles.syncHeader}>
                   <Text style={styles.syncTitle}>Syncing your library</Text>
-                  <Text style={styles.syncSubtitle}>Syncing your files from the indexer.</Text>
+                  <Text style={styles.syncSubtitle}>Catching up on new files...</Text>
                 </View>
-                {count > 0 && (
-                  <Text style={styles.syncCounts}>{count.toLocaleString()} files synced</Text>
-                )}
                 <View style={styles.progressTrack}>
                   <View
                     style={[styles.progressFill, { width: `${Math.round(progress * 100)}%` }]}
@@ -137,10 +133,6 @@ const styles = StyleSheet.create({
     color: palette.gray[400],
     fontSize: 15,
     textAlign: 'center',
-  },
-  syncCounts: {
-    color: palette.gray[500],
-    fontSize: 12,
   },
   progressTrack: {
     width: '60%',

--- a/apps/mobile/src/managers/app.ts
+++ b/apps/mobile/src/managers/app.ts
@@ -83,8 +83,8 @@ export async function initApp(): Promise<void> {
   if (hasOnboarded) {
     steps.push({
       id: 'connect',
-      label: 'Connecting to indexer',
-      message: 'Initializing SDK...',
+      label: 'Sia network',
+      message: 'Connecting to the Sia network...',
       runner: async () => {
         await reconnectIndexer()
       },
@@ -92,15 +92,11 @@ export async function initApp(): Promise<void> {
 
     steps.push({
       id: 'cleanup',
-      label: 'Cleaning up old files',
-      message: 'Cleaning up old files...',
-      runner: async (updateMessage) => {
+      label: 'Local storage',
+      message: 'Tidying up your cache...',
+      runner: async () => {
         await app().files.autoPurgeWithCleanup()
-        await runFsOrphanScanner({
-          onProgress: (removed) => {
-            updateMessage(`Cleaning up old files... ${removed} removed`)
-          },
-        })
+        await runFsOrphanScanner()
         await runFsEvictionScanner()
       },
     })


### PR DESCRIPTION
Clearer startup and sync progress copy; sync screen shows only the percent bar without a file-count line.
