### PR TITLE
fix(mobile,core): pause uploads and import scanner during initial library sync

### DIFF
--- a/.changeset/pause-uploads-during-sync-gate.md
+++ b/.changeset/pause-uploads-during-sync-gate.md
@@ -1,0 +1,6 @@
+---
+mobile: patch
+core: patch
+---
+
+Pause uploads and the photo import scanner while the initial library sync is in progress, so sync-down isn't competing with the upload pipeline for the JS thread and the database.

--- a/apps/mobile/src/managers/importScanner.ts
+++ b/apps/mobile/src/managers/importScanner.ts
@@ -50,11 +50,17 @@ export function getImportBackoffEntries() {
   return scanner.getBackoffEntries()
 }
 
+async function run(signal: AbortSignal): Promise<void> {
+  if (app().sync.getState().syncGateStatus === 'active') {
+    logger.debug('importScanner', 'skipped', { reason: 'sync_gate_active' })
+    return
+  }
+  await runImportScanner(signal)
+}
+
 export const { init: initImportScanner, triggerNow: triggerImportScanner } = createServiceInterval({
   name: 'importScanner',
-  worker: async (signal) => {
-    await runImportScanner(signal)
-  },
+  worker: run,
   interval: IMPORT_SCANNER_INTERVAL,
 })
 

--- a/apps/mobile/src/managers/uploader.test.ts
+++ b/apps/mobile/src/managers/uploader.test.ts
@@ -21,6 +21,7 @@ jest.mock('@siastorage/core/config', () => ({
 
 import {
   PACKER_IDLE_TIMEOUT,
+  PACKER_POLL_INTERVAL,
   SECTOR_SIZE,
   SLAB_FILL_THRESHOLD,
   SLAB_SIZE,
@@ -1381,6 +1382,29 @@ describe('UploadManager', () => {
 
       await manager.shutdown()
       expect(manager.isSuspended).toBe(true)
+    })
+  })
+
+  describe('sync gate', () => {
+    afterEach(() => {
+      app().sync.setState({ syncGateStatus: 'idle' })
+    })
+
+    it('skips processing while syncGateStatus is active and resumes after dismissal', async () => {
+      app().sync.setState({ syncGateStatus: 'active' })
+      manager.initialize(app(), internal(), defaultAdapters())
+
+      const entry = await createTestFile('gated-1', 1000)
+      manager.enqueue([entry])
+
+      await jest.advanceTimersByTimeAsync(0)
+      expect(mockPacker.add).not.toHaveBeenCalled()
+
+      app().sync.setState({ syncGateStatus: 'dismissed' })
+      await jest.advanceTimersByTimeAsync(PACKER_POLL_INTERVAL)
+      await jest.advanceTimersByTimeAsync(0)
+
+      expect(mockPacker.add).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/packages/core/src/services/uploader.ts
+++ b/packages/core/src/services/uploader.ts
@@ -532,6 +532,12 @@ export class UploadManager {
         continue
       }
 
+      if (this.app.sync.getState().syncGateStatus === 'active') {
+        logger.debug('uploadManager', 'skipped', { reason: 'sync_gate_active' })
+        await this.waitForWorkOrTimeout(PACKER_POLL_INTERVAL)
+        continue
+      }
+
       const next = this.explicitQueue.shift() ?? this.polledFiles.shift() ?? null
 
       if (next) {


### PR DESCRIPTION
The "Syncing your library" splash was competing with the uploader and the photo-import scanner for the JS thread and the SQLite write lock, slowing the very thing the user was waiting on. Both services now skip their tick while the sync gate is active.
