### PR TITLE
feat(core): resolve directories and tags in bulk during sync-down

### DIFF
--- a/.changeset/sync-down-bulk-dir-tag-resolution.md
+++ b/.changeset/sync-down-bulk-dir-tag-resolution.md
@@ -1,0 +1,5 @@
+---
+core: patch
+---
+
+Resolve directories and tags in bulk during sync-down, replacing per-row lookups with a single SELECT and a bulk INSERT OR IGNORE per batch. Significantly speeds up large initial syncs.

--- a/packages/core/src/db/operations/directories.test.ts
+++ b/packages/core/src/db/operations/directories.test.ts
@@ -20,6 +20,7 @@ import {
   sanitizeDirectoryPath,
   sanitizeDirectorySegment,
   syncDirectoryFromMetadata,
+  syncManyDirectoriesFromMetadata,
 } from './directories'
 import { insertFile, queryFileById } from './files'
 import { db, setupTestDb, teardownTestDb } from './test-setup'
@@ -866,5 +867,76 @@ describe('natural sort order', () => {
     const dirs = await queryAllDirectoriesWithCounts(db())
     const names = dirs.map((d) => d.path)
     expect(names).toEqual(['Folder 1', 'Folder 2', 'Folder 3', 'Folder 10', 'Folder 20'])
+  })
+})
+
+describe('syncManyDirectoriesFromMetadata', () => {
+  async function listAllPaths(): Promise<string[]> {
+    const rows = await db().getAllAsync<{ path: string }>(
+      'SELECT path FROM directories ORDER BY path',
+    )
+    return rows.map((r) => r.path)
+  }
+
+  async function getDirectoryId(fileId: string): Promise<string | null> {
+    const row = await db().getFirstAsync<{ directoryId: string | null }>(
+      'SELECT directoryId FROM files WHERE id = ?',
+      fileId,
+    )
+    return row?.directoryId ?? null
+  }
+
+  it('creates all path prefixes for nested directories', async () => {
+    await createTestFile('f1')
+    await syncManyDirectoriesFromMetadata(db(), [{ fileId: 'f1', directoryPath: 'a/b/c' }])
+    expect(await listAllPaths()).toEqual(['a', 'a/b', 'a/b/c'])
+    expect(await getDirectoryId('f1')).not.toBeNull()
+  })
+
+  it('dedups shared prefixes across paths', async () => {
+    await createTestFile('f1')
+    await createTestFile('f2')
+    await syncManyDirectoriesFromMetadata(db(), [
+      { fileId: 'f1', directoryPath: 'a/b/c' },
+      { fileId: 'f2', directoryPath: 'a/b/d' },
+    ])
+    // a, a/b, a/b/c, a/b/d — exactly four rows
+    expect(await listAllPaths()).toEqual(['a', 'a/b', 'a/b/c', 'a/b/d'])
+  })
+
+  it('is idempotent on rerun', async () => {
+    await createTestFile('f1')
+    await syncManyDirectoriesFromMetadata(db(), [{ fileId: 'f1', directoryPath: 'a/b' }])
+    const before = await listAllPaths()
+    await syncManyDirectoriesFromMetadata(db(), [{ fileId: 'f1', directoryPath: 'a/b' }])
+    expect(await listAllPaths()).toEqual(before)
+  })
+
+  it('reuses existing directories instead of inserting duplicates', async () => {
+    await getOrCreateDirectoryAtPath(db(), 'a/b')
+    await createTestFile('f1')
+    await syncManyDirectoriesFromMetadata(db(), [{ fileId: 'f1', directoryPath: 'a/b/c' }])
+    expect(await listAllPaths()).toEqual(['a', 'a/b', 'a/b/c'])
+  })
+
+  it('skips entries whose path sanitizes to empty', async () => {
+    await createTestFile('f1')
+    await syncManyDirectoriesFromMetadata(db(), [{ fileId: 'f1', directoryPath: '...' }])
+    expect(await listAllPaths()).toEqual([])
+    expect(await getDirectoryId('f1')).toBeNull()
+  })
+
+  it('returns the previous (name, directoryId) groups for the affected files', async () => {
+    await getOrCreateDirectoryAtPath(db(), 'old')
+    const oldDir = await db().getFirstAsync<{ id: string }>(
+      "SELECT id FROM directories WHERE path = 'old'",
+    )
+    await createTestFile('f1')
+    await db().runAsync('UPDATE files SET directoryId = ? WHERE id = ?', oldDir!.id, 'f1')
+
+    const oldGroups = await syncManyDirectoriesFromMetadata(db(), [
+      { fileId: 'f1', directoryPath: 'new' },
+    ])
+    expect(oldGroups).toEqual([{ name: 'f1.jpg', directoryId: oldDir!.id }])
   })
 })

--- a/packages/core/src/db/operations/directories.ts
+++ b/packages/core/src/db/operations/directories.ts
@@ -285,18 +285,75 @@ export async function syncDirectoryFromMetadata(
   }
 }
 
+async function ensureDirectoriesAtPaths(
+  db: DatabaseAdapter,
+  fullPaths: Iterable<string>,
+): Promise<Map<string, string>> {
+  // Expand each input path into its sanitized normal form and all of
+  // its prefixes so a/b/c also creates a and a/b. Map the original
+  // input string to the normalized path so callers can look up by what
+  // they passed in.
+  const inputToNormalized = new Map<string, string>()
+  const prefixes = new Set<string>()
+  for (const raw of fullPaths) {
+    const segments = raw.split('/').map(sanitizeDirectorySegment).filter(Boolean)
+    if (segments.length === 0) {
+      inputToNormalized.set(raw, '')
+      continue
+    }
+    let cur = ''
+    for (const seg of segments) {
+      cur = cur ? `${cur}/${seg}` : seg
+      prefixes.add(cur)
+    }
+    inputToNormalized.set(raw, cur)
+  }
+  if (prefixes.size === 0) return new Map()
+
+  const arr = [...prefixes]
+  const ph = arr.map(() => '?').join(',')
+  const existing = await db.getAllAsync<{ id: string; path: string }>(
+    `SELECT id, path FROM directories WHERE path IN (${ph})`,
+    ...arr,
+  )
+  const pathToId = new Map(existing.map((r) => [r.path, r.id]))
+  const missing = arr.filter((p) => !pathToId.has(p))
+  if (missing.length > 0) {
+    const now = Date.now()
+    const rows = missing.map((path) => ({
+      id: uniqueId(),
+      path,
+      createdAt: now,
+      nameSortKey: naturalSortKey(path),
+    }))
+    await sql.insertMany(db, 'directories', rows, { conflictClause: 'OR IGNORE' })
+    // OR IGNORE may have rejected rows that another writer inserted
+    // first — re-SELECT to pick up the actual id for every missing path.
+    const phM = missing.map(() => '?').join(',')
+    const inserted = await db.getAllAsync<{ id: string; path: string }>(
+      `SELECT id, path FROM directories WHERE path IN (${phM})`,
+      ...missing,
+    )
+    for (const r of inserted) pathToId.set(r.path, r.id)
+  }
+
+  const result = new Map<string, string>()
+  for (const [input, normalized] of inputToNormalized) {
+    if (!normalized) continue
+    const id = pathToId.get(normalized)
+    if (id) result.set(input, id)
+  }
+  return result
+}
+
 export async function syncManyDirectoriesFromMetadata(
   db: DatabaseAdapter,
   entries: { fileId: string; directoryPath: string }[],
 ): Promise<{ name: string; directoryId: string | null }[]> {
   if (entries.length === 0) return []
 
-  const dirPaths = [...new Set(entries.map((e) => e.directoryPath))]
-  const dirMap = new Map<string, string>()
-  for (const path of dirPaths) {
-    const dir = await getOrCreateDirectoryAtPath(db, path)
-    dirMap.set(path, dir.id)
-  }
+  const dirPaths = new Set(entries.map((e) => e.directoryPath))
+  const pathToId = await ensureDirectoriesAtPaths(db, dirPaths)
 
   const fileIds = entries.map((e) => e.fileId)
   const ph = fileIds.map(() => '?').join(',')
@@ -307,8 +364,9 @@ export async function syncManyDirectoriesFromMetadata(
 
   const byDirId = new Map<string, string[]>()
   for (const entry of entries) {
-    const dirId = dirMap.get(entry.directoryPath)!
-    const list = byDirId.get(dirId) || []
+    const dirId = pathToId.get(entry.directoryPath)
+    if (!dirId) continue
+    const list = byDirId.get(dirId) ?? []
     list.push(entry.fileId)
     byDirId.set(dirId, list)
   }

--- a/packages/core/src/db/operations/tags.test.ts
+++ b/packages/core/src/db/operations/tags.test.ts
@@ -14,6 +14,7 @@ import {
   removeTagFromFile,
   renameTag,
   SYSTEM_TAGS,
+  syncManyTagsFromMetadata,
   syncTagsFromMetadata,
   toggleFavorite,
 } from './tags'
@@ -491,5 +492,69 @@ describe('deleteTag', () => {
     await expect(deleteTag(db(), SYSTEM_TAGS.favorites.id)).rejects.toThrow(
       'System tags cannot be deleted',
     )
+  })
+})
+
+describe('syncManyTagsFromMetadata', () => {
+  it('creates each unique tag exactly once across files', async () => {
+    await createTestFile('f1')
+    await createTestFile('f2')
+    await syncManyTagsFromMetadata(db(), [
+      { fileId: 'f1', tagNames: ['vacation', 'beach'] },
+      { fileId: 'f2', tagNames: ['vacation', 'sunset'] },
+    ])
+    const all = await queryAllTagsWithCounts(db())
+    const userTags = all
+      .filter((t) => t.system === 0)
+      .map((t) => t.name)
+      .sort()
+    expect(userTags).toEqual(['beach', 'sunset', 'vacation'])
+
+    expect((await queryTagNamesForFile(db(), 'f1'))?.sort()).toEqual(['beach', 'vacation'])
+    expect((await queryTagNamesForFile(db(), 'f2'))?.sort()).toEqual(['sunset', 'vacation'])
+  })
+
+  it('reuses existing tags rather than inserting duplicates', async () => {
+    await getOrCreateTag(db(), 'vacation')
+    await createTestFile('f1')
+    await syncManyTagsFromMetadata(db(), [{ fileId: 'f1', tagNames: ['vacation', 'beach'] }])
+    const all = await queryAllTagsWithCounts(db())
+    const matches = all.filter((t) => t.name === 'vacation')
+    expect(matches).toHaveLength(1)
+  })
+
+  it('updates usedAt for every tag in the batch', async () => {
+    await createTestFile('f1')
+
+    jest.useFakeTimers().setSystemTime(new Date('2026-01-01T00:00:00Z'))
+    await syncManyTagsFromMetadata(db(), [{ fileId: 'f1', tagNames: ['old'] }])
+
+    jest.useFakeTimers().setSystemTime(new Date('2026-04-28T12:00:00Z'))
+    await syncManyTagsFromMetadata(db(), [{ fileId: 'f1', tagNames: ['old', 'fresh'] }])
+
+    const all = await queryAllTagsWithCounts(db())
+    const old = all.find((t) => t.name === 'old')!
+    const fresh = all.find((t) => t.name === 'fresh')!
+    const expected = new Date('2026-04-28T12:00:00Z').getTime()
+    expect(old.usedAt).toBe(expected)
+    expect(fresh.usedAt).toBe(expected)
+
+    jest.useRealTimers()
+  })
+
+  it('is idempotent on rerun', async () => {
+    await createTestFile('f1')
+    await syncManyTagsFromMetadata(db(), [{ fileId: 'f1', tagNames: ['a', 'b'] }])
+    const before = (await queryTagNamesForFile(db(), 'f1'))?.sort()
+    await syncManyTagsFromMetadata(db(), [{ fileId: 'f1', tagNames: ['a', 'b'] }])
+    const after = (await queryTagNamesForFile(db(), 'f1'))?.sort()
+    expect(after).toEqual(before)
+  })
+
+  it('skips empty/whitespace-only names', async () => {
+    await createTestFile('f1')
+    await syncManyTagsFromMetadata(db(), [{ fileId: 'f1', tagNames: ['', '  ', 'real'] }])
+    const names = await queryTagNamesForFile(db(), 'f1')
+    expect(names).toEqual(['real'])
   })
 })

--- a/packages/core/src/db/operations/tags.ts
+++ b/packages/core/src/db/operations/tags.ts
@@ -142,6 +142,57 @@ export async function syncTagsFromMetadata(
   })
 }
 
+async function ensureTagsByName(
+  db: DatabaseAdapter,
+  names: Iterable<string>,
+): Promise<Map<string, string>> {
+  const trimmed = new Map<string, string>() // raw -> trimmed
+  const set = new Set<string>()
+  for (const raw of names) {
+    const t = raw.trim()
+    if (!t) continue
+    trimmed.set(raw, t)
+    set.add(t)
+  }
+  if (set.size === 0) return new Map()
+
+  const arr = [...set]
+  const ph = arr.map(() => '?').join(',')
+  const existing = await db.getAllAsync<{ id: string; name: string }>(
+    `SELECT id, name FROM tags WHERE name IN (${ph})`,
+    ...arr,
+  )
+  const nameToId = new Map(existing.map((r) => [r.name, r.id]))
+  const missing = arr.filter((n) => !nameToId.has(n))
+  if (missing.length > 0) {
+    const now = Date.now()
+    const rows = missing.map((name) => ({
+      id: uniqueId(),
+      name,
+      createdAt: now,
+      usedAt: now,
+      system: 0,
+    }))
+    await sql.insertMany(db, 'tags', rows, { conflictClause: 'OR IGNORE' })
+    const phM = missing.map(() => '?').join(',')
+    const inserted = await db.getAllAsync<{ id: string; name: string }>(
+      `SELECT id, name FROM tags WHERE name IN (${phM})`,
+      ...missing,
+    )
+    for (const r of inserted) nameToId.set(r.name, r.id)
+  }
+
+  const phAll = arr.map(() => '?').join(',')
+  await db.runAsync(`UPDATE tags SET usedAt = ? WHERE name IN (${phAll})`, Date.now(), ...arr)
+
+  const result = new Map<string, string>()
+  for (const [raw, name] of trimmed) {
+    const id = nameToId.get(name)
+    if (id) result.set(raw, id)
+  }
+  return result
+}
+
 export async function syncManyTagsFromMetadata(
   db: DatabaseAdapter,
   entries: { fileId: string; tagNames: string[] }[],
@@ -156,11 +207,7 @@ export async function syncManyTagsFromMetadata(
     }
   }
 
-  const tagMap = new Map<string, string>()
-  for (const name of allTagNames) {
-    const tag = await getOrCreateTag(db, name)
-    tagMap.set(name, tag.id)
-  }
+  const tagMap = await ensureTagsByName(db, allTagNames)
 
   const fileIds = entries.map((e) => e.fileId)
   const ph = fileIds.map(() => '?').join(',')


### PR DESCRIPTION
Sync-down's per-batch directory and tag handling ran one SQL statement per row, producing hundreds of autocommits per batch on the SQLite write lock. The whole pass is now bulked — a handful of statements per batch instead of a per-row loop.
