### PR TITLE
fix(core): make upload manager suspend non-blocking

### DIFF
--- a/.changeset/log-forwarder-non-blocking-stop.md
+++ b/.changeset/log-forwarder-non-blocking-stop.md
@@ -1,0 +1,6 @@
+---
+core: patch
+mobile: patch
+---
+
+Made the remote log forwarder's stop non-blocking and skipped its ticker entirely when no remote endpoint is configured, so iOS suspension no longer waits on an in-flight log POST.

--- a/.changeset/uploader-suspend-non-blocking.md
+++ b/.changeset/uploader-suspend-non-blocking.md
@@ -1,0 +1,6 @@
+---
+core: patch
+mobile: patch
+---
+
+Made the upload manager's suspend non-blocking so iOS suspension completes faster when the upload loop is mid-iteration.

--- a/apps/mobile/src/managers/suspension.ts
+++ b/apps/mobile/src/managers/suspension.ts
@@ -94,11 +94,12 @@ const manager = createSuspensionManager({
   hooks: {
     onBeforeSuspend: async () => {
       await logSuspendDiagnostics()
-      // Drain JS log buffer to DB before halting the HTTP ticker;
-      // stopLogForwarder awaits any in-flight ship so its cursor
-      // UPDATE doesn't race the DB close.
+      // Drain JS log buffer to DB before halting the HTTP ticker.
+      // stopLogForwarder doesn't await in-flight network work — the
+      // cursor only advances on success, so a request killed mid-flight
+      // by iOS suspension just re-ships next session.
       await stopLogAppender()
-      await stopLogForwarder()
+      stopLogForwarder()
       // Cancel in-flight downloads (disk I/O contention with SQLite fsync
       // is a known 0xdead10cc trigger) and pause the photo-archive walk
       // (an independent loop not driven by the service scheduler, so it

--- a/packages/core/src/services/logForwarder.test.ts
+++ b/packages/core/src/services/logForwarder.test.ts
@@ -350,6 +350,7 @@ describe('LogForwarder', () => {
     await forwarder.shipPending()
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(state.cursor.current).toBe(2)
+    forwarder.stop()
   })
 
   it('persists token to secrets and clears it when set to empty', async () => {
@@ -428,7 +429,7 @@ describe('LogForwarder', () => {
       await jest.advanceTimersByTimeAsync(2000)
       expect(fetchMock).toHaveBeenCalledTimes(1)
 
-      await forwarder.stop()
+      forwarder.stop()
 
       const before = fetchMock.mock.calls.length
       state.rows.push({
@@ -444,7 +445,7 @@ describe('LogForwarder', () => {
       jest.useRealTimers()
     })
 
-    it('awaits an in-flight shipPending before resolving', async () => {
+    it('does not await in-flight shipPending — kills the timer immediately', async () => {
       const state = makeApp()
       let resolveFetch: (v: Response) => void = () => {}
       fetchMock.mockImplementationOnce(
@@ -466,27 +467,22 @@ describe('LogForwarder', () => {
       const shipP = forwarder.shipPending()
       // Defer to microtasks so shipPending sets inflight before stop runs.
       await Promise.resolve()
-      let stopResolved = false
-      const stopP = forwarder.stop().then(() => {
-        stopResolved = true
-      })
-      // stop() must NOT resolve while fetch is pending.
-      await Promise.resolve()
-      expect(stopResolved).toBe(false)
+      // stop() returns synchronously even with fetch pending.
+      forwarder.stop()
+      expect(fetchMock).toHaveBeenCalledTimes(1)
 
+      // Settle the in-flight to avoid an unhandled promise.
       resolveFetch(new Response('', { status: 200 }))
       await shipP
-      await stopP
-      expect(stopResolved).toBe(true)
     })
 
-    it('is idempotent — calling twice does not throw', async () => {
+    it('is idempotent — calling twice does not throw', () => {
       const state = makeApp()
       const forwarder = new LogForwarder(state.app, snapshot(state))
       forwarder.start()
 
-      await forwarder.stop()
-      await forwarder.stop()
+      forwarder.stop()
+      forwarder.stop()
     })
 
     it('blocks future shipPending calls after stop until restart', async () => {
@@ -501,7 +497,7 @@ describe('LogForwarder', () => {
       })
       const forwarder = new LogForwarder(state.app, snapshot(state))
 
-      await forwarder.stop()
+      forwarder.stop()
       const before = fetchMock.mock.calls.length
       await forwarder.shipPending()
       expect(fetchMock).toHaveBeenCalledTimes(before)
@@ -509,7 +505,7 @@ describe('LogForwarder', () => {
       forwarder.start(60_000)
       await new Promise((r) => setTimeout(r, 0))
       expect(fetchMock.mock.calls.length).toBeGreaterThan(before)
-      await forwarder.stop()
+      forwarder.stop()
     })
   })
 })

--- a/packages/core/src/services/logForwarder.ts
+++ b/packages/core/src/services/logForwarder.ts
@@ -4,7 +4,7 @@ import type { AppService } from '../app/service'
 const REMOTE_LOG_TOKEN_KEY = 'remoteLogToken'
 const REMOTE_LOG_TIMEOUT_MS = 30_000
 const REMOTE_LOG_BATCH_SIZE = 200
-const REMOTE_LOG_INTERVAL_MS = 2000
+const REMOTE_LOG_INTERVAL_MS = 10_000
 const ID_PREFIX_LEN = 8
 
 type Snapshot = {
@@ -81,10 +81,13 @@ export class LogForwarder {
     }
   }
 
-  /** Start the HTTP shipping ticker. Idempotent. Drains immediately so any
-   * backlog from a previous offline session ships without waiting for a tick. */
+  /** Start the HTTP shipping ticker. Idempotent. No-op when remote logging
+   * isn't configured — no point ticking just to early-return in shipPending.
+   * Drains immediately so backlog from a previous offline session ships
+   * without waiting for a tick. */
   start(intervalMs: number = REMOTE_LOG_INTERVAL_MS): void {
     if (this.httpTimer) return
+    if (!this.snapshot.enabled || !this.snapshot.endpoint) return
     this.stopped = false
     this.httpTimer = setInterval(() => {
       void this.shipPending()
@@ -92,15 +95,16 @@ export class LogForwarder {
     void this.shipPending()
   }
 
-  /** Stop the HTTP ticker and await any in-flight ship. The DB appender is
+  /** Stop the HTTP ticker. Doesn't await in-flight network work — the
+   * cursor only advances on success, so a request killed mid-flight by
+   * iOS suspension just re-ships next session. The DB appender is
    * unaffected. Idempotent. */
-  async stop(): Promise<void> {
+  stop(): void {
     this.stopped = true
     if (this.httpTimer) {
       clearInterval(this.httpTimer)
       this.httpTimer = null
     }
-    if (this.inflight) await this.inflight
   }
 
   /** Persist config changes and refresh the snapshot used by the HTTP sink. */
@@ -121,6 +125,14 @@ export class LogForwarder {
         await this.app.secrets.setItem(REMOTE_LOG_TOKEN_KEY, update.token)
         this.snapshot.token = update.token
       }
+    }
+    // Re-evaluate ticker state — newly-enabled config should start
+    // shipping; newly-disabled should stop. start()/stop() are both
+    // idempotent.
+    if (this.snapshot.enabled && this.snapshot.endpoint) {
+      this.start()
+    } else {
+      this.stop()
     }
   }
 
@@ -213,17 +225,18 @@ let instance: LogForwarder | null = null
 /** Initialize the singleton forwarder, register the DB appender, and start
  * the HTTP ticker. */
 export async function initLogForwarder(app: AppService): Promise<void> {
-  if (instance) await instance.stop()
+  if (instance) instance.stop()
   instance = await LogForwarder.create(app)
   setLogAppender(instance.appender)
   instance.start()
 }
 
-/** Stop the singleton HTTP ticker and await any in-flight ship. Called on
- * suspend so the cursor UPDATE doesn't race the DB close. Idempotent. */
-export async function stopLogForwarder(): Promise<void> {
+/** Stop the singleton HTTP ticker. Doesn't await in-flight network work
+ * — the cursor only advances on success, so a request killed mid-flight
+ * by iOS suspension just re-ships next session. Idempotent. */
+export function stopLogForwarder(): void {
   if (!instance) return
-  await instance.stop()
+  instance.stop()
 }
 
 /** Re-register the appender and restart the HTTP ticker after suspension. */

--- a/packages/core/src/services/uploader.ts
+++ b/packages/core/src/services/uploader.ts
@@ -162,8 +162,6 @@ export class UploadManager {
   private _suspended = false
   /** Resolves to unblock the loop when resume() is called. */
   private _resumeResolve: (() => void) | null = null
-  /** Resolves to signal the caller of suspend() that the loop has parked. */
-  private _parkedResolve: (() => void) | null = null
   /** Resolves the waitForWorkOrTimeout promise when wake() is called. */
   private wakeResolver: (() => void) | null = null
   /** Whether saveBatchObjects succeeded and invalidation is pending. */
@@ -314,10 +312,6 @@ export class UploadManager {
       this._resumeResolve()
       this._resumeResolve = null
     }
-    if (this._parkedResolve) {
-      this._parkedResolve()
-      this._parkedResolve = null
-    }
 
     if (this.packer) {
       logger.info('uploadManager', 'batch_cancel', {
@@ -365,27 +359,25 @@ export class UploadManager {
     this.wake()
   }
 
-  /** Cached promise so multiple suspend() calls return the same promise
-   * instead of overwriting _parkedResolve and leaving earlier callers hanging. */
-  private _suspendPromise: Promise<void> | null = null
-
+  // Non-blocking. Sets the flag and wakes the loop; the loop parks itself
+  // at the top of its next iteration. Return type stays Promise<void> for
+  // the SuspensionAdapters interface, but resolves immediately — Diff A's
+  // DB gate (reads reject, writes park during 'suspending'/'closed') is
+  // the synchronization primitive now, so we don't need to await the loop
+  // reaching its park point before proceeding with the rest of the suspend
+  // flow. Lets Phase 1 finish in milliseconds even when the loop is
+  // mid-iteration on a slow file.
   suspend(): Promise<void> {
-    if (this._suspendPromise) return this._suspendPromise
     logger.info('uploadManager', 'suspending')
     this._suspended = true
     this.wake()
-    if (!this.active) return Promise.resolve()
-    this._suspendPromise = new Promise<void>((resolve) => {
-      this._parkedResolve = resolve
-    })
-    return this._suspendPromise
+    return Promise.resolve()
   }
 
   resume(): void {
     if (!this._suspended) return
     logger.info('uploadManager', 'resuming')
     this._suspended = false
-    this._suspendPromise = null // Allow future suspend() calls to create a new promise.
     if (this._resumeResolve) {
       this._resumeResolve()
       this._resumeResolve = null
@@ -523,10 +515,6 @@ export class UploadManager {
   private async runLoop(): Promise<void> {
     while (this.active) {
       if (this._suspended) {
-        if (this._parkedResolve) {
-          this._parkedResolve()
-          this._parkedResolve = null
-        }
         await this.waitForResume()
         if (!this.active) break
         continue


### PR DESCRIPTION
iOS suspension's Phase 0/1 was awaiting work that didn't need awaiting (the upload loop's current iteration, an in-flight log POST - for devs with logs configured), eating seconds of the OS grace window. Both suspend() calls now set their flag and return immediately - the DB gate handles the actual synchronization.