### PR TITLE
feat(node-adapters): add platform adapters for node/bun

### DIFF
--- a/.changeset/node-adapters-foundation.md
+++ b/.changeset/node-adapters-foundation.md
@@ -1,0 +1,5 @@
+---
+node-adapters: minor
+---
+
+Add platform adapters for paths, file I/O, storage, MIME detection, thumbnails, uploads, and Bun SQLite.

--- a/apps/integration/test/adapters/thumbnail.ts
+++ b/apps/integration/test/adapters/thumbnail.ts
@@ -1,53 +1,6 @@
 import type { ThumbnailAdapter } from '@siastorage/core/adapters'
 
-let sharp: any
-try {
-  sharp = require('sharp')
-} catch {
-  // sharp not available
-}
-
-export function createSharpThumbnailAdapter(): ThumbnailAdapter | undefined {
-  if (!sharp) return undefined
-  return {
-    async generateImageThumbnail(sourcePath: string, targetSize: number) {
-      const filePath = sourcePath.replace('file://', '')
-      const buf = await sharp(filePath)
-        .resize(targetSize, targetSize, { fit: 'inside' })
-        .webp({ quality: 80 })
-        .toBuffer()
-      return {
-        data: buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength),
-        mimeType: 'image/webp',
-      }
-    },
-    async generateImageThumbnails(sourcePath: string, sizes: number[]) {
-      const results = new Map()
-      for (const size of sizes) {
-        const filePath = sourcePath.replace('file://', '')
-        const buf = await sharp(filePath)
-          .resize(size, size, { fit: 'inside' })
-          .webp({ quality: 80 })
-          .toBuffer()
-        results.set(size, {
-          data: buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength),
-          mimeType: 'image/webp',
-        })
-      }
-      return results
-    },
-    async generateVideoThumbnail() {
-      const placeholder = Buffer.alloc(64)
-      return {
-        data: placeholder.buffer.slice(
-          placeholder.byteOffset,
-          placeholder.byteOffset + placeholder.byteLength,
-        ),
-        mimeType: 'image/webp',
-      }
-    },
-  }
-}
+export { createSharpThumbnailAdapter } from '@siastorage/node-adapters/thumbnail'
 
 export function createMockThumbnailAdapter(
   overrides?: Partial<ThumbnailAdapter>,

--- a/bun.lock
+++ b/bun.lock
@@ -167,9 +167,12 @@
         "@siastorage/core": "workspace:*",
         "@siastorage/logger": "workspace:*",
         "better-sqlite3": "12.6.2",
+        "sharp": "0.33.5",
       },
       "devDependencies": {
         "@types/better-sqlite3": "7.6.13",
+        "jest": "29.7.0",
+        "ts-jest": "29.4.6",
         "typescript": "5.9.3",
       },
     },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "postinstall": "npm rebuild better-sqlite3",
     "lint": "oxlint . && oxfmt --check .",
     "typecheck": "bun run --filter '*' typecheck",
-    "test": "bun --cwd packages/core test && bun --cwd apps/mobile test && bun --cwd apps/integration test",
+    "test": "bun --cwd packages/core test && bun --cwd packages/node-adapters test && bun --cwd apps/mobile test && bun --cwd apps/integration test",
     "mobile:fresh": "bun --cwd apps/mobile fresh",
     "mobile:start": "bun --cwd apps/mobile start",
     "mobile:dev:ios:simulator": "bun --cwd apps/mobile dev:ios:simulator",

--- a/packages/node-adapters/jest.config.cjs
+++ b/packages/node-adapters/jest.config.cjs
@@ -1,0 +1,31 @@
+module.exports = {
+  testEnvironment: 'node',
+  testTimeout: 30000,
+  testMatch: ['<rootDir>/test/**/*.test.ts'],
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: {
+          target: 'ES2022',
+          module: 'commonjs',
+          moduleResolution: 'node',
+          esModuleInterop: true,
+          strict: true,
+          baseUrl: '.',
+          paths: {
+            '@siastorage/logger': ['../../packages/logger/src/index.ts'],
+            '@siastorage/core/*': ['../../packages/core/src/*'],
+            '@siafoundation/sia-storage': [
+              '../../node_modules/@siafoundation/sia-storage/dist/index.node.d.ts',
+            ],
+          },
+        },
+      },
+    ],
+  },
+  moduleNameMapper: {
+    '^@siastorage/logger$': '<rootDir>/../../packages/logger/src/index.ts',
+    '^@siastorage/core/(.*)$': '<rootDir>/../../packages/core/src/$1',
+  },
+}

--- a/packages/node-adapters/package.json
+++ b/packages/node-adapters/package.json
@@ -8,20 +8,29 @@
     ".": "./src/index.ts",
     "./database": "./src/database.ts",
     "./storage": "./src/storage.ts",
-    "./crypto": "./src/crypto.ts"
+    "./crypto": "./src/crypto.ts",
+    "./paths": "./src/paths.ts",
+    "./fsIO": "./src/fsIO.ts",
+    "./uploader": "./src/uploader.ts",
+    "./detectMimeType": "./src/detectMimeType.ts",
+    "./thumbnail": "./src/thumbnail.ts",
+    "./bunDatabase": "./src/bunDatabase.ts"
   },
   "scripts": {
     "lint": "oxlint . && oxfmt --check .",
     "typecheck": "tsc --noEmit",
-    "test": "echo 'No tests yet'"
+    "test": "jest"
   },
   "dependencies": {
     "@siastorage/core": "workspace:*",
     "@siastorage/logger": "workspace:*",
-    "better-sqlite3": "12.6.2"
+    "better-sqlite3": "12.6.2",
+    "sharp": "0.33.5"
   },
   "devDependencies": {
     "@types/better-sqlite3": "7.6.13",
+    "jest": "29.7.0",
+    "ts-jest": "29.4.6",
     "typescript": "5.9.3"
   }
 }

--- a/packages/node-adapters/src/bunDatabase.ts
+++ b/packages/node-adapters/src/bunDatabase.ts
@@ -1,6 +1,6 @@
 import type { DatabaseAdapter, SQLParam, SQLRunResult } from '@siastorage/core/adapters'
 import { logger } from '@siastorage/logger'
-import sqlite3 from 'better-sqlite3'
+import { Database } from 'bun:sqlite'
 
 const SLOW_QUERY_THRESHOLD = 500
 
@@ -15,20 +15,18 @@ function logSlowQuery(method: string, sql: string, start: number) {
   }
 }
 
-export function createBetterSqlite3Database(
-  path = ':memory:',
-): DatabaseAdapter & { close(): void } {
-  const db = new sqlite3(path)
-  db.pragma('journal_mode = WAL')
+export function createBunDatabase(path = ':memory:'): DatabaseAdapter & { close(): void } {
+  const db = new Database(path)
+  db.exec('PRAGMA journal_mode = WAL')
   // synchronous = NORMAL moves fsync out of the per-commit path; durability
   // cost only applies to full OS crashes, which sync-down recovers from.
-  db.pragma('synchronous = NORMAL')
+  db.exec('PRAGMA synchronous = NORMAL')
   // Bound the WAL at ~2MB so a long-running daemon doesn't accumulate disk.
-  db.pragma('wal_autocheckpoint = 500')
+  db.exec('PRAGMA wal_autocheckpoint = 500')
   // Wait up to 5s on lock contention before returning SQLITE_BUSY, so CLI
   // clients connecting mid-write don't fail spuriously.
-  db.pragma('busy_timeout = 5000')
-  db.pragma('foreign_keys = ON')
+  db.exec('PRAGMA busy_timeout = 5000')
+  db.exec('PRAGMA foreign_keys = ON')
 
   return {
     async getAllAsync<T>(sql: string, ...params: SQLParam[]): Promise<T[]> {

--- a/packages/node-adapters/src/detectMimeType.ts
+++ b/packages/node-adapters/src/detectMimeType.ts
@@ -1,0 +1,27 @@
+import { detectMimeType, MAGIC_BYTES_LENGTH } from '@siastorage/core/lib/detectMimeType'
+import * as fs from 'fs'
+import * as path from 'path'
+
+export function createNodeDetectMimeType(): (filePath: string) => Promise<string | null> {
+  return async (filePath: string): Promise<string | null> => {
+    const resolved = filePath.replace(/^file:\/\//, '')
+    const fileName = path.basename(resolved)
+    let bytes: Uint8Array | undefined
+
+    try {
+      const fd = fs.openSync(resolved, 'r')
+      try {
+        const buf = Buffer.alloc(MAGIC_BYTES_LENGTH)
+        const bytesRead = fs.readSync(fd, buf, 0, MAGIC_BYTES_LENGTH, 0)
+        bytes = new Uint8Array(buf.buffer, buf.byteOffset, bytesRead)
+      } finally {
+        fs.closeSync(fd)
+      }
+    } catch {
+      // File not readable, fall back to extension only
+    }
+
+    const result = detectMimeType({ fileName, bytes })
+    return result === 'application/octet-stream' ? null : result
+  }
+}

--- a/packages/node-adapters/src/fsIO.ts
+++ b/packages/node-adapters/src/fsIO.ts
@@ -1,0 +1,65 @@
+import { extFromMime } from '@siastorage/core/lib/fileTypes'
+import type { FsIOAdapter } from '@siastorage/core/services/fsFileUri'
+import * as fs from 'fs/promises'
+import * as path from 'path'
+
+export function createNodeFsIO(filesDir: string): FsIOAdapter {
+  function filePath(fileId: string, type: string): string {
+    const ext = extFromMime(type)
+    return path.join(filesDir, `${fileId}${ext}`)
+  }
+
+  return {
+    uri(fileId, type) {
+      return filePath(fileId, type)
+    },
+
+    async size(fileId, type) {
+      try {
+        const stat = await fs.stat(filePath(fileId, type))
+        return { value: stat.size }
+      } catch (e: any) {
+        if (e?.code === 'ENOENT') {
+          return { value: null, error: 'not_found' }
+        }
+        return { value: null, error: 'stat_error' }
+      }
+    },
+
+    async remove(fileId, type) {
+      try {
+        await fs.unlink(filePath(fileId, type))
+      } catch (e: any) {
+        if (e?.code !== 'ENOENT') throw e
+      }
+    },
+
+    async copy(file, sourceUri) {
+      const target = filePath(file.id, file.type)
+      const sourcePath = sourceUri.replace(/^file:\/\//, '')
+      await fs.copyFile(sourcePath, target)
+      const stat = await fs.stat(target)
+      return { uri: target, size: stat.size }
+    },
+
+    async writeFile(file, data) {
+      const target = filePath(file.id, file.type)
+      const buf = Buffer.from(data)
+      await fs.writeFile(target, buf)
+      return { uri: target, size: buf.byteLength }
+    },
+
+    async list() {
+      try {
+        return await fs.readdir(filesDir)
+      } catch (e: any) {
+        if (e?.code === 'ENOENT') return []
+        throw e
+      }
+    },
+
+    async ensureDirectory() {
+      await fs.mkdir(filesDir, { recursive: true })
+    },
+  }
+}

--- a/packages/node-adapters/src/index.ts
+++ b/packages/node-adapters/src/index.ts
@@ -1,3 +1,10 @@
+// Foundation
 export { createNodeCryptoAdapter } from './crypto'
 export { createBetterSqlite3Database } from './database'
-export { createInMemoryStorage } from './storage'
+export { createBunDatabase } from './bunDatabase'
+export { createInMemoryStorage, createJsonFileStorage } from './storage'
+export { getDataDir, getPaths, ensureDataDir } from './paths'
+export { createNodeFsIO } from './fsIO'
+export { createNodeUploaderAdapters } from './uploader'
+export { createNodeDetectMimeType } from './detectMimeType'
+export { createSharpThumbnailAdapter } from './thumbnail'

--- a/packages/node-adapters/src/paths.ts
+++ b/packages/node-adapters/src/paths.ts
@@ -1,0 +1,28 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+export function getDataDir(): string {
+  return process.env.SIA_DATA_DIR || path.join(os.homedir(), '.siastorage')
+}
+
+export function getPaths(dataDir: string) {
+  return {
+    dataDir,
+    dbPath: path.join(dataDir, 'data.db'),
+    configPath: path.join(dataDir, 'config.json'),
+    storagePath: path.join(dataDir, 'storage.json'),
+    secretsPath: path.join(dataDir, 'secrets.json'),
+    statePath: path.join(dataDir, 'state.json'),
+    filesDir: path.join(dataDir, 'files'),
+    pidPath: path.join(dataDir, 'daemon.pid'),
+    lockPath: path.join(dataDir, 'daemon.lock'),
+    sockPath: path.join(dataDir, 'daemon.sock'),
+    logPath: path.join(dataDir, 'daemon.log'),
+  }
+}
+
+export function ensureDataDir(dataDir: string): void {
+  fs.mkdirSync(dataDir, { recursive: true })
+  fs.mkdirSync(path.join(dataDir, 'files'), { recursive: true })
+}

--- a/packages/node-adapters/src/storage.ts
+++ b/packages/node-adapters/src/storage.ts
@@ -1,4 +1,6 @@
 import type { StorageAdapter } from '@siastorage/core/adapters'
+import * as fs from 'fs'
+import * as path from 'path'
 
 export function createInMemoryStorage(): StorageAdapter {
   const store = new Map<string, string>()
@@ -12,6 +14,45 @@ export function createInMemoryStorage(): StorageAdapter {
     },
     async deleteItem(key: string): Promise<void> {
       store.delete(key)
+    },
+  }
+}
+
+export function createJsonFileStorage(filePath: string, opts?: { mode?: number }): StorageAdapter {
+  const mode = opts?.mode ?? 0o644
+  let cache: Record<string, string>
+
+  try {
+    const raw = fs.readFileSync(filePath, 'utf-8')
+    cache = JSON.parse(raw)
+    if (typeof cache !== 'object' || cache === null || Array.isArray(cache)) {
+      cache = {}
+    }
+  } catch {
+    cache = {}
+  }
+
+  function persist(): void {
+    const dir = path.dirname(filePath)
+    fs.mkdirSync(dir, { recursive: true })
+    // Write to a temp file then atomically rename so a crash mid-write
+    // can never leave a half-written or empty file in place.
+    const tmpPath = `${filePath}.${process.pid}.tmp`
+    fs.writeFileSync(tmpPath, JSON.stringify(cache, null, 2), { mode })
+    fs.renameSync(tmpPath, filePath)
+  }
+
+  return {
+    async getItem(key: string): Promise<string | null> {
+      return cache[key] ?? null
+    },
+    async setItem(key: string, value: string): Promise<void> {
+      cache[key] = value
+      persist()
+    },
+    async deleteItem(key: string): Promise<void> {
+      delete cache[key]
+      persist()
     },
   }
 }

--- a/packages/node-adapters/src/thumbnail.ts
+++ b/packages/node-adapters/src/thumbnail.ts
@@ -1,0 +1,41 @@
+import type { ThumbnailAdapter, ThumbnailResult } from '@siastorage/core/adapters'
+import sharp from 'sharp'
+
+export function createSharpThumbnailAdapter(): ThumbnailAdapter {
+  return {
+    async generateImageThumbnail(sourcePath: string, targetSize: number): Promise<ThumbnailResult> {
+      const filePath = sourcePath.replace(/^file:\/\//, '')
+      const buf: Buffer = await sharp(filePath)
+        .resize(targetSize, targetSize, { fit: 'inside', withoutEnlargement: true })
+        .webp({ quality: 80 })
+        .toBuffer()
+      return {
+        data: buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer,
+        mimeType: 'image/webp',
+      }
+    },
+
+    async generateImageThumbnails(
+      sourcePath: string,
+      sizes: number[],
+    ): Promise<Map<number, ThumbnailResult>> {
+      const results = new Map<number, ThumbnailResult>()
+      for (const size of sizes) {
+        const filePath = sourcePath.replace(/^file:\/\//, '')
+        const buf: Buffer = await sharp(filePath)
+          .resize(size, size, { fit: 'inside', withoutEnlargement: true })
+          .webp({ quality: 80 })
+          .toBuffer()
+        results.set(size, {
+          data: buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer,
+          mimeType: 'image/webp',
+        })
+      }
+      return results
+    },
+
+    async generateVideoThumbnail(): Promise<ThumbnailResult> {
+      throw new Error('Video thumbnails not supported')
+    },
+  }
+}

--- a/packages/node-adapters/src/uploader.ts
+++ b/packages/node-adapters/src/uploader.ts
@@ -1,0 +1,46 @@
+import type { Reader } from '@siastorage/core/adapters'
+import type { UploaderAdapters } from '@siastorage/core/services/uploader'
+import { open, type FileHandle } from 'fs/promises'
+
+const CHUNK_SIZE = 64 * 1024
+
+export function createNodeUploaderAdapters(): UploaderAdapters {
+  return {
+    createFileReader(uri: string): Reader {
+      const filePath = uri.replace(/^file:\/\//, '')
+      let handle: FileHandle | null = null
+      let offset = 0
+      let done = false
+
+      return {
+        async read(): Promise<ArrayBuffer> {
+          if (done) return new ArrayBuffer(0)
+          if (!handle) handle = await open(filePath, 'r')
+
+          // Copy into a standalone Buffer — Bun's Buffer.subarray() shares
+          // an internal memory pool that NAPI bindings can't read from.
+          const chunk = Buffer.allocUnsafe(CHUNK_SIZE)
+          const { bytesRead } = await handle.read(chunk, 0, CHUNK_SIZE, offset)
+          if (bytesRead === 0) {
+            done = true
+            await handle.close()
+            handle = null
+            return new ArrayBuffer(0)
+          }
+          offset += bytesRead
+
+          if (bytesRead < CHUNK_SIZE) {
+            const final = Buffer.allocUnsafe(bytesRead)
+            chunk.copy(final, 0, 0, bytesRead)
+            return final.buffer.slice(final.byteOffset, final.byteOffset + final.byteLength)
+          }
+          return chunk.buffer.slice(chunk.byteOffset, chunk.byteOffset + chunk.byteLength)
+        },
+      }
+    },
+
+    progressScheduler(cb: () => void) {
+      setImmediate(cb)
+    },
+  }
+}

--- a/packages/node-adapters/test/detectMimeType.test.ts
+++ b/packages/node-adapters/test/detectMimeType.test.ts
@@ -1,0 +1,58 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { createNodeDetectMimeType } from '../src/detectMimeType'
+
+let tempDir: string
+let detect: ReturnType<typeof createNodeDetectMimeType>
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sia-mime-test-'))
+  detect = createNodeDetectMimeType()
+})
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true })
+})
+
+describe('createNodeDetectMimeType', () => {
+  it('detects PNG file correctly', async () => {
+    const filePath = path.join(tempDir, 'test.png')
+    // PNG magic bytes
+    const header = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+    fs.writeFileSync(filePath, Buffer.concat([header, Buffer.alloc(100)]))
+    const result = await detect(filePath)
+    expect(result).toBe('image/png')
+  })
+
+  it('detects JPEG file correctly', async () => {
+    const filePath = path.join(tempDir, 'test.jpg')
+    // JPEG magic bytes
+    const header = Buffer.from([0xff, 0xd8, 0xff, 0xe0])
+    fs.writeFileSync(filePath, Buffer.concat([header, Buffer.alloc(100)]))
+    const result = await detect(filePath)
+    expect(result).toBe('image/jpeg')
+  })
+
+  it('returns null for unknown binary', async () => {
+    const filePath = path.join(tempDir, 'test.bin')
+    fs.writeFileSync(filePath, Buffer.alloc(100, 0x00))
+    const result = await detect(filePath)
+    expect(result).toBeNull()
+  })
+
+  it('falls back to extension when magic bytes inconclusive', async () => {
+    const filePath = path.join(tempDir, 'test.mp4')
+    fs.writeFileSync(filePath, Buffer.alloc(10, 0x00))
+    const result = await detect(filePath)
+    expect(result).toBe('video/mp4')
+  })
+
+  it('handles file:// prefix', async () => {
+    const filePath = path.join(tempDir, 'test.jpg')
+    const header = Buffer.from([0xff, 0xd8, 0xff, 0xe0])
+    fs.writeFileSync(filePath, Buffer.concat([header, Buffer.alloc(100)]))
+    const result = await detect(`file://${filePath}`)
+    expect(result).toBe('image/jpeg')
+  })
+})

--- a/packages/node-adapters/test/fsIO.test.ts
+++ b/packages/node-adapters/test/fsIO.test.ts
@@ -1,0 +1,106 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { createNodeFsIO } from '../src/fsIO'
+
+let filesDir: string
+let fsIO: ReturnType<typeof createNodeFsIO>
+
+beforeEach(() => {
+  filesDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sia-fsio-test-'))
+  fsIO = createNodeFsIO(filesDir)
+})
+
+afterEach(() => {
+  fs.rmSync(filesDir, { recursive: true, force: true })
+})
+
+describe('uri', () => {
+  it('returns correct path with extension from MIME type', () => {
+    const uri = fsIO.uri('abc123', 'image/jpeg')
+    expect(uri).toBe(path.join(filesDir, 'abc123.jpg'))
+  })
+
+  it('handles unknown MIME type', () => {
+    const uri = fsIO.uri('abc123', 'application/octet-stream')
+    expect(uri).toContain('abc123')
+  })
+})
+
+describe('size', () => {
+  it('returns file size for existing file', async () => {
+    const filePath = path.join(filesDir, 'abc123.jpg')
+    fs.writeFileSync(filePath, 'hello')
+    const result = await fsIO.size('abc123', 'image/jpeg')
+    expect(result).toEqual({ value: 5 })
+  })
+
+  it('returns not_found for missing file', async () => {
+    const result = await fsIO.size('missing', 'image/jpeg')
+    expect(result).toEqual({ value: null, error: 'not_found' })
+  })
+})
+
+describe('remove', () => {
+  it('deletes file', async () => {
+    const filePath = path.join(filesDir, 'abc123.jpg')
+    fs.writeFileSync(filePath, 'data')
+    await fsIO.remove('abc123', 'image/jpeg')
+    expect(fs.existsSync(filePath)).toBe(false)
+  })
+
+  it('does not throw for missing file', async () => {
+    await expect(fsIO.remove('missing', 'image/jpeg')).resolves.not.toThrow()
+  })
+})
+
+describe('copy', () => {
+  it('copies file and returns correct URI and size', async () => {
+    const sourceFile = path.join(filesDir, 'source.tmp')
+    fs.writeFileSync(sourceFile, 'copy me')
+    const result = await fsIO.copy({ id: 'dest', type: 'image/png' }, sourceFile)
+    expect(result.size).toBe(7)
+    expect(result.uri).toBe(path.join(filesDir, 'dest.png'))
+    expect(fs.readFileSync(result.uri, 'utf-8')).toBe('copy me')
+  })
+})
+
+describe('writeFile', () => {
+  it('writes ArrayBuffer data and returns correct URI and size', async () => {
+    const data = new TextEncoder().encode('hello world').buffer as ArrayBuffer
+    const result = await fsIO.writeFile!({ id: 'written', type: 'image/jpeg' }, data)
+    expect(result.size).toBe(11)
+    expect(result.uri).toBe(path.join(filesDir, 'written.jpg'))
+    expect(fs.readFileSync(result.uri, 'utf-8')).toBe('hello world')
+  })
+})
+
+describe('list', () => {
+  it('returns filenames in directory', async () => {
+    fs.writeFileSync(path.join(filesDir, 'a.jpg'), '')
+    fs.writeFileSync(path.join(filesDir, 'b.png'), '')
+    const files = await fsIO.list()
+    expect(files.sort()).toEqual(['a.jpg', 'b.png'])
+  })
+
+  it('returns empty array for missing directory', async () => {
+    const emptyFsIO = createNodeFsIO(path.join(filesDir, 'nonexistent'))
+    const files = await emptyFsIO.list()
+    expect(files).toEqual([])
+  })
+})
+
+describe('ensureDirectory', () => {
+  it('creates directory recursively', async () => {
+    const nestedDir = path.join(filesDir, 'a', 'b', 'c')
+    const nestedFsIO = createNodeFsIO(nestedDir)
+    await nestedFsIO.ensureDirectory()
+    expect(fs.existsSync(nestedDir)).toBe(true)
+  })
+
+  it('is idempotent', async () => {
+    await fsIO.ensureDirectory()
+    await fsIO.ensureDirectory()
+    expect(fs.existsSync(filesDir)).toBe(true)
+  })
+})

--- a/packages/node-adapters/test/paths.test.ts
+++ b/packages/node-adapters/test/paths.test.ts
@@ -1,0 +1,70 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { ensureDataDir, getDataDir, getPaths } from '../src/paths'
+
+describe('getDataDir', () => {
+  const originalEnv = process.env.SIA_DATA_DIR
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.SIA_DATA_DIR
+    } else {
+      process.env.SIA_DATA_DIR = originalEnv
+    }
+  })
+
+  it('returns ~/.siastorage by default', () => {
+    delete process.env.SIA_DATA_DIR
+    expect(getDataDir()).toBe(path.join(os.homedir(), '.siastorage'))
+  })
+
+  it('respects SIA_DATA_DIR env var', () => {
+    process.env.SIA_DATA_DIR = '/tmp/custom-sia'
+    expect(getDataDir()).toBe('/tmp/custom-sia')
+  })
+})
+
+describe('getPaths', () => {
+  it('returns all expected paths joined to dataDir', () => {
+    const dataDir = '/test/data'
+    const p = getPaths(dataDir)
+    expect(p.dataDir).toBe('/test/data')
+    expect(p.dbPath).toBe('/test/data/data.db')
+    expect(p.configPath).toBe('/test/data/config.json')
+    expect(p.storagePath).toBe('/test/data/storage.json')
+    expect(p.secretsPath).toBe('/test/data/secrets.json')
+    expect(p.statePath).toBe('/test/data/state.json')
+    expect(p.filesDir).toBe('/test/data/files')
+    expect(p.pidPath).toBe('/test/data/daemon.pid')
+    expect(p.lockPath).toBe('/test/data/daemon.lock')
+    expect(p.sockPath).toBe('/test/data/daemon.sock')
+    expect(p.logPath).toBe('/test/data/daemon.log')
+  })
+})
+
+describe('ensureDataDir', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sia-paths-test-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('creates dataDir and filesDir', () => {
+    const dataDir = path.join(tempDir, 'nested', 'data')
+    ensureDataDir(dataDir)
+    expect(fs.existsSync(dataDir)).toBe(true)
+    expect(fs.existsSync(path.join(dataDir, 'files'))).toBe(true)
+  })
+
+  it('is idempotent', () => {
+    const dataDir = path.join(tempDir, 'data')
+    ensureDataDir(dataDir)
+    ensureDataDir(dataDir)
+    expect(fs.existsSync(dataDir)).toBe(true)
+  })
+})

--- a/packages/node-adapters/test/storage.test.ts
+++ b/packages/node-adapters/test/storage.test.ts
@@ -1,0 +1,113 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { createInMemoryStorage, createJsonFileStorage } from '../src/storage'
+
+describe('createInMemoryStorage', () => {
+  it('returns null for missing keys', async () => {
+    const storage = createInMemoryStorage()
+    expect(await storage.getItem('missing')).toBeNull()
+  })
+
+  it('sets and gets items', async () => {
+    const storage = createInMemoryStorage()
+    await storage.setItem('key', 'value')
+    expect(await storage.getItem('key')).toBe('value')
+  })
+
+  it('deletes items', async () => {
+    const storage = createInMemoryStorage()
+    await storage.setItem('key', 'value')
+    await storage.deleteItem('key')
+    expect(await storage.getItem('key')).toBeNull()
+  })
+})
+
+describe('createJsonFileStorage', () => {
+  let tempDir: string
+  let storagePath: string
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sia-storage-test-'))
+    storagePath = path.join(tempDir, 'storage.json')
+  })
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('returns null for missing keys', async () => {
+    const storage = createJsonFileStorage(storagePath)
+    expect(await storage.getItem('missing')).toBeNull()
+  })
+
+  it('sets and gets an item', async () => {
+    const storage = createJsonFileStorage(storagePath)
+    await storage.setItem('key', 'value')
+    expect(await storage.getItem('key')).toBe('value')
+  })
+
+  it('overwrites an existing item', async () => {
+    const storage = createJsonFileStorage(storagePath)
+    await storage.setItem('key', 'first')
+    await storage.setItem('key', 'second')
+    expect(await storage.getItem('key')).toBe('second')
+  })
+
+  it('deletes an item', async () => {
+    const storage = createJsonFileStorage(storagePath)
+    await storage.setItem('key', 'value')
+    await storage.deleteItem('key')
+    expect(await storage.getItem('key')).toBeNull()
+  })
+
+  it('persists across instances', async () => {
+    const storage1 = createJsonFileStorage(storagePath)
+    await storage1.setItem('persist', 'yes')
+
+    const storage2 = createJsonFileStorage(storagePath)
+    expect(await storage2.getItem('persist')).toBe('yes')
+  })
+
+  it('handles multiple keys', async () => {
+    const storage = createJsonFileStorage(storagePath)
+    await storage.setItem('a', '1')
+    await storage.setItem('b', '2')
+    await storage.setItem('c', '3')
+    expect(await storage.getItem('a')).toBe('1')
+    expect(await storage.getItem('b')).toBe('2')
+    expect(await storage.getItem('c')).toBe('3')
+  })
+
+  it('handles missing file gracefully', async () => {
+    const storage = createJsonFileStorage(path.join(tempDir, 'nonexistent.json'))
+    expect(await storage.getItem('key')).toBeNull()
+    await storage.setItem('key', 'value')
+    expect(await storage.getItem('key')).toBe('value')
+  })
+
+  it('handles corrupt JSON file gracefully', async () => {
+    fs.writeFileSync(storagePath, 'not json{{{')
+    const storage = createJsonFileStorage(storagePath)
+    expect(await storage.getItem('key')).toBeNull()
+    await storage.setItem('key', 'value')
+    expect(await storage.getItem('key')).toBe('value')
+  })
+
+  it('respects file mode option', async () => {
+    const storage = createJsonFileStorage(storagePath, { mode: 0o600 })
+    await storage.setItem('secret', 'value')
+    const stat = fs.statSync(storagePath)
+    // eslint-disable-next-line no-bitwise
+    const mode = stat.mode & 0o777
+    expect(mode).toBe(0o600)
+  })
+
+  it('creates parent directory if it does not exist', async () => {
+    const nested = path.join(tempDir, 'a', 'b', 'storage.json')
+    const storage = createJsonFileStorage(nested)
+    await storage.setItem('key', 'value')
+    expect(fs.existsSync(nested)).toBe(true)
+    expect(await storage.getItem('key')).toBe('value')
+  })
+})

--- a/packages/node-adapters/test/thumbnail.test.ts
+++ b/packages/node-adapters/test/thumbnail.test.ts
@@ -1,0 +1,90 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { createSharpThumbnailAdapter } from '../src/thumbnail'
+
+let tempDir: string
+let adapter: ReturnType<typeof createSharpThumbnailAdapter>
+
+let testImagePath: string
+
+beforeAll(async () => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sia-thumb-test-'))
+  testImagePath = path.join(tempDir, 'test.png')
+  const sharp = require('sharp')
+  await sharp({
+    create: {
+      width: 200,
+      height: 150,
+      channels: 3,
+      background: { r: 255, g: 0, b: 0 },
+    },
+  })
+    .png()
+    .toFile(testImagePath)
+})
+
+afterAll(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true })
+})
+
+beforeEach(() => {
+  adapter = createSharpThumbnailAdapter()
+})
+
+describe('generateImageThumbnail', () => {
+  it('generates thumbnail at target size', async () => {
+    const result = await adapter.generateImageThumbnail(testImagePath, 50)
+    expect(result.data.byteLength).toBeGreaterThan(0)
+    expect(result.mimeType).toBe('image/webp')
+
+    // Verify dimensions
+    const sharp = require('sharp')
+    const meta = await sharp(Buffer.from(result.data)).metadata()
+    expect(meta.width).toBeLessThanOrEqual(50)
+    expect(meta.height).toBeLessThanOrEqual(50)
+  })
+
+  it('outputs WebP format', async () => {
+    const result = await adapter.generateImageThumbnail(testImagePath, 50)
+    const buf = Buffer.from(result.data)
+    // WebP starts with RIFF....WEBP
+    expect(buf.slice(0, 4).toString()).toBe('RIFF')
+    expect(buf.slice(8, 12).toString()).toBe('WEBP')
+  })
+
+  it('does not enlarge beyond original size', async () => {
+    const result = await adapter.generateImageThumbnail(testImagePath, 1000)
+    const sharp = require('sharp')
+    const meta = await sharp(Buffer.from(result.data)).metadata()
+    expect(meta.width).toBeLessThanOrEqual(200)
+    expect(meta.height).toBeLessThanOrEqual(150)
+  })
+
+  it('handles file:// prefix', async () => {
+    const result = await adapter.generateImageThumbnail(`file://${testImagePath}`, 50)
+    expect(result.data.byteLength).toBeGreaterThan(0)
+  })
+})
+
+describe('generateImageThumbnails', () => {
+  it('returns Map with all requested sizes', async () => {
+    const sizes = [32, 64, 128]
+    const results = await adapter.generateImageThumbnails(testImagePath, sizes)
+    expect(results.size).toBe(3)
+    for (const size of sizes) {
+      const result = results.get(size)
+      expect(result).toBeDefined()
+      expect(result!.data.byteLength).toBeGreaterThan(0)
+      expect(result!.mimeType).toBe('image/webp')
+    }
+  })
+})
+
+describe('generateVideoThumbnail', () => {
+  it('throws with descriptive error', async () => {
+    await expect(adapter.generateVideoThumbnail(testImagePath, 50)).rejects.toThrow(
+      'Video thumbnails not supported',
+    )
+  })
+})

--- a/packages/node-adapters/test/uploader.test.ts
+++ b/packages/node-adapters/test/uploader.test.ts
@@ -1,0 +1,96 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { createNodeUploaderAdapters } from '../src/uploader'
+
+let tempDir: string
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sia-uploader-test-'))
+})
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true })
+})
+
+describe('createFileReader', () => {
+  const adapters = createNodeUploaderAdapters()
+
+  it('reads small file completely', async () => {
+    const filePath = path.join(tempDir, 'small.txt')
+    const content = 'hello world'
+    fs.writeFileSync(filePath, content)
+
+    const reader = adapters.createFileReader(filePath)
+    const chunks: ArrayBuffer[] = []
+    let chunk = await reader.read()
+    while (chunk.byteLength > 0) {
+      chunks.push(chunk)
+      chunk = await reader.read()
+    }
+
+    const combined = Buffer.concat(chunks.map((c) => Buffer.from(c)))
+    expect(combined.toString()).toBe(content)
+  })
+
+  it('reads large file in chunks', async () => {
+    const filePath = path.join(tempDir, 'large.bin')
+    const size = 256 * 1024 // 256KB, larger than 64KB chunk size
+    const data = Buffer.alloc(size, 0xab)
+    fs.writeFileSync(filePath, data)
+
+    const reader = adapters.createFileReader(filePath)
+    const chunks: ArrayBuffer[] = []
+    let chunk = await reader.read()
+    while (chunk.byteLength > 0) {
+      chunks.push(chunk)
+      chunk = await reader.read()
+    }
+
+    expect(chunks.length).toBeGreaterThan(1)
+    const combined = Buffer.concat(chunks.map((c) => Buffer.from(c)))
+    expect(combined.length).toBe(size)
+    expect(combined.equals(data)).toBe(true)
+  })
+
+  it('returns empty ArrayBuffer on EOF', async () => {
+    const filePath = path.join(tempDir, 'eof.txt')
+    fs.writeFileSync(filePath, 'x')
+
+    const reader = adapters.createFileReader(filePath)
+    await reader.read() // content
+    const eof = await reader.read()
+    expect(eof.byteLength).toBe(0)
+  })
+
+  it('handles empty file', async () => {
+    const filePath = path.join(tempDir, 'empty.txt')
+    fs.writeFileSync(filePath, '')
+
+    const reader = adapters.createFileReader(filePath)
+    const chunk = await reader.read()
+    expect(chunk.byteLength).toBe(0)
+  })
+
+  it('handles file:// prefix', async () => {
+    const filePath = path.join(tempDir, 'prefixed.txt')
+    fs.writeFileSync(filePath, 'data')
+
+    const reader = adapters.createFileReader(`file://${filePath}`)
+    const chunk = await reader.read()
+    expect(Buffer.from(chunk).toString()).toBe('data')
+  })
+})
+
+describe('progressScheduler', () => {
+  it('calls callback asynchronously', async () => {
+    const adapters = createNodeUploaderAdapters()
+    let called = false
+    adapters.progressScheduler!(() => {
+      called = true
+    })
+    expect(called).toBe(false)
+    await new Promise((r) => setTimeout(r, 10))
+    expect(called).toBe(true)
+  })
+})

--- a/packages/node-adapters/tsconfig.json
+++ b/packages/node-adapters/tsconfig.json
@@ -1,4 +1,11 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src"]
+  "compilerOptions": {
+    "paths": {
+      "@siafoundation/sia-storage": [
+        "../../node_modules/@siafoundation/sia-storage/dist/index.node.d.ts"
+      ]
+    }
+  },
+  "include": ["src", "test"]
 }


### PR DESCRIPTION
Adds Node/Bun implementations of core's adapter interfaces for the CLI / daemon (which will also power the desktop apps): bun:sqlite and better-sqlite3 backends, streaming file I/O for uploads, sharp thumbnails, mime sniffing, atomic JSON storage, and the ~/.siastorage data-dir layout. Each adapter has a unit test.
