### PR TITLE
fix(sync-gate): persist across suspensions and gate background services

### DIFF
--- a/.changeset/gate-thumbnail-syncup-on-sync-gate.md
+++ b/.changeset/gate-thumbnail-syncup-on-sync-gate.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Hold off thumbnail generation, metadata sync-up, and new-photo ingestion for the full initial sync window so the library finishes catching up before background work resumes.

--- a/.changeset/preserve-syncgate-on-suspend.md
+++ b/.changeset/preserve-syncgate-on-suspend.md
@@ -1,0 +1,5 @@
+---
+core: patch
+---
+
+Preserve the sync gate across suspension aborts so it stays up until sync actually completes.

--- a/apps/mobile/src/managers/syncDownEvents.test.ts
+++ b/apps/mobile/src/managers/syncDownEvents.test.ts
@@ -1428,6 +1428,31 @@ describe('syncDownEvents', () => {
 
       await app().settings.setAutoSyncDownEvents(true)
     })
+
+    test("preserves 'active' gate when aborted mid-sync", async () => {
+      app().sync.setState({ syncGateStatus: 'pending' })
+      const largeBatch = makeEvents(500)
+      const heartbeat = makeEvents(1, 500)
+      internal().setSdk({
+        objectEvents: jest.fn().mockResolvedValueOnce(largeBatch).mockResolvedValueOnce(heartbeat),
+        appKey: () => mockAppKey,
+      } as any)
+      await run(new AbortController().signal)
+      expect(app().sync.getState().syncGateStatus).toBe('active')
+
+      const aborted = new AbortController()
+      aborted.abort()
+      await run(aborted.signal)
+      expect(app().sync.getState().syncGateStatus).toBe('active')
+    })
+
+    test("preserves 'pending' gate when aborted before any sync", async () => {
+      app().sync.setState({ syncGateStatus: 'pending' })
+      const aborted = new AbortController()
+      aborted.abort()
+      await run(aborted.signal)
+      expect(app().sync.getState().syncGateStatus).toBe('pending')
+    })
   })
 
   test('delete event on already-tombstoned file preserves tombstone when no objects remain', async () => {

--- a/apps/mobile/src/managers/syncNewPhotos.ts
+++ b/apps/mobile/src/managers/syncNewPhotos.ts
@@ -46,6 +46,12 @@ export async function run(signal?: AbortSignal): Promise<void> {
     logger.debug('syncNewPhotos', 'skipped', { reason: 'no_permission' })
     return
   }
+  // Hard gate: hold off ingesting new camera-roll photos during the
+  // initial sync window, just for resource coordination.
+  if (app().sync.getState().syncGateStatus === 'active') {
+    logger.debug('syncNewPhotos', 'skipped', { reason: 'sync_gate_active' })
+    return
+  }
   if (signal?.aborted) return
   const enabledAt = await getSyncNewPhotosEnabledAt()
 

--- a/apps/mobile/src/managers/syncUpMetadata.ts
+++ b/apps/mobile/src/managers/syncUpMetadata.ts
@@ -20,6 +20,14 @@ export async function runSyncUpMetadata(batchSize: number, signal?: AbortSignal)
 }
 
 async function run(signal: AbortSignal): Promise<void> {
+  // Hard gate: don't push metadata up during the initial sync-down
+  // window — wait for the library to fully land before pushing changes.
+  if (app().sync.getState().syncGateStatus === 'active') {
+    logger.debug('syncUpMetadata', 'skipped', { reason: 'sync_gate_active' })
+    return
+  }
+  // Per-tick gate: keep sync-up off the wire while a sync-down batch is
+  // writing, so the two cycles never overlap.
   if (app().sync.getState().isSyncingDown) {
     logger.debug('syncUpMetadata', 'skipped', { reason: 'syncing_down' })
     return

--- a/apps/mobile/src/managers/thumbnailScanner.ts
+++ b/apps/mobile/src/managers/thumbnailScanner.ts
@@ -30,6 +30,15 @@ export async function runThumbnailScanner(signal?: AbortSignal): Promise<Thumbna
 }
 
 async function run(signal: AbortSignal): Promise<void> {
+  // Hard gate: hold off for the entire initial sync window so we don't
+  // generate thumbs locally for files whose remote thumbnails are about
+  // to land in the same catch-up.
+  if (app().sync.getState().syncGateStatus === 'active') {
+    logger.debug('thumbnailScanner', 'skipped', { reason: 'sync_gate_active' })
+    return
+  }
+  // Per-tick gate: a sync-down batch is mid-flight — skip thumbnail
+  // generation while sync-down is writing, just for resource coordination.
   if (app().sync.getState().isSyncingDown) {
     logger.debug('thumbnailScanner', 'skipped', { reason: 'syncing_down' })
     return

--- a/packages/core/src/services/syncDownEvents.ts
+++ b/packages/core/src/services/syncDownEvents.ts
@@ -180,7 +180,12 @@ export async function syncDownEventsBatch(
     logger.info('syncDownEvents', 'synced', { total: counts.total })
     const willContinue = totalEventsFetched > 1 && !signal.aborted
     const endGateStatus = app.sync.getState().syncGateStatus
-    const dismissGate = endGateStatus === 'pending' || (endGateStatus === 'active' && !willContinue)
+    // Preserve the gate on suspension abort: it must stay shown to the user
+    // and continue blocking other services across sessions until sync
+    // actually completes — never dismissed against an incomplete sync.
+    const dismissGate =
+      !signal.aborted &&
+      (endGateStatus === 'pending' || (endGateStatus === 'active' && !willContinue))
     app.sync.setState({
       isSyncingDown: willContinue,
       syncDownCount: counts.total,


### PR DESCRIPTION
The sync gate was dismissed when suspension aborted a mid-batch sync, leaving subsequent sessions ungated against an incomplete catch-up. It now stays up (and shows the init UI) across aborts and also gates thumbnailScanner, syncUpMetadata, and syncNewPhotos so they hold off until any catch-up sync is complete.
