### PR TITLE
fix(mobile): trim background-task work

### DIFF
--- a/.changeset/defer-cache-eviction-in-bg.md
+++ b/.changeset/defer-cache-eviction-in-bg.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Cache eviction during background tasks now waits 30 seconds before starting and runs only inside the longer iOS background processing task — the 30-second app-refresh wake stays focused on upload polling, and the longer wake gives the upload manager time to spin up before the scanner competes for the JS thread and database.

--- a/.changeset/skip-orphan-scan-in-background.md
+++ b/.changeset/skip-orphan-scan-in-background.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Stop running the orphaned-file cleanup scan in the background and at startup; it now runs only from Settings → Advanced → Clear local files.

--- a/apps/mobile/src/lib/scheduleAfter.ts
+++ b/apps/mobile/src/lib/scheduleAfter.ts
@@ -1,0 +1,18 @@
+import { isAbortError } from '@siastorage/core/lib/errors'
+import { delayWithSignal } from './delayWithSignal'
+
+/** Run `fn` after `ms`. If the signal aborts during the delay, `fn` never runs. */
+export async function scheduleAfter<T>(
+  ms: number,
+  signal: AbortSignal,
+  fn: (signal: AbortSignal) => Promise<T>,
+): Promise<T | undefined> {
+  try {
+    await delayWithSignal(ms, signal)
+  } catch (e) {
+    if (isAbortError(e)) return undefined
+    throw e
+  }
+  if (signal.aborted) return undefined
+  return await fn(signal)
+}

--- a/apps/mobile/src/managers/app.ts
+++ b/apps/mobile/src/managers/app.ts
@@ -17,7 +17,6 @@ import { resetViewSettings } from '../stores/viewSettings'
 import { initBackgroundTasks } from './backgroundTasks'
 import { initDbOptimize } from './dbOptimize'
 import { runFsEvictionScanner } from './fsEvictionScanner'
-import { runFsOrphanScanner } from './fsOrphanScanner'
 import { initImportScanner } from './importScanner'
 import { initLogRotation } from './logRotation'
 import { initPerfMonitor } from './perfMonitor'
@@ -107,7 +106,6 @@ export async function initApp(): Promise<void> {
       message: 'Tidying up your cache...',
       runner: async () => {
         await app().files.autoPurgeWithCleanup()
-        await runFsOrphanScanner()
         await runFsEvictionScanner()
       },
     })

--- a/apps/mobile/src/managers/backgroundTasks.test.ts
+++ b/apps/mobile/src/managers/backgroundTasks.test.ts
@@ -98,11 +98,6 @@ jest.mock('./fsEvictionScanner', () => ({
   runFsEvictionScanner: () => mockRunFsEvictionScanner(),
 }))
 
-const mockRunFsOrphanScanner = jest.fn(() => Promise.resolve(undefined))
-jest.mock('./fsOrphanScanner', () => ({
-  runFsOrphanScanner: () => mockRunFsOrphanScanner(),
-}))
-
 jest.mock('./syncPhotosArchive', () => ({
   triggerRecentScanIfNeeded: jest.fn(() => Promise.resolve(false)),
 }))
@@ -151,7 +146,6 @@ describe('backgroundTasks', () => {
     clearPendingDelays()
     mockGetFileStatsLocal.mockReset()
     mockRunFsEvictionScanner.mockReset().mockResolvedValue(undefined)
-    mockRunFsOrphanScanner.mockReset().mockResolvedValue(undefined)
     mockRegister.mockReset().mockResolvedValue(undefined)
     mockRelease.mockReset().mockResolvedValue(undefined)
     mockGetIsSuspended.mockReset().mockReturnValue(false)
@@ -350,14 +344,6 @@ describe('backgroundTasks', () => {
   })
 
   describe('scanners', () => {
-    it('runs fsOrphanScanner during background work', async () => {
-      mockGetFileStatsLocal.mockResolvedValue({ count: 0, totalBytes: 0 })
-
-      await taskCallback('com.transistorsoft.fetch')
-
-      expect(mockRunFsOrphanScanner).toHaveBeenCalledTimes(1)
-    })
-
     it('runs fsEvictionScanner during background work', async () => {
       mockGetFileStatsLocal.mockResolvedValue({ count: 0, totalBytes: 0 })
 

--- a/apps/mobile/src/managers/backgroundTasks.test.ts
+++ b/apps/mobile/src/managers/backgroundTasks.test.ts
@@ -98,10 +98,6 @@ jest.mock('./fsEvictionScanner', () => ({
   runFsEvictionScanner: () => mockRunFsEvictionScanner(),
 }))
 
-jest.mock('./syncPhotosArchive', () => ({
-  triggerRecentScanIfNeeded: jest.fn(() => Promise.resolve(false)),
-}))
-
 jest.mock('./uploader', () => ({
   getUploadManager: jest.fn(() => ({
     packedCount: 0,
@@ -330,13 +326,15 @@ describe('backgroundTasks', () => {
       const processingTask = taskCallback('com.transistorsoft.processing')
       await flushPromises()
 
-      expect(getPendingDelayCount()).toBe(2)
+      // fetch parks one delay (upload poll). processing parks two: the
+      // upload poll and the deferred-scan settle delay.
+      expect(getPendingDelayCount()).toBe(3)
 
       // Timeout only affects its own task.
       timeoutCallback('com.transistorsoft.fetch')
       await fetchTask
 
-      expect(getPendingDelayCount()).toBe(1)
+      expect(getPendingDelayCount()).toBe(2)
 
       timeoutCallback('com.transistorsoft.processing')
       await processingTask
@@ -344,12 +342,45 @@ describe('backgroundTasks', () => {
   })
 
   describe('scanners', () => {
-    it('runs fsEvictionScanner during background work', async () => {
+    it('does not run fsEvictionScanner inside the BGAppRefreshTask budget', async () => {
       mockGetFileStatsLocal.mockResolvedValue({ count: 0, totalBytes: 0 })
 
       await taskCallback('com.transistorsoft.fetch')
 
+      expect(mockRunFsEvictionScanner).not.toHaveBeenCalled()
+    })
+
+    it('defers fsEvictionScanner behind the settle delay in BGProcessingTask', async () => {
+      mockGetFileStatsLocal.mockResolvedValue({ count: 0, totalBytes: 0 })
+
+      const taskPromise = taskCallback('com.transistorsoft.processing')
+      await flushPromises()
+
+      // Eviction has not started — the settle delay is parked.
+      expect(mockRunFsEvictionScanner).not.toHaveBeenCalled()
+      expect(getPendingDelayCount()).toBeGreaterThanOrEqual(1)
+
+      // Resolve the settle delay so the scanner runs.
+      const settleDelay = mockPendingDelays[0]
+      settleDelay.resolve()
+      await taskPromise
+
       expect(mockRunFsEvictionScanner).toHaveBeenCalledTimes(1)
+    })
+
+    it('cancels the settle delay when the BG task aborts before it fires', async () => {
+      mockGetFileStatsLocal.mockResolvedValue({ count: 1, totalBytes: 100 })
+
+      const taskPromise = taskCallback('com.transistorsoft.processing')
+      await flushPromises()
+
+      // Both delays are parked: the upload poll's 10s and the scan settle 30s.
+      expect(getPendingDelayCount()).toBeGreaterThanOrEqual(1)
+
+      timeoutCallback('com.transistorsoft.processing')
+      await taskPromise
+
+      expect(mockRunFsEvictionScanner).not.toHaveBeenCalled()
     })
   })
 

--- a/apps/mobile/src/managers/backgroundTasks.ts
+++ b/apps/mobile/src/managers/backgroundTasks.ts
@@ -7,7 +7,6 @@ import { delayWithSignal } from '../lib/delayWithSignal'
 import { app } from '../stores/appService'
 import { getFileStatsLocal } from '../stores/files'
 import { runFsEvictionScanner } from './fsEvictionScanner'
-import { runFsOrphanScanner } from './fsOrphanScanner'
 import {
   getIsSuspended,
   registerBackgroundTaskLifecycle,
@@ -316,11 +315,11 @@ async function runBackgroundWork(config: TaskConfig, state: TaskState) {
   const isConnected = app().connection.getState().isConnected
   log('app_ready', { connected: isConnected })
 
-  // Skip one-shot scanners if the app is foregrounded — startup already
-  // runs these. The upload polling loop below still runs regardless.
+  // Skip eviction if the app is foregrounded — startup already runs it.
+  // The upload polling loop below still runs regardless. The orphan
+  // scanner is not invoked from any background path; it only runs from
+  // the "Clear local files" settings action.
   if (AppState.currentState !== 'active') {
-    await runFsOrphanScanner({ signal })
-    if (signal.aborted) return
     await runFsEvictionScanner({ signal })
     if (signal.aborted) return
     await triggerRecentScanIfNeeded()

--- a/apps/mobile/src/managers/backgroundTasks.ts
+++ b/apps/mobile/src/managers/backgroundTasks.ts
@@ -4,6 +4,7 @@ import { logger } from '@siastorage/logger'
 import { AppState, Platform } from 'react-native'
 import BackgroundFetch, { type BackgroundFetchConfig } from 'react-native-background-fetch'
 import { delayWithSignal } from '../lib/delayWithSignal'
+import { scheduleAfter } from '../lib/scheduleAfter'
 import { app } from '../stores/appService'
 import { getFileStatsLocal } from '../stores/files'
 import { runFsEvictionScanner } from './fsEvictionScanner'
@@ -12,7 +13,6 @@ import {
   registerBackgroundTaskLifecycle,
   releaseBackgroundTaskLifecycle,
 } from './suspension'
-import { triggerRecentScanIfNeeded } from './syncPhotosArchive'
 import { getUploadManager } from './uploader'
 
 /**
@@ -315,15 +315,16 @@ async function runBackgroundWork(config: TaskConfig, state: TaskState) {
   const isConnected = app().connection.getState().isConnected
   log('app_ready', { connected: isConnected })
 
-  // Skip eviction if the app is foregrounded — startup already runs it.
-  // The upload polling loop below still runs regardless. The orphan
-  // scanner is not invoked from any background path; it only runs from
-  // the "Clear local files" settings action.
-  if (AppState.currentState !== 'active') {
-    await runFsEvictionScanner({ signal })
-    if (signal.aborted) return
-    await triggerRecentScanIfNeeded()
-    if (signal.aborted) return
+  // Defer scanners past the upload manager's spin-up. Skip in the 30s
+  // BGAppRefreshTask — no headroom after the delay.
+  if (AppState.currentState !== 'active' && config.type !== 'BGAppRefreshTask') {
+    void scheduleAfter(secondsInMs(30), signal, async (s) => {
+      await runFsEvictionScanner({ signal: s })
+      if (s.aborted) return
+      // Disabled for now — need to evaluate how this works and what
+      // user-facing settings should gate it before re-enabling.
+      // await triggerRecentScanIfNeeded()
+    })
   }
 
   const manager = getUploadManager()!


### PR DESCRIPTION
Drops the orphan-file scan from background tasks (now only runs from Settings → Advanced → Clear local files) and defers cache eviction 30 s into BGProcessingTask / Android wakes so it doesn't compete with the upload manager's spin-up.
