### PR TITLE
feat(mobile,core): add opt-in log forwarding to a user-supplied HTTP endpoint

### DIFF
--- a/.changeset/remote-log-endpoint.md
+++ b/.changeset/remote-log-endpoint.md
@@ -1,0 +1,7 @@
+---
+mobile: patch
+core: minor
+logger: minor
+---
+
+Added optional log forwarding under Settings → Advanced — every log entry is sent as NDJSON to a user-supplied HTTP endpoint with optional Bearer auth, and resumes from a saved cursor after offline gaps.

--- a/apps/mobile/src/components/InsetGroup.tsx
+++ b/apps/mobile/src/components/InsetGroup.tsx
@@ -170,6 +170,7 @@ type InputRowProps = {
   | 'autoCapitalize'
   | 'autoCorrect'
   | 'editable'
+  | 'secureTextEntry'
 >
 
 export function InsetGroupInputRow({ label, description, ...inputProps }: InputRowProps) {

--- a/apps/mobile/src/components/LogView.tsx
+++ b/apps/mobile/src/components/LogView.tsx
@@ -2,6 +2,7 @@ import {
   formatDataPairs,
   getLevelColorHex,
   getScopeColorHex,
+  type LogData,
   type LogEntry,
 } from '@siastorage/logger'
 import { useCallback, useEffect, useRef } from 'react'
@@ -54,7 +55,10 @@ export function LogView({ isFollowing, onTotalCountChange, onScrollAwayFromBotto
   const renderLogItem = useCallback(({ item, index }: { item: LogEntry; index: number }) => {
     const scopeColor = getScopeColorHex(item.scope)
     const levelColor = getLevelColorHex(item.level) ?? palette.gray[50]
-    const dataPart = formatDataPairs(item.data)
+    // Hide context fields (device/account) on-device — they're already known
+    // here. They remain on every log row in the DB, terminal, exports, and
+    // the wire format for cross-device correlation.
+    const dataPart = formatDataPairs(stripContext(item.data))
 
     return (
       <Text key={`${index}-${item.timestamp}-${item.scope}`} style={styles.line}>
@@ -106,6 +110,23 @@ export function LogView({ isFollowing, onTotalCountChange, onScrollAwayFromBotto
       />
     </View>
   )
+}
+
+const CONTEXT_KEYS = new Set(['device', 'account'])
+
+function stripContext(data?: LogData): LogData | undefined {
+  if (!data) return data
+  const out: Record<string, unknown> = {}
+  let dropped = false
+  for (const key of Object.keys(data)) {
+    if (CONTEXT_KEYS.has(key)) {
+      dropped = true
+      continue
+    }
+    out[key] = data[key]
+  }
+  if (!dropped) return data
+  return Object.keys(out).length > 0 ? (out as LogData) : undefined
 }
 
 const styles = StyleSheet.create({

--- a/apps/mobile/src/components/SettingsAdvancedInfo.tsx
+++ b/apps/mobile/src/components/SettingsAdvancedInfo.tsx
@@ -1,16 +1,16 @@
-import type { NativeStackScreenProps } from '@react-navigation/native-stack'
 import { useShowAdvanced } from '@siastorage/core/stores'
 import { Alert } from 'react-native'
 import { humanSize } from '../lib/humanSize'
 import { runFsEvictionScanner } from '../managers/fsEvictionScanner'
 import { runFsOrphanScanner } from '../managers/fsOrphanScanner'
-import type { MenuStackParamList } from '../stacks/types'
 import { app } from '../stores/appService'
 import { InsetGroupLink, InsetGroupSection, InsetGroupToggleRow } from './InsetGroup'
 
-type Props = NativeStackScreenProps<MenuStackParamList, 'Advanced'>
+type Props = {
+  onImport: () => void
+}
 
-export function SettingsAdvancedInfo(_props: Props) {
+export function SettingsAdvancedInfo({ onImport }: Props) {
   const showAdvanced = useShowAdvanced()
 
   const handleClearLocalFiles = async () => {
@@ -42,10 +42,10 @@ export function SettingsAdvancedInfo(_props: Props) {
 
   return (
     <>
-      <InsetGroupSection
-        header="Debugging"
-        footer="Shows extra technical details like file IDs, hashes, and URIs on file info screens."
-      >
+      <InsetGroupSection header="Debugging">
+        <InsetGroupLink label="Import" onPress={onImport} />
+      </InsetGroupSection>
+      <InsetGroupSection footer="Shows extra technical details like file IDs, hashes, and URIs on file info screens.">
         <InsetGroupToggleRow
           label="Show advanced information"
           value={showAdvanced.data ?? false}

--- a/apps/mobile/src/components/SettingsAdvancedLogs.tsx
+++ b/apps/mobile/src/components/SettingsAdvancedLogs.tsx
@@ -1,0 +1,105 @@
+import { getRemoteLogToken, setRemoteLogConfig } from '@siastorage/core/services/logForwarder'
+import { useRemoteLogEnabled, useRemoteLogEndpoint } from '@siastorage/core/stores'
+import { flushLogs, logger } from '@siastorage/logger'
+import { useEffect, useState } from 'react'
+import { Alert } from 'react-native'
+import { useToast } from '../lib/toastContext'
+import {
+  InsetGroupInputRow,
+  InsetGroupLink,
+  InsetGroupSection,
+  InsetGroupToggleRow,
+} from './InsetGroup'
+
+type Props = {
+  onViewLogs: () => void
+}
+
+function isValidEndpoint(value: string): boolean {
+  if (!value) return true
+  try {
+    const url = new URL(value)
+    return url.protocol === 'http:' || url.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+export function SettingsAdvancedLogs({ onViewLogs }: Props) {
+  const enabled = useRemoteLogEnabled()
+  const endpoint = useRemoteLogEndpoint()
+  const toast = useToast()
+
+  const [endpointDraft, setEndpointDraft] = useState<string>('')
+  const [tokenDraft, setTokenDraft] = useState<string>('')
+
+  useEffect(() => {
+    if (endpoint.data !== undefined) setEndpointDraft(endpoint.data)
+  }, [endpoint.data])
+
+  useEffect(() => {
+    let active = true
+    getRemoteLogToken().then((value) => {
+      if (active) setTokenDraft(value ?? '')
+    })
+    return () => {
+      active = false
+    }
+  }, [])
+
+  return (
+    <>
+      <InsetGroupSection header="Logs">
+        <InsetGroupLink label="View logs" onPress={onViewLogs} />
+      </InsetGroupSection>
+      <InsetGroupSection footer="When enabled, every log entry is also sent as NDJSON to your endpoint. Compatible with any HTTP receiver that accepts application/x-ndjson.">
+        <InsetGroupToggleRow
+          label="Forward logs to endpoint"
+          value={enabled.data ?? false}
+          onValueChange={(v) => setRemoteLogConfig({ enabled: v })}
+        />
+        <InsetGroupInputRow
+          label="Endpoint URL"
+          value={endpointDraft}
+          placeholder="https://logs.example.com/ingest"
+          keyboardType="url"
+          autoCapitalize="none"
+          autoCorrect={false}
+          onChangeText={setEndpointDraft}
+          onBlur={() => {
+            const next = endpointDraft.trim()
+            if (next === (endpoint.data ?? '')) return
+            if (!isValidEndpoint(next)) {
+              Alert.alert('Invalid URL', 'Enter a valid http(s) URL or leave the field blank.')
+              setEndpointDraft(endpoint.data ?? '')
+              return
+            }
+            setRemoteLogConfig({ endpoint: next })
+          }}
+        />
+        <InsetGroupInputRow
+          label="Bearer token"
+          value={tokenDraft}
+          placeholder="Optional"
+          secureTextEntry
+          autoCapitalize="none"
+          autoCorrect={false}
+          onChangeText={setTokenDraft}
+          onBlur={() => {
+            const next = tokenDraft.trim()
+            setRemoteLogConfig({ token: next === '' ? null : next })
+          }}
+        />
+        <InsetGroupLink
+          label="Send test log"
+          showChevron={false}
+          onPress={() => {
+            logger.info('remoteLog', 'test', { source: 'settings' })
+            flushLogs()
+            toast.show('Sent test log')
+          }}
+        />
+      </InsetGroupSection>
+    </>
+  )
+}

--- a/apps/mobile/src/managers/app.ts
+++ b/apps/mobile/src/managers/app.ts
@@ -2,6 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 import { getErrorMessage } from '@siastorage/core/lib/errors'
 import { shutdownAllServiceIntervals } from '@siastorage/core/lib/serviceInterval'
 import { activateSyncGate } from '@siastorage/core/services/syncDownEvents'
+import { applyLogContext } from '@siastorage/core/services/logForwarder'
 import { stopLogAppender } from '@siastorage/logger'
 import { mutate } from 'swr'
 import { initializeDB, resetDb, setJournalMode } from '../db'
@@ -33,6 +34,16 @@ import { getUploadManager } from './uploader'
 const FORCED_RESET_VERSION: string | null = '71936'
 
 export async function initApp(): Promise<void> {
+  // Tag every subsequent log with device + account before any subsystem
+  // fires. Reading both here means initApp called after sign-in (e.g., from
+  // OnboardingFinishedScreen) lands on the right context instead of wiping
+  // the account just-set by refreshLogAccount.
+  const [deviceId, mnemonicHash] = await Promise.all([
+    app().settings.getDeviceId(),
+    app().auth.getMnemonicHash(),
+  ])
+  applyLogContext(deviceId, mnemonicHash)
+
   if (FORCED_RESET_VERSION) {
     const completed = await app().settings.getCompletedResetVersion()
     const hasOnboarded = await app().settings.getHasOnboarded()
@@ -157,11 +168,18 @@ export async function resetData() {
   app().caches.libraryVersion.invalidate()
 }
 
-// AsyncStorage keys preserved across a resync-style reset so the user stays
-// signed in, reconnects to the same indexer, and doesn't re-run onboarding.
-// Auth identity (mnemonicHash, appKeys) lives in SecureStore and is untouched
-// when keepAuth is true.
-const RESYNC_KEEP_KEYS = ['hasOnboarded', 'indexerURL', 'completedResetVersion']
+// Preserved across both reset paths so log forwarding survives — useful for
+// debugging the reset flows themselves. Cursor is intentionally NOT preserved:
+// the DB is dropped, so a stale cursor would stall shipping.
+const REMOTE_LOG_KEEP_KEYS = ['remoteLogEnabled', 'remoteLogEndpoint', 'deviceId']
+
+// Resync additionally preserves onboarding/indexer so the user stays signed in.
+const RESYNC_KEEP_KEYS = [
+  'hasOnboarded',
+  'indexerURL',
+  'completedResetVersion',
+  ...REMOTE_LOG_KEEP_KEYS,
+]
 
 async function clearAppState({ keepAuth }: { keepAuth: boolean }) {
   // Tear down the SDK first so the rust layer stops retrying uploads against
@@ -178,19 +196,16 @@ async function clearAppState({ keepAuth }: { keepAuth: boolean }) {
   // Drop and recreate all database tables.
   await resetDb()
 
-  if (keepAuth) {
-    // Resync path: preserve the auth-adjacent AsyncStorage keys so the user
-    // stays onboarded and reconnects to the same indexer on next init. Auth
-    // identity (mnemonicHash, appKeys) lives in SecureStore and is untouched.
-    const allKeys = await AsyncStorage.getAllKeys()
-    const toRemove = allKeys.filter((key) => !RESYNC_KEEP_KEYS.includes(key))
-    if (toRemove.length > 0) {
-      await AsyncStorage.multiRemove(toRemove)
-    }
-  } else {
-    // Sign-out path: wipe everything including SecureStore auth so the next
-    // launch returns to onboarding.
-    await AsyncStorage.clear()
+  // Wipe AsyncStorage except the keep list. The Bearer token lives in
+  // SecureStore and is preserved by both paths.
+  const keepKeys = keepAuth ? RESYNC_KEEP_KEYS : REMOTE_LOG_KEEP_KEYS
+  const allKeys = await AsyncStorage.getAllKeys()
+  const toRemove = allKeys.filter((key) => !keepKeys.includes(key))
+  if (toRemove.length > 0) {
+    await AsyncStorage.multiRemove(toRemove)
+  }
+  if (!keepAuth) {
+    // Sign-out also clears auth identity so the next launch returns to onboarding.
     await app().auth.clearAppKeys()
     await app().auth.clearMnemonicHash()
   }

--- a/apps/mobile/src/screens/SettingsAdvancedScreen.tsx
+++ b/apps/mobile/src/screens/SettingsAdvancedScreen.tsx
@@ -1,7 +1,7 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack'
-import { InsetGroupLink, InsetGroupSection } from '../components/InsetGroup'
 import { SettingsAdvancedDatabase } from '../components/SettingsAdvancedDatabase'
 import { SettingsAdvancedInfo } from '../components/SettingsAdvancedInfo'
+import { SettingsAdvancedLogs } from '../components/SettingsAdvancedLogs'
 import { SettingsAdvancedSync } from '../components/SettingsAdvancedSync'
 import { SettingsAdvancedTransfers } from '../components/SettingsAdvancedTransfers'
 import { SettingsScrollLayout } from '../components/SettingsLayout'
@@ -9,15 +9,11 @@ import type { MenuStackParamList } from '../stacks/types'
 
 type Props = NativeStackScreenProps<MenuStackParamList, 'Advanced'>
 
-export function SettingsAdvancedScreen(props: Props) {
-  const { navigation } = props
+export function SettingsAdvancedScreen({ navigation }: Props) {
   return (
     <SettingsScrollLayout>
-      <InsetGroupSection header="Tools">
-        <InsetGroupLink label="Import" onPress={() => navigation.navigate('Import')} />
-        <InsetGroupLink label="Logs" onPress={() => navigation.navigate('Logs')} />
-      </InsetGroupSection>
-      <SettingsAdvancedInfo {...props} />
+      <SettingsAdvancedLogs onViewLogs={() => navigation.navigate('Logs')} />
+      <SettingsAdvancedInfo onImport={() => navigation.navigate('Import')} />
       <SettingsAdvancedTransfers />
       <SettingsAdvancedSync />
       <SettingsAdvancedDatabase />

--- a/apps/mobile/src/stores/logs.ts
+++ b/apps/mobile/src/stores/logs.ts
@@ -1,11 +1,6 @@
+import { initLogForwarder, resumeLogForwarder } from '@siastorage/core/services/logForwarder'
 import { swrCacheBy } from '@siastorage/core/stores'
-import {
-  type LogEntry,
-  type LogLevel,
-  logger,
-  serializeData,
-  setLogAppender,
-} from '@siastorage/logger'
+import { type LogEntry, type LogLevel, logger } from '@siastorage/logger'
 import useSWR from 'swr'
 import { app } from './appService'
 
@@ -20,11 +15,13 @@ export async function initLogger(): Promise<void> {
     return
   }
 
-  setLogAppender(appendLogsToDb)
+  await initLogForwarder(app())
   logger.info('logs', 'init')
 
-  const storedLevel = await getLogLevel()
-  const storedScopes = await app().settings.getLogScopes()
+  const [storedLevel, storedScopes] = await Promise.all([
+    getLogLevel(),
+    app().settings.getLogScopes(),
+  ])
   logLevel = storedLevel
   logScopes = storedScopes
   cache.invalidate('level')
@@ -36,7 +33,7 @@ export async function initLogger(): Promise<void> {
 /** Re-register the log appender after suspension without re-reading
  * settings. initLogger() can't be reused due to its hasInit guard. */
 export function resumeLogger(): void {
-  setLogAppender(appendLogsToDb)
+  resumeLogForwarder()
 }
 
 export function useAvailableScopes() {
@@ -87,22 +84,6 @@ export async function toggleLogScope(scope: string): Promise<void> {
     ? current.filter((s) => s !== scope)
     : [...current, scope]
   await setLogScopes(newScopes)
-}
-
-async function appendLogsToDb(entries: LogEntry[]): Promise<void> {
-  try {
-    await app().logs.appendMany(
-      entries.map((entry) => ({
-        timestamp: entry.timestamp,
-        level: entry.level,
-        scope: entry.scope,
-        message: entry.message,
-        data: serializeData(entry.data),
-      })),
-    )
-  } catch (error) {
-    console.warn('[logs] Failed to append logs:', error)
-  }
 }
 
 export async function readLogs(

--- a/apps/mobile/src/stores/sdk.ts
+++ b/apps/mobile/src/stores/sdk.ts
@@ -21,6 +21,7 @@ import { err, ok, type Result, uint8ToHex } from '@siastorage/core'
 import { APP_KEY } from '@siastorage/core/config'
 import { getErrorMessage, isAbortError } from '@siastorage/core/lib/errors'
 import { raceWithTimeout, withTimeout } from '@siastorage/core/lib/timeout'
+import { refreshLogAccount } from '@siastorage/core/services/logForwarder'
 import { useConnectionState } from '@siastorage/core/stores'
 import { logger } from '@siastorage/logger'
 import { AppState, Platform } from 'react-native'
@@ -198,6 +199,7 @@ export async function authenticateIndexer(indexerURL: string): Promise<Authentic
       if (connected) {
         logger.info('sdk', 'already_registered')
         app().settings.setIndexerURL(indexerURL)
+        await refreshLogAccount()
         const sdk = getMobileSdkAuth().getLastSdk()
         if (sdk) {
           await setSdkWithUploader(sdk)
@@ -287,6 +289,7 @@ export async function registerWithIndexer(
     await app().auth.setMnemonicHash(mnemonic)
     await app().auth.onConnected(keyHex, indexerURL)
     await app().settings.setIndexerURL(indexerURL)
+    await refreshLogAccount()
 
     app().connection.setState({ isAuthing: false, isConnected: true })
     pendingApproval = null

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,6 +34,7 @@
     "./db/sql": "./src/db/sql.ts",
     "./db/operations": "./src/db/operations/index.ts",
     "./services": "./src/services/index.ts",
+    "./services/logForwarder": "./src/services/logForwarder.ts",
     "./services/logRotation": "./src/services/logRotation.ts",
     "./services/syncDownEvents": "./src/services/syncDownEvents.ts",
     "./services/syncUpMetadata": "./src/services/syncUpMetadata.ts",

--- a/packages/core/src/app/namespaces/db.ts
+++ b/packages/core/src/app/namespaces/db.ts
@@ -559,6 +559,7 @@ export function buildDbNamespaces(
         const rows = await ops.queryLogs(db, opts as Parameters<typeof ops.queryLogs>[1])
         return rows.map(parseLogRow)
       },
+      readSinceId: (sinceId, limit) => ops.queryLogsSinceId(db, sinceId, limit),
       count: (opts?: { logLevel?: string; logScopes?: string[] }) =>
         ops.queryLogCount(db, opts as Parameters<typeof ops.queryLogCount>[1]),
       clear: () => ops.deleteAllLogs(db),

--- a/packages/core/src/app/namespaces/settings.ts
+++ b/packages/core/src/app/namespaces/settings.ts
@@ -1,5 +1,6 @@
 import type { StorageAdapter } from '../../adapters/storage'
 import { DEFAULT_INDEXER_URL, DEFAULT_MAX_DOWNLOADS } from '../../config'
+import { uniqueId } from '../../lib/uniqueId'
 import type { AppCaches, AppService } from '../service'
 
 /** Builds the settings namespace: typed getters/setters backed by key-value storage. */
@@ -74,6 +75,19 @@ export function buildSettingsNamespace(
     setLogScopes: async (v) => {
       await storage.setItem('logScopes', v.join(','))
       caches.settings.invalidate('logScopes')
+    },
+    getRemoteLogEnabled: () => getBool('remoteLogEnabled', false),
+    setRemoteLogEnabled: (v) => setBool('remoteLogEnabled', v),
+    getRemoteLogEndpoint: () => getStr('remoteLogEndpoint', ''),
+    setRemoteLogEndpoint: (v) => setStr('remoteLogEndpoint', v),
+    getRemoteLogCursor: () => getNum('remoteLogCursor', 0),
+    setRemoteLogCursor: (v) => setNum('remoteLogCursor', v),
+    getDeviceId: async () => {
+      const existing = await storage.getItem('deviceId')
+      if (existing) return existing
+      const next = uniqueId().slice(0, 8)
+      await storage.setItem('deviceId', next)
+      return next
     },
     getFsEvictionLastRun: () => getNum('fsEvictionLastRun', 0),
     setFsEvictionLastRun: (v) => setNum('fsEvictionLastRun', v),

--- a/packages/core/src/app/service.ts
+++ b/packages/core/src/app/service.ts
@@ -476,6 +476,20 @@ export interface AppService {
     ): Promise<void>
     /** Reads log entries with optional level, scope, and limit filters. */
     read(opts?: { logLevel?: string; logScopes?: string[]; limit?: number }): Promise<any[]>
+    /** Reads up to `limit` log entries with id greater than `sinceId`, oldest first. */
+    readSinceId(
+      sinceId: number,
+      limit: number,
+    ): Promise<
+      {
+        id: number
+        timestamp: string
+        level: string
+        scope: string
+        message: string
+        data: string | null
+      }[]
+    >
     /** Returns the count of log entries matching the filters. */
     count(opts?: { logLevel?: string; logScopes?: string[] }): Promise<number>
     /** Deletes all log entries. */
@@ -540,6 +554,20 @@ export interface AppService {
     getLogScopes(): Promise<string[]>
     /** Sets the enabled log scopes. */
     setLogScopes(value: string[]): Promise<void>
+    /** Returns whether remote log forwarding is enabled. */
+    getRemoteLogEnabled(): Promise<boolean>
+    /** Sets the remote log forwarding flag. */
+    setRemoteLogEnabled(value: boolean): Promise<void>
+    /** Returns the configured remote log endpoint URL. */
+    getRemoteLogEndpoint(): Promise<string>
+    /** Sets the remote log endpoint URL. */
+    setRemoteLogEndpoint(value: string): Promise<void>
+    /** Returns the highest log id successfully shipped to the remote endpoint. */
+    getRemoteLogCursor(): Promise<number>
+    /** Sets the highest log id shipped to the remote endpoint. */
+    setRemoteLogCursor(value: number): Promise<void>
+    /** Returns the persistent per-install device identifier, generating one on first read. */
+    getDeviceId(): Promise<string>
     /** Returns the timestamp of the last file system eviction run. */
     getFsEvictionLastRun(): Promise<number>
     /** Sets the timestamp of the last file system eviction run. */

--- a/packages/core/src/db/operations/index.ts
+++ b/packages/core/src/db/operations/index.ts
@@ -140,9 +140,11 @@ export {
   insertLog,
   insertManyLogs,
   type LogRow,
+  type LogRowWithId,
   queryAvailableLogScopes,
   queryLogCount,
   queryLogs,
+  queryLogsSinceId,
   rotateLogs,
 } from './logs'
 export {

--- a/packages/core/src/db/operations/logs.ts
+++ b/packages/core/src/db/operations/logs.ts
@@ -85,6 +85,8 @@ export type LogRow = {
   data: string | null
 }
 
+export type LogRowWithId = LogRow & { id: number }
+
 export async function queryLogs(
   db: DatabaseAdapter,
   opts?: { logLevel?: LogLevel; logScopes?: string[]; limit?: number },
@@ -94,6 +96,18 @@ export async function queryLogs(
     opts?.limit !== undefined && Number.isFinite(opts.limit) ? ` LIMIT ${opts.limit | 0}` : ''
   const query = `SELECT timestamp, level, scope, message, data FROM logs ${whereClause} ORDER BY createdAt DESC, id DESC${limitClause}`
   return db.getAllAsync<LogRow>(query, ...params)
+}
+
+export async function queryLogsSinceId(
+  db: DatabaseAdapter,
+  sinceId: number,
+  limit: number,
+): Promise<LogRowWithId[]> {
+  return db.getAllAsync<LogRowWithId>(
+    'SELECT id, timestamp, level, scope, message, data FROM logs WHERE id > ? ORDER BY id ASC LIMIT ?',
+    sinceId,
+    limit | 0,
+  )
 }
 
 export async function queryLogCount(

--- a/packages/core/src/services/logForwarder.test.ts
+++ b/packages/core/src/services/logForwarder.test.ts
@@ -1,0 +1,411 @@
+import type { LogEntry } from '@siastorage/logger'
+import * as loggerPkg from '@siastorage/logger'
+import type { AppService } from '../app/service'
+import { LogForwarder } from './logForwarder'
+
+type Row = {
+  id: number
+  timestamp: string
+  level: string
+  scope: string
+  message: string
+  data: string | null
+}
+
+type MockApp = {
+  app: AppService
+  rows: Row[]
+  appendedToDb: {
+    timestamp: string
+    level: string
+    scope: string
+    message: string
+    data: string | null
+  }[]
+  cursor: { current: number }
+  setCursorCalls: number[]
+  enabled: boolean
+  endpoint: string
+  token: string | null
+  deviceId: string
+  mnemonicHash: string | null
+  secretsCalls: { setItem: number; deleteItem: number; getItem: number }
+}
+
+function makeApp(initial?: Partial<MockApp>): MockApp {
+  const state: MockApp = {
+    app: {} as AppService,
+    rows: [],
+    appendedToDb: [],
+    cursor: { current: 0 },
+    setCursorCalls: [],
+    enabled: true,
+    endpoint: 'https://logs.example.com/ingest',
+    token: null,
+    deviceId: 'device-test-fixed',
+    mnemonicHash: null,
+    secretsCalls: { setItem: 0, deleteItem: 0, getItem: 0 },
+    ...initial,
+  }
+
+  const settings = {
+    getRemoteLogEnabled: async () => state.enabled,
+    setRemoteLogEnabled: async (v: boolean) => {
+      state.enabled = v
+    },
+    getRemoteLogEndpoint: async () => state.endpoint,
+    setRemoteLogEndpoint: async (v: string) => {
+      state.endpoint = v
+    },
+    getRemoteLogCursor: async () => state.cursor.current,
+    setRemoteLogCursor: async (v: number) => {
+      state.cursor.current = v
+      state.setCursorCalls.push(v)
+    },
+    getDeviceId: async () => state.deviceId,
+  }
+
+  const auth = {
+    getMnemonicHash: async () => state.mnemonicHash,
+  }
+
+  const secrets = {
+    getItem: async (_key: string) => {
+      state.secretsCalls.getItem++
+      return state.token
+    },
+    setItem: async (_key: string, value: string) => {
+      state.secretsCalls.setItem++
+      state.token = value
+    },
+    deleteItem: async (_key: string) => {
+      state.secretsCalls.deleteItem++
+      state.token = null
+    },
+  }
+
+  const logs = {
+    appendMany: async (
+      entries: {
+        timestamp: string
+        level: string
+        scope: string
+        message: string
+        data: string | null
+      }[],
+    ) => {
+      state.appendedToDb.push(...entries)
+      const startId = state.rows.length > 0 ? state.rows[state.rows.length - 1].id : 0
+      for (let i = 0; i < entries.length; i++) {
+        const e = entries[i]
+        state.rows.push({
+          id: startId + i + 1,
+          timestamp: e.timestamp,
+          level: e.level,
+          scope: e.scope,
+          message: e.message,
+          data: e.data,
+        })
+      }
+    },
+    readSinceId: async (sinceId: number, limit: number) =>
+      state.rows.filter((r) => r.id > sinceId).slice(0, limit),
+  }
+
+  state.app = { settings, secrets, logs, auth } as unknown as AppService
+  return state
+}
+
+function entry(message: string, data?: Record<string, unknown>): LogEntry {
+  return { timestamp: '2026-01-01T00:00:00.000Z', level: 'info', scope: 'test', message, data }
+}
+
+function seedRows(state: MockApp, count: number): void {
+  const next = [...Array(count)].map((_, i) => ({
+    id: state.rows.length + i + 1,
+    timestamp: `2026-01-01T00:00:0${i % 10}.000Z`,
+    level: 'info',
+    scope: 'test',
+    message: `msg-${state.rows.length + i + 1}`,
+    data: null,
+  }))
+  state.rows.push(...next)
+}
+
+function snapshot(state: MockApp) {
+  return {
+    enabled: state.enabled,
+    endpoint: state.endpoint,
+    cursor: state.cursor.current,
+    token: state.token,
+    deviceId: state.deviceId,
+  }
+}
+
+describe('LogForwarder', () => {
+  let fetchMock: jest.Mock
+  let warnSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    fetchMock = jest.fn().mockResolvedValue({ ok: true, status: 200 })
+    global.fetch = fetchMock as unknown as typeof fetch
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  it('does nothing when disabled', async () => {
+    const state = makeApp({ enabled: false })
+    seedRows(state, 5)
+    const forwarder = new LogForwarder(state.app, snapshot(state))
+    await forwarder.shipPending()
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(state.cursor.current).toBe(0)
+  })
+
+  it('does nothing when endpoint is empty', async () => {
+    const state = makeApp({ endpoint: '' })
+    seedRows(state, 5)
+    const forwarder = new LogForwarder(state.app, snapshot(state))
+    await forwarder.shipPending()
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(state.cursor.current).toBe(0)
+  })
+
+  it('does nothing when there are no entries past the cursor', async () => {
+    const state = makeApp()
+    state.cursor.current = 5
+    seedRows(state, 5)
+    const forwarder = new LogForwarder(state.app, snapshot(state))
+    await forwarder.shipPending()
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(state.cursor.current).toBe(5)
+  })
+
+  it('ships pending rows as NDJSON and advances the cursor on success', async () => {
+    const state = makeApp()
+    seedRows(state, 3)
+    const forwarder = new LogForwarder(state.app, snapshot(state))
+
+    await forwarder.shipPending()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe(state.endpoint)
+    expect(init.method).toBe('POST')
+    expect(init.headers['Content-Type']).toBe('application/x-ndjson')
+    const body = init.body as string
+    expect(body.endsWith('\n')).toBe(true)
+    const lines = body.trim().split('\n')
+    expect(lines).toHaveLength(3)
+    for (const line of lines) {
+      expect(() => JSON.parse(line)).not.toThrow()
+    }
+    expect(state.cursor.current).toBe(3)
+    expect(state.setCursorCalls).toEqual([3])
+  })
+
+  it('includes Authorization header when a token is set', async () => {
+    const state = makeApp({ token: 'secret-xyz' })
+    seedRows(state, 1)
+    const forwarder = new LogForwarder(state.app, snapshot(state))
+    await forwarder.shipPending()
+    const init = fetchMock.mock.calls[0][1]
+    expect(init.headers.Authorization).toBe('Bearer secret-xyz')
+  })
+
+  it('omits Authorization header when no token is set', async () => {
+    const state = makeApp()
+    seedRows(state, 1)
+    const forwarder = new LogForwarder(state.app, snapshot(state))
+    await forwarder.shipPending()
+    const init = fetchMock.mock.calls[0][1]
+    expect(init.headers.Authorization).toBeUndefined()
+  })
+
+  it('does not advance the cursor when fetch rejects (offline)', async () => {
+    fetchMock.mockRejectedValue(new TypeError('Network request failed'))
+    const state = makeApp()
+    seedRows(state, 4)
+    const forwarder = new LogForwarder(state.app, snapshot(state))
+
+    await forwarder.shipPending()
+
+    expect(state.cursor.current).toBe(0)
+    expect(state.setCursorCalls).toEqual([])
+  })
+
+  it('does not advance the cursor on a non-2xx response', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 401 })
+    const state = makeApp()
+    seedRows(state, 4)
+    const forwarder = new LogForwarder(state.app, snapshot(state))
+
+    await forwarder.shipPending()
+
+    expect(state.cursor.current).toBe(0)
+    expect(state.setCursorCalls).toEqual([])
+  })
+
+  it('skips overlapping calls while a request is in flight', async () => {
+    let resolveFetch: ((value: { ok: boolean; status: number }) => void) | undefined
+    fetchMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve
+        }),
+    )
+    const state = makeApp()
+    seedRows(state, 2)
+    const forwarder = new LogForwarder(state.app, snapshot(state))
+
+    const first = forwarder.shipPending()
+    await forwarder.shipPending()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    resolveFetch?.({ ok: true, status: 200 })
+    await first
+    expect(state.cursor.current).toBe(2)
+  })
+
+  it('appender does not call fetch — sinks are decoupled', async () => {
+    const state = makeApp()
+    const forwarder = new LogForwarder(state.app, snapshot(state))
+
+    await forwarder.appender([entry('a'), entry('b')])
+
+    expect(state.appendedToDb).toHaveLength(2)
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(state.cursor.current).toBe(0)
+  })
+
+  it('writes to the DB even when the HTTP sink fails (sink independence)', async () => {
+    fetchMock.mockRejectedValue(new TypeError('offline'))
+    const state = makeApp()
+    const forwarder = new LogForwarder(state.app, snapshot(state))
+
+    await forwarder.appender([entry('a'), entry('b')])
+    await forwarder.shipPending()
+
+    expect(state.appendedToDb).toHaveLength(2)
+    expect(state.appendedToDb.map((e) => e.message)).toEqual(['a', 'b'])
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(state.cursor.current).toBe(0)
+  })
+
+  it('replays the offline backlog on the next successful ship', async () => {
+    const state = makeApp()
+    const forwarder = new LogForwarder(state.app, snapshot(state))
+
+    await forwarder.appender([entry('1'), entry('2'), entry('3')])
+    fetchMock.mockRejectedValue(new TypeError('offline'))
+    await forwarder.shipPending()
+    expect(state.cursor.current).toBe(0)
+
+    fetchMock.mockResolvedValue({ ok: true, status: 200 })
+    await forwarder.shipPending()
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const successCallBody = (fetchMock.mock.calls[1][1].body as string).trim().split('\n')
+    expect(successCallBody).toHaveLength(3)
+    expect(state.cursor.current).toBe(3)
+  })
+
+  it('advances the cursor incrementally across successive ships', async () => {
+    const state = makeApp()
+    const forwarder = new LogForwarder(state.app, snapshot(state))
+
+    await forwarder.appender([entry('a')])
+    await forwarder.shipPending()
+    expect(state.cursor.current).toBe(1)
+
+    await forwarder.appender([entry('b'), entry('c')])
+    await forwarder.shipPending()
+    expect(state.cursor.current).toBe(3)
+    expect(state.setCursorCalls).toEqual([1, 3])
+  })
+
+  it('catches up backlog without new appender activity (idle ticker)', async () => {
+    const state = makeApp()
+    seedRows(state, 5)
+    const forwarder = new LogForwarder(state.app, snapshot(state))
+
+    await forwarder.shipPending()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(state.cursor.current).toBe(5)
+  })
+
+  it('reflects a config change without re-instantiating', async () => {
+    const state = makeApp({ enabled: false })
+    seedRows(state, 2)
+    const forwarder = new LogForwarder(state.app, snapshot(state))
+
+    await forwarder.shipPending()
+    expect(fetchMock).not.toHaveBeenCalled()
+
+    await forwarder.setConfig({ enabled: true })
+    await forwarder.shipPending()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(state.cursor.current).toBe(2)
+  })
+
+  it('persists token to secrets and clears it when set to empty', async () => {
+    const state = makeApp()
+    const forwarder = new LogForwarder(state.app, snapshot(state))
+
+    await forwarder.setConfig({ token: 'tok' })
+    expect(state.secretsCalls.setItem).toBe(1)
+    expect(state.token).toBe('tok')
+
+    await forwarder.setConfig({ token: '' })
+    expect(state.secretsCalls.deleteItem).toBe(1)
+    expect(state.token).toBeNull()
+  })
+
+  it('seeds the log context with device only when not authed', async () => {
+    const state = makeApp()
+    const spy = jest.spyOn(loggerPkg, 'setLogContext')
+    await LogForwarder.create(state.app)
+    expect(spy).toHaveBeenLastCalledWith({ device: state.deviceId })
+    spy.mockRestore()
+  })
+
+  it('seeds the log context with device + 8-char account when authed', async () => {
+    const state = makeApp({ mnemonicHash: 'abcdef0123456789'.repeat(4) })
+    const spy = jest.spyOn(loggerPkg, 'setLogContext')
+    await LogForwarder.create(state.app)
+    expect(spy).toHaveBeenLastCalledWith({ device: state.deviceId, account: 'abcdef01' })
+    spy.mockRestore()
+  })
+
+  it('refreshAccount updates the log context with the new (trimmed) account', async () => {
+    const state = makeApp()
+    const forwarder = new LogForwarder(state.app, snapshot(state))
+    state.mnemonicHash = 'fedcba9876543210'.repeat(4)
+    const spy = jest.spyOn(loggerPkg, 'setLogContext')
+    await forwarder.refreshAccount()
+    expect(spy).toHaveBeenLastCalledWith({ device: state.deviceId, account: 'fedcba98' })
+    spy.mockRestore()
+  })
+
+  it('passes the data field through from DB to wire', async () => {
+    const state = makeApp()
+    state.rows.push({
+      id: 1,
+      timestamp: '2026-01-01T00:00:00.000Z',
+      level: 'info',
+      scope: 'test',
+      message: 'hello',
+      data: JSON.stringify({ device: 'devabc12', account: 'acct1234', extra: 1 }),
+    })
+    const forwarder = new LogForwarder(state.app, snapshot(state))
+
+    await forwarder.shipPending()
+
+    const line = JSON.parse((fetchMock.mock.calls[0][1].body as string).trim())
+    expect(line.data).toEqual({ device: 'devabc12', account: 'acct1234', extra: 1 })
+  })
+})

--- a/packages/core/src/services/logForwarder.ts
+++ b/packages/core/src/services/logForwarder.ts
@@ -1,0 +1,231 @@
+import { type LogEntry, serializeData, setLogAppender, setLogContext } from '@siastorage/logger'
+import type { AppService } from '../app/service'
+
+const REMOTE_LOG_TOKEN_KEY = 'remoteLogToken'
+const REMOTE_LOG_TIMEOUT_MS = 30_000
+const REMOTE_LOG_BATCH_SIZE = 200
+const REMOTE_LOG_INTERVAL_MS = 2000
+const ID_PREFIX_LEN = 8
+
+type Snapshot = {
+  enabled: boolean
+  endpoint: string
+  cursor: number
+  token: string | null
+  deviceId: string
+}
+
+export type RemoteLogConfigUpdate = {
+  enabled?: boolean
+  endpoint?: string
+  token?: string | null
+}
+
+type LogRowWire = {
+  id: number
+  timestamp: string
+  level: string
+  scope: string
+  message: string
+  data: string | null
+}
+
+/**
+ * Forwards structured logs to a user-supplied HTTP endpoint as NDJSON. The DB
+ * sink and HTTP sink run independently: the appender only writes to the local
+ * log table; a separate ticker reads since a persisted cursor and POSTs the
+ * batch. A network outage stalls the cursor but never blocks DB persistence.
+ */
+export class LogForwarder {
+  private snapshot: Snapshot
+  private inflight = false
+  private httpTimer: ReturnType<typeof setInterval> | null = null
+
+  constructor(
+    private readonly app: AppService,
+    snapshot: Snapshot,
+  ) {
+    this.snapshot = snapshot
+  }
+
+  static async create(app: AppService): Promise<LogForwarder> {
+    const [enabled, endpoint, cursor, token, deviceId, mnemonicHash] = await Promise.all([
+      app.settings.getRemoteLogEnabled(),
+      app.settings.getRemoteLogEndpoint(),
+      app.settings.getRemoteLogCursor(),
+      app.secrets.getItem(REMOTE_LOG_TOKEN_KEY),
+      app.settings.getDeviceId(),
+      app.auth.getMnemonicHash(),
+    ])
+    applyLogContext(deviceId, mnemonicHash)
+    return new LogForwarder(app, { enabled, endpoint, cursor, token, deviceId })
+  }
+
+  /** Appender registered with the logger package: persists every entry
+   * locally. Independent of the HTTP sink — a network outage cannot affect
+   * the DB write that this function performs. */
+  appender = async (entries: LogEntry[]): Promise<void> => {
+    try {
+      await this.app.logs.appendMany(
+        entries.map((entry) => ({
+          timestamp: entry.timestamp,
+          level: entry.level,
+          scope: entry.scope,
+          message: entry.message,
+          data: serializeData(entry.data),
+        })),
+      )
+    } catch (error) {
+      console.warn('[logForwarder] db append failed:', error)
+    }
+  }
+
+  /** Start the HTTP shipping ticker. Idempotent. Drains immediately so any
+   * backlog from a previous offline session ships without waiting for a tick. */
+  start(intervalMs: number = REMOTE_LOG_INTERVAL_MS): void {
+    if (this.httpTimer) return
+    this.httpTimer = setInterval(() => {
+      void this.shipPending()
+    }, intervalMs)
+    void this.shipPending()
+  }
+
+  /** Stop the HTTP shipping ticker. The DB sink is unaffected. */
+  stop(): void {
+    if (this.httpTimer) {
+      clearInterval(this.httpTimer)
+      this.httpTimer = null
+    }
+  }
+
+  /** Persist config changes and refresh the snapshot used by the HTTP sink. */
+  async setConfig(update: RemoteLogConfigUpdate): Promise<void> {
+    if (update.enabled !== undefined) {
+      await this.app.settings.setRemoteLogEnabled(update.enabled)
+      this.snapshot.enabled = update.enabled
+    }
+    if (update.endpoint !== undefined) {
+      await this.app.settings.setRemoteLogEndpoint(update.endpoint)
+      this.snapshot.endpoint = update.endpoint
+    }
+    if (update.token !== undefined) {
+      if (!update.token) {
+        await this.app.secrets.deleteItem(REMOTE_LOG_TOKEN_KEY)
+        this.snapshot.token = null
+      } else {
+        await this.app.secrets.setItem(REMOTE_LOG_TOKEN_KEY, update.token)
+        this.snapshot.token = update.token
+      }
+    }
+  }
+
+  getToken(): Promise<string | null> {
+    return this.app.secrets.getItem(REMOTE_LOG_TOKEN_KEY)
+  }
+
+  /** Re-read the user identity (mnemonic hash) and update the log context so
+   * subsequent log entries carry the new accountId in their data field. Reset
+   * and sign-out are handled automatically because LogForwarder is recreated
+   * on app re-init. */
+  async refreshAccount(): Promise<void> {
+    const mnemonicHash = await this.app.auth.getMnemonicHash()
+    applyLogContext(this.snapshot.deviceId, mnemonicHash)
+  }
+
+  /**
+   * Read the next batch of unshipped rows from the DB and POST them. Cursor
+   * advances only on success, so an offline gap is replayed on the next call.
+   * Skip while a request is in flight to avoid fan-out on a degraded network.
+   */
+  async shipPending(): Promise<void> {
+    if (!this.snapshot.enabled || !this.snapshot.endpoint || this.inflight) return
+    this.inflight = true
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), REMOTE_LOG_TIMEOUT_MS)
+    try {
+      const rows = await this.app.logs.readSinceId(this.snapshot.cursor, REMOTE_LOG_BATCH_SIZE)
+      if (rows.length === 0) return
+      const body = rows.map(rowToWireLine).join('')
+      const headers: Record<string, string> = { 'Content-Type': 'application/x-ndjson' }
+      if (this.snapshot.token) headers.Authorization = `Bearer ${this.snapshot.token}`
+      const res = await fetch(this.snapshot.endpoint, {
+        method: 'POST',
+        headers,
+        body,
+        signal: controller.signal,
+      })
+      if (!res.ok) {
+        console.warn('[logForwarder] endpoint returned', res.status)
+        return
+      }
+      const lastId = rows[rows.length - 1].id
+      this.snapshot.cursor = lastId
+      await this.app.settings.setRemoteLogCursor(lastId)
+    } catch (error) {
+      console.warn('[logForwarder] ship failed:', error)
+    } finally {
+      clearTimeout(timeoutId)
+      this.inflight = false
+    }
+  }
+}
+
+function rowToWireLine(row: LogRowWire): string {
+  return `${JSON.stringify({
+    id: row.id,
+    timestamp: row.timestamp,
+    level: row.level,
+    scope: row.scope,
+    message: row.message,
+    data: row.data ? safeParse(row.data) : undefined,
+  })}\n`
+}
+
+function safeParse(s: string): unknown {
+  try {
+    return JSON.parse(s)
+  } catch {
+    return s
+  }
+}
+
+/** Set the log context from the current device id and (optional) mnemonic
+ * hash. Account is the trimmed prefix of the hash. Used at app boot, after
+ * sign-in, and on reset so every code path lands on the same context shape. */
+export function applyLogContext(deviceId: string, mnemonicHash: string | null): void {
+  const account = mnemonicHash ? mnemonicHash.slice(0, ID_PREFIX_LEN) : null
+  setLogContext(account ? { device: deviceId, account } : { device: deviceId })
+}
+
+let instance: LogForwarder | null = null
+
+/** Initialize the singleton forwarder, register the DB appender, and start
+ * the HTTP ticker. */
+export async function initLogForwarder(app: AppService): Promise<void> {
+  if (instance) instance.stop()
+  instance = await LogForwarder.create(app)
+  setLogAppender(instance.appender)
+  instance.start()
+}
+
+/** Re-register the appender and restart the HTTP ticker after suspension. */
+export function resumeLogForwarder(): void {
+  if (!instance) return
+  setLogAppender(instance.appender)
+  instance.start()
+}
+
+export function setRemoteLogConfig(update: RemoteLogConfigUpdate): Promise<void> {
+  if (!instance) throw new Error('logForwarder not initialized')
+  return instance.setConfig(update)
+}
+
+export function getRemoteLogToken(): Promise<string | null> {
+  return instance ? instance.getToken() : Promise.resolve(null)
+}
+
+/** Re-read the current account key and refresh the log context. Call after
+ * sign-in so the new accountId reaches both the wire and the terminal. */
+export function refreshLogAccount(): Promise<void> {
+  return instance ? instance.refreshAccount() : Promise.resolve()
+}

--- a/packages/core/src/stores/index.ts
+++ b/packages/core/src/stores/index.ts
@@ -34,6 +34,8 @@ export {
   useLogScopes,
   useMaxDownloads,
   usePhotoImportDirectory,
+  useRemoteLogEnabled,
+  useRemoteLogEndpoint,
   useShowAdvanced,
   useStatusDisplayMode,
 } from './settings'

--- a/packages/core/src/stores/settings.ts
+++ b/packages/core/src/stores/settings.ts
@@ -74,3 +74,19 @@ export function useLogScopes() {
   const app = useApp()
   return useSWR(app.caches.settings.key('logScopes'), () => app.settings.getLogScopes())
 }
+
+/** Returns whether remote log forwarding is enabled. */
+export function useRemoteLogEnabled() {
+  const app = useApp()
+  return useSWR(app.caches.settings.key('remoteLogEnabled'), () =>
+    app.settings.getRemoteLogEnabled(),
+  )
+}
+
+/** Returns the configured remote log endpoint URL. */
+export function useRemoteLogEndpoint() {
+  const app = useApp()
+  return useSWR(app.caches.settings.key('remoteLogEndpoint'), () =>
+    app.settings.getRemoteLogEndpoint(),
+  )
+}

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -10,4 +10,4 @@ export {
   SCOPE_COLORS,
 } from './logColors'
 export type { LogData, LogEntry, LogLevel } from './logger'
-export { formatDataPairs, logger, rustLogger, serializeData } from './logger'
+export { formatDataPairs, logger, rustLogger, serializeData, setLogContext } from './logger'

--- a/packages/logger/src/logColors.ts
+++ b/packages/logger/src/logColors.ts
@@ -1,6 +1,7 @@
 // ANSI color codes for terminal output.
 export const ANSI_RESET = '\x1b[0m'
 export const ANSI_BOLD = '\x1b[1m'
+export const ANSI_DIM = '\x1b[2m'
 const ANSI_CYAN = '\x1b[36m'
 const ANSI_GREEN = '\x1b[32m'
 const ANSI_YELLOW = '\x1b[33m'

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -1,5 +1,5 @@
 import { appendLog } from './logAppender'
-import { ANSI_BOLD, ANSI_RESET, getLevelColorAnsi, getScopeColorAnsi } from './logColors'
+import { ANSI_BOLD, ANSI_DIM, ANSI_RESET, getLevelColorAnsi, getScopeColorAnsi } from './logColors'
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
 
@@ -122,36 +122,66 @@ export function formatDataPairs(data?: LogData): string {
   return pairs.join(' ')
 }
 
+const NO_ACCOUNT_PLACEHOLDER = '--------'
+
 function formatTerminalLog(
   level: LogLevel,
   scope: string,
   timestamp: string,
   msg: string,
   data?: LogData,
+  context?: Record<string, unknown>,
 ): string {
   const levelColor = getLevelColorAnsi(level)
   const scopeColor = getScopeColorAnsi(scope)
   const levelUpper = level.toUpperCase().padEnd(5)
+  const contextPart = formatContextTags(context)
   const dataPart = formatDataPairs(data)
   const messagePart = dataPart ? `${msg} ${dataPart}` : msg
-  return `${timestamp} ${levelColor}${ANSI_BOLD}${levelUpper}${ANSI_RESET} ${scopeColor}${ANSI_BOLD}[${scope}]${ANSI_RESET} ${messagePart}`
+  return `${timestamp} ${levelColor}${ANSI_BOLD}${levelUpper}${ANSI_RESET} ${contextPart}${scopeColor}${ANSI_BOLD}[${scope}]${ANSI_RESET} ${messagePart}`
+}
+
+function formatContextTags(context?: Record<string, unknown>): string {
+  if (!context?.device) return ''
+  const account = context.account ? String(context.account) : NO_ACCOUNT_PLACEHOLDER
+  return `${ANSI_DIM}[${String(context.device)}][${account}]${ANSI_RESET}`
+}
+
+let logContext: Record<string, unknown> = {}
+
+/** Set per-process context fields (e.g., device id, account id) merged into
+ * the data field of every subsequent log entry. The merged data flows into
+ * the buffer, the DB sink, the terminal output, and the wire format. The
+ * in-app log viewer is responsible for hiding these keys when displaying
+ * entries on-device. Caller-supplied data keys win on conflict. */
+export function setLogContext(ctx: Record<string, unknown>): void {
+  logContext = ctx
+}
+
+function mergeContext(data?: LogData): LogData | undefined {
+  if (Object.keys(logContext).length === 0) return data
+  return { ...(logContext as LogData), ...(data ?? {}) }
 }
 
 function createLogger(level: LogLevel) {
   return (scope: string, msg: string, data?: LogData) => {
     const timestamp = formatTimestamp()
+    const merged = mergeContext(data)
     const entry: LogEntry = {
       timestamp,
       level,
       scope,
       message: msg,
-      data,
+      data: merged,
     }
 
     appendLog(entry)
 
     if (shouldLogToTerminal(level, scope)) {
-      console.log(formatTerminalLog(level, scope, timestamp, msg, data))
+      // Pass original data (without context) plus the context separately so
+      // the formatter can render device/account as front tags rather than
+      // mixing them into the trailing key=value data part.
+      console.log(formatTerminalLog(level, scope, timestamp, msg, data, logContext))
     }
   }
 }


### PR DESCRIPTION
Adds a Settings → Advanced toggle that, when enabled, ships every log entry as NDJSON to a user-supplied HTTP endpoint with optional Bearer auth — for live multi-device debugging via any NDJSON receiver.
