### PR TITLE
fix(mobile): photo import folder honors nested paths

### DIFF
--- a/.changeset/fix-photo-import-nested-folder.md
+++ b/.changeset/fix-photo-import-nested-folder.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Fixed photo import folder dropping the slash when set to a nested path like `Media/iOS Sync`, which previously caused photos to land in a flattened `MediaiOS Sync` folder at the root.

--- a/apps/mobile/src/lib/processAssets.test.ts
+++ b/apps/mobile/src/lib/processAssets.test.ts
@@ -571,6 +571,32 @@ describe('syncAssets — eager background sync for recent photos', () => {
       expect(dirs).toHaveLength(1)
       expect(dirs[0].path).toBe('Camera Roll')
     })
+
+    it('places files into a nested import directory path with separators', async () => {
+      await app().settings.setPhotoImportDirectory('Media/iOS Sync')
+      const assets = [
+        {
+          id: undefined,
+          name: 'photo.jpg',
+          sourceUri: 'file:///photo.jpg',
+          type: 'image/jpeg',
+          timestamp: '2021-01-01',
+        },
+      ]
+      const { files } = await syncAssets(assets, 'file', {
+        addToImportDirectory: true,
+      })
+      expect(files).toHaveLength(1)
+      const dirs = await app().directories.getAll()
+      const paths = dirs.map((d) => d.path).sort()
+      expect(paths).toEqual(['Media', 'Media/iOS Sync'])
+      const leaf = dirs.find((d) => d.path === 'Media/iOS Sync')!
+      const row = await db().getFirstAsync<{ directoryId: string | null }>(
+        'SELECT directoryId FROM files WHERE id = ?',
+        files[0].id,
+      )
+      expect(row?.directoryId).toBe(leaf.id)
+    })
   })
 })
 

--- a/apps/mobile/src/lib/processAssets.ts
+++ b/apps/mobile/src/lib/processAssets.ts
@@ -130,7 +130,7 @@ async function moveMediaToImportDirectory(files: FileRecord[]): Promise<void> {
     .filter((f) => f.type.startsWith('image/') || f.type.startsWith('video/'))
     .map((f) => f.id)
   if (mediaFileIds.length > 0) {
-    const dir = await app().directories.getOrCreate(photoImportDir)
+    const dir = await app().directories.getOrCreateAtPath(photoImportDir)
     await app().directories.moveFiles(mediaFileIds, dir.id)
   }
 }


### PR DESCRIPTION
Fixed photo import folder dropping the slash when set to a nested path like `Media/iOS Sync`, which previously caused photos to land in a flattened `MediaiOS Sync` folder at the root.
