### PR TITLE
feat(node-adapters): add cli daemon infrastructure

### DIFF
--- a/.changeset/node-adapters-daemon-infra.md
+++ b/.changeset/node-adapters-daemon-infra.md
@@ -1,0 +1,5 @@
+---
+node-adapters: minor
+---
+
+Add Unix socket IPC server/client, file-based process locking, and daemon state persistence.

--- a/packages/node-adapters/package.json
+++ b/packages/node-adapters/package.json
@@ -14,7 +14,10 @@
     "./uploader": "./src/uploader.ts",
     "./detectMimeType": "./src/detectMimeType.ts",
     "./thumbnail": "./src/thumbnail.ts",
-    "./bunDatabase": "./src/bunDatabase.ts"
+    "./bunDatabase": "./src/bunDatabase.ts",
+    "./lock": "./src/lock.ts",
+    "./ipc": "./src/ipc.ts",
+    "./state": "./src/state.ts"
   },
   "scripts": {
     "lint": "oxlint . && oxfmt --check .",

--- a/packages/node-adapters/src/index.ts
+++ b/packages/node-adapters/src/index.ts
@@ -8,3 +8,11 @@ export { createNodeFsIO } from './fsIO'
 export { createNodeUploaderAdapters } from './uploader'
 export { createNodeDetectMimeType } from './detectMimeType'
 export { createSharpThumbnailAdapter } from './thumbnail'
+
+// Daemon infrastructure
+export { acquireLock, isDaemonRunning, readDaemonPid } from './lock'
+export type { LockHandle } from './lock'
+export { startIpcServer, sendIpcCommand, connectToIpc } from './ipc'
+export type { IpcHandler, IpcServer } from './ipc'
+export { readState, writeState, removeState } from './state'
+export type { DaemonState } from './state'

--- a/packages/node-adapters/src/ipc.ts
+++ b/packages/node-adapters/src/ipc.ts
@@ -1,0 +1,135 @@
+import { logger } from '@siastorage/logger'
+import * as fs from 'fs'
+import * as net from 'net'
+
+export type IpcHandler = (method: string, params: Record<string, unknown>) => Promise<unknown>
+
+export type IpcServer = {
+  close: () => void
+}
+
+export function startIpcServer(sockPath: string, handler: IpcHandler): IpcServer {
+  // Remove stale socket file
+  try {
+    fs.unlinkSync(sockPath)
+  } catch {
+    // may not exist
+  }
+
+  const server = net.createServer((socket) => {
+    let buffer = ''
+
+    socket.on('data', (chunk) => {
+      buffer += chunk.toString()
+      const lines = buffer.split('\n')
+      buffer = lines.pop() ?? ''
+
+      for (const line of lines) {
+        if (!line.trim()) continue
+        handleMessage(line, socket, handler)
+      }
+    })
+
+    socket.on('error', () => {
+      // Client disconnected
+    })
+  })
+
+  server.listen(sockPath, () => {
+    logger.debug('ipc', 'server_listening', { path: sockPath })
+  })
+
+  server.on('error', (err) => {
+    logger.error('ipc', 'server_error', { error: err })
+  })
+
+  return {
+    close() {
+      server.close()
+      try {
+        fs.unlinkSync(sockPath)
+      } catch {
+        // may not exist
+      }
+    },
+  }
+}
+
+async function handleMessage(line: string, socket: net.Socket, handler: IpcHandler): Promise<void> {
+  try {
+    const { id, method, params } = JSON.parse(line)
+    try {
+      const result = await handler(method, params ?? {})
+      socket.write(`${JSON.stringify({ id, ok: true, result })}\n`)
+    } catch (e) {
+      socket.write(
+        `${JSON.stringify({
+          id,
+          ok: false,
+          error: e instanceof Error ? e.message : String(e),
+        })}\n`,
+      )
+    }
+  } catch {
+    socket.write(`${JSON.stringify({ ok: false, error: 'Invalid JSON' })}\n`)
+  }
+}
+
+export function connectToIpc(sockPath: string): Promise<net.Socket> {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection(sockPath, () => {
+      resolve(socket)
+    })
+    socket.on('error', reject)
+  })
+}
+
+export async function sendIpcCommand(
+  sockPath: string,
+  method: string,
+  params: Record<string, unknown> = {},
+  timeout = 30_000,
+): Promise<unknown> {
+  const socket = await connectToIpc(sockPath)
+  const id = `${Date.now()}-${Math.random()}`
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      socket.destroy()
+      reject(new Error(`IPC command '${method}' timed out after ${timeout}ms`))
+    }, timeout)
+
+    let buffer = ''
+
+    socket.on('data', (chunk) => {
+      buffer += chunk.toString()
+      const lines = buffer.split('\n')
+      buffer = lines.pop() ?? ''
+
+      for (const line of lines) {
+        if (!line.trim()) continue
+        try {
+          const response = JSON.parse(line)
+          if (response.id === id) {
+            clearTimeout(timer)
+            socket.end()
+            if (response.ok) {
+              resolve(response.result)
+            } else {
+              reject(new Error(response.error))
+            }
+          }
+        } catch {
+          // Ignore malformed response lines
+        }
+      }
+    })
+
+    socket.on('error', (err) => {
+      clearTimeout(timer)
+      reject(err)
+    })
+
+    socket.write(`${JSON.stringify({ id, method, params })}\n`)
+  })
+}

--- a/packages/node-adapters/src/lock.ts
+++ b/packages/node-adapters/src/lock.ts
@@ -1,0 +1,67 @@
+import * as fs from 'fs'
+
+export type LockHandle = {
+  fd: number
+  release: () => void
+}
+
+export function acquireLock(lockPath: string, pidPath: string): LockHandle | null {
+  try {
+    const fd = fs.openSync(lockPath, 'w')
+
+    try {
+      fs.ftruncateSync(fd)
+      fs.writeSync(fd, String(process.pid))
+      fs.fsyncSync(fd)
+
+      fs.writeFileSync(pidPath, String(process.pid))
+
+      return {
+        fd,
+        release() {
+          try {
+            fs.closeSync(fd)
+          } catch {
+            // fd may already be closed
+          }
+          try {
+            fs.unlinkSync(lockPath)
+          } catch {
+            // file may already be removed
+          }
+          try {
+            fs.unlinkSync(pidPath)
+          } catch {
+            // file may already be removed
+          }
+        },
+      }
+    } catch {
+      fs.closeSync(fd)
+      return null
+    }
+  } catch {
+    return null
+  }
+}
+
+export function isDaemonRunning(pidPath: string): boolean {
+  const pid = readDaemonPid(pidPath)
+  if (pid === null) return false
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function readDaemonPid(pidPath: string): number | null {
+  try {
+    const raw = fs.readFileSync(pidPath, 'utf-8').trim()
+    const pid = parseInt(raw, 10)
+    return Number.isNaN(pid) ? null : pid
+  } catch {
+    return null
+  }
+}

--- a/packages/node-adapters/src/state.ts
+++ b/packages/node-adapters/src/state.ts
@@ -1,0 +1,36 @@
+import * as fs from 'fs'
+
+/**
+ * Liveness breadcrumb the daemon writes to disk so a CLI client can
+ * answer "is the daemon alive and where do I reach it?" without opening
+ * a socket. App state (sync, uploads, etc.) is NOT written here — clients
+ * fetch it through the AppService IPC proxy instead.
+ */
+export type DaemonState = {
+  pid: number
+  startedAt: number
+  connected: boolean
+}
+
+export function readState(statePath: string): DaemonState | null {
+  try {
+    const raw = fs.readFileSync(statePath, 'utf-8')
+    const parsed = JSON.parse(raw)
+    if (typeof parsed !== 'object' || parsed === null) return null
+    return parsed as DaemonState
+  } catch {
+    return null
+  }
+}
+
+export function writeState(statePath: string, state: DaemonState): void {
+  fs.writeFileSync(statePath, JSON.stringify(state, null, 2))
+}
+
+export function removeState(statePath: string): void {
+  try {
+    fs.unlinkSync(statePath)
+  } catch {
+    // may not exist
+  }
+}

--- a/packages/node-adapters/test/ipc.test.ts
+++ b/packages/node-adapters/test/ipc.test.ts
@@ -1,0 +1,154 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { sendIpcCommand, startIpcServer } from '../src/ipc'
+import type { IpcServer } from '../src/ipc'
+
+let tempDir: string
+let sockPath: string
+let server: IpcServer | null
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sia-ipc-test-'))
+  sockPath = path.join(tempDir, 'test.sock')
+  server = null
+})
+
+afterEach(() => {
+  server?.close()
+  fs.rmSync(tempDir, { recursive: true, force: true })
+})
+
+function waitForServer(): Promise<void> {
+  return new Promise((r) => setTimeout(r, 50))
+}
+
+describe('IPC server and client', () => {
+  it('server starts and client can send command', async () => {
+    server = startIpcServer(sockPath, async (method) => {
+      return { echo: method }
+    })
+    await waitForServer()
+    const result = await sendIpcCommand(sockPath, 'test')
+    expect(result).toEqual({ echo: 'test' })
+  })
+
+  it('handler receives correct method and params', async () => {
+    let receivedMethod = ''
+    let receivedParams: Record<string, unknown> = {}
+
+    server = startIpcServer(sockPath, async (method, params) => {
+      receivedMethod = method
+      receivedParams = params
+      return 'ok'
+    })
+    await waitForServer()
+
+    await sendIpcCommand(sockPath, 'doSomething', { key: 'value', num: 42 })
+    expect(receivedMethod).toBe('doSomething')
+    expect(receivedParams).toEqual({ key: 'value', num: 42 })
+  })
+
+  it('returns handler result as ok: true', async () => {
+    server = startIpcServer(sockPath, async () => {
+      return { data: [1, 2, 3] }
+    })
+    await waitForServer()
+
+    const result = await sendIpcCommand(sockPath, 'test')
+    expect(result).toEqual({ data: [1, 2, 3] })
+  })
+
+  it('returns handler error as rejection', async () => {
+    server = startIpcServer(sockPath, async () => {
+      throw new Error('Something went wrong')
+    })
+    await waitForServer()
+
+    await expect(sendIpcCommand(sockPath, 'fail')).rejects.toThrow('Something went wrong')
+  })
+
+  it('handles multiple sequential commands', async () => {
+    let counter = 0
+    server = startIpcServer(sockPath, async () => {
+      counter++
+      return { count: counter }
+    })
+    await waitForServer()
+
+    const r1 = await sendIpcCommand(sockPath, 'inc')
+    const r2 = await sendIpcCommand(sockPath, 'inc')
+    const r3 = await sendIpcCommand(sockPath, 'inc')
+    expect(r1).toEqual({ count: 1 })
+    expect(r2).toEqual({ count: 2 })
+    expect(r3).toEqual({ count: 3 })
+  })
+
+  it('handles concurrent commands', async () => {
+    server = startIpcServer(sockPath, async (method) => {
+      await new Promise((r) => setTimeout(r, 10))
+      return { method }
+    })
+    await waitForServer()
+
+    const results = await Promise.all([
+      sendIpcCommand(sockPath, 'a'),
+      sendIpcCommand(sockPath, 'b'),
+      sendIpcCommand(sockPath, 'c'),
+    ])
+    expect(results).toEqual([{ method: 'a' }, { method: 'b' }, { method: 'c' }])
+  })
+
+  it('client times out if server does not respond', async () => {
+    const handlerRef: { resolve: (() => void) | null } = { resolve: null }
+    server = startIpcServer(sockPath, async () => {
+      await new Promise<void>((r) => {
+        handlerRef.resolve = r
+      })
+      return 'too late'
+    })
+    await waitForServer()
+
+    await expect(sendIpcCommand(sockPath, 'slow', {}, 100)).rejects.toThrow('timed out')
+    // Unblock the handler so the server can clean up
+    handlerRef.resolve?.()
+  })
+
+  it('client gets error if socket does not exist', async () => {
+    await expect(sendIpcCommand(sockPath, 'test')).rejects.toThrow()
+  })
+
+  it('server removes stale socket file on start', async () => {
+    fs.writeFileSync(sockPath, 'stale')
+    server = startIpcServer(sockPath, async () => 'ok')
+    await waitForServer()
+
+    const result = await sendIpcCommand(sockPath, 'test')
+    expect(result).toBe('ok')
+  })
+
+  it('close cleans up socket file', async () => {
+    server = startIpcServer(sockPath, async () => 'ok')
+    await waitForServer()
+    server.close()
+    server = null
+    expect(fs.existsSync(sockPath)).toBe(false)
+  })
+
+  it('server handles malformed JSON without crashing', async () => {
+    server = startIpcServer(sockPath, async () => 'ok')
+    await waitForServer()
+
+    // Send malformed JSON, then a valid command
+    const net = require('net')
+    const socket = net.createConnection(sockPath)
+    await new Promise<void>((r) => socket.on('connect', r))
+    socket.write('not json\n')
+    await new Promise((r) => setTimeout(r, 50))
+    socket.end()
+
+    // Server should still work
+    const result = await sendIpcCommand(sockPath, 'test')
+    expect(result).toBe('ok')
+  })
+})

--- a/packages/node-adapters/test/lock.test.ts
+++ b/packages/node-adapters/test/lock.test.ts
@@ -1,0 +1,93 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { acquireLock, isDaemonRunning, readDaemonPid } from '../src/lock'
+
+let tempDir: string
+let lockPath: string
+let pidPath: string
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sia-lock-test-'))
+  lockPath = path.join(tempDir, 'daemon.lock')
+  pidPath = path.join(tempDir, 'daemon.pid')
+})
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true })
+})
+
+describe('acquireLock', () => {
+  it('succeeds and returns handle with fd', () => {
+    const handle = acquireLock(lockPath, pidPath)
+    expect(handle).not.toBeNull()
+    expect(handle!.fd).toBeGreaterThanOrEqual(0)
+    handle!.release()
+  })
+
+  it('writes PID to pid file', () => {
+    const handle = acquireLock(lockPath, pidPath)
+    expect(handle).not.toBeNull()
+    const pid = fs.readFileSync(pidPath, 'utf-8').trim()
+    expect(parseInt(pid, 10)).toBe(process.pid)
+    handle!.release()
+  })
+
+  it('writes PID to lock file', () => {
+    const handle = acquireLock(lockPath, pidPath)
+    expect(handle).not.toBeNull()
+    const content = fs.readFileSync(lockPath, 'utf-8').trim()
+    expect(parseInt(content, 10)).toBe(process.pid)
+    handle!.release()
+  })
+})
+
+describe('release', () => {
+  it('removes lock and pid files', () => {
+    const handle = acquireLock(lockPath, pidPath)
+    expect(handle).not.toBeNull()
+    handle!.release()
+    expect(fs.existsSync(lockPath)).toBe(false)
+    expect(fs.existsSync(pidPath)).toBe(false)
+  })
+
+  it('is idempotent', () => {
+    const handle = acquireLock(lockPath, pidPath)
+    expect(handle).not.toBeNull()
+    handle!.release()
+    expect(() => handle!.release()).not.toThrow()
+  })
+})
+
+describe('isDaemonRunning', () => {
+  it('returns true when current process PID is in pid file', () => {
+    fs.writeFileSync(pidPath, String(process.pid))
+    expect(isDaemonRunning(pidPath)).toBe(true)
+  })
+
+  it('returns false when pid file does not exist', () => {
+    expect(isDaemonRunning(pidPath)).toBe(false)
+  })
+
+  it('returns false when PID is not a running process', () => {
+    // Use a PID that almost certainly doesn't exist
+    fs.writeFileSync(pidPath, '99999999')
+    expect(isDaemonRunning(pidPath)).toBe(false)
+  })
+})
+
+describe('readDaemonPid', () => {
+  it('returns PID from file', () => {
+    fs.writeFileSync(pidPath, '12345')
+    expect(readDaemonPid(pidPath)).toBe(12345)
+  })
+
+  it('returns null for missing file', () => {
+    expect(readDaemonPid(pidPath)).toBeNull()
+  })
+
+  it('returns null for corrupt file', () => {
+    fs.writeFileSync(pidPath, 'not a number')
+    expect(readDaemonPid(pidPath)).toBeNull()
+  })
+})

--- a/packages/node-adapters/test/state.test.ts
+++ b/packages/node-adapters/test/state.test.ts
@@ -1,0 +1,62 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import type { DaemonState } from '../src/state'
+import { readState, removeState, writeState } from '../src/state'
+
+let tempDir: string
+let statePath: string
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sia-state-test-'))
+  statePath = path.join(tempDir, 'state.json')
+})
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true })
+})
+
+describe('state', () => {
+  it('writeState then readState round-trips correctly', () => {
+    const state: DaemonState = {
+      pid: 12345,
+      startedAt: Date.now(),
+      connected: true,
+    }
+    writeState(statePath, state)
+    const read = readState(statePath)
+    expect(read).toEqual(state)
+  })
+
+  it('readState returns null for missing file', () => {
+    expect(readState(statePath)).toBeNull()
+  })
+
+  it('readState returns null for corrupt JSON', () => {
+    fs.writeFileSync(statePath, 'not json{{{')
+    expect(readState(statePath)).toBeNull()
+  })
+
+  it('removeState deletes the file', () => {
+    writeState(statePath, { pid: 1, startedAt: 0, connected: false })
+    removeState(statePath)
+    expect(fs.existsSync(statePath)).toBe(false)
+  })
+
+  it('removeState does not throw for missing file', () => {
+    expect(() => removeState(statePath)).not.toThrow()
+  })
+
+  it('state includes all fields', () => {
+    const state: DaemonState = {
+      pid: 1,
+      startedAt: 1000,
+      connected: false,
+    }
+    writeState(statePath, state)
+    const read = readState(statePath)
+    expect(read).toHaveProperty('pid', 1)
+    expect(read).toHaveProperty('startedAt', 1000)
+    expect(read).toHaveProperty('connected', false)
+  })
+})


### PR DESCRIPTION
Adds the sia daemon's runtime plumbing: a Unix-socket JSON-line IPC server for clients to reach it, a PID-based file lock with stale-process detection, and a ~/.siastorage/state.json file holding { pid, startedAt, connected } so clients can check daemon liveness without opening a socket.
