### PR TITLE
fix(mobile,core): tighten suspension budgets and add BG-task self-deadline

### DIFF
--- a/.changeset/suspension-budget-tightening.md
+++ b/.changeset/suspension-budget-tightening.md
@@ -1,0 +1,6 @@
+---
+mobile: patch
+core: patch
+---
+
+Tightened the iOS background-suspension cleanup budget and added a self-deadline to background tasks so cleanup completes inside the task's allotted wake window instead of racing iOS's expiration callback.

--- a/apps/mobile/src/managers/backgroundTasks.ts
+++ b/apps/mobile/src/managers/backgroundTasks.ts
@@ -268,12 +268,31 @@ async function waitForInitialization(
  * allowing the app to continue already scheduled work. If we ever make the
  * work these tasks more explicit, we may want to take this into account.
  */
+// Soft deadline per task type, leaving headroom inside the OS budget for
+// release + suspend cleanup. iOS does NOT reliably extend a BGTask via
+// beginBackgroundTask from inside the expirationHandler (Apple DTS forum
+// thread 126438), so cleanup must complete inside the task's wake window.
+// BGAppRefreshTask: 30s hard cap (WWDC 2019 Session 707) → 5s reserved.
+// BGProcessingTask: no documented cap; ~5min is empirical convention →
+// 25s reserved. BackgroundTask (Android Worker): 10min hard cap → 30s.
+function softDeadlineMs(type: TaskConfig['type']): number {
+  switch (type) {
+    case 'BGAppRefreshTask':
+      return secondsInMs(25)
+    case 'BGProcessingTask':
+      return secondsInMs(270)
+    case 'BackgroundTask':
+      return minutesInMs(9) + secondsInMs(30)
+  }
+}
+
 async function runBackgroundWork(config: TaskConfig, state: TaskState) {
   const log = logTask(config, state)
 
   const controller = new AbortController()
   state.controller = controller
   const { signal } = controller
+  const deadlineMs = softDeadlineMs(config.type)
 
   // Register with the suspension manager. Ensures the DB is open before
   // we start querying. If the app was suspended, this triggers a resume.
@@ -341,6 +360,15 @@ async function runBackgroundWork(config: TaskConfig, state: TaskState) {
   })
 
   while (!signal.aborted) {
+    // TODO: query UIApplication.backgroundTimeRemaining via a native
+    // module and self-abort when it dips below the cleanup budget,
+    // instead of using a fixed soft deadline. Lets us use whatever
+    // the OS is actually willing to give us this invocation.
+    if (Date.now() - state.startTime >= deadlineMs) {
+      log('soft_deadline_reached', { elapsedMs: Date.now() - state.startTime })
+      controller.abort()
+      break
+    }
     const stats = await getFileStatsLocal({ localOnly: true })
     if (signal.aborted) break
     log('still_uploading', {

--- a/apps/mobile/src/managers/suspension.ts
+++ b/apps/mobile/src/managers/suspension.ts
@@ -54,15 +54,15 @@ async function logSuspendDiagnostics(): Promise<void> {
   }
 }
 
-// Hard deadline for service drain. iOS gives ~30s via beginBackgroundTask
-// before freezing the process. Production logs show real drain completes
-// in 0–1.4s, so 5s is ~3.5× the observed worst case with plenty of margin.
-// The remaining ~25s of the iOS window goes to Phase 4 (drain in-flight
-// native SQLite queries) and Phase 5 (WAL checkpoint + close) — which is
-// where the fsync-overrun that triggers 0xdead10cc actually happens.
-// Android doesn't enforce file-lock checks on suspend, but the sequence
-// runs harmlessly there.
-const HARD_DEADLINE_MS = 5_000
+// Hard deadline for Phase 2 service drain. Roughly the scale we expect
+// service drain to take — observed timings are well under 2s in normal
+// runs. Not sized against any iOS API budget: grace from
+// applicationDidEnterBackground is short, and beginBackgroundTask's
+// extended grant is discretionary and cannot extend a BGTask from
+// inside its expirationHandler (Apple DTS forum thread 126438).
+// Android doesn't enforce file-lock checks on suspend, but the
+// sequence runs harmlessly there.
+const HARD_DEADLINE_MS = 1_500
 
 const manager = createSuspensionManager({
   scheduler: {
@@ -151,9 +151,12 @@ export function teardownSuspensionManager(): void {
 }
 
 /**
- * Wrap an async operation with an iOS beginBackgroundTask grant so the
- * process isn't suspended while the operation is in flight. iOS gives
- * ~30s of additional execution time. On Android this is a no-op.
+ * Wrap an async operation with an iOS beginBackgroundTask assertion.
+ * Best-effort only: the assertion is granted at iOS's discretion and
+ * does NOT extend a BGTask from inside its expirationHandler (Apple
+ * DTS forum thread 126438). Cleanup is sized to fit inside the
+ * BGTask's wake window (see softDeadlineMs in backgroundTasks.ts)
+ * instead of relying on this. Android no-op.
  */
 async function withIosExecutionTime<T>(fn: () => Promise<T>): Promise<T> {
   await BackgroundTimer.start(0)

--- a/packages/core/src/services/suspension.ts
+++ b/packages/core/src/services/suspension.ts
@@ -101,11 +101,12 @@ export function createSuspensionManager(adapters: SuspensionAdapters) {
       logger.debug('suspension', 'db_gated')
 
       // Phase 4: Drain queries already dispatched to the native queue.
-      // Use remaining budget from the hard deadline so a stuck query
-      // can't block suspension indefinitely.
+      // Floor of 300ms covers the rare case where Phase 2 ate the entire
+      // hard deadline; with reads rejecting on suspending, inflight is
+      // typically zero by the time we reach Phase 4.
       const dbDrainStart = Date.now()
       const elapsedMs = dbDrainStart - drainStart
-      const remainingMs = Math.max(hardDeadlineMs - elapsedMs, 1000)
+      const remainingMs = Math.max(hardDeadlineMs - elapsedMs, 300)
       const dbDrainResult = await raceWithTimeout(db.waitForIdle(), remainingMs)
       const dbDrainMs = Date.now() - dbDrainStart
       if (!dbDrainResult.ok) {
@@ -133,8 +134,9 @@ export function createSuspensionManager(adapters: SuspensionAdapters) {
       // Phase 5: Checkpoint WAL to release file locks, then close. Race
       // against the remaining deadline — if native close hangs on fsync,
       // the OS kill is coming regardless, so we don't wait forever in JS.
+      // Floor of 500ms gives WAL truncate enough headroom on slow disks.
       const dbCloseStart = Date.now()
-      const closeBudget = Math.max(hardDeadlineMs - (dbCloseStart - drainStart), 1000)
+      const closeBudget = Math.max(hardDeadlineMs - (dbCloseStart - drainStart), 500)
       const closed = await raceWithTimeout(db.close(), closeBudget)
       const dbCloseMs = Date.now() - dbCloseStart
       if (closed.ok) {


### PR DESCRIPTION
The old shutdown budget assumed iOS would hand us 30s of grace via beginBackgroundTask to wrap up, which it turns out doesn't actually happen from inside a BGTask's expiration callback — so cleanup was racing iOS's kill signal. This tightens the cleanup ceilings to roughly what we actually need, and stops trusting the OS expiration callback as anything but a last resort: each BG task now gives itself a soft deadline (25s for app-refresh, 270s for processing, 9.5min on Android) and shuts itself down with time to spare.
