### PR TITLE
fix(mobile): decode percent-encoded file:// URIs before copying imports

### DIFF
--- a/.changeset/fix-import-filenames-with-spaces.md
+++ b/.changeset/fix-import-filenames-with-spaces.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Fixed an issue where importing files with spaces (or other special characters) in their names would fail silently. Closes https://github.com/SiaFoundation/sia-storage-app/issues/610

--- a/apps/mobile/src/adapters/fsIO.test.ts
+++ b/apps/mobile/src/adapters/fsIO.test.ts
@@ -13,6 +13,8 @@ jest.mock('react-native-fs', () => ({
 
 const statMock = jest.mocked(RNFS.stat)
 const existsMock = jest.mocked(RNFS.exists)
+const unlinkMock = jest.mocked(RNFS.unlink)
+const copyFileMock = jest.mocked(RNFS.copyFile)
 
 function mockStatResult(size: number): RNFS.StatResult {
   return {
@@ -71,5 +73,55 @@ describe('fsIO adapter size()', () => {
     existsMock.mockResolvedValue(true)
     const result = await adapter.size('file1', 'image/jpeg')
     expect(result).toEqual({ value: null, error: 'stat_error' })
+  })
+})
+
+describe('fsIO adapter copy()', () => {
+  const adapter = createFsIOAdapter()
+  const file = { id: 'file1', type: 'image/png' }
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    existsMock.mockResolvedValue(false)
+    copyFileMock.mockResolvedValue(undefined)
+    statMock.mockResolvedValue(mockStatResult(1024))
+  })
+
+  // Regression for issue #610: iOS Document Picker hands us a
+  // percent-encoded file:// URL, but RNFS expects a real path.
+  it('decodes percent-encoded file:// URIs', async () => {
+    await adapter.copy(
+      file,
+      'file:///tmp/sia.storage-Inbox/Screenshot%202025-09-03%20at%2018.13.41.png',
+    )
+    expect(copyFileMock).toHaveBeenCalledWith(
+      '/tmp/sia.storage-Inbox/Screenshot 2025-09-03 at 18.13.41.png',
+      expect.any(String),
+    )
+  })
+
+  it('strips the file:// prefix from unencoded URIs', async () => {
+    await adapter.copy(file, 'file:///tmp/clean.png')
+    expect(copyFileMock).toHaveBeenCalledWith('/tmp/clean.png', expect.any(String))
+  })
+
+  it('passes non-file URIs through unchanged', async () => {
+    await adapter.copy(file, 'ph://abc123')
+    expect(copyFileMock).toHaveBeenCalledWith('ph://abc123', expect.any(String))
+  })
+
+  // A malformed file:// URI (literal % not part of an escape) shouldn't
+  // throw — fall back to the raw path so RNFS just reports the missing
+  // file as it would have before the decode.
+  it('falls back to the raw path when decoding fails', async () => {
+    await adapter.copy(file, 'file:///tmp/50% off.txt')
+    expect(copyFileMock).toHaveBeenCalledWith('/tmp/50% off.txt', expect.any(String))
+  })
+
+  it('removes an existing target before copying', async () => {
+    existsMock.mockResolvedValue(true)
+    await adapter.copy(file, 'file:///tmp/clean.png')
+    expect(unlinkMock).toHaveBeenCalledTimes(1)
+    expect(copyFileMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/mobile/src/adapters/fsIO.ts
+++ b/apps/mobile/src/adapters/fsIO.ts
@@ -10,6 +10,20 @@ function fsFileUri(fileId: string, type: string): string {
   return `${fsStorageDirectoryUri}/${fileId}${extFromMime(type)}`
 }
 
+// iOS pickers (Document Picker, share inbox) hand us percent-encoded
+// `file://` URLs — `Screenshot%202025-09-03.png` — but RNFS expects a
+// real filesystem path with literal spaces. Fall back to the raw path
+// if decoding throws on a malformed URI (literal `%` + non-hex).
+function fileUriToPath(uri: string): string {
+  if (!uri.startsWith('file://')) return uri
+  const path = uri.slice('file://'.length)
+  try {
+    return decodeURIComponent(path)
+  } catch {
+    return path
+  }
+}
+
 export function createFsIOAdapter(): FsIOAdapter {
   return {
     uri(fileId, type) {
@@ -38,7 +52,7 @@ export function createFsIOAdapter(): FsIOAdapter {
       if (await RNFS.exists(targetUri)) {
         await RNFS.unlink(targetUri)
       }
-      await RNFS.copyFile(sourceUri.replace(/^file:\/\//, ''), targetUri)
+      await RNFS.copyFile(fileUriToPath(sourceUri), targetUri)
       const stat = await RNFS.stat(targetUri)
       return { uri: targetUri, size: stat.size }
     },


### PR DESCRIPTION
Importing a file with spaces (or any character the OS percent-encodes) silently failed: pickers hand us a file:// URL like Screenshot%202025-09-03.png, but the copy step only stripped the scheme and passed the still-encoded path to RNFS, which couldn't find the real file on disk. The adapter now decodes the path component when converting file:// URIs to filesystem paths, with a try/catch fallback so a malformed % sequence degrades to the old behavior instead of throwing. https://github.com/SiaFoundation/sia-storage-app/issues/610