### PR TITLE
feat(core): add file resolution facade, upload batch visibility, and APP_META constant

### DIFF
--- a/.changeset/facade-methods-app-meta.md
+++ b/.changeset/facade-methods-app-meta.md
@@ -1,0 +1,5 @@
+---
+core: minor
+---
+
+Add `files.getByNameInDirectoryPath` facade method, `uploader.currentBatch` introspection, and `APP_META` config constant.

--- a/apps/mobile/src/stores/sdk.ts
+++ b/apps/mobile/src/stores/sdk.ts
@@ -18,7 +18,7 @@
  */
 
 import { err, ok, type Result, uint8ToHex } from '@siastorage/core'
-import { APP_KEY } from '@siastorage/core/config'
+import { APP_META } from '@siastorage/core/config'
 import { getErrorMessage, isAbortError } from '@siastorage/core/lib/errors'
 import { raceWithTimeout, withTimeout } from '@siastorage/core/lib/timeout'
 import { refreshLogAccount } from '@siastorage/core/services/logForwarder'
@@ -33,10 +33,7 @@ import { initializeUploader } from '../managers/uploader'
 import { app, getMobileSdkAuth, internal } from './appService'
 
 const APP_META_JSON = JSON.stringify({
-  appID: APP_KEY,
-  name: 'Sia Storage',
-  description: 'Privacy-first, decentralized cloud storage',
-  serviceURL: 'https://sia.storage',
+  ...APP_META,
   callbackUrl: 'sia://callback',
   logoUrl: 'https://app.sia.storage/icon.png',
 })

--- a/packages/core/src/adapters/sdk.ts
+++ b/packages/core/src/adapters/sdk.ts
@@ -84,6 +84,9 @@ export interface DownloadOptions {
   maxInflight: number
   offset: bigint
   length: bigint | undefined
+  shardDownloaded?: {
+    progress: (p: ShardProgress) => void
+  }
 }
 
 export interface ObjectEvent {

--- a/packages/core/src/app/namespaces/db.ts
+++ b/packages/core/src/app/namespaces/db.ts
@@ -202,6 +202,8 @@ export function buildDbNamespaces(
       getCurrentByNamesInDirectory: (names, directoryId) =>
         ops.readCurrentFilesByNamesInDirectory(db, names, directoryId),
       getByName: (name) => ops.readFileByName(db, name),
+      getByNameInDirectoryPath: (name, directoryPath) =>
+        ops.readFileByNameInDirectoryPath(db, name, directoryPath),
       getByContentHash: (hash) => ops.readFileByContentHash(db, hash),
       getByContentHashes: (hashes) => ops.readFilesByContentHashes(db, hashes),
       query: (opts) => ops.queryFiles(db, opts),

--- a/packages/core/src/app/namespaces/uploader.ts
+++ b/packages/core/src/app/namespaces/uploader.ts
@@ -61,6 +61,9 @@ export function buildUploaderNamespace(
     isRunning() {
       return manager.packedCount > 0 || manager.uploadedCount > 0
     },
+    currentBatch() {
+      return manager.currentBatch
+    },
   }
 
   return { namespace, manager }

--- a/packages/core/src/app/service.ts
+++ b/packages/core/src/app/service.ts
@@ -143,6 +143,8 @@ export interface AppService {
     getCurrentByNamesInDirectory(names: string[], directoryId: string | null): Promise<FileRecord[]>
     /** Returns a file by name (current version). */
     getByName(name: string): Promise<FileRecord | null>
+    /** Returns a file by name within a directory path. */
+    getByNameInDirectoryPath(name: string, directoryPath: string): Promise<FileRecord | null>
     /** Returns a file by content hash. */
     getByContentHash(hash: string): Promise<FileRecord | null>
     /** Returns files by content hashes. */
@@ -747,6 +749,11 @@ export interface AppService {
     shutdown(): Promise<void>
     /** Returns whether the upload manager is actively processing. */
     isRunning(): boolean
+    /** Returns the current batch being packed, or null if idle. */
+    currentBatch(): {
+      batchId: string
+      files: Array<{ fileId: string; name: string; size: number }>
+    } | null
   }
   /** Returns the list of known hosts from the indexer. */
   hosts(): Promise<Host[]>

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -2,6 +2,13 @@ import { daysInMs, minutesInMs, secondsInMs } from '../lib/time'
 
 // App key, used to identify itself to the indexer. 32 bytes hex string.
 export const APP_KEY = 'ac38d91cfb250d50820a0c658628662b8c2dcfc6a5f3fe4d5755eb0a7b67eeac'
+// App metadata for indexer registration. All platforms use the same identity.
+export const APP_META = {
+  appID: APP_KEY,
+  name: 'Sia Storage',
+  description: 'Privacy-first, decentralized cloud storage',
+  serviceURL: 'https://sia.storage',
+} as const
 // Default indexer.
 export const DEFAULT_INDEXER_URL = 'https://sia.storage'
 // Max concurrent uploads.

--- a/packages/core/src/db/operations/directories.ts
+++ b/packages/core/src/db/operations/directories.ts
@@ -1,10 +1,11 @@
 import type { DatabaseAdapter } from '../../adapters/db'
 import { naturalSortKey } from '../../lib/naturalSortKey'
 import { uniqueId } from '../../lib/uniqueId'
-import type { FileRecordRow } from '../../types/files'
+import type { FileRecord, FileRecordRow } from '../../types/files'
 import * as sql from '../sql'
-import { recalculateCurrentForGroup, recalculateCurrentForGroups } from './files'
+import { recalculateCurrentForGroup, recalculateCurrentForGroups, transformRow } from './files'
 import { buildRecordFilter } from './library'
+import { queryObjectRefsForFile } from './localObjects'
 import { trashFilesAndThumbnails } from './trash'
 
 export type Directory = {
@@ -523,6 +524,17 @@ export async function queryFileByNameInDirectory(
     fileName,
     directoryPath,
   )
+}
+
+export async function readFileByNameInDirectoryPath(
+  db: DatabaseAdapter,
+  fileName: string,
+  directoryPath: string,
+): Promise<FileRecord | null> {
+  const row = await queryFileByNameInDirectory(db, fileName, directoryPath)
+  if (!row) return null
+  const objects = await queryObjectRefsForFile(db, row.id)
+  return transformRow(row, objects)
 }
 
 export async function queryFilesByDirectoryPath(

--- a/packages/core/src/db/operations/index.ts
+++ b/packages/core/src/db/operations/index.ts
@@ -21,6 +21,7 @@ export {
   queryDirectoryPathForFile,
   queryFileByNameInDirectory,
   queryFilesByDirectoryPath,
+  readFileByNameInDirectoryPath,
   renameDirectory,
   sanitizeDirectoryPath,
   sanitizeDirectorySegment,

--- a/packages/core/src/services/uploader.ts
+++ b/packages/core/src/services/uploader.ts
@@ -426,6 +426,21 @@ export class UploadManager {
     })
   }
 
+  get currentBatch(): {
+    batchId: string
+    files: { fileId: string; name: string; size: number }[]
+  } | null {
+    if (!this.batch) return null
+    return {
+      batchId: this.batch.batchId,
+      files: this.batch.files.map((f) => ({
+        fileId: f.fileId,
+        name: f.file?.name ?? f.fileId,
+        size: f.size,
+      })),
+    }
+  }
+
   get flushHistory(): FlushRecord[] {
     return this._flushHistory
   }


### PR DESCRIPTION
The CLI (and the desktop app it'll back) need three small API additions on the core app service: looking up a file by (name, directoryPath) for path-based commands, peeking at the upload manager's current batch for status output across the IPC boundary, and a shared APP_META constant so every platform identifies itself to the indexer with the same payload. Adds files.getByNameInDirectoryPath, uploader.currentBatch(), and APP_META, with mobile's SDK store now consuming the constant instead of inlining the literal.