### PR TITLE
feat(node-adapters): add SDK wrapper, auth, and download adapters

### DIFF
--- a/.changeset/node-adapters-sdk-auth.md
+++ b/.changeset/node-adapters-sdk-auth.md
@@ -1,0 +1,5 @@
+---
+node-adapters: minor
+---
+
+Add SDK adapter with pinned objects and sealing, auth adapter with Builder pattern, and download adapter.

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "siastorage",
@@ -164,6 +163,7 @@
       "name": "@siastorage/node-adapters",
       "version": "0.0.1",
       "dependencies": {
+        "@siafoundation/sia-storage": "0.0.9",
         "@siastorage/core": "workspace:*",
         "@siastorage/logger": "workspace:*",
         "better-sqlite3": "12.6.2",
@@ -830,6 +830,18 @@
     "@react-navigation/native-stack": ["@react-navigation/native-stack@7.14.4", "", { "dependencies": { "@react-navigation/elements": "^2.9.10", "color": "^4.2.3", "sf-symbols-typescript": "^2.1.0", "warn-once": "^0.1.1" }, "peerDependencies": { "@react-navigation/native": "^7.1.33", "react": ">= 18.2.0", "react-native": "*", "react-native-safe-area-context": ">= 4.0.0", "react-native-screens": ">= 4.0.0" } }, "sha512-HFEnM5Q7JY3FmmiolD/zvgY+9sxZAyVGPZJoz7BdTvJmi1VHOdplf24YiH45mqeitlGnaOlvNT55rH4abHJ5eA=="],
 
     "@react-navigation/routers": ["@react-navigation/routers@7.5.3", "", { "dependencies": { "nanoid": "^3.3.11" } }, "sha512-1tJHg4KKRJuQ1/EvJxatrMef3NZXEPzwUIUZ3n1yJ2t7Q97siwRtbynRpQG9/69ebbtiZ8W3ScOZF/OmhvM4Rg=="],
+
+    "@siafoundation/sia-storage": ["@siafoundation/sia-storage@0.0.9", "", { "optionalDependencies": { "@siafoundation/sia-storage-darwin-arm64": "0.0.9", "@siafoundation/sia-storage-darwin-x64": "0.0.9", "@siafoundation/sia-storage-linux-arm64-gnu": "0.0.9", "@siafoundation/sia-storage-linux-x64-gnu": "0.0.9", "@siafoundation/sia-storage-win32-x64-msvc": "0.0.9" } }, "sha512-Cb4oWWdAltn9aC4g1utPK+BNmqBBbMIYIOLS37/dCChtIe35XPelXXKHO0ZZafej75f8okJ1DrG1bdxrzG/DgQ=="],
+
+    "@siafoundation/sia-storage-darwin-arm64": ["@siafoundation/sia-storage-darwin-arm64@0.0.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-t195gflM+1WX1PszyUBbwyQnkBjOKSIOtO70a3cNnR2d4kyAMPWzBV3jTWDajUE3ouWOD6Mof69C8BlpyN/+cA=="],
+
+    "@siafoundation/sia-storage-darwin-x64": ["@siafoundation/sia-storage-darwin-x64@0.0.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-e0F24QC04DRDbR/EROhag94h2LWT1PDRAeK/UYDhMgOdrsmimIrT72KWtblFG3vo885jq9/v8c75TqGwJ3AGCQ=="],
+
+    "@siafoundation/sia-storage-linux-arm64-gnu": ["@siafoundation/sia-storage-linux-arm64-gnu@0.0.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-QOoMXQjIXr9OAa/0bLz0dRqBQebJDhLbbfCkLIYm/yN7aGiMQSdFq3/jy5rZ9kgW4aJCsFzYjt8DaO6nK7jWtg=="],
+
+    "@siafoundation/sia-storage-linux-x64-gnu": ["@siafoundation/sia-storage-linux-x64-gnu@0.0.9", "", { "os": "linux", "cpu": "x64" }, "sha512-h0PnqAAkPBcszcszvDU+2+U+Rcvn7xxcnTZ6Bcw7Pvb6rf1qjvCi0G+3KdggdUCCp3W+YBj/X9FtVcmVyF95cQ=="],
+
+    "@siafoundation/sia-storage-win32-x64-msvc": ["@siafoundation/sia-storage-win32-x64-msvc@0.0.9", "", { "os": "win32", "cpu": "x64" }, "sha512-eAA2hA4UO+xXyq8kmC9tQ9gZmbnp+7sJA27kX/Xm9yVVGphAVO0kVtDjW6SUJ9Kj0G2tnP8jx83pHH9wVyY0WA=="],
 
     "@siastorage/benchmark": ["@siastorage/benchmark@workspace:apps/benchmark"],
 

--- a/packages/node-adapters/package.json
+++ b/packages/node-adapters/package.json
@@ -17,7 +17,10 @@
     "./bunDatabase": "./src/bunDatabase.ts",
     "./lock": "./src/lock.ts",
     "./ipc": "./src/ipc.ts",
-    "./state": "./src/state.ts"
+    "./state": "./src/state.ts",
+    "./sdk": "./src/sdk.ts",
+    "./auth": "./src/auth.ts",
+    "./download": "./src/download.ts"
   },
   "scripts": {
     "lint": "oxlint . && oxfmt --check .",
@@ -25,6 +28,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@siafoundation/sia-storage": "0.0.9",
     "@siastorage/core": "workspace:*",
     "@siastorage/logger": "workspace:*",
     "better-sqlite3": "12.6.2",

--- a/packages/node-adapters/src/auth.ts
+++ b/packages/node-adapters/src/auth.ts
@@ -1,0 +1,121 @@
+import { hexToUint8, uint8ToHex } from '@siastorage/core'
+import type { SdkAuthAdapters } from '@siastorage/core/adapters'
+import { logger } from '@siastorage/logger'
+import {
+  AppKey,
+  type AppMetadata,
+  Builder,
+  type Sdk,
+  generateRecoveryPhrase,
+  initSia,
+  setLogger,
+  validateRecoveryPhrase,
+} from '@siafoundation/sia-storage'
+
+export type NodeSdkAuthResult = {
+  adapters: SdkAuthAdapters
+  /**
+   * Returns the raw native SDK after a successful connect/register.
+   * Intended for `createNodeSdkAdapter(getLastSdk()!)` during daemon bootstrap.
+   */
+  getLastSdk(): Sdk | null
+}
+
+/** Parses the JSON contract used by `app.auth.builder.create(indexerURL, appMetaJson)`. */
+function parseAppMeta(json: string): AppMetadata {
+  const parsed = JSON.parse(json) as {
+    appID: string
+    name: string
+    description: string
+    serviceURL: string
+    callbackUrl?: string
+    logoUrl?: string
+  }
+  return {
+    id: Buffer.from(parsed.appID, 'hex'),
+    name: parsed.name,
+    description: parsed.description,
+    serviceUrl: parsed.serviceURL,
+    callbackUrl: parsed.callbackUrl,
+    logoUrl: parsed.logoUrl,
+  }
+}
+
+export function createNodeSdkAuthAdapter(): NodeSdkAuthResult {
+  let builder: Builder | null = null
+  let abortController: AbortController | null = null
+  let lastSdk: Sdk | null = null
+  let initialized = false
+
+  async function ensureInit() {
+    if (initialized) return
+    await initSia()
+    setLogger((message) => logger.debug('sdk', message), 'debug')
+    initialized = true
+  }
+
+  const adapters: SdkAuthAdapters = {
+    async createBuilder(indexerUrl: string, appMetaJson: string): Promise<void> {
+      await ensureInit()
+      builder = new Builder(indexerUrl, parseAppMeta(appMetaJson))
+    },
+
+    async requestConnection(): Promise<string> {
+      if (!builder) throw new Error('No builder instance')
+      await builder.requestConnection()
+      return builder.responseUrl()
+    },
+
+    async waitForApproval(): Promise<void> {
+      if (!builder) throw new Error('No builder instance')
+      abortController = new AbortController()
+      const abortPromise = new Promise<never>((_, reject) => {
+        abortController!.signal.addEventListener('abort', () => {
+          reject(new Error('Auth cancelled'))
+        })
+      })
+      try {
+        await Promise.race([builder.waitForApproval(), abortPromise])
+      } finally {
+        abortController = null
+      }
+    },
+
+    async connectWithKey(keyHex: string): Promise<boolean> {
+      if (!builder) throw new Error('No builder instance')
+      await ensureInit()
+      const appKey = new AppKey(Buffer.from(hexToUint8(keyHex)))
+      const sdk = await builder.connected(appKey)
+      if (!sdk) return false
+      lastSdk = sdk
+      return true
+    },
+
+    async register(mnemonic: string): Promise<string> {
+      if (!builder) throw new Error('No builder instance')
+      const sdk = await builder.register(mnemonic)
+      lastSdk = sdk
+      return uint8ToHex(new Uint8Array(sdk.appKey().export()))
+    },
+
+    generateRecoveryPhrase(): string {
+      return generateRecoveryPhrase()
+    },
+
+    validateRecoveryPhrase(phrase: string): void {
+      validateRecoveryPhrase(phrase)
+    },
+
+    cancelAuth(): void {
+      abortController?.abort()
+      abortController = null
+    },
+  }
+
+  return {
+    adapters,
+    getLastSdk() {
+      return lastSdk
+    },
+  }
+}

--- a/packages/node-adapters/src/download.ts
+++ b/packages/node-adapters/src/download.ts
@@ -1,0 +1,87 @@
+import type { DownloadLikeRef } from '@siastorage/core/adapters'
+import type { DownloadObjectAdapter } from '@siastorage/core/app'
+import { DOWNLOAD_MAX_INFLIGHT } from '@siastorage/core/config'
+import type { FsIOAdapter } from '@siastorage/core/services/fsFileUri'
+import { createWriteStream } from 'fs'
+import { unlink } from 'fs/promises'
+
+/**
+ * Streams a pull-based download into the file backing `fsIO.uri(file.id, file.type)`.
+ * Bounded memory: one chunk in flight at a time. Cleans up the partial file on error.
+ */
+async function streamToFs(
+  dl: DownloadLikeRef,
+  file: { id: string; type: string },
+  totalSize: number | undefined,
+  fsIO: FsIOAdapter,
+  signal: AbortSignal,
+  onProgress: (progress: number) => void,
+): Promise<void> {
+  await fsIO.ensureDirectory()
+  const targetPath = fsIO.uri(file.id, file.type)
+  const writeStream = createWriteStream(targetPath)
+  let bytesWritten = 0
+
+  try {
+    while (true) {
+      const chunk = await dl.read({ signal })
+      if (chunk.byteLength === 0) break
+      const buf = Buffer.from(chunk)
+      // Backpressure: if the kernel buffer is full, wait for drain so we
+      // don't accumulate chunks in JS memory faster than disk can absorb.
+      if (!writeStream.write(buf)) {
+        await new Promise<void>((resolve) => writeStream.once('drain', resolve))
+      }
+      bytesWritten += buf.byteLength
+      if (typeof totalSize === 'number' && totalSize > 0) {
+        onProgress(Math.min(1, bytesWritten / totalSize))
+      }
+    }
+    await new Promise<void>((resolve, reject) => {
+      writeStream.end((err: NodeJS.ErrnoException | null | undefined) =>
+        err ? reject(err) : resolve(),
+      )
+    })
+    onProgress(1)
+  } catch (e) {
+    writeStream.destroy()
+    await unlink(targetPath).catch(() => {})
+    throw e
+  } finally {
+    await dl.cancel().catch(() => {})
+  }
+}
+
+export function createNodeDownloadAdapter(deps: {
+  fsIO: FsIOAdapter
+  getAppKey: (indexerURL: string) => Promise<Uint8Array | null>
+}): DownloadObjectAdapter {
+  return {
+    async download({ file, object, sdk, onProgress, signal }) {
+      const keyBytes = await deps.getAppKey(object.indexerURL)
+      if (!keyBytes) throw new Error(`No AppKey found for indexer: ${object.indexerURL}`)
+
+      const appKey = sdk.openAppKey(keyBytes)
+      const pinnedObject = sdk.openPinnedObject(appKey, object)
+
+      const dl = await sdk.download(pinnedObject, {
+        maxInflight: DOWNLOAD_MAX_INFLIGHT,
+        offset: BigInt(0),
+        length: undefined,
+      })
+
+      await streamToFs(dl, file, file.size, deps.fsIO, signal, onProgress)
+    },
+
+    async downloadFromShareUrl({ file, url, sdk, onProgress, signal }) {
+      const sharedObject = await sdk.sharedObject(url)
+      const dl = await sdk.download(sharedObject, {
+        maxInflight: DOWNLOAD_MAX_INFLIGHT,
+        offset: BigInt(0),
+        length: undefined,
+      })
+
+      await streamToFs(dl, file, undefined, deps.fsIO, signal, onProgress)
+    },
+  }
+}

--- a/packages/node-adapters/src/index.ts
+++ b/packages/node-adapters/src/index.ts
@@ -16,3 +16,9 @@ export { startIpcServer, sendIpcCommand, connectToIpc } from './ipc'
 export type { IpcHandler, IpcServer } from './ipc'
 export { readState, writeState, removeState } from './state'
 export type { DaemonState } from './state'
+
+// SDK integration
+export { createNodeSdkAdapter } from './sdk'
+export { createNodeSdkAuthAdapter } from './auth'
+export type { NodeSdkAuthResult } from './auth'
+export { createNodeDownloadAdapter } from './download'

--- a/packages/node-adapters/src/sdk.ts
+++ b/packages/node-adapters/src/sdk.ts
@@ -1,0 +1,368 @@
+import {
+  AddressProtocol,
+  type Account,
+  type AccountApp,
+  type AppKeyRef,
+  type DownloadLikeRef,
+  type DownloadOptions,
+  type Host,
+  type ObjectEvent,
+  type ObjectsCursor,
+  type PackedUploadRef,
+  type PinnedObjectRef,
+  type Reader,
+  type SdkAdapter,
+  type SealedObjectRef,
+  type ShardProgress,
+  type UploadOptions,
+} from '@siastorage/core/adapters'
+import type { LocalObject } from '@siastorage/core/encoding/localObject'
+import {
+  AppKey,
+  PinnedObject,
+  type PackedUpload,
+  type Sdk,
+  type SealedObject,
+  type ShardProgress as NativeShardProgress,
+} from '@siafoundation/sia-storage'
+
+// WeakMaps recover the native handle backing a wrapped ref. WeakMap means
+// when the ref is GC'd, the entry clears automatically — no manual cleanup.
+const nativePinnedObjects = new WeakMap<PinnedObjectRef, PinnedObject>()
+const nativeAppKeys = new WeakMap<AppKeyRef, AppKey>()
+
+function toArrayBuffer(buf: Uint8Array): ArrayBuffer {
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer
+}
+
+function castShardProgress(p: NativeShardProgress): ShardProgress {
+  return {
+    hostKey: p.hostKey,
+    shardSize: BigInt(p.shardSize),
+    shardIndex: p.shardIndex,
+    slabIndex: p.slabIndex,
+    elapsedMs: BigInt(p.elapsedMs),
+  }
+}
+
+function bridgeShardCallback(
+  cb: { progress: (p: ShardProgress) => void } | undefined,
+): ((p: NativeShardProgress) => void) | undefined {
+  if (!cb) return undefined
+  return (p) => cb.progress(castShardProgress(p))
+}
+
+function readerToReadableStream(reader: Reader): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    async pull(controller) {
+      const chunk = await reader.read()
+      if (chunk.byteLength === 0) controller.close()
+      else controller.enqueue(new Uint8Array(chunk))
+    },
+  })
+}
+
+function readableStreamToDownloadLikeRef(stream: ReadableStream<Uint8Array>): DownloadLikeRef {
+  const reader = stream.getReader()
+  return {
+    async read(control) {
+      if (control?.signal.aborted) {
+        await reader.cancel().catch(() => {})
+        throw new Error('Download aborted')
+      }
+      const { value, done } = await reader.read()
+      if (done || !value) return new ArrayBuffer(0)
+      return value.buffer.slice(
+        value.byteOffset,
+        value.byteOffset + value.byteLength,
+      ) as ArrayBuffer
+    },
+    async cancel() {
+      await reader.cancel().catch(() => {})
+    },
+  }
+}
+
+async function consumeStreamToBuffer(stream: ReadableStream<Uint8Array>): Promise<ArrayBuffer> {
+  const reader = stream.getReader()
+  const chunks: Uint8Array[] = []
+  let total = 0
+  try {
+    while (true) {
+      const { value, done } = await reader.read()
+      if (done) break
+      chunks.push(value)
+      total += value.byteLength
+    }
+  } finally {
+    await reader.cancel().catch(() => {})
+  }
+  const combined = new Uint8Array(total)
+  let offset = 0
+  for (const c of chunks) {
+    combined.set(c, offset)
+    offset += c.byteLength
+  }
+  return combined.buffer.slice(0, total) as ArrayBuffer
+}
+
+function localObjectToSealedObject(object: LocalObject): SealedObject {
+  return {
+    id: object.id,
+    encryptedDataKey: Buffer.from(new Uint8Array(object.encryptedDataKey)),
+    encryptedMetadataKey: Buffer.from(new Uint8Array(object.encryptedMetadataKey)),
+    slabs: object.slabs.map((s) => ({
+      encryptionKey: Buffer.from(new Uint8Array(s.encryptionKey)),
+      minShards: s.minShards,
+      sectors: s.sectors,
+      offset: s.offset,
+      length: s.length,
+    })),
+    encryptedMetadata: Buffer.from(new Uint8Array(object.encryptedMetadata)),
+    dataSignature: Buffer.from(new Uint8Array(object.dataSignature)),
+    metadataSignature: Buffer.from(new Uint8Array(object.metadataSignature)),
+    createdAt: object.createdAt,
+    updatedAt: object.updatedAt,
+  }
+}
+
+function requireNativeAppKey(ref: AppKeyRef, op: string): AppKey {
+  const native = nativeAppKeys.get(ref)
+  if (!native) throw new Error(`Cannot ${op}: AppKey was not created by this adapter`)
+  return native
+}
+
+function requireNativePinnedObject(ref: PinnedObjectRef): PinnedObject {
+  const native = nativePinnedObjects.get(ref)
+  if (!native) throw new Error('PinnedObject was not created by this adapter')
+  return native
+}
+
+function nativeProtocolToEnum(protocol: string): AddressProtocol {
+  if (protocol === 'SiaMux') return AddressProtocol.SiaMux
+  if (protocol === 'Quic') return AddressProtocol.Quic
+  throw new Error(`Unknown AddressProtocol: ${protocol}`)
+}
+
+function wrapAppKey(key: AppKey): AppKeyRef {
+  const ref: AppKeyRef = {
+    export_() {
+      return toArrayBuffer(key.export())
+    },
+    publicKey() {
+      return key.publicKey()
+    },
+    sign(message: ArrayBuffer) {
+      return toArrayBuffer(key.sign(Buffer.from(message)))
+    },
+    verifySignature(message: ArrayBuffer, signature: ArrayBuffer) {
+      return key.verifySignature(Buffer.from(message), Buffer.from(signature))
+    },
+  }
+  nativeAppKeys.set(ref, key)
+  return ref
+}
+
+function wrapPinnedObject(obj: PinnedObject): PinnedObjectRef {
+  const ref: PinnedObjectRef = {
+    id() {
+      return obj.id()
+    },
+    metadata() {
+      return toArrayBuffer(obj.metadata())
+    },
+    updateMetadata(metadata: ArrayBuffer) {
+      obj.updateMetadata(Buffer.from(metadata))
+    },
+    size() {
+      return obj.size()
+    },
+    encodedSize() {
+      return obj.encodedSize()
+    },
+    seal(appKey: AppKeyRef): SealedObjectRef {
+      const nativeKey = requireNativeAppKey(appKey, 'seal')
+      const sealed = obj.seal(nativeKey)
+      return {
+        id: sealed.id,
+        encryptedDataKey: toArrayBuffer(sealed.encryptedDataKey),
+        encryptedMetadataKey: toArrayBuffer(sealed.encryptedMetadataKey),
+        slabs: sealed.slabs.map((s) => ({
+          encryptionKey: toArrayBuffer(s.encryptionKey),
+          minShards: s.minShards,
+          sectors: s.sectors,
+          offset: s.offset,
+          length: s.length,
+        })),
+        encryptedMetadata: toArrayBuffer(sealed.encryptedMetadata),
+        dataSignature: toArrayBuffer(sealed.dataSignature),
+        metadataSignature: toArrayBuffer(sealed.metadataSignature),
+        createdAt: sealed.createdAt,
+        updatedAt: sealed.updatedAt,
+      }
+    },
+    slabs() {
+      return obj.slabs().map((s) => ({
+        encryptionKey: toArrayBuffer(s.encryptionKey),
+        minShards: s.minShards,
+        sectors: s.sectors,
+        offset: s.offset,
+        length: s.length,
+      }))
+    },
+    createdAt() {
+      return obj.createdAt()
+    },
+    updatedAt() {
+      return obj.updatedAt()
+    },
+  }
+  nativePinnedObjects.set(ref, obj)
+  return ref
+}
+
+function wrapPackedUpload(packed: PackedUpload): PackedUploadRef {
+  return {
+    async add(reader: Reader): Promise<bigint> {
+      return packed.add(readerToReadableStream(reader))
+    },
+    async cancel(): Promise<void> {
+      await packed.cancel()
+    },
+    async finalize(): Promise<PinnedObjectRef[]> {
+      const objects = await packed.finalize()
+      return objects.map(wrapPinnedObject)
+    },
+    length() {
+      return packed.length()
+    },
+    remaining() {
+      return packed.remaining()
+    },
+    slabs() {
+      return packed.slabs()
+    },
+  }
+}
+
+export function createNodeSdkAdapter(sdk: Sdk): SdkAdapter {
+  return {
+    async objectEvents(cursor: ObjectsCursor | undefined, limit: number): Promise<ObjectEvent[]> {
+      const events = await sdk.objectEvents(cursor, limit)
+      return events.map((e) => ({
+        id: e.id,
+        deleted: e.deleted || undefined,
+        updatedAt: e.updatedAt,
+        object: e.object ? wrapPinnedObject(e.object) : undefined,
+      }))
+    },
+
+    async updateObjectMetadata(pinnedObject: PinnedObjectRef): Promise<void> {
+      await sdk.updateObjectMetadata(requireNativePinnedObject(pinnedObject))
+    },
+
+    async download(
+      pinnedObject: PinnedObjectRef,
+      options: DownloadOptions,
+    ): Promise<DownloadLikeRef> {
+      const native = requireNativePinnedObject(pinnedObject)
+      const stream = sdk.download(native, {
+        maxInflight: options.maxInflight,
+        offset: options.offset,
+        length: options.length,
+        onShardDownloaded: bridgeShardCallback(options.shardDownloaded),
+      })
+      return readableStreamToDownloadLikeRef(stream)
+    },
+
+    async uploadPacked(options: UploadOptions): Promise<PackedUploadRef> {
+      const packed = sdk.uploadPacked({
+        maxInflight: options.maxInflight,
+        dataShards: options.dataShards,
+        parityShards: options.parityShards,
+        onShardUploaded: bridgeShardCallback(options.shardUploaded),
+      })
+      return wrapPackedUpload(packed)
+    },
+
+    async pinObject(pinnedObject: PinnedObjectRef): Promise<void> {
+      await sdk.pinObject(requireNativePinnedObject(pinnedObject))
+    },
+
+    async deleteObject(objectId: string): Promise<void> {
+      await sdk.deleteObject(objectId)
+    },
+
+    async getPinnedObject(objectId: string): Promise<PinnedObjectRef> {
+      const obj = await sdk.object(objectId)
+      return wrapPinnedObject(obj)
+    },
+
+    async sharedObject(url: string): Promise<PinnedObjectRef> {
+      const obj = await sdk.sharedObject(url)
+      return wrapPinnedObject(obj)
+    },
+
+    shareObject(object: PinnedObjectRef, validUntil: Date): string {
+      return sdk.shareObject(requireNativePinnedObject(object), validUntil)
+    },
+
+    openAppKey(bytes: Uint8Array): AppKeyRef {
+      return wrapAppKey(new AppKey(Buffer.from(bytes)))
+    },
+
+    openPinnedObject(appKey: AppKeyRef, object: LocalObject): PinnedObjectRef {
+      const nativeKey = requireNativeAppKey(appKey, 'openPinnedObject')
+      const sealed = localObjectToSealedObject(object)
+      return wrapPinnedObject(PinnedObject.open(nativeKey, sealed))
+    },
+
+    appKey(): AppKeyRef {
+      return wrapAppKey(sdk.appKey())
+    },
+
+    /**
+     * Returns the entire object as an ArrayBuffer. Defeats streaming —
+     * only use for small objects (e.g., share-URL metadata fetches).
+     */
+    async downloadByObjectId(objectId: string): Promise<ArrayBuffer> {
+      const obj = await sdk.object(objectId)
+      const stream = sdk.download(obj, { maxInflight: 1, offset: BigInt(0), length: undefined })
+      return consumeStreamToBuffer(stream)
+    },
+
+    async hosts(): Promise<Host[]> {
+      const hosts = await sdk.hosts()
+      return hosts.map((h) => ({
+        publicKey: h.publicKey,
+        addresses: h.addresses.map((a) => ({
+          protocol: nativeProtocolToEnum(a.protocol),
+          address: a.address,
+        })),
+        countryCode: h.countryCode,
+        latitude: h.latitude,
+        longitude: h.longitude,
+        goodForUpload: h.goodForUpload,
+      }))
+    },
+
+    async account(): Promise<Account> {
+      const info = await sdk.account()
+      const app: AccountApp = {
+        id: info.app.id,
+        description: info.app.description,
+        serviceUrl: info.app.serviceUrl,
+        logoUrl: info.app.logoUrl,
+      }
+      return {
+        accountKey: info.accountKey,
+        maxPinnedData: info.maxPinnedData,
+        remainingStorage: info.remainingStorage,
+        pinnedData: info.pinnedData,
+        pinnedSize: info.pinnedSize,
+        app,
+        lastUsed: info.lastUsed,
+      }
+    },
+  }
+}

--- a/packages/node-adapters/test/auth.test.ts
+++ b/packages/node-adapters/test/auth.test.ts
@@ -1,0 +1,196 @@
+import { createNodeSdkAuthAdapter } from '../src/auth'
+
+// Mock @siafoundation/sia-storage module for testing
+jest.mock('@siafoundation/sia-storage', () => {
+  const mockSdk = {
+    appKey: () => ({
+      export: () => Buffer.alloc(32),
+      publicKey: () => 'ed25519:test',
+      sign: (_msg: Buffer) => Buffer.alloc(64),
+      verifySignature: () => true,
+    }),
+    _native: {},
+  }
+
+  let approvalResolve: (() => void) | null = null
+  let connectResult: any = mockSdk
+
+  const MockBuilder = jest.fn().mockImplementation(() => ({
+    requestConnection: jest.fn().mockResolvedValue(undefined),
+    responseUrl: jest.fn().mockReturnValue('https://sia.storage/approve?token=abc'),
+    waitForApproval: jest.fn().mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          approvalResolve = resolve
+        }),
+    ),
+    connected: jest.fn().mockImplementation(async () => connectResult),
+    register: jest.fn().mockResolvedValue(mockSdk),
+  }))
+
+  return {
+    Builder: MockBuilder,
+    AppKey: jest.fn().mockImplementation((seed: Buffer) => ({
+      export: () => seed,
+      publicKey: () => 'ed25519:test',
+      _native: {},
+    })),
+    initSia: jest.fn().mockResolvedValue(undefined),
+    setLogger: jest.fn(),
+    generateRecoveryPhrase: jest
+      .fn()
+      .mockReturnValue(
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+      ),
+    validateRecoveryPhrase: jest.fn(),
+    // Expose test helpers
+    __test__: {
+      resolveApproval: () => approvalResolve?.(),
+      setConnectResult: (result: any) => {
+        connectResult = result
+      },
+    },
+  }
+})
+
+const siaStorage = require('@siafoundation/sia-storage')
+
+describe('createNodeSdkAuthAdapter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    siaStorage.__test__.setConnectResult({
+      appKey: () => ({
+        export: () => new Uint8Array(32),
+        publicKey: () => 'ed25519:test',
+      }),
+      _native: {},
+    })
+  })
+
+  it('createBuilder parses appMetaJson and creates builder', async () => {
+    const { adapters } = createNodeSdkAuthAdapter()
+    await adapters.createBuilder(
+      'https://sia.storage',
+      JSON.stringify({
+        appID: '00'.repeat(32),
+        name: 'Test',
+        description: 'Test app',
+        serviceURL: 'https://test.com',
+      }),
+    )
+    expect(siaStorage.Builder).toHaveBeenCalledWith(
+      'https://sia.storage',
+      expect.objectContaining({
+        name: 'Test',
+        description: 'Test app',
+        serviceUrl: 'https://test.com',
+      }),
+    )
+  })
+
+  it('requestConnection returns approval URL', async () => {
+    const { adapters } = createNodeSdkAuthAdapter()
+    await adapters.createBuilder(
+      'https://sia.storage',
+      JSON.stringify({
+        appID: '00'.repeat(32),
+        name: 'Test',
+        description: 'Test',
+        serviceURL: 'https://test.com',
+      }),
+    )
+    const url = await adapters.requestConnection()
+    expect(url).toBe('https://sia.storage/approve?token=abc')
+  })
+
+  it('connectWithKey returns true when connected', async () => {
+    const { adapters, getLastSdk } = createNodeSdkAuthAdapter()
+    await adapters.createBuilder(
+      'https://sia.storage',
+      JSON.stringify({
+        appID: '00'.repeat(32),
+        name: 'Test',
+        description: 'Test',
+        serviceURL: 'https://test.com',
+      }),
+    )
+    const connected = await adapters.connectWithKey('ab'.repeat(32))
+    expect(connected).toBe(true)
+    expect(getLastSdk()).not.toBeNull()
+  })
+
+  it('connectWithKey returns false when not connected', async () => {
+    siaStorage.__test__.setConnectResult(null)
+    const { adapters, getLastSdk } = createNodeSdkAuthAdapter()
+    await adapters.createBuilder(
+      'https://sia.storage',
+      JSON.stringify({
+        appID: '00'.repeat(32),
+        name: 'Test',
+        description: 'Test',
+        serviceURL: 'https://test.com',
+      }),
+    )
+    const connected = await adapters.connectWithKey('ab'.repeat(32))
+    expect(connected).toBe(false)
+    expect(getLastSdk()).toBeNull()
+  })
+
+  it('register returns appKeyHex and stashes sdk', async () => {
+    const { adapters, getLastSdk } = createNodeSdkAuthAdapter()
+    await adapters.createBuilder(
+      'https://sia.storage',
+      JSON.stringify({
+        appID: '00'.repeat(32),
+        name: 'Test',
+        description: 'Test',
+        serviceURL: 'https://test.com',
+      }),
+    )
+    const hex = await adapters.register(
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    )
+    expect(typeof hex).toBe('string')
+    expect(hex.length).toBe(64) // 32 bytes as hex
+    expect(getLastSdk()).not.toBeNull()
+  })
+
+  it('generateRecoveryPhrase returns 12-word phrase', () => {
+    const { adapters } = createNodeSdkAuthAdapter()
+    const phrase = adapters.generateRecoveryPhrase()
+    expect(typeof phrase).toBe('string')
+    const words = (phrase as string).split(' ')
+    expect(words.length).toBe(12)
+  })
+
+  it('validateRecoveryPhrase delegates to sia-storage', () => {
+    const { adapters } = createNodeSdkAuthAdapter()
+    adapters.validateRecoveryPhrase('test phrase')
+    expect(siaStorage.validateRecoveryPhrase).toHaveBeenCalledWith('test phrase')
+  })
+
+  it('cancelAuth aborts pending waitForApproval', async () => {
+    const { adapters } = createNodeSdkAuthAdapter()
+    await adapters.createBuilder(
+      'https://sia.storage',
+      JSON.stringify({
+        appID: '00'.repeat(32),
+        name: 'Test',
+        description: 'Test',
+        serviceURL: 'https://test.com',
+      }),
+    )
+
+    const waitPromise = adapters.waitForApproval()
+    adapters.cancelAuth()
+    await expect(waitPromise).rejects.toThrow('Auth cancelled')
+  })
+
+  it('throws if no builder instance', async () => {
+    const { adapters } = createNodeSdkAuthAdapter()
+    await expect(adapters.requestConnection()).rejects.toThrow('No builder instance')
+    await expect(adapters.waitForApproval()).rejects.toThrow('No builder instance')
+    await expect(adapters.connectWithKey('ab'.repeat(32))).rejects.toThrow('No builder instance')
+    await expect(adapters.register('test')).rejects.toThrow('No builder instance')
+  })
+})

--- a/packages/node-adapters/test/sdk.test.ts
+++ b/packages/node-adapters/test/sdk.test.ts
@@ -1,0 +1,291 @@
+import { AddressProtocol } from '@siastorage/core/adapters'
+import { createNodeSdkAdapter } from '../src/sdk'
+
+// Mock sia-storage types that mirror the real classes
+function createMockAppKey() {
+  const seed = Buffer.alloc(32, 0xab)
+  return {
+    publicKey: () => 'ed25519:abcdef0123456789',
+    sign: (msg: Uint8Array) => Buffer.from([...msg].reverse()),
+    verifySignature: (_msg: Uint8Array, _sig: Uint8Array) => true,
+    export: () => new Uint8Array(seed),
+    _native: {} as any,
+  }
+}
+
+function createMockPinnedObject(id = 'obj-1') {
+  const metadata = Buffer.from(JSON.stringify({ name: 'test.txt' }))
+  return {
+    id: () => id,
+    size: () => BigInt(1024),
+    encodedSize: () => BigInt(2048),
+    metadata: () => new Uint8Array(metadata),
+    updateMetadata: jest.fn(),
+    seal: (appKey: any) => ({
+      id,
+      encryptedDataKey: Buffer.alloc(32),
+      encryptedMetadataKey: Buffer.alloc(32),
+      slabs: [
+        {
+          encryptionKey: Buffer.alloc(32),
+          minShards: 10,
+          sectors: [{ root: 'abc', hostKey: 'host1' }],
+          offset: 0,
+          length: 4096,
+        },
+      ],
+      encryptedMetadata: Buffer.alloc(16),
+      dataSignature: Buffer.alloc(64),
+      metadataSignature: Buffer.alloc(64),
+      createdAt: new Date('2024-01-01'),
+      updatedAt: new Date('2024-01-02'),
+    }),
+    slabs: () => [
+      {
+        encryptionKey: Buffer.alloc(32),
+        minShards: 10,
+        sectors: [{ root: 'abc', hostKey: 'host1' }],
+        offset: 0,
+        length: 4096,
+      },
+    ],
+    createdAt: () => new Date('2024-01-01'),
+    updatedAt: () => new Date('2024-01-02'),
+    _native: {} as any,
+  }
+}
+
+function createMockSdk() {
+  const appKey = createMockAppKey()
+  const pinnedObj = createMockPinnedObject()
+
+  return {
+    appKey: () => appKey,
+    objectEvents: jest.fn(async () => [
+      {
+        id: 'evt-1',
+        deleted: false,
+        updatedAt: new Date('2024-01-01'),
+        object: pinnedObj,
+      },
+      {
+        id: 'evt-2',
+        deleted: true,
+        updatedAt: new Date('2024-01-02'),
+        object: null,
+      },
+    ]),
+    updateObjectMetadata: jest.fn(async () => {}),
+    download: jest.fn((_obj: any, _opts: any) => {
+      // New SDK shape: returns a ReadableStream of bytes
+      const data = Buffer.from('downloaded data')
+      return new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array(data))
+          controller.close()
+        },
+      })
+    }),
+    uploadPacked: jest.fn((_opts: any) => ({
+      add: jest.fn(async (stream: ReadableStream<Uint8Array>) => {
+        const reader = stream.getReader()
+        let total = 0
+        while (true) {
+          const { value, done } = await reader.read()
+          if (done) break
+          total += value.byteLength
+        }
+        return BigInt(total)
+      }),
+      cancel: jest.fn(async () => {}),
+      finalize: jest.fn(async () => [pinnedObj]),
+      length: () => BigInt(100),
+      remaining: () => BigInt(50),
+      slabs: () => BigInt(1),
+    })),
+    pinObject: jest.fn(async () => {}),
+    deleteObject: jest.fn(async () => {}),
+    object: jest.fn(async () => pinnedObj),
+    shareObject: jest.fn(() => 'https://share.example.com/abc'),
+    sharedObject: jest.fn(async () => pinnedObj),
+    hosts: jest.fn(async () => [
+      {
+        publicKey: 'host-pk-1',
+        addresses: [
+          { protocol: 'SiaMux' as const, address: '1.2.3.4:9981' },
+          { protocol: 'Quic' as const, address: '1.2.3.4:9982' },
+        ],
+        countryCode: 'US',
+        latitude: 37.7,
+        longitude: -122.4,
+        goodForUpload: true,
+      },
+    ]),
+    account: jest.fn(async () => ({
+      accountKey: 'acct-key-1',
+      maxPinnedData: BigInt(1_000_000_000),
+      remainingStorage: BigInt(500_000_000),
+      pinnedData: BigInt(500_000_000),
+      pinnedSize: BigInt(600_000_000),
+      ready: true,
+      app: {
+        id: 'app-1',
+        name: 'TestApp',
+        description: 'Test application',
+        serviceUrl: 'https://test.example.com',
+        logoUrl: 'https://test.example.com/logo.png',
+      },
+      lastUsed: new Date('2024-06-01'),
+    })),
+    _native: {} as any,
+  }
+}
+
+describe('createNodeSdkAdapter', () => {
+  it('appKey returns wrapped AppKeyRef', () => {
+    const mockSdk = createMockSdk()
+    const adapter = createNodeSdkAdapter(mockSdk as any)
+    const key = adapter.appKey()
+    expect(key.publicKey()).toBe('ed25519:abcdef0123456789')
+    expect(key.export_()).toBeInstanceOf(ArrayBuffer)
+    expect(key.export_().byteLength).toBe(32)
+  })
+
+  it('appKey sign/verify converts between ArrayBuffer and Uint8Array', () => {
+    const mockSdk = createMockSdk()
+    const adapter = createNodeSdkAdapter(mockSdk as any)
+    const key = adapter.appKey()
+    const message = new ArrayBuffer(4)
+    new Uint8Array(message).set([1, 2, 3, 4])
+    const sig = key.sign(message)
+    expect(sig).toBeInstanceOf(ArrayBuffer)
+    expect(key.verifySignature(message, sig)).toBe(true)
+  })
+
+  it('objectEvents maps events correctly', async () => {
+    const mockSdk = createMockSdk()
+    const adapter = createNodeSdkAdapter(mockSdk as any)
+    const events = await adapter.objectEvents(undefined, 100)
+    expect(events).toHaveLength(2)
+    expect(events[0].id).toBe('evt-1')
+    expect(events[0].object).toBeDefined()
+    expect(events[0].object!.id()).toBe('obj-1')
+    expect(events[1].id).toBe('evt-2')
+    expect(events[1].deleted).toBe(true)
+    expect(events[1].object).toBeUndefined()
+  })
+
+  it('download returns a DownloadLikeRef yielding ArrayBuffer chunks', async () => {
+    const mockSdk = createMockSdk()
+    const adapter = createNodeSdkAdapter(mockSdk as any)
+
+    // First get a pinned object through the adapter so it's registered in WeakMap
+    const obj = await adapter.getPinnedObject('test')
+    const dl = await adapter.download(obj, {
+      maxInflight: 1,
+      offset: BigInt(0),
+      length: undefined,
+    })
+    const chunks: ArrayBuffer[] = []
+    while (true) {
+      const chunk = await dl.read()
+      if (chunk.byteLength === 0) break
+      chunks.push(chunk)
+    }
+    await dl.cancel()
+    expect(chunks.length).toBe(1)
+    expect(chunks[0]).toBeInstanceOf(ArrayBuffer)
+    expect(Buffer.from(chunks[0]).toString()).toBe('downloaded data')
+  })
+
+  it('uploadPacked passes options correctly', async () => {
+    const mockSdk = createMockSdk()
+    const adapter = createNodeSdkAdapter(mockSdk as any)
+    const packed = await adapter.uploadPacked({
+      maxInflight: 10,
+      dataShards: 10,
+      parityShards: 3,
+    })
+    expect(packed.length()).toBe(BigInt(100))
+    expect(packed.remaining()).toBe(BigInt(50))
+    expect(packed.slabs()).toBe(BigInt(1))
+  })
+
+  it('uploadPacked.finalize returns wrapped PinnedObjectRef array', async () => {
+    const mockSdk = createMockSdk()
+    const adapter = createNodeSdkAdapter(mockSdk as any)
+    const packed = await adapter.uploadPacked({
+      maxInflight: 10,
+      dataShards: 10,
+      parityShards: 3,
+    })
+    const objects = await packed.finalize()
+    expect(objects).toHaveLength(1)
+    expect(objects[0].id()).toBe('obj-1')
+    expect(objects[0].metadata()).toBeInstanceOf(ArrayBuffer)
+  })
+
+  it('hosts maps protocol strings to AddressProtocol enum', async () => {
+    const mockSdk = createMockSdk()
+    const adapter = createNodeSdkAdapter(mockSdk as any)
+    const hosts = await adapter.hosts()
+    expect(hosts).toHaveLength(1)
+    expect(hosts[0].publicKey).toBe('host-pk-1')
+    expect(hosts[0].addresses[0].protocol).toBe(AddressProtocol.SiaMux)
+    expect(hosts[0].addresses[1].protocol).toBe(AddressProtocol.Quic)
+  })
+
+  it('account maps AccountInfo to Account (drops ready)', async () => {
+    const mockSdk = createMockSdk()
+    const adapter = createNodeSdkAdapter(mockSdk as any)
+    const account = await adapter.account()
+    expect(account.accountKey).toBe('acct-key-1')
+    expect(account.maxPinnedData).toBe(BigInt(1_000_000_000))
+    expect(account.app.id).toBe('app-1')
+    expect(account.app.description).toBe('Test application')
+    expect((account as any).ready).toBeUndefined()
+  })
+
+  it('downloadByObjectId concatenates chunks to single ArrayBuffer', async () => {
+    const mockSdk = createMockSdk()
+    const adapter = createNodeSdkAdapter(mockSdk as any)
+    const data = await adapter.downloadByObjectId('obj-1')
+    expect(data).toBeInstanceOf(ArrayBuffer)
+    expect(Buffer.from(data).toString()).toBe('downloaded data')
+  })
+
+  it('getPinnedObject wraps result correctly', async () => {
+    const mockSdk = createMockSdk()
+    const adapter = createNodeSdkAdapter(mockSdk as any)
+    const obj = await adapter.getPinnedObject('obj-1')
+    expect(obj.id()).toBe('obj-1')
+    expect(obj.size()).toBe(BigInt(1024))
+    expect(obj.metadata()).toBeInstanceOf(ArrayBuffer)
+  })
+
+  it('PinnedObjectRef.seal() returns SealedObjectRef with ArrayBuffer fields', async () => {
+    const mockSdk = createMockSdk()
+    const adapter = createNodeSdkAdapter(mockSdk as any)
+    const obj = await adapter.getPinnedObject('obj-1')
+    const appKey = adapter.appKey()
+    const sealed = obj.seal(appKey)
+    expect(sealed.id).toBe('obj-1')
+    expect(sealed.encryptedDataKey).toBeInstanceOf(ArrayBuffer)
+    expect(sealed.encryptedMetadataKey).toBeInstanceOf(ArrayBuffer)
+    expect(sealed.encryptedMetadata).toBeInstanceOf(ArrayBuffer)
+    expect(sealed.dataSignature).toBeInstanceOf(ArrayBuffer)
+    expect(sealed.metadataSignature).toBeInstanceOf(ArrayBuffer)
+    expect(sealed.slabs[0].encryptionKey).toBeInstanceOf(ArrayBuffer)
+  })
+
+  it('PinnedObjectRef.slabs() returns ArrayBuffer encryptionKeys', async () => {
+    const mockSdk = createMockSdk()
+    const adapter = createNodeSdkAdapter(mockSdk as any)
+    const obj = await adapter.getPinnedObject('obj-1')
+    const slabs = obj.slabs()
+    expect(slabs).toHaveLength(1)
+    expect(slabs[0].encryptionKey).toBeInstanceOf(ArrayBuffer)
+    expect(slabs[0].minShards).toBe(10)
+    expect(slabs[0].sectors[0].root).toBe('abc')
+  })
+})


### PR DESCRIPTION
Plugs the native @siafoundation/sia-storage SDK into core's adapter interfaces:
- createNodeSdkAdapter: wraps the SDK as core's SdkAdapter, including the Reader to ReadableStream and ReadableStream to DownloadLikeRef bridges the new SDK requires.
- createNodeSdkAuthAdapter: Builder-based connect/register flow with cancellation.
- createNodeDownloadAdapter: streams downloads to disk via fs.createWriteStream with backpressure.
