### PR TITLE
chore(mobile): use literal runtimeVersion from package.json version

### DIFF
--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -117,9 +117,7 @@ export default {
         },
       ],
     ],
-    runtimeVersion: {
-      policy: 'appVersion',
-    },
+    runtimeVersion: version,
     extra: {
       prod: RELEASE,
       appGroup: APP_GROUP,


### PR DESCRIPTION
Inlines the runtime version string which fixes an Expo CLI symlink native dirs issue when running in a git worktree.
