### PR TITLE
feat(mobile): require external power for BGProcessingTask

### DIFF
--- a/.changeset/bg-processing-requires-charging.md
+++ b/.changeset/bg-processing-requires-charging.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Background tasks now run only while the device is charging, fixing iOS CPU crashes during overnight uploads.

--- a/apps/mobile/src/managers/backgroundTasks.test.ts
+++ b/apps/mobile/src/managers/backgroundTasks.test.ts
@@ -383,4 +383,26 @@ describe('backgroundTasks', () => {
       expect(BackgroundFetch.finish).toHaveBeenCalledWith('unknown-task-id')
     })
   })
+
+  describe('task constraints', () => {
+    it('BGProcessingTask is scheduled with charging + network constraints', () => {
+      expect(BackgroundFetch.scheduleTask).toHaveBeenCalledWith(
+        expect.objectContaining({
+          taskId: 'com.transistorsoft.processing',
+          requiresCharging: true,
+          requiresNetworkConnectivity: true,
+          requiresBatteryNotLow: true,
+        }),
+      )
+    })
+
+    it('BGAppRefreshTask (configure) is configured with charging + network + battery constraints', () => {
+      const configCall = (BackgroundFetch.configure as jest.Mock).mock.calls[0]
+      expect(configCall[0]).toMatchObject({
+        requiresCharging: true,
+        requiresBatteryNotLow: true,
+        requiredNetworkType: 2,
+      })
+    })
+  })
 })

--- a/apps/mobile/src/managers/backgroundTasks.ts
+++ b/apps/mobile/src/managers/backgroundTasks.ts
@@ -61,16 +61,24 @@ const taskConfigs: Record<TaskId, TaskConfig> = {
 }
 
 /**
- * Background fetch wakes up the app and runs with the suspended app state.
- * It runs when the following conditions are met:
- * - Unmetered network connection
- * - Battery is not low
- * - The app is NOT fully terminated
+ * Constraints applied to JS-side task scheduling. The library types/README
+ * label every field [Android only], but the iOS bridge maps a subset for
+ * BGProcessingTask (see scheduleTask call below). For BGAppRefreshTask
+ * (configure), Apple's API has no constraint properties — iOS ignores
+ * all four and picks fire times itself. See
+ * node_modules/react-native-background-fetch/ios/RNBackgroundFetch/RNBackgroundFetch.m.
  */
 const sharedConfig: BackgroundFetchConfig = {
+  // Android only. iOS BGProcessingTask uses requiresNetworkConnectivity (set per-task below).
   requiredNetworkType: BackgroundFetch.NETWORK_TYPE_UNMETERED,
+  // Android only. iOS has no equivalent on either task type.
   requiresBatteryNotLow: true,
-  requiresCharging: false,
+  // Android: WorkManager constraint. iOS BGProcessingTask: forwarded as
+  // BGProcessingTaskRequest.requiresExternalPower, which also disables
+  // iOS's 80%-CPU-over-60s monitor — fixes our cpu_resource_fatal crashes.
+  // iOS BGAppRefreshTask: ignored (no-op).
+  requiresCharging: true,
+  // Android only.
   requiresDeviceIdle: false,
 }
 
@@ -201,6 +209,10 @@ export async function initBackgroundTasks() {
         periodic: true,
         delay: minutesInMs(31),
         ...sharedConfig,
+        // iOS BGProcessingTask only — bridge forwards as
+        // BGProcessingTaskRequest.requiresNetworkConnectivity. Android's
+        // network constraint comes from requiredNetworkType in sharedConfig.
+        requiresNetworkConnectivity: true,
       })
       logger.info('backgroundTask', 'task_scheduled', {
         taskId: bgProcessingTaskConfig.id,


### PR DESCRIPTION
Require charging for background uploads to avoid iOS cpu_resource_fatal crashes (forwards as requiresExternalPower, which disables the 80%-CPU monitor).
