### PR TITLE
feat(mobile): keep SWR disabled outside foreground state

### DIFF
--- a/.changeset/bg-task-swr-disable.md
+++ b/.changeset/bg-task-swr-disable.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+SWR refetches now mirror app foreground state — paused while in background (including during BG-task wakeups), enabled when the user is using the app.

--- a/.changeset/suspension-on-foreground-active-hook.md
+++ b/.changeset/suspension-on-foreground-active-hook.md
@@ -1,0 +1,5 @@
+---
+core: minor
+---
+
+Add `onForegroundActive` optional hook to `createSuspensionManager`. Fires synchronously on every `setAppState('foreground')` call, including no-op calls — covers the case where the manager is already resumed (e.g. by a BG task) and the user subsequently foregrounds, where `onAfterResume` does not fire.

--- a/apps/integration/test/app.ts
+++ b/apps/integration/test/app.ts
@@ -159,6 +159,15 @@ export interface TestApp {
   /** Convenience: register → run fn → release (always releases even if
    * fn throws). Mirrors what backgroundTasks.ts does in production. */
   simulateBackgroundTask(id: string, fn: () => Promise<void>): Promise<void>
+  /** Cumulative call counts for the suspension manager hooks. Tests use
+   * this to assert that platform-level glue (e.g. SWR re-enable) fires
+   * correctly across the four BG-task lifecycle scenarios. Read-only —
+   * the harness owns the counters; tests should only inspect them. */
+  readonly hookCalls: Readonly<{
+    onBeforeSuspend: number
+    onAfterResume: number
+    onForegroundActive: number
+  }>
 
   app: AppService
   internal: AppServiceInternal
@@ -350,6 +359,12 @@ export function createTestApp(
     interval: DB_OPTIMIZE_INTERVAL,
   })
 
+  const hookCalls = {
+    onBeforeSuspend: 0,
+    onAfterResume: 0,
+    onForegroundActive: 0,
+  }
+
   const suspensionManager = createSuspensionManager({
     scheduler: {
       pause: () => scheduler.pause(),
@@ -369,6 +384,17 @@ export function createTestApp(
       waitForIdle: () => Promise.resolve(),
       close: async () => testDb.close(),
       reopen: () => testDb.open(),
+    },
+    hooks: {
+      onBeforeSuspend: () => {
+        hookCalls.onBeforeSuspend += 1
+      },
+      onAfterResume: () => {
+        hookCalls.onAfterResume += 1
+      },
+      onForegroundActive: () => {
+        hookCalls.onForegroundActive += 1
+      },
     },
     hardDeadlineMs: 15_000,
   })
@@ -440,6 +466,8 @@ export function createTestApp(
         await suspensionManager.releaseBackgroundTask(id)
       }
     },
+
+    hookCalls,
 
     triggerSyncDown() {
       syncDown.triggerNow()

--- a/apps/integration/test/suspension.test.ts
+++ b/apps/integration/test/suspension.test.ts
@@ -407,6 +407,9 @@ describe('Suspension', () => {
     it('normal completion → auto-suspends when app is background', async () => {
       await app.setAppState('background')
       expect(app.isSuspended()).toBe(true)
+      // onBeforeSuspend fires once on the first auto-suspend; no foreground.
+      expect(app.hookCalls.onBeforeSuspend).toBe(1)
+      expect(app.hookCalls.onForegroundActive).toBe(0)
 
       await app.simulateBackgroundTask('bg-fetch', async () => {
         expect(app.isSuspended()).toBe(false) // register reopened DB
@@ -417,6 +420,11 @@ describe('Suspension', () => {
       // Release auto-suspended because appState=background and no more tasks.
       expect(app.isSuspended()).toBe(true)
       expect(app.getRunningBackgroundTaskIds()).toEqual([])
+      // BG task wake fired onAfterResume once; release re-triggered
+      // onBeforeSuspend. User never foregrounded.
+      expect(app.hookCalls.onAfterResume).toBe(1)
+      expect(app.hookCalls.onBeforeSuspend).toBe(2)
+      expect(app.hookCalls.onForegroundActive).toBe(0)
     }, 60_000)
 
     it('timeout path still releases and re-suspends (crash-1 regression guard)', async () => {
@@ -433,6 +441,9 @@ describe('Suspension', () => {
 
       expect(app.isSuspended()).toBe(true)
       expect(app.getRunningBackgroundTaskIds()).toEqual([])
+      // Same hook shape as normal completion — BG-task wake didn't fire
+      // onForegroundActive because AppState stayed 'background'.
+      expect(app.hookCalls.onForegroundActive).toBe(0)
     }, 60_000)
 
     it('overlapping tasks — DB stays open until last release', async () => {
@@ -454,6 +465,10 @@ describe('Suspension', () => {
       await app.releaseBackgroundTask('B')
       expect(app.isSuspended()).toBe(true) // only now
       expect(app.getRunningBackgroundTaskIds()).toEqual([])
+      // Two registers, but only the first triggers a real resume; second
+      // is a no-op (already active). Foreground hook must not fire.
+      expect(app.hookCalls.onAfterResume).toBe(1)
+      expect(app.hookCalls.onForegroundActive).toBe(0)
     }, 60_000)
 
     it('user foregrounds during BG task — release does not suspend', async () => {
@@ -462,10 +477,17 @@ describe('Suspension', () => {
 
       await app.registerBackgroundTask('bg-fetch')
       expect(app.isSuspended()).toBe(false)
+      // BG-task wake didn't fire onForegroundActive — appState still bg.
+      expect(app.hookCalls.onForegroundActive).toBe(0)
 
-      // User opens the app while the BG task is still registered.
+      // User opens the app while the BG task is still registered. The
+      // manager is already resumed, so onAfterResume does NOT fire a
+      // second time. onForegroundActive must fire here — that's the whole
+      // reason this hook exists.
       await app.setAppState('foreground')
       expect(app.isSuspended()).toBe(false)
+      expect(app.hookCalls.onForegroundActive).toBe(1)
+      expect(app.hookCalls.onAfterResume).toBe(1) // unchanged from BG-task wake
 
       await app.releaseBackgroundTask('bg-fetch')
       expect(app.isSuspended()).toBe(false) // user still has app open

--- a/apps/mobile/src/lib/swr.ts
+++ b/apps/mobile/src/lib/swr.ts
@@ -1,8 +1,16 @@
-// Global SWR enabled flag for background suspension.
-// SWR's isPaused callback polls this on each revalidation attempt.
-// Flipping the flag is synchronous and takes effect immediately.
+// Global SWR enabled flag. SWR's isPaused callback polls this on each
+// revalidation attempt; flipping the flag is synchronous and takes
+// effect immediately. Mirrors AppState: enabled when foregrounded,
+// disabled otherwise — the suspension manager flips it on AppState
+// transitions.
+//
+// Initialized from AppState so a cold-start BG-task launch doesn't fire
+// SWR fetchers from the initial React mount before the suspension
+// manager has wired up its handlers.
 
-let enabled = true
+import { AppState } from 'react-native'
+
+let enabled = AppState.currentState === 'active'
 
 export function setSWREnabled(value: boolean): void {
   enabled = value

--- a/apps/mobile/src/managers/suspension.ts
+++ b/apps/mobile/src/managers/suspension.ts
@@ -102,20 +102,22 @@ const manager = createSuspensionManager({
       pauseArchiveSync()
     },
     onAfterResume: () => {
-      setSWREnabled(true)
+      // SWR re-enable lives in onForegroundActive, not here — onAfterResume
+      // also fires on BG-task wakes (AppState stays 'background'), where
+      // we want SWR to stay off.
       resumeLogger()
-      // Any SWR hook that mounted while we were paused got isLoading:false with
-      // no data and no error — isPaused gates revalidation events but doesn't
-      // trigger them when it flips back, so those hooks stay frozen. Force a
-      // global revalidation so newly-mounted (and any stale) keys refetch.
-      // Fires when iOS delivers a deep link before the app fully resumes, which
-      // mounts screens against a paused SWR.
-      void swrGlobalMutate(() => true)
       // Resume archive walk from the same cursor if it wasn't complete.
       void resumeArchiveSync()
       // Eviction's frequency gate short-circuits when it ran recently, so a
       // quick app-switch is cheap; a long suspension triggers a real pass.
       void runFsEvictionScanner()
+    },
+    onForegroundActive: () => {
+      // iOS-only path. The mobile AppState listener routes 'active'
+      // through manager.setAppState('foreground') which fires this hook;
+      // the Android branch in initSuspensionManager calls the helper
+      // directly because Android skips the manager's suspend flow.
+      reEnableSWROnForeground()
     },
   },
   hardDeadlineMs: HARD_DEADLINE_MS,
@@ -142,8 +144,28 @@ export function initSuspensionManager(): void {
     // so the flow only fires when the user actually leaves.
     if (Platform.OS === 'ios') {
       onAppStateChange(nextState)
+    } else if (nextState === 'active') {
+      // Android skips the manager's suspend flow because AppState
+      // 'background' fires for picker / share-sheet round-trips that
+      // aren't real backgrounding. Call the helper directly instead of
+      // routing through the manager hook.
+      reEnableSWROnForeground()
     }
   })
+}
+
+/** Flips SWR back on and forces revalidation of every subscribed hook.
+ * Two callers: the iOS path via the manager's onForegroundActive hook
+ * (integration-test covered) and the Android branch above (direct).
+ * The mutate is necessary because SWR's isPaused gates revalidation
+ * events but doesn't trigger them when the flag flips back — hooks that
+ * mounted against a paused SWR stay frozen until something kicks them.
+ * Covers the iOS deep-link case where a screen mounts during the resume
+ * race before SWR un-pauses. */
+function reEnableSWROnForeground(): void {
+  setSWREnabled(true)
+  void swrGlobalMutate(() => true)
+  logger.info('suspension', 'swr_enabled')
 }
 
 export function teardownSuspensionManager(): void {
@@ -177,6 +199,9 @@ function onAppStateChange(nextState: AppStateStatus): void {
     // until WAL checkpoint + close complete.
     void withIosExecutionTime(() => manager.setAppState('background'))
   } else if (nextState === 'active') {
+    // SWR re-enable now lives in the manager's onForegroundActive hook,
+    // which fires whenever appState transitions to foreground regardless
+    // of the manager's internal resume/suspended state.
     void manager.setAppState('foreground')
   }
 }

--- a/packages/core/src/services/suspension.test.ts
+++ b/packages/core/src/services/suspension.test.ts
@@ -99,3 +99,56 @@ describe('createSuspensionManager deadline behavior', () => {
     expect(manager.isSuspended()).toBe(true)
   })
 })
+
+describe('createSuspensionManager onForegroundActive hook', () => {
+  it('fires on every setAppState(foreground) call, including no-ops', async () => {
+    const onForegroundActive = jest.fn()
+    const onAfterResume = jest.fn()
+    const { adapters } = createAdapters()
+    const manager = createSuspensionManager({
+      ...adapters,
+      hooks: { onForegroundActive, onAfterResume },
+    })
+
+    // Initial appState is 'foreground'. setAppState('foreground') with no
+    // transition still fires the hook — matches iOS 'inactive' → 'active'
+    // flicker semantics where 'active' events should refresh SWR even
+    // when the manager never thought we were 'background'.
+    await manager.setAppState('foreground')
+    expect(onForegroundActive).toHaveBeenCalledTimes(1)
+    expect(onAfterResume).not.toHaveBeenCalled()
+
+    // Real cycle: foreground → background → foreground.
+    await manager.setAppState('background')
+    expect(onForegroundActive).toHaveBeenCalledTimes(1)
+    await manager.setAppState('foreground')
+    expect(onForegroundActive).toHaveBeenCalledTimes(2)
+    expect(onAfterResume).toHaveBeenCalledTimes(1)
+
+    // BG-task wake from suspended fires onAfterResume but not the
+    // foreground hook — appState stays 'background'.
+    await manager.setAppState('background')
+    await manager.registerBackgroundTask('bg')
+    expect(onAfterResume).toHaveBeenCalledTimes(2)
+    expect(onForegroundActive).toHaveBeenCalledTimes(2)
+
+    // User foregrounds while BG task is still running. The manager is
+    // already resumed so onAfterResume does NOT fire again, but
+    // onForegroundActive must — that's the whole reason this hook exists.
+    await manager.setAppState('foreground')
+    expect(onAfterResume).toHaveBeenCalledTimes(2)
+    expect(onForegroundActive).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not fire on setAppState(background) calls', async () => {
+    const onForegroundActive = jest.fn()
+    const { adapters } = createAdapters()
+    const manager = createSuspensionManager({
+      ...adapters,
+      hooks: { onForegroundActive },
+    })
+    await manager.setAppState('background')
+    await manager.setAppState('background')
+    expect(onForegroundActive).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/services/suspension.ts
+++ b/packages/core/src/services/suspension.ts
@@ -31,6 +31,17 @@ export type SuspensionAdapters = {
   hooks?: {
     onBeforeSuspend?(): void | Promise<void>
     onAfterResume?(): void
+    /**
+     * Fires synchronously on every `setAppState('foreground')` call,
+     * including no-op calls where appState was already 'foreground'.
+     * Matches iOS AppState semantics: any 'active' event from the OS is
+     * a "user is here" signal even if it didn't go through 'background'
+     * first (e.g. the brief 'active' → 'inactive' → 'active' flicker
+     * from a notification panel pull-down). Also covers the case where
+     * a BG task already resumed the manager and the user subsequently
+     * foregrounds — onAfterResume doesn't fire there.
+     */
+    onForegroundActive?(): void
   }
   hardDeadlineMs: number
 }
@@ -202,6 +213,13 @@ export function createSuspensionManager(adapters: SuspensionAdapters) {
      */
     setAppState(next: AppStateValue): Promise<void> {
       const prev = appState
+      // Foreground hook fires on every 'foreground' call, including
+      // no-ops, so flickers and BG-task overlaps both reach platform
+      // glue. Background has no equivalent — onBeforeSuspend already
+      // covers the only case that matters there (real suspension).
+      if (next === 'foreground') {
+        hooks?.onForegroundActive?.()
+      }
       if (prev === next) return Promise.resolve()
       appState = next
       const activeCount = runningTasks.size


### PR DESCRIPTION
SWR was fetching during BG-task wakeups because onAfterResume fired even when AppState stayed background. The flag now mirrors true foreground state: initialized from AppState.currentState and re-enabled only via a new onForegroundActive suspension hook.
