### PR TITLE
fix(mobile,core): release iOS background-task assertion before suspension wind-down

### DIFF
--- a/.changeset/pause-swr-when-not-foreground.md
+++ b/.changeset/pause-swr-when-not-foreground.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Reduced background CPU and database load by pausing SWR revalidation while the app isn't foreground-active; data refreshes automatically on return to foreground.

--- a/.changeset/release-bg-task-assertion-first.md
+++ b/.changeset/release-bg-task-assertion-first.md
@@ -1,0 +1,6 @@
+---
+mobile: patch
+core: patch
+---
+
+Fixed iOS RunningBoard 0xDEAD10CC crashes by releasing the background-task assertion before the suspension wind-down, and removed the now-unused DB drain/close pipeline (DELETE-mode SQLite handles uncleanly-suspended connections without intervention).

--- a/.changeset/skip-cpu-heavy-scanners-in-app-refresh.md
+++ b/.changeset/skip-cpu-heavy-scanners-in-app-refresh.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Reduced background CPU usage on iOS by deferring import, orphan, eviction, and photo archive scans during BGAppRefreshTask wakes (where iOS still enforces the 80%-CPU-over-60s monitor with no requiresExternalPower opt-out); they still run during longer BGProcessingTask wakes.

--- a/apps/integration/test/app.ts
+++ b/apps/integration/test/app.ts
@@ -55,26 +55,15 @@ export {
   waitForCondition,
 } from './utils'
 
-export class DatabaseSuspendedError extends Error {
-  constructor() {
-    super('Database is suspended')
-    this.name = 'DatabaseSuspendedError'
-  }
-}
-
 /**
- * Mirrors the real mobile app's DB lifecycle (initializeDB / closeDb / reopen).
- * Uses a file-backed better-sqlite3 database with the same PRAGMAs
- * (WAL, busy_timeout, foreign_keys) and runs migrations on open.
- * The adapter delegates to the active connection; calls throw after close.
- * Supports a query gate that rejects queries while suspended.
+ * File-backed better-sqlite3 database with the same PRAGMAs as the mobile
+ * app (WAL, busy_timeout, foreign_keys). Stays open across suspension —
+ * the suspend pipeline no longer closes the DB.
  */
 function createTestDatabase(dbPath: string) {
   let inner: (DatabaseAdapter & { close(): void }) | null = null
-  let gated = false
 
   function requireOpen(): DatabaseAdapter & { close(): void } {
-    if (gated) throw new DatabaseSuspendedError()
     if (!inner) throw new Error('Database is closed')
     return inner
   }
@@ -104,8 +93,6 @@ function createTestDatabase(dbPath: string) {
       await inner.execAsync(
         'PRAGMA journal_mode = WAL; PRAGMA busy_timeout = 5000; PRAGMA foreign_keys = ON',
       )
-      // Run migrations on the raw connection (not the proxy) so open()
-      // works while the gate is active during resume.
       await runMigrations(inner, sortMigrations(coreMigrations))
     },
     close() {
@@ -113,12 +100,6 @@ function createTestDatabase(dbPath: string) {
         inner.close()
         inner = null
       }
-    },
-    gate() {
-      gated = true
-    },
-    ungate() {
-      gated = false
     },
     get isOpen() {
       return inner !== null
@@ -370,20 +351,11 @@ export function createTestApp(
       pause: () => scheduler.pause(),
       abort: () => scheduler.abortAll(),
       resume: () => scheduler.resume(),
-      waitForIdle: () => scheduler.waitForIdle(),
     },
     uploader: {
       suspend: () => uploadManager.suspend(),
       resume: () => uploadManager.resume(),
       adjustBatchForSuspension: () => uploadManager.adjustBatchForSuspension(),
-      getDiagnostics: () => uploadManager.getDiagnostics(),
-    },
-    db: {
-      gate: () => testDb.gate(),
-      ungate: () => testDb.ungate(),
-      waitForIdle: () => Promise.resolve(),
-      close: async () => testDb.close(),
-      reopen: () => testDb.open(),
     },
     hooks: {
       onBeforeSuspend: () => {
@@ -396,7 +368,6 @@ export function createTestApp(
         hookCalls.onForegroundActive += 1
       },
     },
-    hardDeadlineMs: 15_000,
   })
 
   return {

--- a/apps/integration/test/suspension.test.ts
+++ b/apps/integration/test/suspension.test.ts
@@ -5,14 +5,7 @@
  * phase ordering with real services, uploads, and DB operations.
  */
 import { createEmptyIndexerStorage } from '@siastorage/sdk-mock'
-import {
-  createTestApp,
-  DatabaseSuspendedError,
-  generateTestFiles,
-  sleep,
-  type TestApp,
-  waitForCondition,
-} from './app'
+import { createTestApp, generateTestFiles, sleep, type TestApp, waitForCondition } from './app'
 
 describe('Suspension', () => {
   let app: TestApp
@@ -298,20 +291,15 @@ describe('Suspension', () => {
     expect(app.sdk.getStoredObjects().length).toBe(5)
   }, 60_000)
 
-  it('DB queries are rejected after suspend and work after resume', async () => {
+  it('DB stays usable across suspend/resume', async () => {
     await app.addFiles(generateTestFiles(2, { startId: 1 }))
     await app.waitForNoActiveUploads()
 
     await app.suspend()
-
-    // DB is gated — queries should throw DatabaseSuspendedError.
-    await expect(app.app.files.queryCount({ order: 'ASC' })).rejects.toThrow(DatabaseSuspendedError)
+    expect(await app.app.files.queryCount({ order: 'ASC' })).toBe(2)
 
     await app.resumeFromSuspension()
-
-    // DB is open again — queries work.
-    const count = await app.app.files.queryCount({ order: 'ASC' })
-    expect(count).toBe(2)
+    expect(await app.app.files.queryCount({ order: 'ASC' })).toBe(2)
   }, 60_000)
 
   it('sync-down writes reach the DB during drain', async () => {

--- a/apps/mobile/src/Root.tsx
+++ b/apps/mobile/src/Root.tsx
@@ -6,9 +6,10 @@ import { useHasOnboarded, useShowSplash } from '@siastorage/core/stores'
 import * as ScreenOrientation from 'expo-screen-orientation'
 import { ShareIntentProvider } from 'expo-share-intent'
 import { useEffect } from 'react'
-import { Platform, StatusBar, StyleSheet } from 'react-native'
+import { AppState, Platform, StatusBar, StyleSheet } from 'react-native'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context'
+import { SWRConfig } from 'swr'
 import { AppSplash } from './components/AppSplash'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { ShareIntentConsumer } from './components/ShareIntentConsumer'
@@ -27,6 +28,30 @@ const darkNavigationTheme = {
     background: palette.gray[950],
     card: palette.gray[950],
     primary: palette.blue[400],
+  },
+}
+
+// SWR config for React Native (per the official RN guide):
+//   isVisible: defaults check document.visibilityState (undefined in RN);
+//     without this override SWR treats the app as hidden.
+//   isPaused: skip fetcher dispatch when the app isn't foreground-active,
+//     so background invalidations from sync/upload services don't re-run
+//     fetchers against SQLite for non-rendered components.
+//   initFocus: bridge AppState background→active to SWR's focus signal
+//     (Window.focus doesn't exist in RN); fires after isPaused flips
+//     false, so deferred revalidations land on foreground.
+const swrConfig = {
+  isVisible: () => true,
+  isPaused: () => AppState.currentState !== 'active',
+  initFocus(callback: () => void) {
+    let prev: string = AppState.currentState
+    const sub = AppState.addEventListener('change', (next) => {
+      if ((prev === 'background' || prev === 'inactive') && next === 'active') {
+        callback()
+      }
+      prev = next
+    })
+    return () => sub.remove()
   },
 }
 
@@ -58,7 +83,9 @@ export function Root() {
                 })}
               />
               <AppProvider value={app()}>
-                <RootContent />
+                <SWRConfig value={swrConfig}>
+                  <RootContent />
+                </SWRConfig>
               </AppProvider>
             </SafeAreaView>
           </ToastProvider>

--- a/apps/mobile/src/managers/backgroundTasks.test.ts
+++ b/apps/mobile/src/managers/backgroundTasks.test.ts
@@ -1,4 +1,5 @@
 import BackgroundFetch from 'react-native-background-fetch'
+import { isBgTaskActive } from './bgTaskContext'
 import { initBackgroundTasks } from './backgroundTasks'
 
 // Capture the callbacks passed to BackgroundFetch.configure so we can simulate OS behavior
@@ -107,18 +108,13 @@ jest.mock('./uploader', () => ({
   })),
 }))
 
-// Mock the suspension lifecycle so tests can assert register/release calls
-// on both the normal and timeout paths.
 const mockRegister = jest.fn((_id: string) => Promise.resolve())
 const mockRelease = jest.fn((_id: string) => Promise.resolve())
-const mockGetIsSuspended = jest.fn(() => false)
 jest.mock('./suspension', () => ({
-  getIsSuspended: () => mockGetIsSuspended(),
   registerBackgroundTaskLifecycle: (id: string) => mockRegister(id),
   releaseBackgroundTaskLifecycle: (id: string) => mockRelease(id),
 }))
 
-// Helpers
 const flushPromises = () => new Promise(setImmediate)
 
 function completeNextDelay() {
@@ -144,13 +140,12 @@ describe('backgroundTasks', () => {
     mockRunFsEvictionScanner.mockReset().mockResolvedValue(undefined)
     mockRegister.mockReset().mockResolvedValue(undefined)
     mockRelease.mockReset().mockResolvedValue(undefined)
-    mockGetIsSuspended.mockReset().mockReturnValue(false)
 
     await initBackgroundTasks()
   })
 
   describe('suspension lifecycle', () => {
-    it('registers lifecycle at start of task', async () => {
+    it('registers lifecycle at task start', async () => {
       mockGetFileStatsLocal.mockResolvedValue({ count: 0, totalBytes: 0 })
 
       await taskCallback('com.transistorsoft.fetch')
@@ -159,34 +154,29 @@ describe('backgroundTasks', () => {
       expect(mockRegister).toHaveBeenCalledWith('com.transistorsoft.fetch')
     })
 
-    it('releases lifecycle after normal completion', async () => {
+    it('releases lifecycle on normal completion', async () => {
       mockGetFileStatsLocal.mockResolvedValue({ count: 0, totalBytes: 0 })
 
       await taskCallback('com.transistorsoft.fetch')
 
-      expect(mockRelease).toHaveBeenCalledTimes(1)
       expect(mockRelease).toHaveBeenCalledWith('com.transistorsoft.fetch')
     })
 
-    it('releases lifecycle after timeout — the critical crash-1 regression guard', async () => {
+    it('releases lifecycle on timeout', async () => {
       mockGetFileStatsLocal.mockResolvedValue({ count: 100, totalBytes: 100000 })
 
       const taskPromise = taskCallback('com.transistorsoft.fetch')
       await flushPromises()
 
-      // Task is in a delay, holding the DB open. iOS fires expirationHandler.
       timeoutCallback('com.transistorsoft.fetch')
       await flushPromises()
       await flushPromises()
       await taskPromise
 
-      // Both the normal path (finally block) and the timeout path (IIFE)
-      // call release, resulting in 2 calls for the same invocation.
       expect(mockRelease).toHaveBeenCalledWith('com.transistorsoft.fetch')
-      expect(mockRelease.mock.calls.length).toBeGreaterThanOrEqual(1)
     })
 
-    it('releases lifecycle even when task throws', async () => {
+    it('releases lifecycle even when work throws', async () => {
       mockGetFileStatsLocal.mockRejectedValue(new Error('simulated db error'))
 
       await taskCallback('com.transistorsoft.fetch')
@@ -194,26 +184,127 @@ describe('backgroundTasks', () => {
       expect(mockRelease).toHaveBeenCalledWith('com.transistorsoft.fetch')
     })
 
-    it('releases lifecycle even when AppState.currentState is active', async () => {
-      // The manager decides whether to actually suspend; the handler
-      // just always calls release. Confirms the guard was removed.
+    it('calls BackgroundFetch.finish before lifecycle release on normal path', async () => {
+      // Pinning this order is the 0xDEAD10CC fix: a slow lifecycle release
+      // can never delay finish past iOS's 5s expiration grace.
       mockGetFileStatsLocal.mockResolvedValue({ count: 0, totalBytes: 0 })
+      const order: string[] = []
+      const finishMock = BackgroundFetch.finish as jest.MockedFunction<
+        typeof BackgroundFetch.finish
+      >
+      finishMock.mockImplementation((id) => {
+        order.push(`finish:${id}`)
+      })
+      mockRelease.mockImplementation(async (id) => {
+        order.push(`release:${id}`)
+      })
 
       await taskCallback('com.transistorsoft.fetch')
 
-      expect(mockRelease).toHaveBeenCalledWith('com.transistorsoft.fetch')
+      expect(order).toEqual(['finish:com.transistorsoft.fetch', 'release:com.transistorsoft.fetch'])
     })
 
-    it('logs handler_exit with didSuspend reading from getIsSuspended', async () => {
-      // After release, the suspension manager reports suspended.
+    it('calls BackgroundFetch.finish before lifecycle release on timeout path', async () => {
+      mockGetFileStatsLocal.mockResolvedValue({ count: 100, totalBytes: 100000 })
+      const order: string[] = []
+      const finishMock = BackgroundFetch.finish as jest.MockedFunction<
+        typeof BackgroundFetch.finish
+      >
+      finishMock.mockImplementation((id) => {
+        order.push(`finish:${id}`)
+      })
+      mockRelease.mockImplementation(async (id) => {
+        order.push(`release:${id}`)
+      })
+
+      const taskPromise = taskCallback('com.transistorsoft.fetch')
+      await flushPromises()
+
+      timeoutCallback('com.transistorsoft.fetch')
+      await flushPromises()
+      await flushPromises()
+      await taskPromise
+
+      const finishIdx = order.indexOf('finish:com.transistorsoft.fetch')
+      const releaseIdx = order.indexOf('release:com.transistorsoft.fetch')
+      expect(finishIdx).toBeGreaterThanOrEqual(0)
+      expect(releaseIdx).toBeGreaterThanOrEqual(0)
+      expect(finishIdx).toBeLessThan(releaseIdx)
+    })
+
+    it('does not double-call finish/release when timeout fires mid-work', async () => {
+      // Race the timeout against the normal callback. Both must converge
+      // on exactly one finish + one release for the same invocation.
+      mockGetFileStatsLocal.mockResolvedValue({ count: 100, totalBytes: 100000 })
+
+      const taskPromise = taskCallback('com.transistorsoft.fetch')
+      await flushPromises()
+
+      timeoutCallback('com.transistorsoft.fetch')
+      await flushPromises()
+      await flushPromises()
+      await taskPromise
+
+      expect(BackgroundFetch.finish).toHaveBeenCalledWith('com.transistorsoft.fetch')
+      expect(
+        (BackgroundFetch.finish as jest.MockedFunction<typeof BackgroundFetch.finish>).mock.calls
+          .length,
+      ).toBe(1)
+      expect(mockRelease).toHaveBeenCalledTimes(1)
+    })
+
+    it('treats a late timeout as a no-op when normal already finalized', async () => {
       mockGetFileStatsLocal.mockResolvedValue({ count: 0, totalBytes: 0 })
-      mockGetIsSuspended.mockReturnValue(true)
 
       await taskCallback('com.transistorsoft.fetch')
+      expect(BackgroundFetch.finish).toHaveBeenCalledTimes(1)
 
-      // The handler asks the manager for suspended state. We don't
-      // introspect logger directly here — assert the read happened.
-      expect(mockGetIsSuspended).toHaveBeenCalled()
+      // Stray expirationHandler firing after we already completed.
+      timeoutCallback('com.transistorsoft.fetch')
+
+      expect(BackgroundFetch.finish).toHaveBeenCalledTimes(1)
+      expect(mockRelease).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('active BG task tracking', () => {
+    it.each([
+      ['com.transistorsoft.fetch', 'BGAppRefreshTask'],
+      ['com.transistorsoft.processing', 'BGProcessingTask'],
+    ] as const)('marks %s as active during the task and clears on exit', async (taskId, type) => {
+      let observed = false
+      mockGetFileStatsLocal.mockImplementation(async () => {
+        observed = isBgTaskActive(type)
+        return { count: 0, totalBytes: 0 }
+      })
+
+      await taskCallback(taskId)
+
+      expect(observed).toBe(true)
+      expect(isBgTaskActive(type)).toBe(false)
+    })
+
+    it('does not stomp fetch active state when a processing task overlaps', async () => {
+      // Cross-type overlap could happen if iOS schedules a processing
+      // task while a fetch task is still mid-flight. Each must stay
+      // independently tracked so finishing one doesn't clear the other.
+      mockGetFileStatsLocal.mockResolvedValue({ count: 100, totalBytes: 100000 })
+
+      const fetchTask = taskCallback('com.transistorsoft.fetch')
+      await flushPromises()
+      const processingTask = taskCallback('com.transistorsoft.processing')
+      await flushPromises()
+      expect(isBgTaskActive('BGAppRefreshTask')).toBe(true)
+      expect(isBgTaskActive('BGProcessingTask')).toBe(true)
+
+      timeoutCallback('com.transistorsoft.processing')
+      await processingTask
+      expect(isBgTaskActive('BGAppRefreshTask')).toBe(true)
+      expect(isBgTaskActive('BGProcessingTask')).toBe(false)
+
+      timeoutCallback('com.transistorsoft.fetch')
+      await fetchTask
+      expect(isBgTaskActive('BGAppRefreshTask')).toBe(false)
     })
   })
 
@@ -342,7 +433,7 @@ describe('backgroundTasks', () => {
   })
 
   describe('scanners', () => {
-    it('does not run fsEvictionScanner inside the BGAppRefreshTask budget', async () => {
+    it('skips fsEvictionScanner inside BGAppRefreshTask budget', async () => {
       mockGetFileStatsLocal.mockResolvedValue({ count: 0, totalBytes: 0 })
 
       await taskCallback('com.transistorsoft.fetch')
@@ -350,31 +441,26 @@ describe('backgroundTasks', () => {
       expect(mockRunFsEvictionScanner).not.toHaveBeenCalled()
     })
 
-    it('defers fsEvictionScanner behind the settle delay in BGProcessingTask', async () => {
+    it('runs fsEvictionScanner after settle delay in BGProcessingTask', async () => {
       mockGetFileStatsLocal.mockResolvedValue({ count: 0, totalBytes: 0 })
 
       const taskPromise = taskCallback('com.transistorsoft.processing')
       await flushPromises()
 
-      // Eviction has not started — the settle delay is parked.
       expect(mockRunFsEvictionScanner).not.toHaveBeenCalled()
       expect(getPendingDelayCount()).toBeGreaterThanOrEqual(1)
 
-      // Resolve the settle delay so the scanner runs.
-      const settleDelay = mockPendingDelays[0]
-      settleDelay.resolve()
+      mockPendingDelays[0].resolve()
       await taskPromise
 
       expect(mockRunFsEvictionScanner).toHaveBeenCalledTimes(1)
     })
 
-    it('cancels the settle delay when the BG task aborts before it fires', async () => {
+    it('cancels the settle delay when BG task aborts before it fires', async () => {
       mockGetFileStatsLocal.mockResolvedValue({ count: 1, totalBytes: 100 })
 
       const taskPromise = taskCallback('com.transistorsoft.processing')
       await flushPromises()
-
-      // Both delays are parked: the upload poll's 10s and the scan settle 30s.
       expect(getPendingDelayCount()).toBeGreaterThanOrEqual(1)
 
       timeoutCallback('com.transistorsoft.processing')
@@ -402,7 +488,7 @@ describe('backgroundTasks', () => {
   })
 
   describe('task constraints', () => {
-    it('BGProcessingTask is scheduled with charging + network constraints', () => {
+    it('schedules BGProcessingTask with charging + network constraints', () => {
       expect(BackgroundFetch.scheduleTask).toHaveBeenCalledWith(
         expect.objectContaining({
           taskId: 'com.transistorsoft.processing',
@@ -413,9 +499,12 @@ describe('backgroundTasks', () => {
       )
     })
 
-    it('BGAppRefreshTask (configure) is configured with charging + network + battery constraints', () => {
-      const configCall = (BackgroundFetch.configure as jest.Mock).mock.calls[0]
-      expect(configCall[0]).toMatchObject({
+    it('configures BGAppRefreshTask with charging + network + battery constraints', () => {
+      const configureMock = BackgroundFetch.configure as jest.MockedFunction<
+        typeof BackgroundFetch.configure
+      >
+      const [config] = configureMock.mock.calls[0]
+      expect(config).toMatchObject({
         requiresCharging: true,
         requiresBatteryNotLow: true,
         requiredNetworkType: 2,

--- a/apps/mobile/src/managers/backgroundTasks.ts
+++ b/apps/mobile/src/managers/backgroundTasks.ts
@@ -7,12 +7,9 @@ import { delayWithSignal } from '../lib/delayWithSignal'
 import { scheduleAfter } from '../lib/scheduleAfter'
 import { app } from '../stores/appService'
 import { getFileStatsLocal } from '../stores/files'
+import { clearActiveBgTask, setActiveBgTask } from './bgTaskContext'
 import { runFsEvictionScanner } from './fsEvictionScanner'
-import {
-  getIsSuspended,
-  registerBackgroundTaskLifecycle,
-  releaseBackgroundTaskLifecycle,
-} from './suspension'
+import { registerBackgroundTaskLifecycle, releaseBackgroundTaskLifecycle } from './suspension'
 import { getUploadManager } from './uploader'
 
 /**
@@ -140,7 +137,10 @@ export async function initBackgroundTasks() {
       // lingering work from a previous invocation.
       resetTaskState(taskId as TaskId)
 
-      transitionTaskState(state, 'running')
+      transitionTaskState(state, 'running', config)
+      // Capture our invocation id so a later re-invocation that resets
+      // shared state can't trick us into finalizing on its behalf.
+      const myInvocationId = state.invocationId
       const log = logTask(config, state)
       log('handler_enter', { path: 'normal' })
       try {
@@ -148,16 +148,26 @@ export async function initBackgroundTasks() {
       } catch (error) {
         log('work_error', { error: error as Error })
       } finally {
-        transitionTaskState(state, 'finished')
-        // Always release — the suspension manager decides whether to
-        // actually suspend based on appState and other running tasks.
-        try {
-          await releaseBackgroundTaskLifecycle(config.id)
-        } catch (error) {
-          log('release_error', { error: error as Error })
+        if (state.invocationId !== myInvocationId) {
+          // A newer invocation has taken over this task slot; it owns
+          // its own finalization.
+          log('handler_exit', { path: 'normal', skipped: 'superseded' })
+        } else if (state.status === 'finished') {
+          // Timeout path already finalized this invocation — calling
+          // finish/release again logs an iOS warning and enqueues
+          // redundant suspend work.
+          log('handler_exit', { path: 'normal', skipped: 'already_finalized' })
+        } else {
+          transitionTaskState(state, 'finished', config)
+          // Release the iOS BG-task assertion BEFORE the wind-down so a
+          // slow lifecycle release can never push us past iOS's 5s
+          // expiration grace (= 0xDEAD10CC kill).
+          BackgroundFetch.finish(config.id)
+          log('handler_exit', { path: 'normal' })
+          void releaseBackgroundTaskLifecycle(config.id).catch((error) => {
+            log('release_error', { error: error as Error })
+          })
         }
-        log('handler_exit', { path: 'normal', didSuspend: getIsSuspended() })
-        BackgroundFetch.finish(config.id)
       }
     },
     (taskId: string) => {
@@ -169,31 +179,30 @@ export async function initBackgroundTasks() {
         return
       }
       const log = logTask(config, state)
+      // If the normal path already finalized this invocation (or none is
+      // running), there's nothing left to clean up — and finish() must
+      // not be called twice.
+      if (state.status !== 'running') {
+        log('timeout', { skipped: 'no_active_invocation' })
+        return
+      }
       log('handler_enter', { path: 'timeout' })
       log('timeout')
 
-      // Abort the work loop immediately — signal.aborted is sticky, so
-      // any subsequent await-point check inside runBackgroundWork will
-      // bail out even if no delayWithSignal is in flight right now.
+      // Abort the work loop. signal.aborted is sticky so the loop bails
+      // at its next await-point even if no delayWithSignal is in flight.
       state.controller?.abort()
-      transitionTaskState(state, 'finished')
+      transitionTaskState(state, 'finished', config)
       log('timeout_finished', { elapsedMs: Date.now() - state.startTime })
 
-      // iOS's timeout callback is void-returning (library can't await a
-      // Promise here), so drive release + finish through a fire-and-
-      // forget IIFE. releaseBackgroundTaskLifecycle acquires
-      // beginBackgroundTask slack internally, giving the WAL checkpoint
-      // + close enough time to complete before iOS freezes the process.
-      ;(async () => {
-        try {
-          await releaseBackgroundTaskLifecycle(config.id)
-        } catch (error) {
-          log('release_error', { error: error as Error })
-        } finally {
-          log('handler_exit', { path: 'timeout', didSuspend: getIsSuspended() })
-          BackgroundFetch.finish(config.id)
-        }
-      })()
+      // We're inside the expirationHandler — iOS gives ~5s before
+      // SIGKILL with 0xDEAD10CC if setTaskCompleted (= finish()) isn't
+      // called. Release first, fire-and-forget the wind-down.
+      BackgroundFetch.finish(config.id)
+      log('handler_exit', { path: 'timeout' })
+      void releaseBackgroundTaskLifecycle(config.id).catch((error) => {
+        log('release_error', { error: error as Error })
+      })
     },
   )
 
@@ -458,12 +467,18 @@ function logTask(config: TaskConfig, state: TaskState) {
   }
 }
 
-function transitionTaskState(state: TaskState, newStatus: 'running' | 'finished') {
+function transitionTaskState(
+  state: TaskState,
+  newStatus: 'running' | 'finished',
+  config: TaskConfig,
+) {
   if (newStatus === 'running') {
     state.startTime = Date.now()
     state.invocationId = Math.random().toString(36).substring(2, 8)
     state.status = 'running'
+    setActiveBgTask(config.id, config.type)
   } else if (newStatus === 'finished') {
     state.status = 'finished'
+    clearActiveBgTask(config.id)
   }
 }

--- a/apps/mobile/src/managers/bgTaskContext.ts
+++ b/apps/mobile/src/managers/bgTaskContext.ts
@@ -1,0 +1,33 @@
+/**
+ * Module-level registry of currently-running BG tasks. Read by CPU-heavy
+ * auto-ticking scanners so they can short-circuit during BGAppRefreshTask
+ * wakes — Apple still enforces the 80%/60s CPU monitor on fetch tasks
+ * (no requiresExternalPower opt-out for them) and a heavy scan can trip
+ * cpu_resource_fatal. BGProcessingTask is exempt because
+ * requiresExternalPower=true disables the monitor.
+ *
+ * Lives in its own file to break a cycle between backgroundTasks.ts
+ * (writer + caller of scanners) and the scanners themselves (readers).
+ *
+ * Tracks per-task-id rather than a single "current type" so overlapping
+ * tasks don't stomp each other (e.g. if a fetch and processing task
+ * overlap, finishing one doesn't clear the other's active state).
+ */
+export type BgTaskType = 'BGAppRefreshTask' | 'BGProcessingTask' | 'BackgroundTask'
+
+const active = new Map<string, BgTaskType>()
+
+export function setActiveBgTask(id: string, type: BgTaskType): void {
+  active.set(id, type)
+}
+
+export function clearActiveBgTask(id: string): void {
+  active.delete(id)
+}
+
+export function isBgTaskActive(type: BgTaskType): boolean {
+  for (const t of active.values()) {
+    if (t === type) return true
+  }
+  return false
+}

--- a/apps/mobile/src/managers/fsEvictionScanner.ts
+++ b/apps/mobile/src/managers/fsEvictionScanner.ts
@@ -4,6 +4,7 @@ import type { CacheEvictionResult } from '@siastorage/core/services'
 import { runCacheEviction } from '@siastorage/core/services'
 import { logger } from '@siastorage/logger'
 import { app } from '../stores/appService'
+import { isBgTaskActive } from './bgTaskContext'
 
 const flight = new SingleInit()
 let activeController: AbortController | null = null
@@ -22,6 +23,13 @@ export function cancelFsEvictionScanner(): void {
 export async function runFsEvictionScanner(
   opts: { force?: boolean; signal?: AbortSignal } = {},
 ): Promise<CacheEvictionResult | undefined> {
+  // BGAppRefreshTask still enforces iOS's 80%/60s CPU monitor; an
+  // eviction scan can trip cpu_resource_fatal. `force` (foreground /
+  // processing task) bypasses the gate. See bgTaskContext.ts.
+  if (!opts.force && isBgTaskActive('BGAppRefreshTask')) {
+    logger.debug('fsEvictionScanner', 'skipped', { reason: 'bg_app_refresh_no_cpu_budget' })
+    return
+  }
   if (!opts.force) {
     const lastRun = await app().settings.getFsEvictionLastRun()
     if (Date.now() - lastRun < FS_EVICTION_FREQUENCY) {

--- a/apps/mobile/src/managers/fsOrphanScanner.ts
+++ b/apps/mobile/src/managers/fsOrphanScanner.ts
@@ -5,6 +5,7 @@ import { runOrphanScanner } from '@siastorage/core/services'
 import { logger } from '@siastorage/logger'
 import { app } from '../stores/appService'
 import { fsFileUriCache } from '../stores/fs'
+import { isBgTaskActive } from './bgTaskContext'
 
 const flight = new SingleInit()
 let activeController: AbortController | null = null
@@ -25,6 +26,13 @@ export async function runFsOrphanScanner(options?: {
   force?: boolean
   signal?: AbortSignal
 }): Promise<OrphanScannerResult | undefined> {
+  // BGAppRefreshTask still enforces iOS's 80%/60s CPU monitor; an fs
+  // walk can trip cpu_resource_fatal. `force` (foreground / processing
+  // task) bypasses the gate. See bgTaskContext.ts.
+  if (!options?.force && isBgTaskActive('BGAppRefreshTask')) {
+    logger.debug('fsOrphanScanner', 'skipped', { reason: 'bg_app_refresh_no_cpu_budget' })
+    return
+  }
   if (!options?.force) {
     const lastRun = await app().settings.getFsOrphanLastRun()
     if (Date.now() - lastRun < FS_ORPHAN_FREQUENCY) {

--- a/apps/mobile/src/managers/importScanner.ts
+++ b/apps/mobile/src/managers/importScanner.ts
@@ -6,6 +6,7 @@ import { calculateContentHash } from '../lib/contentHash'
 import { getMimeType } from '../lib/fileTypes'
 import { getMediaLibraryUri } from '../lib/mediaLibrary'
 import { app } from '../stores/appService'
+import { isBgTaskActive } from './bgTaskContext'
 
 const scanner = new ImportScanner()
 
@@ -51,6 +52,12 @@ export function getImportBackoffEntries() {
 }
 
 async function run(signal: AbortSignal): Promise<void> {
+  // BGAppRefreshTask still enforces iOS's 80%/60s CPU monitor; hashing
+  // here can trip cpu_resource_fatal. See bgTaskContext.ts.
+  if (isBgTaskActive('BGAppRefreshTask')) {
+    logger.debug('importScanner', 'skipped', { reason: 'bg_app_refresh_no_cpu_budget' })
+    return
+  }
   if (app().sync.getState().syncGateStatus === 'active') {
     logger.debug('importScanner', 'skipped', { reason: 'sync_gate_active' })
     return

--- a/apps/mobile/src/managers/suspension.ts
+++ b/apps/mobile/src/managers/suspension.ts
@@ -2,25 +2,13 @@ import {
   abortAllServiceIntervals,
   pauseAllServiceIntervals,
   resumeAllServiceIntervals,
-  waitForAllServiceIntervalsIdle,
 } from '@siastorage/core/lib/serviceInterval'
 import { stopLogForwarder } from '@siastorage/core/services/logForwarder'
 import { createSuspensionManager } from '@siastorage/core/services/suspension'
 import { logger, stopLogAppender } from '@siastorage/logger'
 import { AppState, type AppStateStatus, Platform } from 'react-native'
-import BackgroundTimer from 'react-native-background-timer'
 import RNFS from 'react-native-fs'
-import {
-  closeDb,
-  dbInitialized,
-  getActiveJournalMode,
-  getInflightCount,
-  getWalPath,
-  initializeDB,
-  resumeDb,
-  suspendDb,
-  waitForQueriesIdle,
-} from '../db'
+import { dbInitialized, getActiveJournalMode, getInflightCount, getWalPath } from '../db'
 import { app } from '../stores/appService'
 import { resumeLogger } from '../stores/logs'
 import { cancelFsEvictionScanner, runFsEvictionScanner } from './fsEvictionScanner'
@@ -28,10 +16,8 @@ import { cancelFsOrphanScanner } from './fsOrphanScanner'
 import { isArchiveWalkActive, pauseArchiveSync, resumeArchiveSync } from './syncPhotosArchive'
 import { getUploadManager } from './uploader'
 
-/** Snapshot of subsystem state at suspension start. Lets a future 0xdead10cc
- * investigation see at a glance what was in flight — active DB queries,
- * upload-manager state, photo-archive walk activity, and current WAL size.
- * All values are cheap in-memory reads except WAL size (one RNFS.stat call). */
+/** Logs in-flight subsystem state at suspension start. Useful for diagnosing
+ * any future RunningBoard kill from the surrounding log context. */
 async function logSuspendDiagnostics(): Promise<void> {
   try {
     // Only stat the WAL file when it can exist; in DELETE journal mode
@@ -54,54 +40,25 @@ async function logSuspendDiagnostics(): Promise<void> {
   }
 }
 
-// Hard deadline for Phase 2 service drain. Roughly the scale we expect
-// service drain to take — observed timings are well under 2s in normal
-// runs. Not sized against any iOS API budget: grace from
-// applicationDidEnterBackground is short, and beginBackgroundTask's
-// extended grant is discretionary and cannot extend a BGTask from
-// inside its expirationHandler (Apple DTS forum thread 126438).
-// Android doesn't enforce file-lock checks on suspend, but the
-// sequence runs harmlessly there.
-const HARD_DEADLINE_MS = 1_500
-
 const manager = createSuspensionManager({
   scheduler: {
     pause: pauseAllServiceIntervals,
     abort: abortAllServiceIntervals,
     resume: resumeAllServiceIntervals,
-    waitForIdle: waitForAllServiceIntervalsIdle,
   },
   uploader: {
     suspend: () => getUploadManager()?.suspend() ?? Promise.resolve(),
     resume: () => getUploadManager()?.resume(),
     adjustBatchForSuspension: () => getUploadManager()?.adjustBatchForSuspension(),
-    getDiagnostics: () =>
-      getUploadManager()?.getDiagnostics() ?? {
-        isSuspended: false,
-        batchId: null,
-        filesInBatch: 0,
-        hasPacker: false,
-        finalizing: false,
-      },
-  },
-  db: {
-    gate: suspendDb,
-    ungate: resumeDb,
-    waitForIdle: waitForQueriesIdle,
-    close: closeDb,
-    reopen: () => initializeDB({ reopen: true }),
   },
   hooks: {
+    // Battery hygiene: stop the CPU/network work that was about to be
+    // frozen anyway. All synchronous / fire-and-forget — we don't need
+    // confirmation, just signal stop.
     onBeforeSuspend: async () => {
       await logSuspendDiagnostics()
-      // Non-blocking; awaiting the flush stalls suspend past iOS's
-      // BG-task budget. See stopLogAppender JSDoc.
       stopLogAppender()
       stopLogForwarder()
-      // Cancel in-flight downloads (disk I/O contention with SQLite fsync
-      // is a known 0xdead10cc trigger) and pause the photo-archive walk
-      // (an independent loop not driven by the service scheduler, so it
-      // keeps issuing catalogAssets writes otherwise).
       app().downloads.cancelAll()
       cancelFsEvictionScanner()
       cancelFsOrphanScanner()
@@ -109,14 +66,12 @@ const manager = createSuspensionManager({
     },
     onAfterResume: () => {
       resumeLogger()
-      // Resume archive walk from the same cursor if it wasn't complete.
       void resumeArchiveSync()
-      // Eviction's frequency gate short-circuits when it ran recently, so a
+      // Eviction's frequency gate short-circuits if it ran recently, so a
       // quick app-switch is cheap; a long suspension triggers a real pass.
       void runFsEvictionScanner()
     },
   },
-  hardDeadlineMs: HARD_DEADLINE_MS,
 })
 
 let subscription: ReturnType<typeof AppState.addEventListener> | null = null
@@ -129,15 +84,10 @@ export function initSuspensionManager(): void {
   subscription = AppState.addEventListener('change', (nextState) => {
     logger.info('appState', 'state_changed', { from: appStateRef, to: nextState })
     appStateRef = nextState
-    // The suspend/close flow exists for iOS 0xdead10cc protection (mach
-    // exception when iOS freezes the process while the SQLite WAL lock
-    // is held). Android has no analog, and on Android many things that
-    // aren't really "backgrounding" — opening image/document pickers,
-    // share sheets — still fire AppState 'background'. Running the full
-    // flow on every picker round-trip degrades the experience: cancels
-    // in-flight downloads, closes and reopens the DB, re-runs migration
-    // checks, pauses all services. iOS pickers don't background the app,
-    // so the flow only fires when the user actually leaves.
+    // Android fires 'background' for picker / share-sheet round-trips
+    // that aren't real backgrounding; running the pipeline there degrades
+    // the experience. iOS pickers don't background the app, so the flow
+    // only fires when the user actually leaves.
     if (Platform.OS === 'ios') {
       onAppStateChange(nextState)
     }
@@ -149,70 +99,37 @@ export function teardownSuspensionManager(): void {
   subscription = null
 }
 
-/**
- * Wrap an async operation with an iOS beginBackgroundTask assertion.
- * Best-effort only: the assertion is granted at iOS's discretion and
- * does NOT extend a BGTask from inside its expirationHandler (Apple
- * DTS forum thread 126438). Cleanup is sized to fit inside the
- * BGTask's wake window (see softDeadlineMs in backgroundTasks.ts)
- * instead of relying on this. Android no-op.
- */
-async function withIosExecutionTime<T>(fn: () => Promise<T>): Promise<T> {
-  await BackgroundTimer.start(0)
-  try {
-    return await fn()
-  } finally {
-    BackgroundTimer.stop()
-  }
-}
-
 function onAppStateChange(nextState: AppStateStatus): void {
   if (nextState === 'background') {
     if (!dbInitialized) {
       logger.debug('suspension', 'skipped', { reason: 'db_not_initialized' })
       return
     }
-    // Init's cleanup/services steps issue many DB queries; running the
-    // suspend gate concurrently with them races the close against
-    // in-flight queries. Defer until init completes — iOS may suspend
-    // us "naturally" without our cleanup, same as before this listener
-    // attached early.
+    // Init's cleanup steps issue many DB queries; let init finish first.
     if (app().init.getState().isInitializing) {
       logger.debug('suspension', 'skipped', { reason: 'init_in_progress' })
       return
     }
-    // Fire-and-forget; errors surface via the manager's own logging.
-    // The setAppState Promise resolves after any enqueued doSuspend
-    // settles, so BackgroundTimer keeps iOS from freezing the process
-    // until WAL checkpoint + close complete.
-    void withIosExecutionTime(() => manager.setAppState('background'))
+    void manager.setAppState('background')
   } else if (nextState === 'active') {
-    // Always safe — setAppState('foreground') enqueues doResume which
-    // is a no-op when state !== 'suspended'.
     void manager.setAppState('foreground')
   }
 }
 
-/**
- * Called by backgroundTasks.ts at the start of every BG task invocation.
- * Registers the task with the suspension manager and returns once the
- * DB is open (reopen happens inside the manager's queue if needed).
- */
+/** Called at the start of every BG task — resumes the manager if suspended. */
 export function registerBackgroundTaskLifecycle(id: string): Promise<void> {
   return manager.registerBackgroundTask(id)
 }
 
 /**
- * Called by backgroundTasks.ts at the end of every BG task invocation,
- * including the timeout path. If this is the last running BG task and
- * the app is in background, triggers a suspend. Wrapped with
- * beginBackgroundTask to keep iOS from freezing the process during the
- * WAL checkpoint and close.
+ * Called at the end of every BG task (normal completion + expirationHandler).
+ * Suspends if it was the last running task and the app is backgrounded.
+ *
+ * Callers MUST have already called `BackgroundFetch.finish()` (or the
+ * equivalent platform release) before invoking this. iOS kills with
+ * 0xDEAD10CC if the BG-task assertion is held past the 5s expiration
+ * warning, and this lifecycle release does not satisfy that contract.
  */
 export function releaseBackgroundTaskLifecycle(id: string): Promise<void> {
-  return withIosExecutionTime(() => manager.releaseBackgroundTask(id))
-}
-
-export function getIsSuspended(): boolean {
-  return manager.isSuspended()
+  return manager.releaseBackgroundTask(id)
 }

--- a/apps/mobile/src/managers/syncPhotosArchive.test.ts
+++ b/apps/mobile/src/managers/syncPhotosArchive.test.ts
@@ -4,12 +4,15 @@ import {
 } from '@siastorage/core/config'
 import * as MediaLibrary from 'expo-media-library'
 import { catalogAssets } from '../lib/processAssets'
+import { clearActiveBgTask, setActiveBgTask } from './bgTaskContext'
 import {
   getArchiveSyncCompletedAt,
   getLastRecentScanAt,
   getPhotosArchiveCursor,
   getPhotosArchiveDisplayDate,
+  isArchiveWalkActive,
   restartPhotosArchiveCursor,
+  resumeArchiveSync,
   run,
   setArchiveSyncCompletedAt,
   setLastRecentScanAt,
@@ -241,6 +244,21 @@ describe('syncPhotosArchive', () => {
       { addToImportDirectory: true },
       undefined,
     )
+  })
+
+  describe('resumeArchiveSync', () => {
+    it('does not start the walk during a BGAppRefreshTask', async () => {
+      // Cursor is non-DONE (set by restartPhotosArchiveCursor in beforeEach),
+      // so without the gate resume would kick off runArchiveWalk and set
+      // activeWalk. With the gate, the function returns before that.
+      setActiveBgTask('com.transistorsoft.fetch', 'BGAppRefreshTask')
+      try {
+        await resumeArchiveSync()
+        expect(isArchiveWalkActive()).toBe(false)
+      } finally {
+        clearActiveBgTask('com.transistorsoft.fetch')
+      }
+    })
   })
 
   describe('triggerRecentScanIfNeeded', () => {

--- a/apps/mobile/src/managers/syncPhotosArchive.ts
+++ b/apps/mobile/src/managers/syncPhotosArchive.ts
@@ -47,6 +47,7 @@ import useSWR from 'swr'
 import { getMediaLibraryPermissions } from '../lib/mediaLibraryPermissions'
 import { catalogAssets } from '../lib/processAssets'
 import { app } from '../stores/appService'
+import { isBgTaskActive } from './bgTaskContext'
 
 const PAGE_SIZE = 500
 const CURSOR_DONE = 'done'
@@ -91,6 +92,10 @@ export function isArchiveWalkActive(): boolean {
 /** Restart the walk from where it left off if cursor isn't DONE. */
 export async function resumeArchiveSync(): Promise<void> {
   if (activeWalk) return
+  // Don't restart during a fetch wake — the loop would just spin against
+  // run()'s gate, hammering AsyncStorage every iteration. Walk will
+  // resume on the next foreground or processing-task wake.
+  if (isBgTaskActive('BGAppRefreshTask')) return
   const cursor = await getPhotosArchiveCursor()
   if (cursor === CURSOR_DONE) return
   walkAbortController = new AbortController()
@@ -113,6 +118,12 @@ async function runArchiveWalk(signal: AbortSignal): Promise<void> {
 export async function run(signal?: AbortSignal) {
   logger.debug('syncPhotosArchive', 'tick')
   if (signal?.aborted) return
+  // BGAppRefreshTask still enforces iOS's 80%/60s CPU monitor; photo
+  // walks can trip cpu_resource_fatal. See bgTaskContext.ts.
+  if (isBgTaskActive('BGAppRefreshTask')) {
+    logger.debug('syncPhotosArchive', 'skipped', { reason: 'bg_app_refresh_no_cpu_budget' })
+    return
+  }
   if (!(await getMediaLibraryPermissions())) {
     logger.debug('syncPhotosArchive', 'skipped', { reason: 'no_permission' })
     return

--- a/packages/core/src/services/suspension.test.ts
+++ b/packages/core/src/services/suspension.test.ts
@@ -1,161 +1,214 @@
 import { createSuspensionManager, type SuspensionAdapters } from './suspension'
 
-function createAdapters(overrides?: {
-  schedulerWaitForIdle?: () => Promise<void>
-  dbWaitForIdle?: () => Promise<void>
-  dbClose?: () => Promise<void>
-  hardDeadlineMs?: number
-}): {
-  adapters: SuspensionAdapters
-  scheduler: SuspensionAdapters['scheduler']
-  db: SuspensionAdapters['db']
-  uploader: SuspensionAdapters['uploader']
-} {
-  const scheduler: SuspensionAdapters['scheduler'] = {
-    pause: jest.fn(),
-    abort: jest.fn(),
-    resume: jest.fn(),
-    waitForIdle: jest.fn(overrides?.schedulerWaitForIdle ?? (() => Promise.resolve())),
-  }
-  const uploader: SuspensionAdapters['uploader'] = {
-    suspend: jest.fn(() => Promise.resolve()),
-    resume: jest.fn(),
-    adjustBatchForSuspension: jest.fn(),
-    getDiagnostics: jest.fn(() => ({
-      isSuspended: false,
-      batchId: null,
-      filesInBatch: 0,
-      hasPacker: false,
-      finalizing: false,
-    })),
-  }
-  const db: SuspensionAdapters['db'] = {
-    gate: jest.fn(),
-    ungate: jest.fn(),
-    waitForIdle: jest.fn(overrides?.dbWaitForIdle ?? (() => Promise.resolve())),
-    close: jest.fn(overrides?.dbClose ?? (() => Promise.resolve())),
-    reopen: jest.fn(() => Promise.resolve()),
-  }
-  const adapters: SuspensionAdapters = {
-    scheduler,
-    uploader,
-    db,
-    hardDeadlineMs: overrides?.hardDeadlineMs ?? 100,
-  }
-  return { adapters, scheduler, db, uploader }
+type Mocks = {
+  scheduler: { [K in keyof SuspensionAdapters['scheduler']]: jest.Mock }
+  uploader: { [K in keyof SuspensionAdapters['uploader']]: jest.Mock }
+  hooks: { [K in keyof NonNullable<SuspensionAdapters['hooks']>]: jest.Mock }
 }
 
-describe('createSuspensionManager deadline behavior', () => {
-  beforeEach(() => {
-    jest.useFakeTimers()
-  })
+function createAdapters(
+  opts: {
+    trace?: string[]
+    uploaderSuspend?: () => Promise<void> | void
+    onBeforeSuspend?: () => void | Promise<void>
+  } = {},
+): { adapters: SuspensionAdapters; mocks: Mocks } {
+  const trace = opts.trace
+  const recordEvent = (name: string) => () => {
+    if (trace) trace.push(name)
+  }
+  const mocks: Mocks = {
+    scheduler: {
+      pause: jest.fn(recordEvent('pause')),
+      abort: jest.fn(recordEvent('abort')),
+      resume: jest.fn(recordEvent('resume')),
+    },
+    uploader: {
+      suspend: jest.fn(opts.uploaderSuspend ?? recordEvent('uploader.suspend')),
+      resume: jest.fn(),
+      adjustBatchForSuspension: jest.fn(),
+    },
+    hooks: {
+      onBeforeSuspend: jest.fn(opts.onBeforeSuspend ?? recordEvent('onBeforeSuspend')),
+      onAfterResume: jest.fn(),
+      onForegroundActive: jest.fn(),
+    },
+  }
+  return {
+    adapters: { scheduler: mocks.scheduler, uploader: mocks.uploader, hooks: mocks.hooks },
+    mocks,
+  }
+}
 
-  afterEach(() => {
-    jest.useRealTimers()
-  })
-
-  it('reaches suspended even when scheduler.waitForIdle never resolves', async () => {
-    const { adapters, db } = createAdapters({
-      schedulerWaitForIdle: () => new Promise(() => {}),
-      hardDeadlineMs: 100,
-    })
+describe('doSuspend', () => {
+  it('runs flag flips + onBeforeSuspend in order, then marks suspended', async () => {
+    const trace: string[] = []
+    const { adapters, mocks } = createAdapters({ trace })
     const manager = createSuspensionManager(adapters)
 
-    const suspendPromise = manager.suspend()
-    await jest.advanceTimersByTimeAsync(500)
-    await suspendPromise
+    await manager.suspend()
 
+    expect(trace).toEqual(['pause', 'abort', 'uploader.suspend', 'onBeforeSuspend'])
     expect(manager.isSuspended()).toBe(true)
-    expect(db.gate).toHaveBeenCalled()
-    expect(db.close).toHaveBeenCalled()
+    expect(mocks.hooks.onBeforeSuspend).toHaveBeenCalledTimes(1)
   })
 
-  // Closing while inflight > 0 produces a UAF (TestFlight crash #29).
-  // If db drain times out, the manager aborts the suspend and ungates
-  // instead of proceeding to close. iOS may kill us for holding the lock,
-  // but a clean kill is cheaper than corruption.
-  it('aborts suspend when db.waitForIdle never resolves', async () => {
-    const { adapters, db, scheduler, uploader } = createAdapters({
-      dbWaitForIdle: () => new Promise(() => {}),
-      hardDeadlineMs: 100,
+  it('is a no-op when not active', async () => {
+    const { adapters, mocks } = createAdapters()
+    const manager = createSuspensionManager(adapters)
+    await manager.suspend()
+    mocks.scheduler.pause.mockClear()
+
+    await manager.suspend()
+
+    expect(mocks.scheduler.pause).not.toHaveBeenCalled()
+  })
+
+  it('rolls back to active when onBeforeSuspend throws', async () => {
+    const { adapters, mocks } = createAdapters({
+      onBeforeSuspend: () => {
+        throw new Error('boom')
+      },
     })
     const manager = createSuspensionManager(adapters)
 
-    const suspendPromise = manager.suspend()
-    await jest.advanceTimersByTimeAsync(2000)
-    await suspendPromise
+    await manager.suspend()
 
     expect(manager.isSuspended()).toBe(false)
-    expect(db.close).not.toHaveBeenCalled()
-    expect(db.ungate).toHaveBeenCalled()
-    expect(scheduler.resume).toHaveBeenCalled()
-    expect(uploader.resume).toHaveBeenCalled()
-  })
-
-  it('reaches suspended even when db.close never resolves', async () => {
-    const { adapters } = createAdapters({
-      dbClose: () => new Promise(() => {}),
-      hardDeadlineMs: 100,
-    })
-    const manager = createSuspensionManager(adapters)
-
-    const suspendPromise = manager.suspend()
-    await jest.advanceTimersByTimeAsync(5000)
-    await suspendPromise
-
-    expect(manager.isSuspended()).toBe(true)
+    expect(mocks.scheduler.resume).toHaveBeenCalledTimes(1)
+    expect(mocks.uploader.resume).toHaveBeenCalledTimes(1)
   })
 })
 
-describe('createSuspensionManager onForegroundActive hook', () => {
-  it('fires on every setAppState(foreground) call, including no-ops', async () => {
-    const onForegroundActive = jest.fn()
-    const onAfterResume = jest.fn()
-    const { adapters } = createAdapters()
-    const manager = createSuspensionManager({
-      ...adapters,
-      hooks: { onForegroundActive, onAfterResume },
-    })
+describe('doResume', () => {
+  it('restores services and runs onAfterResume', async () => {
+    const { adapters, mocks } = createAdapters()
+    const manager = createSuspensionManager(adapters)
+    await manager.suspend()
 
-    // Initial appState is 'foreground'. setAppState('foreground') with no
-    // transition still fires the hook — matches iOS 'inactive' → 'active'
-    // flicker semantics where 'active' events should refresh SWR even
-    // when the manager never thought we were 'background'.
+    await manager.resume()
+
+    expect(manager.isSuspended()).toBe(false)
+    expect(mocks.hooks.onAfterResume).toHaveBeenCalledTimes(1)
+    expect(mocks.uploader.adjustBatchForSuspension).toHaveBeenCalledTimes(1)
+    expect(mocks.uploader.resume).toHaveBeenCalledTimes(1)
+    expect(mocks.scheduler.resume).toHaveBeenCalledTimes(1)
+  })
+
+  it('only adjusts batch when not suspended', async () => {
+    const { adapters, mocks } = createAdapters()
+    const manager = createSuspensionManager(adapters)
+
+    await manager.resume()
+
+    expect(mocks.uploader.adjustBatchForSuspension).toHaveBeenCalledTimes(1)
+    expect(mocks.hooks.onAfterResume).not.toHaveBeenCalled()
+    expect(mocks.uploader.resume).not.toHaveBeenCalled()
+    expect(mocks.scheduler.resume).not.toHaveBeenCalled()
+  })
+})
+
+describe('BG task gating', () => {
+  it('blocks suspend while a BG task is running', async () => {
+    const { adapters, mocks } = createAdapters()
+    const manager = createSuspensionManager(adapters)
+
+    await manager.registerBackgroundTask('bg')
+    await manager.setAppState('background')
+
+    expect(manager.isSuspended()).toBe(false)
+    expect(mocks.scheduler.pause).not.toHaveBeenCalled()
+  })
+
+  it('suspends when the last BG task releases and app is backgrounded', async () => {
+    const { adapters } = createAdapters()
+    const manager = createSuspensionManager(adapters)
+
+    await manager.setAppState('background')
+    await manager.registerBackgroundTask('bg')
+    await manager.releaseBackgroundTask('bg')
+
+    expect(manager.isSuspended()).toBe(true)
+  })
+
+  it('does not suspend on release when app is foregrounded', async () => {
+    const { adapters } = createAdapters()
+    const manager = createSuspensionManager(adapters)
+
+    await manager.registerBackgroundTask('bg')
+    await manager.releaseBackgroundTask('bg')
+
+    expect(manager.isSuspended()).toBe(false)
+  })
+})
+
+describe('AppState transitions', () => {
+  it('cycles foreground → background → foreground cleanly', async () => {
+    const { adapters } = createAdapters()
+    const manager = createSuspensionManager(adapters)
+
+    await manager.setAppState('background')
+    expect(manager.isSuspended()).toBe(true)
+
     await manager.setAppState('foreground')
-    expect(onForegroundActive).toHaveBeenCalledTimes(1)
-    expect(onAfterResume).not.toHaveBeenCalled()
+    expect(manager.isSuspended()).toBe(false)
+  })
+
+  it('serializes a foreground that arrives mid-suspend via the queue', async () => {
+    let releaseHook: () => void = () => {}
+    const blocked = new Promise<void>((r) => {
+      releaseHook = r
+    })
+    const { adapters, mocks } = createAdapters({ onBeforeSuspend: () => blocked })
+    const manager = createSuspensionManager(adapters)
+
+    const suspendPromise = manager.setAppState('background')
+    const resumePromise = manager.setAppState('foreground')
+    releaseHook()
+    await suspendPromise
+    await resumePromise
+
+    expect(mocks.hooks.onAfterResume).toHaveBeenCalledTimes(1)
+    expect(manager.isSuspended()).toBe(false)
+  })
+})
+
+describe('onForegroundActive hook', () => {
+  it('fires on every foreground call, including no-ops and BG-task overlaps', async () => {
+    const { adapters, mocks } = createAdapters()
+    const manager = createSuspensionManager(adapters)
+
+    // No-op foreground (already foreground): fires the hook anyway.
+    await manager.setAppState('foreground')
+    expect(mocks.hooks.onForegroundActive).toHaveBeenCalledTimes(1)
+    expect(mocks.hooks.onAfterResume).not.toHaveBeenCalled()
 
     // Real cycle: foreground → background → foreground.
     await manager.setAppState('background')
-    expect(onForegroundActive).toHaveBeenCalledTimes(1)
     await manager.setAppState('foreground')
-    expect(onForegroundActive).toHaveBeenCalledTimes(2)
-    expect(onAfterResume).toHaveBeenCalledTimes(1)
+    expect(mocks.hooks.onForegroundActive).toHaveBeenCalledTimes(2)
+    expect(mocks.hooks.onAfterResume).toHaveBeenCalledTimes(1)
 
-    // BG-task wake from suspended fires onAfterResume but not the
-    // foreground hook — appState stays 'background'.
+    // BG-task wake from suspended: onAfterResume fires, foreground hook does not (appState stays 'background').
     await manager.setAppState('background')
     await manager.registerBackgroundTask('bg')
-    expect(onAfterResume).toHaveBeenCalledTimes(2)
-    expect(onForegroundActive).toHaveBeenCalledTimes(2)
+    expect(mocks.hooks.onAfterResume).toHaveBeenCalledTimes(2)
+    expect(mocks.hooks.onForegroundActive).toHaveBeenCalledTimes(2)
 
-    // User foregrounds while BG task is still running. The manager is
-    // already resumed so onAfterResume does NOT fire again, but
-    // onForegroundActive must — that's the whole reason this hook exists.
+    // User foregrounds while BG task still running: onAfterResume does NOT
+    // fire again (manager is already resumed); onForegroundActive must.
     await manager.setAppState('foreground')
-    expect(onAfterResume).toHaveBeenCalledTimes(2)
-    expect(onForegroundActive).toHaveBeenCalledTimes(3)
+    expect(mocks.hooks.onAfterResume).toHaveBeenCalledTimes(2)
+    expect(mocks.hooks.onForegroundActive).toHaveBeenCalledTimes(3)
   })
 
-  it('does not fire on setAppState(background) calls', async () => {
-    const onForegroundActive = jest.fn()
-    const { adapters } = createAdapters()
-    const manager = createSuspensionManager({
-      ...adapters,
-      hooks: { onForegroundActive },
-    })
+  it('does not fire on background calls', async () => {
+    const { adapters, mocks } = createAdapters()
+    const manager = createSuspensionManager(adapters)
+
     await manager.setAppState('background')
     await manager.setAppState('background')
-    expect(onForegroundActive).not.toHaveBeenCalled()
+
+    expect(mocks.hooks.onForegroundActive).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/src/services/suspension.ts
+++ b/packages/core/src/services/suspension.ts
@@ -1,5 +1,4 @@
 import { CoalescingQueue } from '../lib/coalescingQueue'
-import { raceWithTimeout } from '../lib/timeout'
 import { logger } from '@siastorage/logger'
 
 export type SuspensionAdapters = {
@@ -7,55 +6,40 @@ export type SuspensionAdapters = {
     pause(): void
     abort(): void
     resume(): void
-    waitForIdle(): Promise<void>
   }
   uploader: {
-    suspend(): Promise<void>
+    suspend(): Promise<void> | void
     resume(): void
     adjustBatchForSuspension(): void
-    getDiagnostics(): {
-      isSuspended: boolean
-      batchId: string | null
-      filesInBatch: number
-      hasPacker: boolean
-      finalizing: boolean
-    }
-  }
-  db: {
-    gate(): void
-    ungate(): void
-    waitForIdle(): Promise<void>
-    close(): Promise<void>
-    reopen(): Promise<void>
   }
   hooks?: {
     onBeforeSuspend?(): void | Promise<void>
     onAfterResume?(): void
     /**
-     * Fires synchronously on every `setAppState('foreground')` call,
-     * including no-op calls where appState was already 'foreground'.
-     * Matches iOS AppState semantics: any 'active' event from the OS is
-     * a "user is here" signal even if it didn't go through 'background'
-     * first (e.g. the brief 'active' → 'inactive' → 'active' flicker
-     * from a notification panel pull-down). Also covers the case where
-     * a BG task already resumed the manager and the user subsequently
-     * foregrounds — onAfterResume doesn't fire there.
+     * Fires on every `setAppState('foreground')` call, including no-ops.
+     * Lets platform glue refresh stale UI state on iOS 'inactive' →
+     * 'active' flickers and on foreground events that happen while a BG
+     * task already resumed the manager (where onAfterResume doesn't fire).
      */
     onForegroundActive?(): void
   }
-  hardDeadlineMs: number
 }
 
 type State = 'active' | 'suspending' | 'suspended' | 'resuming'
 type AppStateValue = 'foreground' | 'background'
 
 export function createSuspensionManager(adapters: SuspensionAdapters) {
-  const { scheduler, uploader, db, hooks, hardDeadlineMs } = adapters
+  const { scheduler, uploader, hooks } = adapters
   let state: State = 'active'
   let appState: AppStateValue = 'foreground'
   const runningTasks = new Set<string>()
   const queue = new CoalescingQueue()
 
+  // Suspend is intentionally just flag flips + one optional hook. iOS
+  // suspends with file handles, sockets, and SQLite mid-step preserved,
+  // so closing the DB / draining queries is unnecessary. The 0xDEAD10CC
+  // contract (release the BG-task assertion within iOS's 5s expiration
+  // grace) is satisfied at the BG-task call site, not here.
   async function doSuspend(): Promise<void> {
     if (state !== 'active') {
       logger.debug('suspension', 'skipped', {
@@ -68,93 +52,15 @@ export function createSuspensionManager(adapters: SuspensionAdapters) {
     logger.info('suspension', 'starting')
 
     try {
-      // Phase 1a: Stop scheduler ticks and signal in-flight workers to
-      // abort. Done before Phase 0 so awaits inside onBeforeSuspend don't
-      // compete with fresh tick queries on the DB mutex — a 28s suspend
-      // was observed from this race.
       scheduler.pause()
       scheduler.abort()
-
-      // Phase 0: Platform-specific pre-work (e.g. flush logs, disable SWR).
+      await uploader.suspend()
       await hooks?.onBeforeSuspend?.()
 
-      // Phase 1b: Park the uploader's async loop. Non-blocking — the
-      // loop checks the flag at its next iteration boundary.
-      await uploader.suspend()
-      logger.debug('suspension', 'services_paused')
-
-      // Phase 2: Drain services with a hard deadline. DB is still open so
-      // workers can complete their current unit of work (DB writes, cursor
-      // updates) without hitting DatabaseSuspendedError.
-      const drainStart = Date.now()
-      const drained = await raceWithTimeout(scheduler.waitForIdle(), hardDeadlineMs)
-
-      if (drained.ok) {
-        logger.debug('suspension', 'services_drained', {
-          drainMs: Date.now() - drainStart,
-        })
-      } else {
-        logger.warn('suspension', 'hard_deadline_reached', {
-          drainMs: Date.now() - drainStart,
-        })
-      }
-
-      // Phase 3: Gate the DB so straggler queries throw
-      // DatabaseSuspendedError instead of reaching the native queue.
-      db.gate()
-      logger.debug('suspension', 'db_gated')
-
-      // Phase 4: Drain queries already dispatched to the native queue.
-      // Floor of 300ms covers the rare case where Phase 2 ate the entire
-      // hard deadline; with reads rejecting on suspending, inflight is
-      // typically zero by the time we reach Phase 4.
-      const dbDrainStart = Date.now()
-      const elapsedMs = dbDrainStart - drainStart
-      const remainingMs = Math.max(hardDeadlineMs - elapsedMs, 300)
-      const dbDrainResult = await raceWithTimeout(db.waitForIdle(), remainingMs)
-      const dbDrainMs = Date.now() - dbDrainStart
-      if (!dbDrainResult.ok) {
-        // Closing while inflight > 0 races the close against in-flight
-        // statements and produces a UAF in sqlite3_mutex_enter. Bail
-        // instead — losing this suspend cycle is preferable to native
-        // corruption. iOS may kill the process for holding the lock,
-        // but a clean kill is cheaper than a use-after-free.
-        logger.warn('suspension', 'db_drain_timeout_aborted', {
-          dbDrainMs,
-          remainingMs,
-        })
-        // TODO: services + uploader resume immediately here, queueing
-        // work behind the stuck inflight queries. Cleaner: defer
-        // resume until inflight drains (new 'recovering' state).
-        hooks?.onAfterResume?.()
-        db.ungate()
-        uploader.resume()
-        scheduler.resume()
-        state = 'active'
-        return
-      }
-      logger.debug('suspension', 'db_drained', { dbDrainMs })
-
-      // Phase 5: Checkpoint WAL to release file locks, then close. Race
-      // against the remaining deadline — if native close hangs on fsync,
-      // the OS kill is coming regardless, so we don't wait forever in JS.
-      // Floor of 500ms gives WAL truncate enough headroom on slow disks.
-      const dbCloseStart = Date.now()
-      const closeBudget = Math.max(hardDeadlineMs - (dbCloseStart - drainStart), 500)
-      const closed = await raceWithTimeout(db.close(), closeBudget)
-      const dbCloseMs = Date.now() - dbCloseStart
-      if (closed.ok) {
-        logger.debug('suspension', 'db_closed', { dbCloseMs })
-      } else {
-        logger.warn('suspension', 'db_close_timeout', { dbCloseMs, closeBudget })
-      }
       state = 'suspended'
+      logger.info('suspension', 'suspended')
     } catch (e) {
-      // Unlikely — each phase handles its own errors internally.
-      // Try to undo partial suspension so the app remains usable.
       logger.error('suspension', 'suspend_error', { error: e as Error })
-      hooks?.onAfterResume?.()
-      db.ungate()
       uploader.resume()
       scheduler.resume()
       state = 'active'
@@ -170,32 +76,17 @@ export function createSuspensionManager(adapters: SuspensionAdapters) {
     state = 'resuming'
     logger.info('suspension', 'resuming')
 
-    try {
-      await db.reopen()
-    } catch (e) {
-      logger.error('suspension', 'resume_error', { error: e as Error })
-      state = 'suspended'
-      return
-    }
-
-    // Ungate after reopen so queries can't reach a closed handle.
-    // reopen() uses the raw database connection (not the gated adapter),
-    // so the gate being active during reopen is harmless.
-    db.ungate()
     hooks?.onAfterResume?.()
-    logger.debug('suspension', 'db_reopened')
-
     uploader.adjustBatchForSuspension()
     uploader.resume()
     scheduler.resume()
+
     state = 'active'
     logger.info('suspension', 'resumed')
   }
 
-  // Guarded wrapper: re-checks preconditions at the moment the queue runs
-  // it, not at enqueue time. Between enqueue and execution, another
-  // registerBackgroundTask could have added a task that should now block
-  // the suspend.
+  // Re-checks preconditions at queue execution time, not at enqueue time:
+  // a BG task may register between enqueue and run.
   async function maybeSuspend(trigger: string): Promise<void> {
     if (runningTasks.size > 0) {
       logger.debug('suspension', 'skipped', {
@@ -216,26 +107,19 @@ export function createSuspensionManager(adapters: SuspensionAdapters) {
   }
 
   return {
-    // Direct triggers — kept for manual control (e.g. tests that want to
-    // force a suspend without touching appState).
     suspend: () => queue.enqueue(doSuspend),
     resume: () => queue.enqueue(doResume),
     isSuspended: () => state === 'suspended',
 
     /**
-     * Record the app's current foreground/background state. When
-     * transitioning to background with no BG tasks running, enqueues a
-     * guarded suspend. When transitioning to foreground, enqueues a
-     * resume (no-op if not suspended). Returns a Promise that resolves
-     * when any enqueued work settles — callers that need to grant iOS
-     * extra execution time (via BackgroundTimer.start) should await it.
+     * Record the app's current foreground/background state. Background
+     * with no BG tasks running enqueues a guarded suspend; foreground
+     * enqueues a resume (no-op if not suspended).
      */
     setAppState(next: AppStateValue): Promise<void> {
       const prev = appState
-      // Foreground hook fires on every 'foreground' call, including
-      // no-ops, so flickers and BG-task overlaps both reach platform
-      // glue. Background has no equivalent — onBeforeSuspend already
-      // covers the only case that matters there (real suspension).
+      // Foreground hook fires on every 'foreground' call (including
+      // no-ops) so flickers and BG-task overlaps both reach platform glue.
       if (next === 'foreground') {
         hooks?.onForegroundActive?.()
       }
@@ -264,10 +148,7 @@ export function createSuspensionManager(adapters: SuspensionAdapters) {
       return queue.enqueue(doResume)
     },
 
-    /**
-     * Register a BG task as running. Ensures the DB is open before
-     * returning so callers can safely query.
-     */
+    /** Register a BG task; resumes the manager so callers can run work. */
     async registerBackgroundTask(id: string): Promise<void> {
       runningTasks.add(id)
       logger.info('suspension', 'register_task', {
@@ -279,11 +160,7 @@ export function createSuspensionManager(adapters: SuspensionAdapters) {
       await queue.enqueue(doResume)
     },
 
-    /**
-     * Release a BG task. If this was the last running task AND the app
-     * is in background, await a guarded suspend. Otherwise return
-     * immediately.
-     */
+    /** Release a BG task; suspends if it was the last one and app is in background. */
     async releaseBackgroundTask(id: string): Promise<void> {
       runningTasks.delete(id)
       const activeCount = runningTasks.size


### PR DESCRIPTION
- RunningBoard kills: we were asking for more time and then trying to do a clean shutdown before signaling complete. The OS sometimes gave us too little time and killed the process. We now signal we're ready to suspend immediately and let the rest of the shutdown freeze and thaw on the next wake.
- CPU kills: caused by background tasks running over 80% CPU for more than 60s. Fetch tasks no longer run heavy services (import, orphan, eviction, photo archive) — only uploads. Processing tasks require power, which removes the CPU restriction, so all the heavy work runs there.
- The DB defaults to DELETE mode, which can freeze and thaw cleanly without releasing file locks — so we don't need to close it on suspend. WAL stays available behind a developer toggle for File Locations testing; we'll revisit before re-enabling it by default.
- SWR pauses revalidation while the app isn't foregrounded; initFocus re-triggers it on return so background invalidations don't fan out to SQLite for nothing.
