### PR TITLE
fix(mobile): photo permission UX and foreground state refresh

### DIFF
--- a/.changeset/fix-android-photo-permission-grants.md
+++ b/.changeset/fix-android-photo-permission-grants.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Fixed Android photo access showing "No access" after granting "Allow all" in system Settings.

--- a/.changeset/foreground-swr-refresh.md
+++ b/.changeset/foreground-swr-refresh.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+SWR-driven UI now refreshes when the app returns to the foreground, so changes that happened while backgrounded (uploads completing, permission toggles, etc.) show up immediately on return.

--- a/.changeset/photo-access-prompts-on-first-tap.md
+++ b/.changeset/photo-access-prompts-on-first-tap.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Tapping "Photo access" on a fresh install now prompts for permission directly instead of opening to a Settings page with no Photos row.

--- a/apps/mobile/src/Root.tsx
+++ b/apps/mobile/src/Root.tsx
@@ -15,9 +15,10 @@ import { ErrorBoundary } from './components/ErrorBoundary'
 import { ShareIntentConsumer } from './components/ShareIntentConsumer'
 import useLinkedURL from './hooks/useLinkedURL'
 import { useReconnectIndexer } from './hooks/useReconnectIndexer'
+import { initForegroundRefresh } from './lib/foregroundRefresh'
 import { ToastProvider } from './lib/toastContext'
 import { initApp, shutdownApp } from './managers/app'
-import { addForegroundFocusListener, getLifecycle } from './managers/lifecycle'
+import { getLifecycle } from './managers/lifecycle'
 import { RootTabs } from './stacks/RootTabs'
 import { app } from './stores/appService'
 import { palette } from './styles/colors'
@@ -32,23 +33,12 @@ const darkNavigationTheme = {
   },
 }
 
-// SWR config for React Native (per the official RN guide):
-//   isVisible: defaults check document.visibilityState (undefined in RN);
-//     without this override SWR treats the app as hidden.
-//   isPaused: skip fetcher dispatch when the app isn't foreground.
-//     Driven by the lifecycle module (lifecycle.ts), which treats iOS
-//     'inactive' as foreground — flickers from banners / Control Center /
-//     Face ID prompts no longer pause SWR.
-//   initFocus: subscribe to lifecycle's foreground-focus signal, which
-//     fires once per transition INTO foreground on a microtask after
-//     suspension manager listeners have run. Guarantees SWR refetches
-//     deferred fetchers on real foreground returns.
+// Treat iOS 'inactive' as foreground (per Apple's docs) so banners /
+// Face ID / Control Center don't pause SWR mid-render; pause only on
+// real backgrounding. Foreground refetch is handled by
+// `initForegroundRefresh`.
 const swrConfig = {
-  isVisible: () => true,
   isPaused: () => getLifecycle() !== 'foreground',
-  initFocus(callback: () => void) {
-    return addForegroundFocusListener(callback)
-  },
 }
 
 export function Root() {
@@ -58,6 +48,8 @@ export function Root() {
       shutdownApp()
     }
   }, [])
+
+  useEffect(() => initForegroundRefresh(), [])
 
   useEffect(() => {
     ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP).catch(() => {

--- a/apps/mobile/src/components/SettingsSyncPhotos.tsx
+++ b/apps/mobile/src/components/SettingsSyncPhotos.tsx
@@ -1,6 +1,5 @@
 import { usePhotoImportDirectory } from '@siastorage/core/stores'
 import { useCallback, useState } from 'react'
-import { Linking } from 'react-native'
 import { useMediaLibraryPermissions } from '../lib/mediaLibraryPermissions'
 import { toggleAutoSyncNewPhotos, useAutoSyncNewPhotos } from '../managers/syncNewPhotos'
 import { useArchiveSyncCompletedAt } from '../managers/syncPhotosArchive'
@@ -13,7 +12,7 @@ import { SelectDirectorySheet } from './SelectDirectorySheet'
 export function SettingsSyncPhotos() {
   const autoSyncNew = useAutoSyncNewPhotos()
   const archiveCompletedAt = useArchiveSyncCompletedAt()
-  const { isSomeAccess, accessLabel } = useMediaLibraryPermissions()
+  const { isSomeAccess, accessLabel, manageAccess } = useMediaLibraryPermissions()
   const photoImportDir = usePhotoImportDirectory()
   const [modalVisible, setModalVisible] = useState(false)
 
@@ -35,17 +34,13 @@ export function SettingsSyncPhotos() {
     void app().settings.setPhotoImportDirectory('')
   }, [])
 
-  const handleOpenPermissionSettings = useCallback(() => {
-    Linking.openSettings().catch(() => {})
-  }, [])
-
   return (
     <>
       <InsetGroupSection header="Photos" footer={photosFooter}>
         <InsetGroupLink
           label="Photo access"
           value={accessLabel}
-          onPress={handleOpenPermissionSettings}
+          onPress={manageAccess}
           showChevron={false}
         />
         <InsetGroupLink

--- a/apps/mobile/src/lib/foregroundRefresh.ts
+++ b/apps/mobile/src/lib/foregroundRefresh.ts
@@ -1,0 +1,16 @@
+import { mutate } from 'swr'
+import { addForegroundFocusListener } from '../managers/lifecycle'
+
+/**
+ * Revalidate every mounted SWR hook on app foreground via
+ * `mutate(() => true)`. SWR's `initFocus` override is inert without a
+ * custom cache `provider` (which would fork the cache from the global
+ * `mutate` used by `swrCache` helpers), so we drive the broadcast
+ * ourselves. The lifecycle module queues this callback on a microtask
+ * after the suspension manager has un-gated the DB.
+ */
+export function initForegroundRefresh(): () => void {
+  return addForegroundFocusListener(() => {
+    void mutate(() => true)
+  })
+}

--- a/apps/mobile/src/lib/mediaLibraryPermissions.ts
+++ b/apps/mobile/src/lib/mediaLibraryPermissions.ts
@@ -1,4 +1,3 @@
-import { useFocusEffect } from '@react-navigation/native'
 import { swrCache } from '@siastorage/core/stores'
 import * as MediaLibrary from 'expo-media-library'
 import { useCallback, useMemo } from 'react'
@@ -6,13 +5,21 @@ import { Linking, Platform } from 'react-native'
 import useSWR from 'swr'
 import { palette } from '../styles/colors'
 
+// Restrict the granular permission set to the media we actually use. With no
+// arg, expo-media-library on Android requires photo + video + audio to all
+// be granted before reporting `granted=true`. Android's "Photos and videos"
+// permission UI only controls photo+video; READ_MEDIA_AUDIO lives under a
+// separate "Music and audio" group the user is never prompted for, so it
+// stays denied and the combined check never flips to ALL.
+const GRANULAR: MediaLibrary.GranularPermission[] = ['photo', 'video']
+
 export async function ensureMediaLibraryPermission(): Promise<boolean> {
-  const res = await MediaLibrary.requestPermissionsAsync()
+  const res = await MediaLibrary.requestPermissionsAsync(false, GRANULAR)
   return res.granted === true
 }
 
 export async function getMediaLibraryPermissions(): Promise<boolean> {
-  const res = await MediaLibrary.getPermissionsAsync()
+  const res = await MediaLibrary.getPermissionsAsync(false, GRANULAR)
   return res.granted === true
 }
 
@@ -20,13 +27,8 @@ export async function getMediaLibraryPermissions(): Promise<boolean> {
 export const mediaLibraryPermissionsCache = swrCache()
 
 export function useMediaLibraryPermissions() {
-  const perms = useSWR(mediaLibraryPermissionsCache.key(), () => MediaLibrary.getPermissionsAsync())
-
-  useFocusEffect(
-    useCallback(() => {
-      void perms.mutate()
-      // oxlint-disable-next-line react/exhaustive-deps -- perms.mutate is stable per SWR, full perms object is not
-    }, [perms.mutate]),
+  const perms = useSWR(mediaLibraryPermissionsCache.key(), () =>
+    MediaLibrary.getPermissionsAsync(false, GRANULAR),
   )
 
   const photosAccess: 'all' | 'limited' | 'none' | 'unknown' = useMemo(() => {
@@ -57,8 +59,17 @@ export function useMediaLibraryPermissions() {
           : palette.gray[500]
 
   const manageAccess = useCallback(async () => {
-    // Open app settings to adjust photo access for this app.
-    // Try the URL scheme first on iOS, then generic openSettings as a fallback.
+    // First-time grant: trigger the OS permission prompt directly. iOS
+    // doesn't add the Photos row to an app's Settings page until the app
+    // has called requestPermissionsAsync at least once, so opening Settings
+    // before that lands on a page with no Photos row to toggle.
+    if (photosAccess === 'none' || photosAccess === 'unknown') {
+      const result = await MediaLibrary.requestPermissionsAsync(false, GRANULAR)
+      mediaLibraryPermissionsCache.invalidate()
+      if (result.granted || result.canAskAgain) return
+      // Permanently denied — fall through to open Settings so the user
+      // can flip the now-visible Photos row.
+    }
     if (Platform.OS === 'ios') {
       try {
         await Linking.openURL('app-settings:')
@@ -69,7 +80,7 @@ export function useMediaLibraryPermissions() {
       await Linking.openSettings()
       return
     } catch {}
-  }, [])
+  }, [photosAccess])
 
   return {
     photosAccess,


### PR DESCRIPTION
Photo access on Android wrongly showed "no access" after granting "Allow all" in Settings - the underlying check required audio too, which Android's Photos page never grants. Separately, the row didn't refresh when returning from Settings; it now refetches correctly on app foreground.