### PR TITLE
fix(mobile): respect bottom safe-area inset on Android chin bar

### DIFF
--- a/.changeset/android-chin-bar-bottom-controls.md
+++ b/.changeset/android-chin-bar-bottom-controls.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Fixed an issue where the bottom toolbar and upload button could be obscured by the Android system navigation bar on devices with 3-button navigation. Closes https://github.com/SiaFoundation/sia-storage-app/issues/546

--- a/apps/mobile/src/components/BottomActionButton.tsx
+++ b/apps/mobile/src/components/BottomActionButton.tsx
@@ -1,6 +1,7 @@
 import type React from 'react'
 import { Pressable, StyleSheet, Text, View } from 'react-native'
 import { colors, palette } from '../styles/colors'
+import { useBottomControlOffset } from './BottomControlBar'
 
 type Props = {
   icon: React.ReactNode
@@ -10,8 +11,9 @@ type Props = {
 }
 
 export function BottomActionButton({ icon, label, onPress, disabled }: Props) {
+  const bottom = useBottomControlOffset()
   return (
-    <View style={styles.wrap} pointerEvents="box-none">
+    <View style={[styles.wrap, { bottom }]} pointerEvents="box-none">
       <Pressable
         accessibilityRole="button"
         onPress={onPress}
@@ -30,7 +32,6 @@ const styles = StyleSheet.create({
     position: 'absolute',
     left: 0,
     right: 0,
-    bottom: 30,
     alignItems: 'center',
   },
   button: {

--- a/apps/mobile/src/components/BottomControlBar.tsx
+++ b/apps/mobile/src/components/BottomControlBar.tsx
@@ -9,6 +9,7 @@ import {
   View,
   type ViewStyle,
 } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { colors, overlay, palette, whiteA } from '../styles/colors'
 import { Gradient } from './Gradient'
 
@@ -28,10 +29,13 @@ export function BottomControlBar({
   variant = 'pill',
 }: Props) {
   const keyboardOffset = useKeyboardOffset(keyboardAware)
+  const bottomOffset = useBottomControlOffset()
 
   return (
     <View style={styles.container} pointerEvents="box-none">
-      <View style={[styles.keyboardAwareContainer, { paddingBottom: 30 + keyboardOffset }]}>
+      <View
+        style={[styles.keyboardAwareContainer, { paddingBottom: bottomOffset + keyboardOffset }]}
+      >
         <Gradient
           fadeTo="bottom"
           overlayTopColor={overlay.gradientLight}
@@ -146,6 +150,18 @@ export const iconColors = {
   active: colors.accentActive,
   inactive: whiteA.a70,
   white: palette.gray[50],
+}
+
+/**
+ * Resolved bottom offset for floating bottom-anchored controls
+ * (BottomControlBar, BottomActionButton). On iOS we keep the historical
+ * 30dp literal; on Android we lift above the system nav bar's chin when
+ * 3-button navigation exposes a non-trivial bottom inset.
+ */
+export function useBottomControlOffset() {
+  const insets = useSafeAreaInsets()
+  if (Platform.OS !== 'android') return 30
+  return Math.max(30, insets.bottom + 12)
 }
 
 /** Returns the height of the keyboard when it is visible. */

--- a/apps/mobile/src/components/FileCarousel/index.tsx
+++ b/apps/mobile/src/components/FileCarousel/index.tsx
@@ -350,10 +350,7 @@ export function FileCarousel({
         </Pressable>
       )}
       {currentFile && (showChrome || isDetailView) && !isDismissing ? (
-        <View
-          style={[styles.controlBarOverlay, { paddingBottom: insets.bottom + 12 }]}
-          pointerEvents="box-none"
-        >
+        <View style={styles.controlBarOverlay} pointerEvents="box-none">
           <FileCarouselControlBar
             viewStyle={viewStyle}
             setViewStyle={setViewStyle}
@@ -411,10 +408,10 @@ const styles = StyleSheet.create({
   },
   controlBarOverlay: {
     position: 'absolute',
+    top: 0,
     bottom: 0,
     left: 0,
     right: 0,
-    alignItems: 'center',
     zIndex: 10,
   },
   accessibilityToggle: {


### PR DESCRIPTION
Floating bottom controls and the FileImport upload button were pinned at a hard-coded 30dp, so Android devices in 3-button nav mode drew them under the system chin once edge-to-edge layout became mandatory. A shared useBottomControlOffset() hook now keeps iOS at 30dp and lifts Android to Math.max(30, insets.bottom + 12).

![Screenshot 2026-05-04 at 4.21.11 PM.png](https://app.graphite.com/user-attachments/assets/08224de6-bf7a-4b6e-b70a-06c906a3904d.png)

