### PR TITLE
fix(core,mobile): stop LogForwarder HTTP ticker on suspend

### DIFF
--- a/.changeset/logforwarder-stop-on-suspend.md
+++ b/.changeset/logforwarder-stop-on-suspend.md
@@ -1,0 +1,6 @@
+---
+core: minor
+mobile: patch
+---
+
+Stop LogForwarder HTTP shipping ticker on suspend so it doesn't compete with the DB drain.

--- a/apps/mobile/src/managers/suspension.ts
+++ b/apps/mobile/src/managers/suspension.ts
@@ -4,6 +4,7 @@ import {
   resumeAllServiceIntervals,
   waitForAllServiceIntervalsIdle,
 } from '@siastorage/core/lib/serviceInterval'
+import { stopLogForwarder } from '@siastorage/core/services/logForwarder'
 import { createSuspensionManager } from '@siastorage/core/services/suspension'
 import { logger, stopLogAppender } from '@siastorage/logger'
 import { AppState, type AppStateStatus, Platform } from 'react-native'
@@ -90,7 +91,11 @@ const manager = createSuspensionManager({
   hooks: {
     onBeforeSuspend: async () => {
       await logSuspendDiagnostics()
+      // Drain JS log buffer to DB before halting the HTTP ticker;
+      // stopLogForwarder awaits any in-flight ship so its cursor
+      // UPDATE doesn't race the DB close.
       await stopLogAppender()
+      await stopLogForwarder()
       setSWREnabled(false)
       // Cancel in-flight downloads (disk I/O contention with SQLite fsync
       // is a known 0xdead10cc trigger) and pause the photo-archive walk

--- a/packages/core/src/services/logForwarder.test.ts
+++ b/packages/core/src/services/logForwarder.test.ts
@@ -408,4 +408,108 @@ describe('LogForwarder', () => {
     const line = JSON.parse((fetchMock.mock.calls[0][1].body as string).trim())
     expect(line.data).toEqual({ device: 'devabc12', account: 'acct1234', extra: 1 })
   })
+
+  describe('stop()', () => {
+    it('clears the HTTP ticker so further intervals do not fire shipPending', async () => {
+      jest.useFakeTimers()
+      const state = makeApp()
+      const forwarder = new LogForwarder(state.app, snapshot(state))
+      forwarder.start(2000)
+
+      // start()'s immediate drain saw no rows; this row makes the next tick fetch.
+      state.rows.push({
+        id: 1,
+        timestamp: 't',
+        level: 'info',
+        scope: 's',
+        message: 'm',
+        data: null,
+      })
+      await jest.advanceTimersByTimeAsync(2000)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+
+      await forwarder.stop()
+
+      const before = fetchMock.mock.calls.length
+      state.rows.push({
+        id: 2,
+        timestamp: 't',
+        level: 'info',
+        scope: 's',
+        message: 'm',
+        data: null,
+      })
+      await jest.advanceTimersByTimeAsync(10000)
+      expect(fetchMock).toHaveBeenCalledTimes(before)
+      jest.useRealTimers()
+    })
+
+    it('awaits an in-flight shipPending before resolving', async () => {
+      const state = makeApp()
+      let resolveFetch: (v: Response) => void = () => {}
+      fetchMock.mockImplementationOnce(
+        () =>
+          new Promise<Response>((r) => {
+            resolveFetch = r
+          }),
+      )
+      state.rows.push({
+        id: 1,
+        timestamp: 't',
+        level: 'info',
+        scope: 's',
+        message: 'm',
+        data: null,
+      })
+      const forwarder = new LogForwarder(state.app, snapshot(state))
+
+      const shipP = forwarder.shipPending()
+      // Defer to microtasks so shipPending sets inflight before stop runs.
+      await Promise.resolve()
+      let stopResolved = false
+      const stopP = forwarder.stop().then(() => {
+        stopResolved = true
+      })
+      // stop() must NOT resolve while fetch is pending.
+      await Promise.resolve()
+      expect(stopResolved).toBe(false)
+
+      resolveFetch(new Response('', { status: 200 }))
+      await shipP
+      await stopP
+      expect(stopResolved).toBe(true)
+    })
+
+    it('is idempotent — calling twice does not throw', async () => {
+      const state = makeApp()
+      const forwarder = new LogForwarder(state.app, snapshot(state))
+      forwarder.start()
+
+      await forwarder.stop()
+      await forwarder.stop()
+    })
+
+    it('blocks future shipPending calls after stop until restart', async () => {
+      const state = makeApp()
+      state.rows.push({
+        id: 1,
+        timestamp: 't',
+        level: 'info',
+        scope: 's',
+        message: 'm',
+        data: null,
+      })
+      const forwarder = new LogForwarder(state.app, snapshot(state))
+
+      await forwarder.stop()
+      const before = fetchMock.mock.calls.length
+      await forwarder.shipPending()
+      expect(fetchMock).toHaveBeenCalledTimes(before)
+
+      forwarder.start(60_000)
+      await new Promise((r) => setTimeout(r, 0))
+      expect(fetchMock.mock.calls.length).toBeGreaterThan(before)
+      await forwarder.stop()
+    })
+  })
 })

--- a/packages/core/src/services/logForwarder.ts
+++ b/packages/core/src/services/logForwarder.ts
@@ -38,7 +38,8 @@ type LogRowWire = {
  */
 export class LogForwarder {
   private snapshot: Snapshot
-  private inflight = false
+  private inflight: Promise<void> | null = null
+  private stopped = false
   private httpTimer: ReturnType<typeof setInterval> | null = null
 
   constructor(
@@ -84,18 +85,22 @@ export class LogForwarder {
    * backlog from a previous offline session ships without waiting for a tick. */
   start(intervalMs: number = REMOTE_LOG_INTERVAL_MS): void {
     if (this.httpTimer) return
+    this.stopped = false
     this.httpTimer = setInterval(() => {
       void this.shipPending()
     }, intervalMs)
     void this.shipPending()
   }
 
-  /** Stop the HTTP shipping ticker. The DB sink is unaffected. */
-  stop(): void {
+  /** Stop the HTTP ticker and await any in-flight ship. The DB appender is
+   * unaffected. Idempotent. */
+  async stop(): Promise<void> {
+    this.stopped = true
     if (this.httpTimer) {
       clearInterval(this.httpTimer)
       this.httpTimer = null
     }
+    if (this.inflight) await this.inflight
   }
 
   /** Persist config changes and refresh the snapshot used by the HTTP sink. */
@@ -138,8 +143,15 @@ export class LogForwarder {
    * Skip while a request is in flight to avoid fan-out on a degraded network.
    */
   async shipPending(): Promise<void> {
-    if (!this.snapshot.enabled || !this.snapshot.endpoint || this.inflight) return
-    this.inflight = true
+    if (this.stopped || this.inflight) return
+    if (!this.snapshot.enabled || !this.snapshot.endpoint) return
+    this.inflight = this.runShip().finally(() => {
+      this.inflight = null
+    })
+    await this.inflight
+  }
+
+  private async runShip(): Promise<void> {
     const controller = new AbortController()
     const timeoutId = setTimeout(() => controller.abort(), REMOTE_LOG_TIMEOUT_MS)
     try {
@@ -165,7 +177,6 @@ export class LogForwarder {
       console.warn('[logForwarder] ship failed:', error)
     } finally {
       clearTimeout(timeoutId)
-      this.inflight = false
     }
   }
 }
@@ -202,10 +213,17 @@ let instance: LogForwarder | null = null
 /** Initialize the singleton forwarder, register the DB appender, and start
  * the HTTP ticker. */
 export async function initLogForwarder(app: AppService): Promise<void> {
-  if (instance) instance.stop()
+  if (instance) await instance.stop()
   instance = await LogForwarder.create(app)
   setLogAppender(instance.appender)
   instance.start()
+}
+
+/** Stop the singleton HTTP ticker and await any in-flight ship. Called on
+ * suspend so the cursor UPDATE doesn't race the DB close. Idempotent. */
+export async function stopLogForwarder(): Promise<void> {
+  if (!instance) return
+  await instance.stop()
 }
 
 /** Re-register the appender and restart the HTTP ticker after suspension. */


### PR DESCRIPTION
The HTTP shipper kept ticking into suspension, racing its cursor write against the DB close. stop() is now async, blocks new ships, and awaits any in-flight request before the suspend hook continues.
