### PR TITLE
fix(core): accumulate sync-up metadata progress across batches

### DIFF
--- a/.changeset/sync-up-metadata-progress.md
+++ b/.changeset/sync-up-metadata-progress.md
@@ -1,0 +1,5 @@
+---
+core: patch
+---
+
+Sync-up metadata progress now accumulates across batches instead of being overwritten by the current batch size on each tick, so the status sheet counts up smoothly toward the total instead of stalling at the batch size.

--- a/packages/core/src/services/syncUpMetadata.ts
+++ b/packages/core/src/services/syncUpMetadata.ts
@@ -237,7 +237,11 @@ export async function syncUpMetadataBatch(
       })
     }),
   )
-  app.sync.setState({ isSyncingUp: true, syncUpProcessed: batch.length })
+  const prevProcessed = app.sync.getState().syncUpProcessed ?? 0
+  app.sync.setState({
+    isSyncingUp: true,
+    syncUpProcessed: prevProcessed + batch.length,
+  })
   if (hasErrors) {
     logger.warn('syncUpMetadata', 'batch_had_errors_cursor_not_advanced')
     app.sync.setState({


### PR DESCRIPTION
The status sheet's sync-up counter was stalling at the current batch size because each tick overwrote syncUpProcessed instead of adding to it, hiding real progress on a multi-batch sync. The progress count now accumulates across batches so the number ticks up smoothly toward the total.
