### PR TITLE
fix(mobile,core): centralize AppState reads and treat iOS inactive as foreground

### DIFF
--- a/.changeset/inactive-is-foreground.md
+++ b/.changeset/inactive-is-foreground.md
@@ -1,0 +1,6 @@
+---
+mobile: patch
+core: patch
+---
+
+Treat iOS `inactive` AppState as a foreground sub-state (per Apple's docs) so SWR data fetches keep running through transient interruptions like notification banners and Face ID prompts instead of pausing.

--- a/.changeset/lifecycle-event-determinism.md
+++ b/.changeset/lifecycle-event-determinism.md
@@ -1,0 +1,6 @@
+---
+mobile: patch
+core: patch
+---
+
+Made iOS foreground/background event handling more deterministic by centralizing AppState reading and emitting transitions in a single fixed order.

--- a/apps/mobile/src/Root.tsx
+++ b/apps/mobile/src/Root.tsx
@@ -6,7 +6,7 @@ import { useHasOnboarded, useShowSplash } from '@siastorage/core/stores'
 import * as ScreenOrientation from 'expo-screen-orientation'
 import { ShareIntentProvider } from 'expo-share-intent'
 import { useEffect } from 'react'
-import { AppState, Platform, StatusBar, StyleSheet } from 'react-native'
+import { Platform, StatusBar, StyleSheet } from 'react-native'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context'
 import { SWRConfig } from 'swr'
@@ -17,6 +17,7 @@ import useLinkedURL from './hooks/useLinkedURL'
 import { useReconnectIndexer } from './hooks/useReconnectIndexer'
 import { ToastProvider } from './lib/toastContext'
 import { initApp, shutdownApp } from './managers/app'
+import { addForegroundFocusListener, getLifecycle } from './managers/lifecycle'
 import { RootTabs } from './stacks/RootTabs'
 import { app } from './stores/appService'
 import { palette } from './styles/colors'
@@ -34,24 +35,19 @@ const darkNavigationTheme = {
 // SWR config for React Native (per the official RN guide):
 //   isVisible: defaults check document.visibilityState (undefined in RN);
 //     without this override SWR treats the app as hidden.
-//   isPaused: skip fetcher dispatch when the app isn't foreground-active,
-//     so background invalidations from sync/upload services don't re-run
-//     fetchers against SQLite for non-rendered components.
-//   initFocus: bridge AppState background→active to SWR's focus signal
-//     (Window.focus doesn't exist in RN); fires after isPaused flips
-//     false, so deferred revalidations land on foreground.
+//   isPaused: skip fetcher dispatch when the app isn't foreground.
+//     Driven by the lifecycle module (lifecycle.ts), which treats iOS
+//     'inactive' as foreground — flickers from banners / Control Center /
+//     Face ID prompts no longer pause SWR.
+//   initFocus: subscribe to lifecycle's foreground-focus signal, which
+//     fires once per transition INTO foreground on a microtask after
+//     suspension manager listeners have run. Guarantees SWR refetches
+//     deferred fetchers on real foreground returns.
 const swrConfig = {
   isVisible: () => true,
-  isPaused: () => AppState.currentState !== 'active',
+  isPaused: () => getLifecycle() !== 'foreground',
   initFocus(callback: () => void) {
-    let prev: string = AppState.currentState
-    const sub = AppState.addEventListener('change', (next) => {
-      if ((prev === 'background' || prev === 'inactive') && next === 'active') {
-        callback()
-      }
-      prev = next
-    })
-    return () => sub.remove()
+    return addForegroundFocusListener(callback)
   },
 }
 

--- a/apps/mobile/src/managers/backgroundTasks.ts
+++ b/apps/mobile/src/managers/backgroundTasks.ts
@@ -1,7 +1,7 @@
 import { minutesInMs, secondsInMs } from '@siastorage/core'
 import { isAbortError } from '@siastorage/core/lib/errors'
 import { logger } from '@siastorage/logger'
-import { AppState, Platform } from 'react-native'
+import { Platform } from 'react-native'
 import BackgroundFetch, { type BackgroundFetchConfig } from 'react-native-background-fetch'
 import { delayWithSignal } from '../lib/delayWithSignal'
 import { scheduleAfter } from '../lib/scheduleAfter'
@@ -9,6 +9,7 @@ import { app } from '../stores/appService'
 import { getFileStatsLocal } from '../stores/files'
 import { clearActiveBgTask, setActiveBgTask } from './bgTaskContext'
 import { runFsEvictionScanner } from './fsEvictionScanner'
+import { getLifecycle } from './lifecycle'
 import { registerBackgroundTaskLifecycle, releaseBackgroundTaskLifecycle } from './suspension'
 import { getUploadManager } from './uploader'
 
@@ -357,7 +358,7 @@ async function runBackgroundWork(config: TaskConfig, state: TaskState) {
 
   // Defer scanners past the upload manager's spin-up. Skip in the 30s
   // BGAppRefreshTask — no headroom after the delay.
-  if (AppState.currentState !== 'active' && config.type !== 'BGAppRefreshTask') {
+  if (getLifecycle() === 'background' && config.type !== 'BGAppRefreshTask') {
     void scheduleAfter(secondsInMs(30), signal, async (s) => {
       await runFsEvictionScanner({ signal: s })
       if (s.aborted) return

--- a/apps/mobile/src/managers/lifecycle.test.ts
+++ b/apps/mobile/src/managers/lifecycle.test.ts
@@ -1,0 +1,370 @@
+type AppStateStatus = 'active' | 'inactive' | 'background' | 'unknown' | 'extension'
+
+let mockCurrentState: AppStateStatus = 'active'
+let mockListeners: Array<(state: AppStateStatus) => void> = []
+const mockRemove = jest.fn()
+
+jest.mock('react-native', () => ({
+  AppState: {
+    get currentState() {
+      return mockCurrentState
+    },
+    addEventListener: jest.fn((_event: string, fn: (state: AppStateStatus) => void) => {
+      mockListeners.push(fn)
+      return { remove: mockRemove }
+    }),
+  },
+}))
+
+// @siastorage/logger is mocked globally in apps/mobile/jest.setup.cjs;
+// we read its `warn` mock by reference to assert on listener-error logging.
+import { logger } from '@siastorage/logger'
+
+import {
+  __resetLifecycleForTesting,
+  addForegroundFocusListener,
+  addLifecycleListener,
+  deriveLifecycle,
+  getLifecycle,
+  initLifecycle,
+} from './lifecycle'
+
+const mockLoggerWarn = logger.warn as jest.Mock
+
+function emit(state: AppStateStatus): void {
+  mockCurrentState = state
+  for (const fn of mockListeners) fn(state)
+}
+
+/**
+ * Reset BOTH the lifecycle module AND the mock listeners array so that
+ * the next initLifecycle re-attaches into a clean slate. Without this the
+ * mock's previous handlers stay in `mockListeners` (the test mock's
+ * `remove` doesn't actually mutate the array), and stale invocations can
+ * mask real bugs.
+ */
+function resetAll(initialState: AppStateStatus = 'active'): void {
+  __resetLifecycleForTesting()
+  mockListeners = []
+  mockRemove.mockClear()
+  mockLoggerWarn.mockClear()
+  mockCurrentState = initialState
+}
+
+beforeEach(() => {
+  resetAll('active')
+})
+
+afterEach(() => {
+  __resetLifecycleForTesting()
+})
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('deriveLifecycle', () => {
+  it.each<[AppStateStatus, 'foreground' | 'background']>([
+    ['active', 'foreground'],
+    ['inactive', 'foreground'],
+    ['background', 'background'],
+    ['unknown', 'background'],
+    ['extension', 'background'],
+  ])('maps %s -> %s', (input, expected) => {
+    expect(deriveLifecycle(input)).toBe(expected)
+  })
+})
+
+describe('lifecycle transitions', () => {
+  it('active -> inactive does NOT fire (both foreground)', async () => {
+    addLifecycleListener(() => {
+      throw new Error('lifecycle listener should not fire')
+    })
+    addForegroundFocusListener(() => {
+      throw new Error('focus listener should not fire')
+    })
+
+    emit('inactive')
+    await flushMicrotasks()
+
+    expect(getLifecycle()).toBe('foreground')
+    expect(mockLoggerWarn).not.toHaveBeenCalled()
+  })
+
+  it('inactive -> active does NOT fire (both foreground)', async () => {
+    resetAll('inactive')
+    const events: string[] = []
+    addLifecycleListener((next) => events.push(next))
+
+    emit('active')
+    await flushMicrotasks()
+
+    expect(events).toEqual([])
+    expect(getLifecycle()).toBe('foreground')
+  })
+
+  it('active -> background fires lifecycle; focus does NOT fire', async () => {
+    const events: Array<{ next: string; prev: string }> = []
+    const focusFires: number[] = []
+    addLifecycleListener((next, prev) => events.push({ next, prev }))
+    addForegroundFocusListener(() => focusFires.push(1))
+
+    emit('background')
+    await flushMicrotasks()
+
+    expect(events).toEqual([{ next: 'background', prev: 'foreground' }])
+    expect(focusFires).toEqual([])
+    expect(getLifecycle()).toBe('background')
+  })
+
+  it('background -> active fires lifecycle synchronously, focus on next microtask', async () => {
+    resetAll('background')
+
+    const trace: string[] = []
+    addLifecycleListener(() => trace.push('lifecycle'))
+    addForegroundFocusListener(() => trace.push('focus'))
+
+    emit('active')
+    // Synchronously after emit: lifecycle ran, focus has not.
+    expect(trace).toEqual(['lifecycle'])
+
+    await flushMicrotasks()
+
+    expect(trace).toEqual(['lifecycle', 'focus'])
+    expect(getLifecycle()).toBe('foreground')
+  })
+
+  it('background -> inactive -> active fires ONE transition (intermediate inactive collapses)', async () => {
+    resetAll('background')
+
+    const events: Array<{ next: string; prev: string }> = []
+    const focusFires: number[] = []
+    addLifecycleListener((next, prev) => events.push({ next, prev }))
+    addForegroundFocusListener(() => focusFires.push(1))
+
+    emit('inactive')
+    emit('active')
+    await flushMicrotasks()
+
+    expect(events).toEqual([{ next: 'foreground', prev: 'background' }])
+    expect(focusFires).toEqual([1])
+  })
+
+  it('repeated emits of the same state are no-ops', async () => {
+    const events: string[] = []
+    const focusFires: number[] = []
+    addLifecycleListener((next) => events.push(next))
+    addForegroundFocusListener(() => focusFires.push(1))
+
+    emit('background')
+    emit('background')
+    emit('background')
+    await flushMicrotasks()
+
+    expect(events).toEqual(['background'])
+    expect(focusFires).toEqual([])
+  })
+
+  it('foreground state changes fire focus exactly once per transition', async () => {
+    resetAll('background')
+
+    const focusFires: number[] = []
+    addForegroundFocusListener(() => focusFires.push(1))
+
+    // One real foreground transition.
+    emit('active')
+    // Plus a flicker that's not a transition.
+    emit('inactive')
+    emit('active')
+    await flushMicrotasks()
+
+    expect(focusFires).toEqual([1])
+  })
+
+  it('unknown maps to background', async () => {
+    const events: Array<{ next: string; prev: string }> = []
+    addLifecycleListener((next, prev) => events.push({ next, prev }))
+
+    emit('unknown')
+    await flushMicrotasks()
+
+    expect(events).toEqual([{ next: 'background', prev: 'foreground' }])
+    expect(getLifecycle()).toBe('background')
+  })
+})
+
+describe('listener subscription', () => {
+  it('multiple listeners all fire; unsubscribing one does not affect others', () => {
+    const a: string[] = []
+    const b: string[] = []
+    const unsubA = addLifecycleListener((next) => a.push(next))
+    addLifecycleListener((next) => b.push(next))
+
+    emit('background')
+    expect(a).toEqual(['background'])
+    expect(b).toEqual(['background'])
+
+    unsubA()
+    emit('active')
+
+    expect(a).toEqual(['background'])
+    expect(b).toEqual(['background', 'foreground'])
+  })
+
+  it('focus listener can be unsubscribed', async () => {
+    resetAll('background')
+
+    const fires: number[] = []
+    const unsub = addForegroundFocusListener(() => fires.push(1))
+
+    emit('active')
+    await flushMicrotasks()
+    expect(fires).toEqual([1])
+
+    unsub()
+    resetAll('background') // keep lifecycle alive but reset for second cycle
+    addForegroundFocusListener(() => {}) // dummy to keep subscription alive
+    emit('active')
+    await flushMicrotasks()
+
+    expect(fires).toEqual([1])
+  })
+
+  it('a listener that subscribes during dispatch does NOT fire for the current transition', () => {
+    const events: string[] = []
+    addLifecycleListener(() => {
+      addLifecycleListener(() => events.push('late'))
+      events.push('first')
+    })
+
+    emit('background')
+
+    // Snapshot iteration: only the original listener fires for this
+    // transition. The newly-added 'late' listener is captured for FUTURE
+    // events but not invoked synchronously here.
+    expect(events).toEqual(['first'])
+  })
+
+  it('a listener that unsubscribes another mid-dispatch: the other still fires (snapshot)', () => {
+    const events: string[] = []
+    let unsubB: (() => void) | null = null
+    addLifecycleListener(() => {
+      events.push('a')
+      unsubB?.()
+    })
+    unsubB = addLifecycleListener(() => events.push('b'))
+
+    emit('background')
+
+    // Both fire on this transition (snapshot before iteration); B is
+    // gone for future transitions.
+    expect(events).toEqual(['a', 'b'])
+
+    emit('active')
+    expect(events).toEqual(['a', 'b', 'a'])
+  })
+})
+
+describe('listener error safety', () => {
+  it('a throwing lifecycle listener does NOT prevent later listeners from running', () => {
+    const events: string[] = []
+    addLifecycleListener(() => {
+      throw new Error('boom')
+    })
+    addLifecycleListener(() => events.push('survived'))
+
+    emit('background')
+
+    expect(events).toEqual(['survived'])
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      'lifecycle',
+      'listener_error',
+      expect.objectContaining({ kind: 'lifecycle' }),
+    )
+  })
+
+  it('a throwing lifecycle listener does NOT prevent the focus signal from firing', async () => {
+    resetAll('background')
+
+    addLifecycleListener(() => {
+      throw new Error('boom')
+    })
+    const focusFires: number[] = []
+    addForegroundFocusListener(() => focusFires.push(1))
+
+    emit('active')
+    await flushMicrotasks()
+
+    expect(focusFires).toEqual([1])
+  })
+
+  it('a throwing focus listener does NOT prevent later focus listeners', async () => {
+    resetAll('background')
+
+    const events: string[] = []
+    addForegroundFocusListener(() => {
+      throw new Error('focus boom')
+    })
+    addForegroundFocusListener(() => events.push('survived'))
+
+    emit('active')
+    await flushMicrotasks()
+
+    expect(events).toEqual(['survived'])
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      'lifecycle',
+      'listener_error',
+      expect.objectContaining({ kind: 'focus' }),
+    )
+  })
+})
+
+describe('initLifecycle', () => {
+  it('is idempotent — calling twice does not double-subscribe', () => {
+    resetAll('active')
+
+    initLifecycle()
+    initLifecycle()
+
+    expect(mockListeners).toHaveLength(1)
+  })
+
+  it('teardown removes the AppState subscription', () => {
+    initLifecycle()
+    expect(mockListeners).toHaveLength(1)
+    __resetLifecycleForTesting()
+
+    expect(mockRemove).toHaveBeenCalledTimes(1)
+  })
+
+  it('teardown clears listeners so re-init starts clean', async () => {
+    const events: string[] = []
+    addLifecycleListener((next) => events.push(`first:${next}`))
+
+    resetAll('active')
+
+    addLifecycleListener((next) => events.push(`second:${next}`))
+    emit('background')
+
+    // The first-cycle listener is gone; only the second-cycle listener
+    // sees this event.
+    expect(events).toEqual(['second:background'])
+  })
+
+  it('addLifecycleListener auto-inits when called before initLifecycle', () => {
+    resetAll('active')
+
+    expect(mockListeners).toHaveLength(0)
+    addLifecycleListener(() => {})
+    expect(mockListeners).toHaveLength(1)
+  })
+
+  it('addForegroundFocusListener auto-inits when called before initLifecycle', () => {
+    resetAll('active')
+
+    expect(mockListeners).toHaveLength(0)
+    addForegroundFocusListener(() => {})
+    expect(mockListeners).toHaveLength(1)
+  })
+})

--- a/apps/mobile/src/managers/lifecycle.ts
+++ b/apps/mobile/src/managers/lifecycle.ts
@@ -1,0 +1,134 @@
+import { logger } from '@siastorage/logger'
+import { AppState, type AppStateStatus, type NativeEventSubscription } from 'react-native'
+
+export type Lifecycle = 'foreground' | 'background'
+
+/**
+ * Maps an `AppState` raw value to our two-state lifecycle.
+ *
+ * 'active' and 'inactive' both map to 'foreground'. Per Apple, 'inactive'
+ * is a foreground sub-state (banner notification, Control Center swipe,
+ * Face ID prompt, screen lock, incoming call). The app cannot transition
+ * directly from 'inactive' to suspended; it always passes through
+ * 'background' first, so 'inactive' carries zero kill risk.
+ *
+ * 'unknown' / 'extension' map to 'background'. iOS BG-task cold starts
+ * surface 'unknown' before the first AppState change event; treating it
+ * as background is what lets the suspension manager actually suspend
+ * after a BG task releases its lifecycle (`maybeSuspend` requires
+ * `appState === 'background'`).
+ */
+export function deriveLifecycle(s: AppStateStatus): Lifecycle {
+  return s === 'active' || s === 'inactive' ? 'foreground' : 'background'
+}
+
+type LifecycleListener = (next: Lifecycle, prev: Lifecycle) => void
+type FocusListener = () => void
+
+let current: Lifecycle | null = null
+const lifecycleListeners = new Set<LifecycleListener>()
+const focusListeners = new Set<FocusListener>()
+let subscription: NativeEventSubscription | null = null
+
+function readCurrent(): Lifecycle {
+  if (current === null) current = deriveLifecycle(AppState.currentState)
+  return current
+}
+
+// Listener throws are caught and logged so one buggy subscriber can't
+// strand the rest of the chain. A lifecycle listener throwing would
+// otherwise prevent the focus signal from queuing, leaving SWR fetchers
+// without a retry signal until the next foreground transition.
+function safeInvoke(fn: () => void, kind: 'lifecycle' | 'focus'): void {
+  try {
+    fn()
+  } catch (error) {
+    logger.warn('lifecycle', 'listener_error', { kind, error: error as Error })
+  }
+}
+
+function handleChange(rawState: AppStateStatus): void {
+  const next = deriveLifecycle(rawState)
+  const prev = readCurrent()
+  if (next === prev) return
+  current = next
+  // Snapshot before iterating so a listener that subscribes/unsubscribes
+  // doesn't change the set of recipients for THIS transition.
+  for (const listener of [...lifecycleListeners]) {
+    safeInvoke(() => listener(next, prev), 'lifecycle')
+  }
+  // Microtask defers focus dispatch until after the current task settles.
+  // Two reasons: (1) any subsystem listening to lifecycle (e.g. the
+  // suspension manager queueing doResume) finishes its sync work first;
+  // (2) a focus listener that re-reads `current` sees the latest value.
+  if (next === 'foreground') {
+    queueMicrotask(() => {
+      for (const listener of [...focusListeners]) {
+        safeInvoke(listener, 'focus')
+      }
+    })
+  }
+}
+
+/**
+ * Attaches the singleton AppState listener. Idempotent — repeat calls
+ * return the same teardown without double-subscribing. Returns a teardown
+ * that detaches the AppState subscription and clears all listeners.
+ *
+ * Most callers don't need to invoke this directly; `addLifecycleListener`
+ * and `addForegroundFocusListener` auto-init on first subscription.
+ */
+export function initLifecycle(): () => void {
+  if (subscription) return teardown
+  current = deriveLifecycle(AppState.currentState)
+  subscription = AppState.addEventListener('change', handleChange)
+  return teardown
+}
+
+function teardown(): void {
+  if (subscription) {
+    subscription.remove()
+    subscription = null
+  }
+  lifecycleListeners.clear()
+  focusListeners.clear()
+  current = null
+}
+
+/** Returns the current lifecycle state. Initializes lazily on first read. */
+export function getLifecycle(): Lifecycle {
+  return readCurrent()
+}
+
+/**
+ * Subscribes to lifecycle transitions ('foreground' ↔ 'background').
+ * Same-state events ('active' ↔ 'inactive') are filtered out and never
+ * fire. Auto-initializes the AppState listener. Returns an unsubscribe.
+ */
+export function addLifecycleListener(fn: LifecycleListener): () => void {
+  initLifecycle()
+  lifecycleListeners.add(fn)
+  return () => {
+    lifecycleListeners.delete(fn)
+  }
+}
+
+/**
+ * Subscribes to foreground focus events. Fires once per transition INTO
+ * foreground, on a microtask after lifecycle listeners have run. This is
+ * the SWR focus signal — guarantees a refetch attempt after every real
+ * background → foreground return. Auto-initializes. Returns an unsubscribe.
+ */
+export function addForegroundFocusListener(fn: FocusListener): () => void {
+  initLifecycle()
+  focusListeners.add(fn)
+  return () => {
+    focusListeners.delete(fn)
+  }
+}
+
+/** Test-only: tears down the singleton subscription and clears all
+ * listeners so each test starts with fresh module state. */
+export function __resetLifecycleForTesting(): void {
+  teardown()
+}

--- a/apps/mobile/src/managers/suspension.ts
+++ b/apps/mobile/src/managers/suspension.ts
@@ -7,7 +7,7 @@ import { stopLogForwarder } from '@siastorage/core/services/logForwarder'
 import { createSuspensionManager } from '@siastorage/core/services/suspension'
 import { logger, stopLogAppender } from '@siastorage/logger'
 import { getBackgroundTimeRemainingMs } from 'background-time-remaining'
-import { AppState, type AppStateStatus, Platform } from 'react-native'
+import { Platform } from 'react-native'
 import BackgroundTimer from 'react-native-background-timer'
 import RNFS from 'react-native-fs'
 import {
@@ -24,6 +24,7 @@ import { app } from '../stores/appService'
 import { resumeLogger } from '../stores/logs'
 import { cancelFsEvictionScanner, runFsEvictionScanner } from './fsEvictionScanner'
 import { cancelFsOrphanScanner } from './fsOrphanScanner'
+import { addLifecycleListener, getLifecycle } from './lifecycle'
 import { isArchiveWalkActive, pauseArchiveSync, resumeArchiveSync } from './syncPhotosArchive'
 import { getUploadManager } from './uploader'
 
@@ -53,14 +54,6 @@ async function logSuspendDiagnostics(): Promise<void> {
   } catch (e) {
     logger.debug('suspension', 'diagnostics_failed', { error: e as Error })
   }
-}
-
-// 'inactive' / 'unknown' / 'extension' don't represent foreground use, and
-// iOS BG-task cold starts often surface 'unknown' before the first AppState
-// event — treating those as background prevents the manager from suspending
-// the moment the BG task releases its lifecycle.
-function toAppStateValue(s: AppStateStatus): 'foreground' | 'background' {
-  return s === 'active' ? 'foreground' : 'background'
 }
 
 const manager = createSuspensionManager(
@@ -104,11 +97,10 @@ const manager = createSuspensionManager(
       },
     },
   },
-  { initialAppState: toAppStateValue(AppState.currentState) },
+  { initialAppState: getLifecycle() },
 )
 
-let subscription: ReturnType<typeof AppState.addEventListener> | null = null
-let appStateRef: AppStateStatus = AppState.currentState
+let unsubscribeLifecycle: (() => void) | null = null
 
 /**
  * Wraps an async operation with a beginBackgroundTask grant on iOS so the
@@ -138,50 +130,45 @@ async function withIosExecutionTime<T>(fn: () => Promise<T>): Promise<T> {
 }
 
 export function initSuspensionManager(): void {
-  if (subscription) return
-  logger.info('appState', 'initial_state', { state: appStateRef })
+  if (unsubscribeLifecycle) return
+  const initial = getLifecycle()
+  logger.info('appState', 'initial_state', { state: initial })
   logger.info('suspension', 'init', {
-    state: appStateRef,
+    state: initial,
     platform: Platform.OS,
     // Foreground reads return ~Number.MAX_VALUE; logging this once at
     // startup confirms the native binding is wired and callable.
     iosBackgroundTimeRemainingMs: getBackgroundTimeRemainingMs(),
   })
-  subscription = AppState.addEventListener('change', (nextState) => {
-    logger.info('appState', 'state_changed', { from: appStateRef, to: nextState })
-    appStateRef = nextState
+  unsubscribeLifecycle = addLifecycleListener((next, prev) => {
+    logger.info('appState', 'state_changed', { from: prev, to: next })
     // Android fires 'background' for picker / share-sheet round-trips
     // that aren't real backgrounding; running the pipeline there degrades
     // the experience. iOS pickers don't background the app, so the flow
     // only fires when the user actually leaves.
-    if (Platform.OS === 'ios') {
-      onAppStateChange(nextState)
+    if (Platform.OS !== 'ios') return
+    if (next === 'background') {
+      if (!dbInitialized) {
+        logger.debug('suspension', 'skipped', { reason: 'db_not_initialized' })
+        return
+      }
+      // Init's cleanup steps issue many DB queries; let init finish first.
+      if (app().init.getState().isInitializing) {
+        logger.debug('suspension', 'skipped', { reason: 'init_in_progress' })
+        return
+      }
+      // The setAppState Promise resolves after the enqueued doSuspend
+      // settles; withIosExecutionTime keeps iOS from freezing us mid-drain.
+      void withIosExecutionTime(() => manager.setAppState('background'))
+    } else {
+      void manager.setAppState('foreground')
     }
   })
 }
 
 export function teardownSuspensionManager(): void {
-  subscription?.remove()
-  subscription = null
-}
-
-function onAppStateChange(nextState: AppStateStatus): void {
-  if (nextState === 'background') {
-    if (!dbInitialized) {
-      logger.debug('suspension', 'skipped', { reason: 'db_not_initialized' })
-      return
-    }
-    // Init's cleanup steps issue many DB queries; let init finish first.
-    if (app().init.getState().isInitializing) {
-      logger.debug('suspension', 'skipped', { reason: 'init_in_progress' })
-      return
-    }
-    // The setAppState Promise resolves after the enqueued doSuspend
-    // settles; withIosExecutionTime keeps iOS from freezing us mid-drain.
-    void withIosExecutionTime(() => manager.setAppState('background'))
-  } else if (nextState === 'active') {
-    void manager.setAppState('foreground')
-  }
+  unsubscribeLifecycle?.()
+  unsubscribeLifecycle = null
 }
 
 /** Called at the start of every BG task — resumes the manager if suspended. */

--- a/apps/mobile/src/stacks/RootTabs.tsx
+++ b/apps/mobile/src/stacks/RootTabs.tsx
@@ -10,9 +10,6 @@ const Tab = createBottomTabNavigator<RootTabParamList>()
 
 export function RootTabs() {
   const hasOnboarded = useHasOnboarded()
-  if (hasOnboarded.data === undefined) {
-    return null
-  }
   if (!hasOnboarded.data) {
     return <OnboardingStack />
   }

--- a/apps/mobile/src/stores/sdk.test.ts
+++ b/apps/mobile/src/stores/sdk.test.ts
@@ -1,3 +1,4 @@
+import { __resetLifecycleForTesting } from '../managers/lifecycle'
 import { closeAuthBrowser, openAuthURL } from '../lib/openAuthUrl'
 import { app, getMobileSdkAuth, internal } from './appService'
 import * as sdkStore from './sdk'
@@ -26,7 +27,15 @@ jest.mock('../lib/openAuthUrl', () => ({
   openAuthURL: jest.fn(),
   closeAuthBrowser: jest.fn(),
 }))
-jest.mock('@siastorage/logger', () => ({ logger: { log: jest.fn() } }))
+jest.mock('@siastorage/logger', () => ({
+  logger: {
+    log: jest.fn(),
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}))
 jest.mock('@siastorage/core/config', () => ({ APP_KEY: '0'.repeat(64) }))
 
 const mockOpenAuthURL = jest.mocked(openAuthURL)
@@ -98,6 +107,9 @@ describe('sdk store', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     sdkStore.resetSdk()
+    // Reset lifecycle module so its singleton AppState listener is
+    // re-attached against the fresh mockAppStateListeners array below.
+    __resetLifecycleForTesting()
 
     mockPlatform.OS = 'ios'
     mockAppStateListeners = []
@@ -619,7 +631,6 @@ describe('sdk store', () => {
 
           expect(error).toBeNull()
           expect(result?.alreadyConnected).toBe(false)
-          expect(mockAppStateSubscription.remove).toHaveBeenCalled()
           expectCleanAuthState()
         } finally {
           jest.useRealTimers()
@@ -649,7 +660,6 @@ describe('sdk store', () => {
 
           expect(error).toBeNull()
           expect(result?.alreadyConnected).toBe(false)
-          expect(mockAppStateSubscription.remove).toHaveBeenCalled()
           expectCleanAuthState()
         } finally {
           jest.useRealTimers()
@@ -675,7 +685,6 @@ describe('sdk store', () => {
           const [, error] = await promise
 
           expect(error?.type).toBe('cancelled')
-          expect(mockAppStateSubscription.remove).toHaveBeenCalled()
           expectCleanAuthState()
         } finally {
           jest.useRealTimers()
@@ -707,7 +716,6 @@ describe('sdk store', () => {
 
           expect(error).toBeNull()
           expect(result?.alreadyConnected).toBe(false)
-          expect(mockAppStateSubscription.remove).toHaveBeenCalled()
           expectCleanAuthState()
         } finally {
           jest.useRealTimers()
@@ -732,7 +740,6 @@ describe('sdk store', () => {
           const [, error] = await promise
 
           expect(error?.type).toBe('cancelled')
-          expect(mockAppStateSubscription.remove).toHaveBeenCalled()
           expectCleanAuthState()
         } finally {
           jest.useRealTimers()
@@ -760,7 +767,6 @@ describe('sdk store', () => {
 
           expect(error?.type).toBe('cancelled')
           expect(mockCloseAuthBrowser).toHaveBeenCalled()
-          expect(mockAppStateSubscription.remove).toHaveBeenCalled()
           expectCleanAuthState()
         } finally {
           jest.useRealTimers()

--- a/apps/mobile/src/stores/sdk.ts
+++ b/apps/mobile/src/stores/sdk.ts
@@ -24,7 +24,8 @@ import { raceWithTimeout, withTimeout } from '@siastorage/core/lib/timeout'
 import { refreshLogAccount } from '@siastorage/core/services/logForwarder'
 import { useConnectionState } from '@siastorage/core/stores'
 import { logger } from '@siastorage/logger'
-import { AppState, Platform } from 'react-native'
+import { Platform } from 'react-native'
+import { addLifecycleListener } from '../managers/lifecycle'
 import type { SdkInterface } from 'react-native-sia'
 import { MobileSdkAdapter } from '../adapters/sdk'
 import { closeAuthBrowser, openAuthURL } from '../lib/openAuthUrl'
@@ -326,15 +327,12 @@ function createAppStateDismissal() {
   const promise = new Promise<void>((r) => {
     resolve = r
   })
-  let wasBackground = false
-  const subscription = AppState.addEventListener('change', (state) => {
-    if (state === 'background') {
-      wasBackground = true
-    } else if (state === 'active' && wasBackground) {
+  const unsubscribe = addLifecycleListener((next, prev) => {
+    if (next === 'foreground' && prev === 'background') {
       resolve()
     }
   })
-  return { promise, subscription }
+  return { promise, unsubscribe }
 }
 
 /**
@@ -412,7 +410,7 @@ async function waitForUserApproval(responseUrl: string): Promise<Result<void, Au
     app().auth.builder.cancel()
     return err({ type: 'cancelled' })
   } finally {
-    androidDismissal?.subscription.remove()
+    androidDismissal?.unsubscribe()
   }
 }
 

--- a/packages/core/src/stores/init.ts
+++ b/packages/core/src/stores/init.ts
@@ -1,5 +1,6 @@
 import useSWR from 'swr'
 import { useApp } from '../app/context'
+import { useHasOnboarded } from './settings'
 import { useSyncGateStatus } from './sync'
 
 /** Returns the full app initialization state including steps and errors. */
@@ -17,8 +18,12 @@ export function useIsInitializing() {
 /** Returns whether the splash screen should be shown during init or on error. */
 export function useShowSplash() {
   const { data } = useInitState()
+  const { data: hasOnboarded } = useHasOnboarded()
   const syncGateStatus = useSyncGateStatus()
-  if (!data) return true
+  // hasOnboarded undefined means the AsyncStorage-backed SWR slot hasn't
+  // resolved yet. Hold the splash so RootTabs never mounts against an
+  // undefined value (which would otherwise render a black screen).
+  if (!data || hasOnboarded === undefined) return true
   return (
     data.isInitializing ||
     !!data.initializationError ||


### PR DESCRIPTION
Goal of this PR is to add some more determinism to the ordering of status change event subscribers, and get rid of any inconsistent states.

- Centralizes iOS foreground/background detection into one lifecycle module so all subsystems (suspension manager, SWR's pause gate, SWR's focus signal) see transitions in a single fixed order instead of each reading AppState independently.
- Reclassifies iOS 'inactive' as a foreground sub-state per Apple's docs, so services keep running through transient interruptions like notification banners and Face ID prompts instead of pausing.