### PR TITLE
ci(release): fix gradle cache and add dry-run mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,11 @@ on:
           - internal
           - production
         default: internal
+      dry_run:
+        description: 'Build only — skip store upload (for verifying CI changes)'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: release-${{ github.ref }}
@@ -47,7 +52,16 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'gradle'
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('bun.lock', 'apps/mobile/package.json') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -78,6 +92,7 @@ jobs:
           SIA_RELEASE_KEY_PASSWORD: ${{ secrets.SIA_RELEASE_KEY_PASSWORD }}
           GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_JSON }}
           GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
           CI: true
         run: bun scripts/releaseAndroid.ts ${{ inputs.track || 'internal' }}
         shell: bash
@@ -147,6 +162,7 @@ jobs:
           RELEASE: 'true'
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APP_STORE_CONNECT_API_KEY_JSON: ${{ secrets.APP_STORE_CONNECT_API_KEY_JSON }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
           CI: true
         run: |
           TRACK="${{ inputs.track || 'internal' }}"

--- a/apps/mobile/scripts/releaseAndroid.ts
+++ b/apps/mobile/scripts/releaseAndroid.ts
@@ -61,11 +61,15 @@ console.log('Step 2/3: Building release AAB...')
 await $`bun scripts/androidGradleTask.ts bundleRelease`
 
 // Step 3: Upload to Play Store
-console.log(`Step 3/3: Uploading to Play Store (${track} track)...`)
-if (track === 'internal') {
-  await $`fastlane android distribute_internal`
+if (Bun.env.DRY_RUN === 'true') {
+  console.log('Step 3/3: DRY_RUN=true — skipping Play Store upload.')
 } else {
-  await $`fastlane android distribute_play_store`
+  console.log(`Step 3/3: Uploading to Play Store (${track} track)...`)
+  if (track === 'internal') {
+    await $`fastlane android distribute_internal`
+  } else {
+    await $`fastlane android distribute_play_store`
+  }
 }
 
 console.log('=== Android release complete! ===')

--- a/apps/mobile/scripts/releaseIos.ts
+++ b/apps/mobile/scripts/releaseIos.ts
@@ -52,11 +52,15 @@ console.log('Step 2/3: Building release IPA...')
 await $`fastlane ios build_ipa`
 
 // Step 3: Upload to App Store Connect
-console.log(`Step 3/3: Uploading to App Store Connect (${track})...`)
-if (track === 'testflight') {
-  await $`fastlane ios distribute_testflight`
+if (Bun.env.DRY_RUN === 'true') {
+  console.log('Step 3/3: DRY_RUN=true — skipping App Store Connect upload.')
 } else {
-  await $`fastlane ios distribute_app_store`
+  console.log(`Step 3/3: Uploading to App Store Connect (${track})...`)
+  if (track === 'testflight') {
+    await $`fastlane ios distribute_testflight`
+  } else {
+    await $`fastlane ios distribute_app_store`
+  }
 }
 
 console.log('=== iOS release complete! ===')


### PR DESCRIPTION
setup-java's cache: 'gradle' errored because Expo generates android/ after checkout; switched to actions/cache over ~/.gradle keyed on lockfiles, and added a dry_run dispatch input that skips the fastlane upload.
