### PR TITLE
feat(mobile): keep screen awake during library sync and archive import

### DIFF
--- a/.changeset/keep-awake-sync-and-archive.md
+++ b/.changeset/keep-awake-sync-and-archive.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Keep the screen awake while the initial library sync and the photo library import are running, so the device doesn't lock mid-progress.

--- a/apps/mobile/src/components/AppSplash.tsx
+++ b/apps/mobile/src/components/AppSplash.tsx
@@ -6,9 +6,11 @@ import {
   useSyncState,
 } from '@siastorage/core/stores'
 import { TriangleAlertIcon } from 'lucide-react-native'
+import { useEffect } from 'react'
 import { Alert, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 import { resetApp } from '../managers/app'
+import { acquireAutoKeepAwake, releaseAutoKeepAwake } from '../managers/autoKeepAwake'
 import { palette } from '../styles/colors'
 import BlocksGrid from './BlocksGrid'
 import BlocksLoader from './BlocksLoader'
@@ -28,6 +30,12 @@ export function AppSplash() {
   const { progress } = useSyncProgress()
   const { top, bottom } = useSafeAreaInsets()
   useSyncGateGuard()
+
+  useEffect(() => {
+    if (syncGateStatus !== 'active') return
+    acquireAutoKeepAwake('sync-gate')
+    return () => releaseAutoKeepAwake('sync-gate')
+  }, [syncGateStatus])
 
   return (
     <SafeAreaView style={styles.screen}>

--- a/apps/mobile/src/managers/app.ts
+++ b/apps/mobile/src/managers/app.ts
@@ -17,6 +17,7 @@ import { resetViewSettings } from '../stores/viewSettings'
 import { initBackgroundTasks } from './backgroundTasks'
 import { initDbOptimize } from './dbOptimize'
 import { runFsEvictionScanner } from './fsEvictionScanner'
+import { initAutoKeepAwake } from './autoKeepAwake'
 import { initImportScanner } from './importScanner'
 import { initLogRotation } from './logRotation'
 import { initPerfMonitor } from './perfMonitor'
@@ -76,6 +77,7 @@ export async function initApp(): Promise<void> {
         await app().fs.ensureStorageDirectory()
         await ensureTempFsStorageDirectory()
         await initKeepAwake()
+        initAutoKeepAwake()
         const maxDownloads = await app().settings.getMaxDownloads()
         await app().downloads.setMaxSlots(maxDownloads)
         const useWal = await getUseWalMode()

--- a/apps/mobile/src/managers/autoKeepAwake.test.ts
+++ b/apps/mobile/src/managers/autoKeepAwake.test.ts
@@ -1,0 +1,168 @@
+type AppStateStatus = 'active' | 'inactive' | 'background' | 'unknown' | 'extension'
+
+let mockCurrentState: AppStateStatus = 'active'
+let mockListeners: Array<(state: AppStateStatus) => void> = []
+const mockRemove = jest.fn()
+
+jest.mock('react-native', () => ({
+  AppState: {
+    get currentState() {
+      return mockCurrentState
+    },
+    addEventListener: jest.fn((_event: string, fn: (state: AppStateStatus) => void) => {
+      mockListeners.push(fn)
+      return { remove: mockRemove }
+    }),
+  },
+}))
+
+const mockActivate = jest.fn().mockResolvedValue(undefined)
+const mockDeactivate = jest.fn()
+
+jest.mock('expo-keep-awake', () => ({
+  activateKeepAwakeAsync: (tag?: string) => mockActivate(tag),
+  deactivateKeepAwake: (tag?: string) => mockDeactivate(tag),
+}))
+
+import {
+  __resetAutoKeepAwakeForTesting,
+  acquireAutoKeepAwake,
+  initAutoKeepAwake,
+  releaseAutoKeepAwake,
+} from './autoKeepAwake'
+import { __resetLifecycleForTesting } from './lifecycle'
+
+function emit(state: AppStateStatus): void {
+  mockCurrentState = state
+  for (const fn of mockListeners) fn(state)
+}
+
+function resetAll(initialState: AppStateStatus = 'active'): void {
+  __resetAutoKeepAwakeForTesting()
+  __resetLifecycleForTesting()
+  mockListeners = []
+  mockRemove.mockClear()
+  mockActivate.mockClear()
+  mockDeactivate.mockClear()
+  mockCurrentState = initialState
+}
+
+beforeEach(() => {
+  resetAll('active')
+})
+
+afterEach(() => {
+  __resetAutoKeepAwakeForTesting()
+  __resetLifecycleForTesting()
+})
+
+describe('acquire / release', () => {
+  it('first acquire in foreground activates the lock', () => {
+    acquireAutoKeepAwake('a')
+    expect(mockActivate).toHaveBeenCalledTimes(1)
+    expect(mockActivate).toHaveBeenCalledWith('auto')
+  })
+
+  it('second acquire (different tag) does not re-activate', () => {
+    acquireAutoKeepAwake('a')
+    acquireAutoKeepAwake('b')
+    expect(mockActivate).toHaveBeenCalledTimes(1)
+  })
+
+  it('double-acquire same tag is idempotent', () => {
+    acquireAutoKeepAwake('a')
+    acquireAutoKeepAwake('a')
+    expect(mockActivate).toHaveBeenCalledTimes(1)
+  })
+
+  it('release with other tags still held does not deactivate', () => {
+    acquireAutoKeepAwake('a')
+    acquireAutoKeepAwake('b')
+    releaseAutoKeepAwake('a')
+    expect(mockDeactivate).not.toHaveBeenCalled()
+  })
+
+  it('release of last tag deactivates the lock', () => {
+    acquireAutoKeepAwake('a')
+    releaseAutoKeepAwake('a')
+    expect(mockDeactivate).toHaveBeenCalledTimes(1)
+    expect(mockDeactivate).toHaveBeenCalledWith('auto')
+  })
+
+  it('double-release same tag is idempotent', () => {
+    acquireAutoKeepAwake('a')
+    releaseAutoKeepAwake('a')
+    releaseAutoKeepAwake('a')
+    expect(mockDeactivate).toHaveBeenCalledTimes(1)
+  })
+
+  it('release of unknown tag is a no-op', () => {
+    releaseAutoKeepAwake('never-acquired')
+    expect(mockDeactivate).not.toHaveBeenCalled()
+  })
+})
+
+describe('lifecycle suspend / resume', () => {
+  it('background deactivates the lock but keeps intent', () => {
+    acquireAutoKeepAwake('a')
+    expect(mockActivate).toHaveBeenCalledTimes(1)
+
+    emit('background')
+    expect(mockDeactivate).toHaveBeenCalledTimes(1)
+  })
+
+  it('foreground after background reactivates if intent remains', () => {
+    acquireAutoKeepAwake('a')
+    emit('background')
+    expect(mockDeactivate).toHaveBeenCalledTimes(1)
+    mockActivate.mockClear()
+
+    emit('active')
+    expect(mockActivate).toHaveBeenCalledTimes(1)
+  })
+
+  it('foreground after background with no intent does not reactivate', () => {
+    acquireAutoKeepAwake('a')
+    releaseAutoKeepAwake('a')
+    emit('background')
+    mockActivate.mockClear()
+
+    emit('active')
+    expect(mockActivate).not.toHaveBeenCalled()
+  })
+
+  it('acquire while backgrounded does not activate the lock', () => {
+    resetAll('background')
+
+    acquireAutoKeepAwake('a')
+    expect(mockActivate).not.toHaveBeenCalled()
+  })
+
+  it('foreground transition activates a tag acquired while backgrounded', () => {
+    resetAll('background')
+
+    acquireAutoKeepAwake('a')
+    expect(mockActivate).not.toHaveBeenCalled()
+
+    emit('active')
+    expect(mockActivate).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('init', () => {
+  it('initAutoKeepAwake is idempotent', () => {
+    initAutoKeepAwake()
+    initAutoKeepAwake()
+    // Lifecycle subscription (single AppState listener) was attached only once.
+    expect(mockListeners).toHaveLength(1)
+  })
+
+  it('acquire without prior init still wires lifecycle', () => {
+    expect(mockListeners).toHaveLength(0)
+    acquireAutoKeepAwake('a')
+    expect(mockListeners).toHaveLength(1)
+
+    emit('background')
+    expect(mockDeactivate).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/mobile/src/managers/autoKeepAwake.ts
+++ b/apps/mobile/src/managers/autoKeepAwake.ts
@@ -1,0 +1,88 @@
+/*
+ * autoKeepAwake — operation-scoped screen wake lock with a tagged intent set.
+ *
+ * Distinct from the user-facing "Keep Awake" toggle in settings.ts (tag
+ * 'manual'), which is an always-on override. This service auto-acquires
+ * during specific in-flight operations (initial sync gate, photo archive
+ * import) and releases when they finish. Acquire is idempotent per tag
+ * (Set semantics, not a counter), so callers pair acquire/release 1:1
+ * and overlapping intents from different tags coexist. The two services
+ * share the underlying expo-keep-awake API via separate tags ('auto' here,
+ * 'manual' for the user toggle).
+ *
+ * Suspend behavior: the wake lock only matters in the foreground. On
+ * background we deactivate the lock but keep the intent set; on
+ * foreground return we reactivate if anything is still held. Callers that
+ * also pause their work on suspend (e.g. archive walk) should still
+ * release explicitly so a returning user with no in-flight ops doesn't
+ * keep the screen on.
+ */
+
+import { logger } from '@siastorage/logger'
+import { activateKeepAwakeAsync, deactivateKeepAwake } from 'expo-keep-awake'
+import { addLifecycleListener, getLifecycle } from './lifecycle'
+
+const KEEP_AWAKE_TAG = 'auto'
+
+const heldTags = new Set<string>()
+let lockActive = false
+let unsubscribeLifecycle: (() => void) | null = null
+
+function activateLock(): void {
+  if (lockActive) return
+  lockActive = true
+  activateKeepAwakeAsync(KEEP_AWAKE_TAG).catch((error) => {
+    // Reset so the next acquire (or foreground transition) retries instead
+    // of being short-circuited by the optimistic flag above.
+    lockActive = false
+    logger.warn('autoKeepAwake', 'activate_failed', { error: error as Error })
+  })
+}
+
+function deactivateLock(): void {
+  if (!lockActive) return
+  lockActive = false
+  try {
+    deactivateKeepAwake(KEEP_AWAKE_TAG)
+  } catch (error) {
+    logger.warn('autoKeepAwake', 'deactivate_failed', { error: error as Error })
+  }
+}
+
+// Lazy so callers that forget initAutoKeepAwake() still get correct
+// suspend/resume behavior on the first acquire.
+function ensureLifecycleSubscription(): void {
+  if (unsubscribeLifecycle) return
+  unsubscribeLifecycle = addLifecycleListener((next) => {
+    if (next === 'background') {
+      deactivateLock()
+    } else if (heldTags.size > 0) {
+      activateLock()
+    }
+  })
+}
+
+/** Adds an intent and activates the lock if the app is foregrounded. */
+export function acquireAutoKeepAwake(tag: string): void {
+  ensureLifecycleSubscription()
+  heldTags.add(tag)
+  if (getLifecycle() === 'foreground') activateLock()
+}
+
+/** Removes an intent and deactivates the lock if no intents remain. */
+export function releaseAutoKeepAwake(tag: string): void {
+  heldTags.delete(tag)
+  if (heldTags.size === 0) deactivateLock()
+}
+
+/** Wires the lifecycle listener up front; safe to call multiple times. */
+export function initAutoKeepAwake(): void {
+  ensureLifecycleSubscription()
+}
+
+export function __resetAutoKeepAwakeForTesting(): void {
+  unsubscribeLifecycle?.()
+  unsubscribeLifecycle = null
+  heldTags.clear()
+  lockActive = false
+}

--- a/apps/mobile/src/managers/syncPhotosArchive.ts
+++ b/apps/mobile/src/managers/syncPhotosArchive.ts
@@ -48,6 +48,7 @@ import { getMediaLibraryPermissions } from '../lib/mediaLibraryPermissions'
 import { catalogAssets } from '../lib/processAssets'
 import { app } from '../stores/appService'
 import { isBgTaskActive } from './bgTaskContext'
+import { acquireAutoKeepAwake, releaseAutoKeepAwake } from './autoKeepAwake'
 
 const PAGE_SIZE = 500
 const CURSOR_DONE = 'done'
@@ -67,21 +68,30 @@ export async function startArchiveSync(): Promise<void> {
   await setPhotosExistingCount(0)
   await restartPhotosArchiveCursor()
   walkAbortController = new AbortController()
+  acquireAutoKeepAwake('archive-walk')
   activeWalk = runArchiveWalk(walkAbortController.signal)
   activeWalk.finally(() => {
     activeWalk = null
     walkAbortController = null
+    releaseAutoKeepAwake('archive-walk')
   })
 }
 
 export async function stopArchiveSync(): Promise<void> {
   walkAbortController?.abort()
+  // Release immediately rather than waiting for the abort to propagate
+  // through runArchiveWalk; the release in activeWalk.finally is idempotent.
+  releaseAutoKeepAwake('archive-walk')
   await setPhotosArchiveCursor(CURSOR_DONE)
 }
 
 /** Abort the in-flight walk without clearing cursor so it resumes from the same page. */
 export function pauseArchiveSync(): void {
   walkAbortController?.abort()
+  // Release immediately on suspend so we don't wait for the abort to
+  // propagate through runArchiveWalk before the activeWalk.finally fires.
+  // The release in finally is then idempotent.
+  releaseAutoKeepAwake('archive-walk')
 }
 
 /** True while a walk is active (for diagnostic logging). */
@@ -99,10 +109,12 @@ export async function resumeArchiveSync(): Promise<void> {
   const cursor = await getPhotosArchiveCursor()
   if (cursor === CURSOR_DONE) return
   walkAbortController = new AbortController()
+  acquireAutoKeepAwake('archive-walk')
   activeWalk = runArchiveWalk(walkAbortController.signal)
   activeWalk.finally(() => {
     activeWalk = null
     walkAbortController = null
+    releaseAutoKeepAwake('archive-walk')
   })
 }
 

--- a/apps/mobile/src/stores/settings.ts
+++ b/apps/mobile/src/stores/settings.ts
@@ -23,7 +23,7 @@ export async function toggleAutoSyncDownEvents() {
 
 // Keep Awake (platform-specific: uses expo-keep-awake)
 
-const KEEP_AWAKE_TAG = 'sync'
+const KEEP_AWAKE_TAG = 'manual'
 
 export async function getKeepAwake(): Promise<boolean> {
   const raw = await app().storage.getItem('keepAwake')


### PR DESCRIPTION
During the initial library-sync splash and the photo archive import modal the device was free to dim and lock the screen mid-progress, even though both are foreground screens the user is actively watching. A small wake-lock service is now held by each operation while it's running and released on completion or app background, so the screen stays on for the duration.
