### PR TITLE
fix(mobile): show local copy in viewer for failed uploads instead of no-slabs error

### DIFF
--- a/.changeset/fix-viewer-shows-local-copy-for-failed-uploads.md
+++ b/.changeset/fix-viewer-shows-local-copy-for-failed-uploads.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Fixed file viewer showing "no slabs" error for failed uploads instead of the local copy. Closes https://github.com/SiaFoundation/sia-storage-app/issues/535

--- a/apps/mobile/src/components/FileViewer/index.tsx
+++ b/apps/mobile/src/components/FileViewer/index.tsx
@@ -44,7 +44,8 @@ export function FileViewer({
   const fileDownload = useDownload(file, 0)
   const { data: fileDownloadState } = useDownloadEntry(file.id)
 
-  const localId = file.hash === '' && file.localId ? file.localId : null
+  const hasNoSealedObjects = Object.keys(file.objects).length === 0
+  const localId = (file.hash === '' || hasNoSealedObjects) && file.localId ? file.localId : null
   const mediaLibrarySwr = useSWR(localId ? ['mediaLibraryUri', localId] : null, () =>
     getMediaLibraryUri(localId),
   )
@@ -70,6 +71,19 @@ export function FileViewer({
   const isQueued = fileDownloadState?.status === 'queued'
 
   const DownloadPanel = useMemo(() => {
+    if (hasNoSealedObjects) {
+      return (
+        <View style={[baseMediaStyle, { justifyContent: 'center', alignItems: 'center', gap: 12 }]}>
+          <CloudDownloadIcon color={colors.textSecondary} size={40} />
+          <Text style={{ color: colors.textPrimary, fontSize: 17, fontWeight: '600' }}>
+            File unavailable
+          </Text>
+          <Text style={{ color: colors.textSecondary, fontSize: 14, textAlign: 'center' }}>
+            This file was never uploaded and the local copy is unavailable.
+          </Text>
+        </View>
+      )
+    }
     return (
       <View style={[baseMediaStyle, { justifyContent: 'center', alignItems: 'center', gap: 20 }]}>
         <TouchableHighlight onPress={onDownloadPress} disabled={isQueued}>
@@ -92,7 +106,14 @@ export function FileViewer({
       </View>
     )
     // oxlint-disable-next-line react/exhaustive-deps -- baseMediaStyle is a static StyleSheet reference, stable across renders
-  }, [isDownloading, isQueued, onDownloadPress, fileDownloadState?.progress, file.size])
+  }, [
+    isDownloading,
+    isQueued,
+    onDownloadPress,
+    fileDownloadState?.progress,
+    file.size,
+    hasNoSealedObjects,
+  ])
 
   const ImportingPanel = useMemo(() => {
     return (


### PR DESCRIPTION
The way that files are handled and the order of everything has drastically changed since the last time I looked at this. I think this is the right fix and it goes for:

```
Local copy exists → viewer shows it normally (the common case)
Local copy also gone → clear explanation instead of a broken download button
```

Feel free to let me know if you'd prefer different copy or no copy or what have you.