### PR TITLE
fix(mobile,core): scope upload status pill to current batch

### DIFF
--- a/.changeset/fix-upload-progress-percent.md
+++ b/.changeset/fix-upload-progress-percent.md
@@ -1,0 +1,6 @@
+---
+mobile: patch
+core: patch
+---
+
+Upload status pill now reflects the current upload batch instead of library-wide totals, so the percent actually advances during uploads.

--- a/.changeset/sync-status-no-flicker.md
+++ b/.changeset/sync-status-no-flicker.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Status pill no longer flashes "Online and synced" between upload batches; it reads "Importing N files" while work is pending.

--- a/.changeset/upload-status-encrypting.md
+++ b/.changeset/upload-status-encrypting.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Upload status reads "Encrypting N files" before the first shard uploads.

--- a/apps/mobile/src/hooks/useAppStatus.tsx
+++ b/apps/mobile/src/hooks/useAppStatus.tsx
@@ -62,14 +62,26 @@ export function useAppStatus(): AppStatus {
   }
 
   if (uploadsProgress.show) {
-    const remaining = uploadsProgress.remaining
-    const hint = compactUploadPercent(uploadsProgress.percentDecimal) ?? undefined
-    const plural = remaining === 1 ? 'file' : 'files'
+    const { packerCount, pendingCount, percentDecimal } = uploadsProgress
+    if (packerCount > 0) {
+      const plural = packerCount === 1 ? 'file' : 'files'
+      const isUploading = percentDecimal > 0
+      const verb = isUploading ? 'Uploading' : 'Encrypting'
+      const hint = isUploading ? (compactUploadPercent(percentDecimal) ?? undefined) : undefined
+      return {
+        visible: true,
+        icon: <CloudUploadIcon size={18} color={palette.blue[400]} />,
+        message: `${verb} ${packerCount.toLocaleString()} ${plural}`,
+        hint,
+        animate: true,
+        level: 'info',
+      }
+    }
+    const plural = pendingCount === 1 ? 'file' : 'files'
     return {
       visible: true,
       icon: <CloudUploadIcon size={18} color={palette.blue[400]} />,
-      message: `Uploading ${remaining.toLocaleString()} ${plural}`,
-      hint,
+      message: `Importing ${pendingCount.toLocaleString()} ${plural}`,
       animate: true,
       level: 'info',
     }

--- a/apps/mobile/src/lib/uploadPercent.ts
+++ b/apps/mobile/src/lib/uploadPercent.ts
@@ -1,15 +1,4 @@
 /**
- * Format a decimal upload percentage as a fixed-width string.
- * Always shows 1 decimal place and pads to 6 characters (e.g. " 99.3%").
- * Used in the status sheet where alignment matters.
- */
-export function humanUploadPercent(decimal?: number, fallback?: string) {
-  if (decimal == null) return fallback ?? '100.0%'
-  const pct = (decimal * 100).toFixed(1)
-  return `${pct}%`.padStart(6)
-}
-
-/**
  * Format a decimal upload percentage for compact display (e.g. header pill).
  * Shows 0 decimal places. Returns null when >= 99% so the caller can
  * show just a spinner instead.

--- a/apps/mobile/src/stores/files.ts
+++ b/apps/mobile/src/stores/files.ts
@@ -96,3 +96,15 @@ export function useFileStatsLocal(params: { localOnly: boolean }, config?: SWRCo
   const key = app().caches.library.key('localStats')
   return useSWR([...key, params], () => getFileStatsLocal(params), config)
 }
+
+export async function getFileCountImporting() {
+  return app().files.queryCount({
+    order: 'ASC',
+    hashEmpty: true,
+  })
+}
+
+export function useFileCountImporting(config?: SWRConfiguration) {
+  const key = app().caches.library.key('importingCount')
+  return useSWR(key, getFileCountImporting, config)
+}

--- a/apps/mobile/src/stores/uploads.ts
+++ b/apps/mobile/src/stores/uploads.ts
@@ -1,15 +1,9 @@
 import type { UploadEntry, UploadStatus } from '@siastorage/core/app'
 import { createProgressThrottle } from '@siastorage/core/lib/progressThrottle'
-import {
-  useAutoScanUploads,
-  useFileCountAll,
-  useFileStatsAll,
-  useUploadEntry,
-} from '@siastorage/core/stores'
+import { useAutoScanUploads, useUploadEntry } from '@siastorage/core/stores'
 import useSWR from 'swr'
-import { humanUploadPercent } from '../lib/uploadPercent'
 import { app } from './appService'
-import { useFileStatsLocal } from './files'
+import { useFileCountImporting, useFileStatsLocal } from './files'
 
 export type UploadState = UploadEntry
 
@@ -64,36 +58,28 @@ export function useActiveUploads(): UploadState[] {
 
 export function useUploadProgress(): {
   show: boolean
-  enabled: boolean
-  remaining: number
+  packerCount: number
+  pendingCount: number
   percentDecimal: number
-  percentComplete: string
-  total: number
 } {
-  const totalCount = useFileCountAll()
-  const totalStats = useFileStatsAll()
-  const localOnlyStats = useFileStatsLocal({ localOnly: true })
   const enabled = useAutoScanUploads()
   const activeUploads = useActiveUploads()
-  const totalFiles = totalCount.data ?? 0
-  const totalBytes = totalStats.data?.totalBytes ?? 0
-  const localOnlyBytes = localOnlyStats.data?.totalBytes ?? 0
-  const uploadedBytes = totalBytes - localOnlyBytes
+  const localOnlyStats = useFileStatsLocal({ localOnly: true })
+  const importingCountQuery = useFileCountImporting()
   const isEnabled = enabled.data ?? false
-  const activeCount = activeUploads.length
-  const activeWeightedProgress = activeUploads
-    .map((u) => u.progress * u.size)
-    .reduce((a, b) => a + b, 0)
-  const percentDecimal = totalBytes
-    ? Math.min((activeWeightedProgress + uploadedBytes) / totalBytes, 1)
-    : 0
+  const packerUploads = activeUploads.filter((u) => ACTIVE_STATUSES.includes(u.status))
+  const packerCount = packerUploads.length
+  const packerTotalBytes = packerUploads.reduce((s, u) => s + u.size, 0)
+  const packerWeightedProgress = packerUploads.reduce((s, u) => s + u.progress * u.size, 0)
+  const percentDecimal = packerTotalBytes > 0 ? packerWeightedProgress / packerTotalBytes : 0
+  const importingCount = importingCountQuery.data ?? 0
+  const localOnlyCount = localOnlyStats.data?.count ?? 0
+  const pendingCount = importingCount + localOnlyCount
 
   return {
-    show: isEnabled && activeCount > 0,
-    enabled: isEnabled,
-    remaining: activeCount,
+    show: isEnabled && (packerCount > 0 || pendingCount > 0),
+    packerCount,
+    pendingCount,
     percentDecimal,
-    percentComplete: humanUploadPercent(percentDecimal),
-    total: totalFiles,
   }
 }

--- a/packages/core/src/app/namespaces/uploads.ts
+++ b/packages/core/src/app/namespaces/uploads.ts
@@ -13,6 +13,7 @@ export function buildUploadsNamespace(caches: AppCaches): AppService['uploads'] 
       state = { uploads: { ...state.uploads, [entry.id]: entry } }
       debounced.flush('all')
       debounced.flush('counts')
+      debounced.flush('active')
       caches.uploads.invalidate(entry.id)
     },
     update: (id, patch) => {
@@ -21,6 +22,7 @@ export function buildUploadsNamespace(caches: AppCaches): AppService['uploads'] 
       state = { uploads: { ...state.uploads, [id]: { ...existing, ...patch } } }
       debounced.invalidate('all')
       debounced.invalidate('counts')
+      debounced.invalidate('active')
       caches.uploads.invalidate(id)
     },
     remove: (id) => {
@@ -28,6 +30,7 @@ export function buildUploadsNamespace(caches: AppCaches): AppService['uploads'] 
       state = { uploads: rest }
       debounced.flush('all')
       debounced.flush('counts')
+      debounced.flush('active')
       caches.uploads.invalidate(id)
     },
     removeMany: (ids) => {


### PR DESCRIPTION
- The percent now reflects how far through the current upload batch you are, instead of how synced your overall backed-up library is which was preventing it from showing.
- Reads "Encrypting N files" before any data leaves the device, then "Uploading N files" with a live percent, and "Importing N files" while photos are still being scanned or waiting for the next batch.
- Status row no longer flashes "Online and synced" between batches.
