### PR TITLE
fix(mobile): refetch SWR after resync to release the splash

### DIFF
--- a/.changeset/fix-resync-splash-strand.md
+++ b/.changeset/fix-resync-splash-strand.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Fixed an issue where the splash could get stuck on "Getting things ready..." after a resync until the app was suspended and reopened.

--- a/apps/mobile/src/managers/app.ts
+++ b/apps/mobile/src/managers/app.ts
@@ -223,8 +223,10 @@ async function clearAppState({ keepAuth }: { keepAuth: boolean }) {
   // Reset cursor caches.
   await resetPhotosArchiveCursor()
 
-  // Clear SWR cache last; must come after store resets to avoid races where
-  // hooks re-read stale data into a fresh cache.
+  // Pin every SWR slot to `undefined` for the reset window so useShowSplash
+  // holds via its `hasOnboarded === undefined` clause — without this, sign-out
+  // briefly remounts RootTabs against the stale cached `true` before the
+  // post-init refetch (in runResetFlow) lands the wiped value.
   await mutate(() => true, undefined, { revalidate: false })
 }
 
@@ -269,6 +271,13 @@ async function runResetFlow({ label, keepAuth }: { label: string; keepAuth: bool
 
   // Re-initialize the app from clean state.
   await initApp()
+
+  // Refetch every SWR slot now that the rebuilt app is healthy. Keys
+  // preserved across resync (hasOnboarded, indexerURL) were pinned to
+  // `undefined` by clearAppState and aren't touched by initApp, so without
+  // this useShowSplash strands the splash on "Getting things ready..." until
+  // the user suspends and reopens the app (which fires the same broadcast).
+  await mutate(() => true)
 }
 
 function resetAllStores() {


### PR DESCRIPTION
After resync, the splash stayed stuck because preserved SWR keys like hasOnboarded were pinned to undefined and never revalidated. The reset flow now broadcasts a global mutate(() => true) so the splash releases without needing to background the app.

