### PR TITLE
fix(mobile): remove blocking operations in suspend

### DIFF
--- a/.changeset/log-appender-non-blocking-stop.md
+++ b/.changeset/log-appender-non-blocking-stop.md
@@ -1,0 +1,7 @@
+---
+core: patch
+logger: patch
+mobile: patch
+---
+
+Made the log appender's stop non-blocking and moved scheduler pause/abort before suspend pre-work, so iOS suspension no longer stalls on a DB flush behind still-ticking services.

--- a/.changeset/scanner-abort-mid-op.md
+++ b/.changeset/scanner-abort-mid-op.md
@@ -1,0 +1,6 @@
+---
+core: patch
+mobile: patch
+---
+
+Made the import scanner and thumbnail scanner exit fast on suspend abort even when a large file is mid hash, copy, or thumbnail generation.

--- a/apps/mobile/src/lib/logAppender.test.ts
+++ b/apps/mobile/src/lib/logAppender.test.ts
@@ -62,7 +62,7 @@ describe('logAppender', () => {
     expect(received[0].message).toBe('manual')
   })
 
-  it('stopLogAppender flushes remaining entries then clears appender', async () => {
+  it('stopLogAppender clears appender without flushing remaining entries', async () => {
     const received: LogEntry[] = []
     setLogAppender((entries) => {
       received.push(...entries)
@@ -73,13 +73,21 @@ describe('logAppender', () => {
 
     await stopLogAppender()
 
-    expect(received).toHaveLength(2)
-    expect(received[0].message).toBe('final1')
-    expect(received[1].message).toBe('final2')
+    // Buffered entries are NOT flushed inline — they remain in the buffer
+    // and will be flushed on the next setLogAppender call. Awaiting a DB
+    // flush here was the cause of iOS 0xdead10cc kills during suspension.
+    expect(received).toHaveLength(0)
 
     appendLog(makeEntry('after-stop'))
     flushLogs()
-    expect(received).toHaveLength(2)
+    expect(received).toHaveLength(0)
+
+    const received2: LogEntry[] = []
+    setLogAppender((entries) => {
+      received2.push(...entries)
+    })
+
+    expect(received2.map((e) => e.message)).toEqual(['final1', 'final2', 'after-stop'])
   })
 
   it('entries buffered after stop are flushed when appender is re-registered', async () => {

--- a/apps/mobile/src/managers/suspension.ts
+++ b/apps/mobile/src/managers/suspension.ts
@@ -94,11 +94,9 @@ const manager = createSuspensionManager({
   hooks: {
     onBeforeSuspend: async () => {
       await logSuspendDiagnostics()
-      // Drain JS log buffer to DB before halting the HTTP ticker.
-      // stopLogForwarder doesn't await in-flight network work — the
-      // cursor only advances on success, so a request killed mid-flight
-      // by iOS suspension just re-ships next session.
-      await stopLogAppender()
+      // Non-blocking; awaiting the flush stalls suspend past iOS's
+      // BG-task budget. See stopLogAppender JSDoc.
+      stopLogAppender()
       stopLogForwarder()
       // Cancel in-flight downloads (disk I/O contention with SQLite fsync
       // is a known 0xdead10cc trigger) and pause the photo-archive walk

--- a/packages/core/src/lib/timeout.test.ts
+++ b/packages/core/src/lib/timeout.test.ts
@@ -1,4 +1,4 @@
-import { raceWithTimeout } from './timeout'
+import { raceWithAbort, raceWithTimeout } from './timeout'
 
 describe('raceWithTimeout', () => {
   beforeEach(() => {
@@ -33,5 +33,63 @@ describe('raceWithTimeout', () => {
     const before = jest.getTimerCount()
     await expect(raceWithTimeout(Promise.reject(new Error('boom')), 5000)).rejects.toThrow('boom')
     expect(jest.getTimerCount()).toBe(before)
+  })
+})
+
+describe('raceWithAbort', () => {
+  it('returns the value when no signal is supplied', async () => {
+    const result = await raceWithAbort(Promise.resolve('done'))
+    expect(result).toEqual({ ok: true, value: 'done' })
+  })
+
+  it('returns the value when the promise settles before the signal fires', async () => {
+    const controller = new AbortController()
+    const result = await raceWithAbort(Promise.resolve(42), controller.signal)
+    expect(result).toEqual({ ok: true, value: 42 })
+  })
+
+  it('returns ok:false when the signal fires first', async () => {
+    const controller = new AbortController()
+    const pending = new Promise<string>(() => {})
+    const racePromise = raceWithAbort(pending, controller.signal)
+    controller.abort()
+    await expect(racePromise).resolves.toEqual({ ok: false })
+  })
+
+  it('returns ok:false synchronously when the signal is already aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const pending = new Promise<string>(() => {})
+    await expect(raceWithAbort(pending, controller.signal)).resolves.toEqual({ ok: false })
+  })
+
+  it('propagates a rejection from the input promise', async () => {
+    const controller = new AbortController()
+    await expect(
+      raceWithAbort(Promise.reject(new Error('boom')), controller.signal),
+    ).rejects.toThrow('boom')
+  })
+
+  it('attaches a no-op catch to the orphan promise on abort', async () => {
+    const controller = new AbortController()
+    let rejectFn: (e: Error) => void = () => {}
+    const pending = new Promise<string>((_, reject) => {
+      rejectFn = reject
+    })
+    const racePromise = raceWithAbort(pending, controller.signal)
+    controller.abort()
+    await expect(racePromise).resolves.toEqual({ ok: false })
+    // Reject the orphan after the race resolved — should not surface as
+    // an unhandled rejection.
+    rejectFn(new Error('orphan'))
+    await new Promise((r) => setImmediate(r))
+  })
+
+  it('removes the abort listener after the promise wins', async () => {
+    const controller = new AbortController()
+    const result = await raceWithAbort(Promise.resolve('done'), controller.signal)
+    expect(result).toEqual({ ok: true, value: 'done' })
+    // Signal still available; aborting now should not affect anything.
+    controller.abort()
   })
 })

--- a/packages/core/src/lib/timeout.ts
+++ b/packages/core/src/lib/timeout.ts
@@ -53,3 +53,41 @@ export async function raceWithTimeout<T>(
     if (timer !== undefined) clearTimeout(timer)
   }
 }
+
+/**
+ * Races a promise against an AbortSignal. Resolves to `{ ok: true, value }`
+ * if the promise fulfills first, or `{ ok: false }` when the signal fires.
+ * With no signal supplied, awaits the promise normally.
+ *
+ * Intended for uncancellable native ops (RNFS.hash, RNFS.copyFile, native
+ * thumbnail generators). The orphan keeps running on its native thread; a
+ * no-op catch is attached so a later rejection doesn't surface as unhandled.
+ */
+export async function raceWithAbort<T>(
+  promise: Promise<T>,
+  signal?: AbortSignal,
+): Promise<{ ok: true; value: T } | { ok: false }> {
+  if (!signal) {
+    return { ok: true, value: await promise }
+  }
+  if (signal.aborted) {
+    promise.catch(() => {})
+    return { ok: false }
+  }
+  let onAbort: (() => void) | undefined
+  try {
+    const result = await Promise.race([
+      promise.then((value) => ({ ok: true as const, value })),
+      new Promise<{ ok: false }>((resolve) => {
+        onAbort = () => resolve({ ok: false })
+        signal.addEventListener('abort', onAbort, { once: true })
+      }),
+    ])
+    if (!result.ok) {
+      promise.catch(() => {})
+    }
+    return result
+  } finally {
+    if (onAbort) signal.removeEventListener('abort', onAbort)
+  }
+}

--- a/packages/core/src/services/importScanner.ts
+++ b/packages/core/src/services/importScanner.ts
@@ -1,6 +1,7 @@
 import { logger } from '@siastorage/logger'
 import type { AppService } from '../app/service'
 import { type BackoffEntry, BackoffTracker } from '../lib/backoffTracker'
+import { raceWithAbort } from '../lib/timeout'
 
 const MAX_PER_TICK = 20
 
@@ -27,8 +28,8 @@ export type GetMimeType = (opts: { name?: string; uri?: string }) => Promise<str
  * Suspension signal policy: accepts AbortSignal. DB-holding loop —
  * each tick processes placeholder files (hash: '') by hashing local
  * files or copying from media library. Checks signal at loop boundaries
- * (phase 1 file loop, phase 2 deferred loop) so workers exit before the
- * DB gate closes.
+ * and races the uncancellable native hash/copy ops against it so the
+ * loop exits fast even mid-file.
  */
 export class ImportScanner {
   private app: AppService | null = null
@@ -167,9 +168,12 @@ export class ImportScanner {
               result.skipped++
               continue
             }
-            // Exit early on suspension before starting CPU-intensive hash.
             if (signal?.aborted) break
-            const outcome = await this.hashExistingFile(file, localFileUri)
+            // Native hash is uncancellable; race against the signal and
+            // let the orphan finish on its thread.
+            const raced = await raceWithAbort(this.hashExistingFile(file, localFileUri), signal)
+            if (!raced.ok) break
+            const outcome = raced.value
             if (outcome.action === 'finalized') {
               updates.push({
                 id: file.id,
@@ -255,14 +259,21 @@ export class ImportScanner {
               }
 
               try {
-                // Exit early on suspension before starting file copy + hash.
                 if (signal?.aborted) break
-                // usedAt: 0 — imported files are evictable as soon as they're uploaded.
-                const uri = await app.fs.copyFile({ id: file.id, type: file.type }, resolved.uri, {
-                  usedAt: 0,
-                })
-                if (signal?.aborted) break
-                const outcome = await this.hashExistingFile(file, uri)
+                // Native copy + hash are uncancellable; race against the
+                // signal and let orphans finish on their threads.
+                // usedAt: 0 — imported files are evictable once uploaded.
+                const copyRaced = await raceWithAbort(
+                  app.fs.copyFile({ id: file.id, type: file.type }, resolved.uri, {
+                    usedAt: 0,
+                  }),
+                  signal,
+                )
+                if (!copyRaced.ok) break
+                const uri = copyRaced.value
+                const hashRaced = await raceWithAbort(this.hashExistingFile(file, uri), signal)
+                if (!hashRaced.ok) break
+                const outcome = hashRaced.value
                 if (outcome.action === 'finalized') {
                   updates.push({
                     id: file.id,

--- a/packages/core/src/services/suspension.ts
+++ b/packages/core/src/services/suspension.ts
@@ -68,14 +68,18 @@ export function createSuspensionManager(adapters: SuspensionAdapters) {
     logger.info('suspension', 'starting')
 
     try {
+      // Phase 1a: Stop scheduler ticks and signal in-flight workers to
+      // abort. Done before Phase 0 so awaits inside onBeforeSuspend don't
+      // compete with fresh tick queries on the DB mutex — a 28s suspend
+      // was observed from this race.
+      scheduler.pause()
+      scheduler.abort()
+
       // Phase 0: Platform-specific pre-work (e.g. flush logs, disable SWR).
       await hooks?.onBeforeSuspend?.()
 
-      // Phase 1: Signal services to stop. pause() prevents new scheduler
-      // ticks, abort() tells in-flight workers to exit at their next
-      // signal.aborted check, upload manager parks its async loop.
-      scheduler.pause()
-      scheduler.abort()
+      // Phase 1b: Park the uploader's async loop. Non-blocking — the
+      // loop checks the flag at its next iteration boundary.
       await uploader.suspend()
       logger.debug('suspension', 'services_paused')
 

--- a/packages/core/src/services/thumbnailScanner.ts
+++ b/packages/core/src/services/thumbnailScanner.ts
@@ -1,5 +1,6 @@
 import { logger } from '@siastorage/logger'
 import type { AppService } from '../app/service'
+import { raceWithAbort } from '../lib/timeout'
 import { uniqueId } from '../lib/uniqueId'
 import { yieldToEventLoop } from '../lib/yieldToEventLoop'
 import type { FileRecord, ThumbSize } from '../types/files'
@@ -91,8 +92,9 @@ export function computeTargetDimensions(
  *
  * Suspension signal policy: accepts AbortSignal. DB-holding loop — each
  * tick queries candidate files and writes thumbnails via app().files /
- * app().thumbs. Checks signal at loop boundaries so straggler workers
- * don't issue queries after the gate and hit DatabaseSuspendedError.
+ * app().thumbs. Checks signal at loop boundaries and races the
+ * uncancellable native thumbnail generator against it so the loop exits
+ * fast even mid-generation.
  */
 export class ThumbnailScanner {
   private app: AppService | null = null
@@ -516,14 +518,21 @@ export class ThumbnailScanner {
               originalHash: c.hash,
               size,
             })
-            const outcome = await this.ensureThumbnailForSize({
-              fileId: c.id,
-              fileHash: c.hash,
-              fileType: c.type,
-              fileLocalId: c.localId,
-              size,
-              sourceUri,
-            })
+            // Native generator is uncancellable; race against the signal
+            // and let the orphan finish on its thread.
+            const raced = await raceWithAbort(
+              this.ensureThumbnailForSize({
+                fileId: c.id,
+                fileHash: c.hash,
+                fileType: c.type,
+                fileLocalId: c.localId,
+                size,
+                sourceUri,
+              }),
+              signal,
+            )
+            if (!raced.ok) break
+            const outcome = raced.value
             await yieldToEventLoop()
             if (outcome.status === 'produced') {
               producedCount++

--- a/packages/logger/src/logAppender.ts
+++ b/packages/logger/src/logAppender.ts
@@ -34,18 +34,16 @@ export function flushLogs(): void {
 }
 
 /**
- * Gracefully stop the log appender: stop the flush interval, flush remaining
- * entries to the appender, then clear the appender. After this call no more
- * entries will be written.
+ * Stop the log appender: clear the flush interval and detach the appender.
+ * Does NOT flush buffered entries — they remain in the buffer and flush on
+ * the next setLogAppender call. Awaiting a DB flush here held iOS suspend
+ * past beginBackgroundTask's budget by queuing behind in-flight service
+ * queries on the expo-sqlite mutex (0xdead10cc).
  */
-export async function stopLogAppender(): Promise<void> {
+export function stopLogAppender(): void {
   if (flushTimer) {
     clearInterval(flushTimer)
     flushTimer = null
-  }
-  if (buffer.length > 0 && appender) {
-    const entries = buffer.splice(0)
-    await appender(entries)
   }
   appender = null
 }


### PR DESCRIPTION
- Make the log appender stop method non-blocking and remove db write.
- Race scanner hash/copy/thumb against abort signal so it does not block service shutdown.
- Pause services before suspend pre-work.
