### PR TITLE
fix(mobile,core): drop reads on suspend, drain before close

### DIFF
--- a/.changeset/db-suspension-hardening.md
+++ b/.changeset/db-suspension-hardening.md
@@ -1,0 +1,6 @@
+---
+mobile: patch
+core: patch
+---
+
+Fixed iOS background-transition crashes caused by races in SQLite handle teardown and query pile-up at the suspend boundary.

--- a/apps/mobile/src/db/index.ts
+++ b/apps/mobile/src/db/index.ts
@@ -18,20 +18,15 @@ export class DatabaseSuspendedError extends Error {
 }
 
 // Suspension lifecycle state (separate from dbInitialized).
-// - 'active':     queries flow normally through the adapter.
-// - 'suspending': new queries park on a waiter queue; in-flight queries drain.
-// - 'closed':     database handle is closed, WAL lock released; waiters park.
-//
-// When not active, queries WAIT instead of reject. This matters during the
-// ~80ms `db.reopen()` window on resume: native callbacks (image picker,
-// share intent) fire their continuation the moment the app foregrounds and
-// race our resume flow. If we rejected, a caller like importFiles would
-// lose its write. Waiters drain inside resumeDb(), so the queued query
-// dispatches to the newly-reopened handle.
-//
-// This preserves 0xdead10cc protection: queued waiters don't touch SQLite's
-// native GCD queue, so there's no fsync in flight when iOS freezes the
-// process. Waiters are just heap objects that drain post-resume.
+// - 'active':     queries flow normally.
+// - 'suspending': close in progress — reads reject (callers retry).
+//                 Writes still park to cover stragglers that didn't
+//                 complete in the Phase 2 service drain.
+// - 'closed':     handle destroyed, reopen imminent — both park.
+//                 This is the load-bearing case: native callbacks (image
+//                 picker, share intent) fire their continuation during the
+//                 ~80ms reopen window and need their INSERTs to land
+//                 against the new handle, since they have no retry path.
 type DbState = 'active' | 'suspending' | 'closed'
 
 let state: DbState = 'active'
@@ -45,8 +40,11 @@ let activeWaiters: Array<() => void> = []
 // or Android foreground transition.
 const WAIT_TIMEOUT_MS = 30_000
 
-function waitForActive(): Promise<void> {
+function waitForActive(intent: 'read' | 'write'): Promise<void> {
   if (state === 'active') return Promise.resolve()
+  if (state === 'suspending' && intent === 'read') {
+    return Promise.reject(new DatabaseSuspendedError())
+  }
   return new Promise<void>((resolve, reject) => {
     let settled = false
     const resolveOnce = () => {
@@ -281,6 +279,11 @@ export async function closeDb(): Promise<void> {
     // triggered by racing queries — sees the closed state and doesn't reopen.
     dbInitialized = false
     state = 'closed'
+    // Wait for in-flight native calls to finish before destroying the
+    // handle. Closing while a getAllAsync is mid-iteration produces a
+    // use-after-free in sqlite3_mutex_enter (TestFlight crash #29).
+    // The suspension manager owns the outer deadline; no timeout here.
+    await waitForQueriesIdle()
     try {
       // Zero the busy timeout so any straggler query blocked on the SQLite
       // mutex fails immediately instead of waiting up to 5 seconds.
@@ -348,13 +351,7 @@ export async function resetDb() {
 // query logging. Reads the module-level `database` variable on every call,
 // so connection swaps from initializeDB/resetDb/reopenDb are transparent.
 class MobileDbAdapter implements DatabaseAdapter {
-  private query<T>(method: string, args: unknown[]): Promise<T> {
-    // Park the call until state === 'active'. During suspend/close/reopen
-    // this blocks the caller rather than rejecting, so native callbacks
-    // that fire their continuation on app foreground (image picker,
-    // share intent) don't lose writes to the ~80ms reopen window. The
-    // common case (state === 'active') skips the microtask detour so
-    // trackStart runs synchronously and in-flight counting is exact.
+  private query<T>(method: string, intent: 'read' | 'write', args: unknown[]): Promise<T> {
     const dispatch = (): Promise<T> => {
       trackStart()
       return withRecovery(async () => {
@@ -373,23 +370,25 @@ class MobileDbAdapter implements DatabaseAdapter {
       }).finally(trackEnd)
     }
     if (state === 'active') return dispatch()
-    return waitForActive().then(dispatch)
+    return waitForActive(intent).then(dispatch)
   }
 
   getAllAsync<T>(sql: string, ...params: SQLParam[]): Promise<T[]> {
-    return this.query('getAllAsync', [sql, ...params])
+    return this.query('getAllAsync', 'read', [sql, ...params])
   }
 
   getFirstAsync<T>(sql: string, ...params: SQLParam[]): Promise<T | null> {
-    return this.query('getFirstAsync', [sql, ...params])
+    return this.query('getFirstAsync', 'read', [sql, ...params])
   }
 
   runAsync(sql: string, ...params: SQLParam[]): Promise<SQLRunResult> {
-    return this.query('runAsync', [sql, ...params])
+    return this.query('runAsync', 'write', [sql, ...params])
   }
 
+  // 'write' because execAsync runs arbitrary SQL — used for PRAGMA + DDL
+  // during init/recovery. Defaulting to write is the safe lock-out.
   execAsync(sql: string): Promise<void> {
-    return this.query('execAsync', [sql])
+    return this.query('execAsync', 'write', [sql])
   }
 
   withTransactionAsync(fn: () => Promise<void>): Promise<void> {
@@ -400,7 +399,7 @@ class MobileDbAdapter implements DatabaseAdapter {
         .finally(trackEnd)
     }
     if (state === 'active') return dispatch()
-    return waitForActive().then(dispatch)
+    return waitForActive('write').then(dispatch)
   }
 }
 

--- a/apps/mobile/src/db/suspension.test.ts
+++ b/apps/mobile/src/db/suspension.test.ts
@@ -59,35 +59,21 @@ describe('state transitions', () => {
 })
 
 describe('query gating', () => {
-  it('getAllAsync parks and resolves after resumeDb', async () => {
+  it('getAllAsync rejects during suspending', async () => {
     suspendDb()
-    const queryPromise = db().getAllAsync<{ v: number }>('SELECT 1 as v')
-    let settled = false
-    queryPromise.then(() => {
-      settled = true
-    })
-    await Promise.resolve()
-    expect(settled).toBe(false)
-    resumeDb()
-    const rows = await queryPromise
-    expect(rows).toEqual([{ v: 1 }])
+    await expect(db().getAllAsync<{ v: number }>('SELECT 1 as v')).rejects.toThrow(
+      DatabaseSuspendedError,
+    )
   })
 
-  it('getFirstAsync parks while suspended', async () => {
+  it('getFirstAsync rejects during suspending', async () => {
     suspendDb()
-    const queryPromise = db().getFirstAsync<{ v: number }>('SELECT 1 as v')
-    let settled = false
-    queryPromise.then(() => {
-      settled = true
-    })
-    await Promise.resolve()
-    expect(settled).toBe(false)
-    resumeDb()
-    const row = await queryPromise
-    expect(row).toEqual({ v: 1 })
+    await expect(db().getFirstAsync<{ v: number }>('SELECT 1 as v')).rejects.toThrow(
+      DatabaseSuspendedError,
+    )
   })
 
-  it('runAsync parks while suspended', async () => {
+  it('runAsync parks during suspending and resolves after resume', async () => {
     suspendDb()
     const queryPromise = db().runAsync('CREATE TABLE IF NOT EXISTS test (id TEXT)')
     let settled = false
@@ -100,7 +86,7 @@ describe('query gating', () => {
     await queryPromise
   })
 
-  it('execAsync parks while suspended', async () => {
+  it('execAsync parks during suspending and resolves after resume', async () => {
     suspendDb()
     const queryPromise = db().execAsync('SELECT 1')
     let settled = false
@@ -113,7 +99,7 @@ describe('query gating', () => {
     await queryPromise
   })
 
-  it('withTransactionAsync parks while suspended', async () => {
+  it('withTransactionAsync parks during suspending and resolves after resume', async () => {
     suspendDb()
     let txRan = false
     const queryPromise = db().withTransactionAsync(async () => {
@@ -131,7 +117,7 @@ describe('query gating', () => {
     expect(txRan).toBe(true)
   })
 
-  it('queries also park in closed state and drain after reopen+resume', async () => {
+  it('reads also park in closed state and drain after reopen+resume', async () => {
     await closeDb()
     const queryPromise = db().getAllAsync<{ v: number }>('SELECT 1 as v')
     let settled = false
@@ -146,11 +132,25 @@ describe('query gating', () => {
     expect(rows).toEqual([{ v: 1 }])
   })
 
-  it('parked query rejects with DatabaseSuspendedError after wait timeout', async () => {
+  it('writes park in closed state and drain after reopen+resume', async () => {
+    await closeDb()
+    const queryPromise = db().runAsync('CREATE TABLE IF NOT EXISTS t (id TEXT)')
+    let settled = false
+    queryPromise.then(() => {
+      settled = true
+    })
+    await Promise.resolve()
+    expect(settled).toBe(false)
+    await initializeDB({ databaseName: ':memory:', reopen: true })
+    resumeDb()
+    await queryPromise
+  })
+
+  it('parked write rejects with DatabaseSuspendedError after wait timeout', async () => {
     jest.useFakeTimers()
     try {
       suspendDb()
-      const queryPromise = db().getAllAsync('SELECT 1')
+      const queryPromise = db().runAsync('SELECT 1')
       queryPromise.catch(() => {})
       jest.advanceTimersByTime(30_000)
       await expect(queryPromise).rejects.toThrow(DatabaseSuspendedError)
@@ -300,15 +300,49 @@ describe('closeDb', () => {
     expect(dbInitialized).toBe(false)
     expect(getDbState()).toBe('closed')
   })
+
+  // Closing while a query iterates the native handle produces a UAF in
+  // sqlite3_mutex_enter (TestFlight crash #29). closeDb must wait for the
+  // serial dispatch queue to be empty before destroying the handle.
+  it('waits for in-flight queries to finish before closeAsync', async () => {
+    let resolveQuery!: () => void
+    jest.spyOn(database, 'getAllAsync').mockImplementationOnce(
+      () =>
+        new Promise<void>((r) => {
+          resolveQuery = r
+        }) as any,
+    )
+    const closeAsyncSpy = jest.spyOn(database, 'closeAsync')
+
+    const queryPromise = db().getAllAsync('SELECT 1')
+
+    let closeDone = false
+    const closePromise = closeDb().then(() => {
+      closeDone = true
+    })
+
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(closeDone).toBe(false)
+    expect(closeAsyncSpy).not.toHaveBeenCalled()
+
+    resolveQuery()
+    await queryPromise
+    await closePromise
+    expect(closeDone).toBe(true)
+    expect(closeAsyncSpy).toHaveBeenCalled()
+  })
 })
 
 describe('full suspend/resume cycle', () => {
-  it('queries parked during suspend/close drain after reopen+resume', async () => {
+  it('reads during suspending reject; reads during closed park and drain after reopen', async () => {
     const rows1 = await db().getAllAsync<{ v: number }>('SELECT 1 as v')
     expect(rows1).toEqual([{ v: 1 }])
 
     suspendDb()
-    const duringSuspend = db().getAllAsync<{ v: number }>('SELECT 1 as v')
+    await expect(db().getAllAsync<{ v: number }>('SELECT 1 as v')).rejects.toThrow(
+      DatabaseSuspendedError,
+    )
 
     await closeDb()
     expect(dbInitialized).toBe(false)
@@ -317,24 +351,36 @@ describe('full suspend/resume cycle', () => {
     await initializeDB({ databaseName: ':memory:', reopen: true })
     resumeDb()
 
-    expect(await duringSuspend).toEqual([{ v: 1 }])
     expect(await duringClosed).toEqual([{ v: 2 }])
+  })
+
+  it('writes during suspending park and resolve after resume; native callback continuations preserved', async () => {
+    suspendDb()
+    const writeDuringSuspend = db().runAsync('CREATE TABLE IF NOT EXISTS t (id TEXT)')
+    let settled = false
+    writeDuringSuspend.then(() => {
+      settled = true
+    })
+    await Promise.resolve()
+    expect(settled).toBe(false)
+    resumeDb()
+    await writeDuringSuspend
   })
 
   it('in-flight query at suspend time completes, then drain resolves', async () => {
     let resolveQuery!: () => void
-    jest.spyOn(database, 'getAllAsync').mockImplementationOnce(
+    jest.spyOn(database, 'runAsync').mockImplementationOnce(
       () =>
         new Promise<void>((r) => {
           resolveQuery = r
         }) as any,
     )
 
-    const queryPromise = db().getAllAsync('SELECT 1')
+    const queryPromise = db().runAsync('CREATE TABLE IF NOT EXISTS x (id TEXT)')
 
     suspendDb()
-    // A new query issued during suspend parks; it does not count toward inflight.
-    const parked = db().getAllAsync<{ v: number }>('SELECT 2 as v')
+    // A new write issued during suspend parks; it does not count toward inflight.
+    const parked = db().runAsync('CREATE TABLE IF NOT EXISTS y (id TEXT)')
     let parkedSettled = false
     parked.then(() => {
       parkedSettled = true
@@ -355,7 +401,7 @@ describe('full suspend/resume cycle', () => {
     expect(drained).toBe(true)
 
     resumeDb()
-    expect(await parked).toEqual([{ v: 2 }])
+    await parked
   })
 
   it('resetDb works after suspend → resume → reinit sequence', async () => {

--- a/apps/mobile/src/managers/suspension.ts
+++ b/apps/mobile/src/managers/suspension.ts
@@ -13,6 +13,7 @@ import RNFS from 'react-native-fs'
 import {
   closeDb,
   dbInitialized,
+  getActiveJournalMode,
   getInflightCount,
   getWalPath,
   initializeDB,
@@ -33,11 +34,15 @@ import { getUploadManager } from './uploader'
  * All values are cheap in-memory reads except WAL size (one RNFS.stat call). */
 async function logSuspendDiagnostics(): Promise<void> {
   try {
-    const walPath = getWalPath()
-    const walStat = await RNFS.stat(walPath).catch((e) => {
-      logger.warn('suspension', 'wal_stat_failed', { error: e as Error })
-      return null
-    })
+    // Only stat the WAL file when it can exist; in DELETE journal mode
+    // there's no -wal sidecar and the stat would log a spurious warning.
+    const walStat =
+      getActiveJournalMode() === 'WAL'
+        ? await RNFS.stat(getWalPath()).catch((e) => {
+            logger.warn('suspension', 'wal_stat_failed', { error: e as Error })
+            return null
+          })
+        : null
     logger.info('suspension', 'diagnostics', {
       inflightQueries: getInflightCount(),
       uploader: getUploadManager()?.getDiagnostics() ?? null,

--- a/packages/core/src/services/suspension.test.ts
+++ b/packages/core/src/services/suspension.test.ts
@@ -70,8 +70,12 @@ describe('createSuspensionManager deadline behavior', () => {
     expect(db.close).toHaveBeenCalled()
   })
 
-  it('reaches suspended even when db.waitForIdle never resolves', async () => {
-    const { adapters, db } = createAdapters({
+  // Closing while inflight > 0 produces a UAF (TestFlight crash #29).
+  // If db drain times out, the manager aborts the suspend and ungates
+  // instead of proceeding to close. iOS may kill us for holding the lock,
+  // but a clean kill is cheaper than corruption.
+  it('aborts suspend when db.waitForIdle never resolves', async () => {
+    const { adapters, db, scheduler, uploader } = createAdapters({
       dbWaitForIdle: () => new Promise(() => {}),
       hardDeadlineMs: 100,
     })
@@ -81,8 +85,11 @@ describe('createSuspensionManager deadline behavior', () => {
     await jest.advanceTimersByTimeAsync(2000)
     await suspendPromise
 
-    expect(manager.isSuspended()).toBe(true)
-    expect(db.close).toHaveBeenCalled()
+    expect(manager.isSuspended()).toBe(false)
+    expect(db.close).not.toHaveBeenCalled()
+    expect(db.ungate).toHaveBeenCalled()
+    expect(scheduler.resume).toHaveBeenCalled()
+    expect(uploader.resume).toHaveBeenCalled()
   })
 
   it('reaches suspended even when db.close never resolves', async () => {

--- a/packages/core/src/services/suspension.ts
+++ b/packages/core/src/services/suspension.ts
@@ -108,14 +108,27 @@ export function createSuspensionManager(adapters: SuspensionAdapters) {
       const remainingMs = Math.max(hardDeadlineMs - elapsedMs, 1000)
       const dbDrainResult = await raceWithTimeout(db.waitForIdle(), remainingMs)
       const dbDrainMs = Date.now() - dbDrainStart
-      if (dbDrainResult.ok) {
-        logger.debug('suspension', 'db_drained', { dbDrainMs })
-      } else {
-        logger.warn('suspension', 'db_drain_timeout', {
+      if (!dbDrainResult.ok) {
+        // Closing while inflight > 0 races the close against in-flight
+        // statements and produces a UAF in sqlite3_mutex_enter. Bail
+        // instead — losing this suspend cycle is preferable to native
+        // corruption. iOS may kill the process for holding the lock,
+        // but a clean kill is cheaper than a use-after-free.
+        logger.warn('suspension', 'db_drain_timeout_aborted', {
           dbDrainMs,
           remainingMs,
         })
+        // TODO: services + uploader resume immediately here, queueing
+        // work behind the stuck inflight queries. Cleaner: defer
+        // resume until inflight drains (new 'recovering' state).
+        hooks?.onAfterResume?.()
+        db.ungate()
+        uploader.resume()
+        scheduler.resume()
+        state = 'active'
+        return
       }
+      logger.debug('suspension', 'db_drained', { dbDrainMs })
 
       // Phase 5: Checkpoint WAL to release file locks, then close. Race
       // against the remaining deadline — if native close hangs on fsync,


### PR DESCRIPTION
The DB adapter's coarse "park everything" suspension policy let queries pile up at the suspend boundary while the close path raced in-flight statements, producing both 0xdead10cc lock-at-suspension kills and use-after-free crashes in sqlite3_mutex_enter during native handle teardown. The gate now distinguishes reads (reject during 'suspending' so callers retry) from writes (still park, so native callbacks like picker / share-intent that fire their INSERT continuation during the ~80ms reopen window land against the new handle), closeDb waits for the native serial queue to drain before destroying the handle, and the suspension manager bails instead of force-closing if drain times out.
