### PR TITLE
fix(mobile,core): import all types to configured media folder

### DIFF
--- a/.changeset/files-create-many-directory-id.md
+++ b/.changeset/files-create-many-directory-id.md
@@ -1,0 +1,5 @@
+---
+core: minor
+---
+
+Add `directoryId` option to `files.createMany` / `insertManyFiles` to file inserted records into a directory atomically.

--- a/.changeset/photo-import-atomic-directory.md
+++ b/.changeset/photo-import-atomic-directory.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Auto-imported photos reliably land in the configured Media folder, even if iOS suspends the app mid-import.

--- a/.changeset/photo-sync-all-types-to-media.md
+++ b/.changeset/photo-sync-all-types-to-media.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Photo sync places every imported file in the configured Media folder regardless of type.

--- a/apps/mobile/src/lib/processAssets.test.ts
+++ b/apps/mobile/src/lib/processAssets.test.ts
@@ -851,6 +851,29 @@ describe('syncAssets — eager background sync for recent photos', () => {
       expect(dirs[0].path).toBe('Camera Roll')
     })
 
+    it('files non-media types into the import directory too', async () => {
+      await app().settings.setPhotoImportDirectory('Camera Roll')
+      const assets = [
+        {
+          id: undefined,
+          name: 'note.txt',
+          sourceUri: 'file:///note.txt',
+          type: 'text/plain',
+          timestamp: '2021-01-01',
+        },
+      ]
+      const { files } = await syncAssets(assets, 'file', {
+        addToImportDirectory: true,
+      })
+      expect(files).toHaveLength(1)
+      const row = await db().getFirstAsync<{ directoryId: string | null }>(
+        'SELECT directoryId FROM files WHERE id = ?',
+        files[0].id,
+      )
+      const dirs = await app().directories.getAll()
+      expect(row?.directoryId).toBe(dirs[0].id)
+    })
+
     it('places files into a nested import directory path with separators', async () => {
       await app().settings.setPhotoImportDirectory('Media/iOS Sync')
       const assets = [
@@ -991,5 +1014,27 @@ describe('catalogAssets — deferred bulk catalog for archive sync', () => {
     const dirs = await app().directories.getAll()
     expect(dirs).toHaveLength(1)
     expect(dirs[0].path).toBe('Camera Roll')
+  })
+
+  it('files non-media types into the import directory too', async () => {
+    await app().settings.setPhotoImportDirectory('Camera Roll')
+    const assets = [
+      {
+        id: 'local-1',
+        name: 'note.txt',
+        sourceUri: 'file:///note.txt',
+        type: 'text/plain',
+        timestamp: '2021-01-01',
+      },
+    ]
+    await catalogAssets(assets, 'file', { addToImportDirectory: true })
+    const rows = await app().files.query({ order: 'ASC' })
+    expect(rows).toHaveLength(1)
+    const row = await db().getFirstAsync<{ directoryId: string | null }>(
+      'SELECT directoryId FROM files WHERE id = ?',
+      rows[0].id,
+    )
+    const dirs = await app().directories.getAll()
+    expect(row?.directoryId).toBe(dirs[0].id)
   })
 })

--- a/apps/mobile/src/lib/processAssets.ts
+++ b/apps/mobile/src/lib/processAssets.ts
@@ -128,16 +128,12 @@ async function parseAssetMetadata(
   }
 }
 
-async function moveMediaToImportDirectory(files: FileRecord[]): Promise<void> {
+// Resolved before createMany so the insert files rows into the directory atomically.
+async function resolveImportDirectoryId(): Promise<string | null> {
   const photoImportDir = await app().settings.getPhotoImportDirectory()
-  if (!photoImportDir) return
-  const mediaFileIds = files
-    .filter((f) => f.type.startsWith('image/') || f.type.startsWith('video/'))
-    .map((f) => f.id)
-  if (mediaFileIds.length > 0) {
-    const dir = await app().directories.getOrCreateAtPath(photoImportDir)
-    await app().directories.moveFiles(mediaFileIds, dir.id)
-  }
+  if (!photoImportDir) return null
+  const dir = await app().directories.getOrCreateAtPath(photoImportDir)
+  return dir.id
 }
 
 type CandidateFileRecord = {
@@ -155,8 +151,7 @@ type CandidateFileRecord = {
 }
 
 type SyncAssetsOptions = {
-  /** Move newly imported media files into the configured photo import
-   * directory. Used by auto-sync. */
+  /** Place new files in the configured photo import directory. Used by auto-sync. */
   addToImportDirectory?: boolean
   /** Skip updating DB records for files that already exist. Prevents
    * spurious updatedAt bumps when the same assets are re-encountered
@@ -177,6 +172,9 @@ export async function syncAssets(
   { addToImportDirectory = false, skipExistingUpdates = false }: SyncAssetsOptions = {},
   signal?: AbortSignal,
 ) {
+  const importDirectoryId = addToImportDirectory ? await resolveImportDirectoryId() : null
+  const importedAt = Date.now()
+
   const candidateFiles: CandidateFileRecord[] = await Promise.all(
     (assets ?? []).map(async (a) => {
       const meta = await parseAssetMetadata(a, defaultFileName)
@@ -260,8 +258,9 @@ export async function syncAssets(
       localId: f.localId,
       name: f.name,
       createdAt: f.createdAt,
-      updatedAt: f.updatedAt,
-      addedAt: Date.now(),
+      // Bump updatedAt so (name, dir) collisions resolve to the freshly synced row.
+      updatedAt: addToImportDirectory ? importedAt : f.updatedAt,
+      addedAt: importedAt,
       type: f.type,
       kind: 'file' as const,
       size: f.size!,
@@ -298,12 +297,8 @@ export async function syncAssets(
       })),
     )
   }
-  await app().files.createMany(newFiles)
+  await app().files.createMany(newFiles, { directoryId: importDirectoryId })
   await app().optimize()
-
-  if (addToImportDirectory) {
-    await moveMediaToImportDirectory(newFiles)
-  }
 
   if (signal?.aborted) {
     return { files: newFiles, updatedFiles: existingFiles, warnings }
@@ -322,8 +317,7 @@ export async function syncAssets(
 }
 
 type CatalogAssetsOptions = {
-  /** Move newly imported media files into the configured photo import
-   * directory. Used by archive sync. */
+  /** Place new files in the configured photo import directory. Used by archive sync. */
   addToImportDirectory?: boolean
 }
 
@@ -340,6 +334,9 @@ export async function catalogAssets(
   { addToImportDirectory = false }: CatalogAssetsOptions = {},
   signal?: AbortSignal,
 ) {
+  const importDirectoryId = addToImportDirectory ? await resolveImportDirectoryId() : null
+  const importedAt = Date.now()
+
   const candidates: FileRecord[] = await Promise.all(
     (assets ?? []).map(async (a) => {
       const meta = await parseAssetMetadata(a, defaultFileName)
@@ -347,7 +344,9 @@ export async function catalogAssets(
         id: uniqueId(),
         localId: a.id ?? null,
         ...meta,
-        addedAt: Date.now(),
+        // Bump updatedAt so (name, dir) collisions resolve to the freshly synced row.
+        updatedAt: addToImportDirectory ? importedAt : meta.updatedAt,
+        addedAt: importedAt,
         kind: 'file' as const,
         size: 0,
         hash: '',
@@ -374,13 +373,11 @@ export async function catalogAssets(
 
   if (signal?.aborted) return { newCount: 0, existingCount: 0 }
 
-  await app().files.createMany(candidates, { conflictClause: 'OR IGNORE' })
+  await app().files.createMany(candidates, {
+    conflictClause: 'OR IGNORE',
+    directoryId: importDirectoryId,
+  })
   await app().optimize()
-
-  if (addToImportDirectory) {
-    const newFiles = candidates.filter((f) => !f.localId || !existingLocalIds.has(f.localId))
-    await moveMediaToImportDirectory(newFiles)
-  }
 
   triggerImportScanner()
 
@@ -447,7 +444,9 @@ export async function importFiles(
             localId: null,
             name,
             createdAt: ts,
-            updatedAt: ts,
+            // Bump updatedAt so a re-import wins the current-version recalc against
+            // an existing row with the same (name, directory).
+            updatedAt: now,
             addedAt: now,
             type,
             kind: 'file' as const,
@@ -477,14 +476,15 @@ export async function importFiles(
     0,
   )
 
-  await app().files.createMany(candidates.map((c) => c.placeholder))
+  await app().files.createMany(
+    candidates.map((c) => c.placeholder),
+    {
+      directoryId: destinationDirectoryId,
+    },
+  )
 
   const insertedCandidates = candidates
   const insertedIds = candidates.map((c) => c.placeholder.id)
-
-  if (destinationDirectoryId !== null && insertedIds.length > 0) {
-    await app().directories.moveFiles(insertedIds, destinationDirectoryId)
-  }
 
   if (assignTagName && insertedIds.length > 0) {
     await app().tags.addToFiles(insertedIds, assignTagName)
@@ -492,7 +492,6 @@ export async function importFiles(
 
   await app().optimize()
 
-  // Fetch post-move records so the caller sees the right directoryId.
   // Preserve candidate order in the returned array.
   let files: FileRecord[] = []
   if (insertedIds.length > 0) {

--- a/packages/core/src/app/namespaces/db.ts
+++ b/packages/core/src/app/namespaces/db.ts
@@ -226,6 +226,7 @@ export function buildDbNamespaces(
         await ops.insertManyFiles(db, records, {
           conflictClause: opts?.conflictClause,
           skipCurrentRecalc: opts?.skipCurrentRecalc,
+          directoryId: opts?.directoryId,
         })
         if (records.length > 0 && !opts?.skipCurrentRecalc) {
           invalidateLibrary()

--- a/packages/core/src/app/service.ts
+++ b/packages/core/src/app/service.ts
@@ -165,10 +165,14 @@ export interface AppService {
       localObject?: LocalObject,
       opts?: { skipInvalidation?: boolean; skipCurrentRecalc?: boolean },
     ): Promise<void>
-    /** Creates multiple files. */
+    /** Creates multiple files. Optionally places them all in a directory in the same insert. */
     createMany(
       records: Omit<FileRecord, 'objects'>[],
-      opts?: { conflictClause?: 'OR IGNORE'; skipCurrentRecalc?: boolean },
+      opts?: {
+        conflictClause?: 'OR IGNORE'
+        skipCurrentRecalc?: boolean
+        directoryId?: string | null
+      },
     ): Promise<void>
     /** Upserts multiple files. */
     upsertMany(

--- a/packages/core/src/db/operations/files.test.ts
+++ b/packages/core/src/db/operations/files.test.ts
@@ -151,6 +151,30 @@ describe('insertManyFiles', () => {
     const results = await queryFiles(db(), { order: 'ASC' })
     expect(results).toHaveLength(0)
   })
+
+  it('files all rows into directoryId when supplied', async () => {
+    const dir = await insertDirectory(db(), 'Media')
+    const records = [makeFileRecord('file-1'), makeFileRecord('file-2')]
+    await insertManyFiles(db(), records, { directoryId: dir.id })
+    const rows = await db().getAllAsync<{ id: string; directoryId: string | null }>(
+      'SELECT id, directoryId FROM files WHERE id IN (?, ?)',
+      'file-1',
+      'file-2',
+    )
+    expect(rows).toHaveLength(2)
+    expect(rows.every((r) => r.directoryId === dir.id)).toBe(true)
+  })
+
+  it('leaves rows at root when directoryId is null or omitted', async () => {
+    await insertManyFiles(db(), [makeFileRecord('file-1')], { directoryId: null })
+    await insertManyFiles(db(), [makeFileRecord('file-2')])
+    const rows = await db().getAllAsync<{ id: string; directoryId: string | null }>(
+      'SELECT id, directoryId FROM files WHERE id IN (?, ?)',
+      'file-1',
+      'file-2',
+    )
+    expect(rows.every((r) => r.directoryId === null)).toBe(true)
+  })
 })
 
 describe('updateFile', () => {

--- a/packages/core/src/db/operations/files.ts
+++ b/packages/core/src/db/operations/files.ts
@@ -867,9 +867,13 @@ export async function readFilesByIds(db: DatabaseAdapter, ids: string[]): Promis
 export async function insertManyFiles(
   db: DatabaseAdapter,
   records: Omit<FileRecord, 'objects'>[],
-  options?: sql.InsertOptions & { skipCurrentRecalc?: boolean },
+  options?: sql.InsertOptions & {
+    skipCurrentRecalc?: boolean
+    directoryId?: string | null
+  },
 ): Promise<void> {
   if (records.length === 0) return
+  const directoryId = options?.directoryId ?? null
   await sql.insertMany(
     db,
     'files',
@@ -877,6 +881,7 @@ export async function insertManyFiles(
       id: r.id,
       name: r.name,
       nameSortKey: naturalSortKey(r.name),
+      directoryId,
       size: r.size,
       createdAt: r.createdAt,
       updatedAt: r.updatedAt,


### PR DESCRIPTION
- Photo sync places every imported file in the configured Media folder regardless of type.
- Auto-imported photos reliably land in the configured Media folder, even if iOS suspends the app mid-import.