### PR TITLE
fix(mobile): note pending imports in status sheet size mode

### DIFF
--- a/.changeset/status-sheet-pending-import-note.md
+++ b/.changeset/status-sheet-pending-import-note.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+The library status sheet's upload progress section now notes when its size totals exclude files still pending import.

--- a/apps/mobile/src/components/LibraryStatusSheet.tsx
+++ b/apps/mobile/src/components/LibraryStatusSheet.tsx
@@ -153,7 +153,11 @@ export function LibraryStatusSheet() {
 
         <InsetGroupSection
           header="Upload progress"
-          footer="Upload progress across all files in the library."
+          footer={
+            mode === 'size' && importingCount > 0
+              ? `Sizes do not include the ${importingCount === 1 ? 'file' : `${importingCount.toLocaleString()} files`} still pending import.`
+              : 'Upload progress across all files in the library.'
+          }
         >
           {categories.map(([label, cat]) => {
             const value = categoryValue(mode, cat)


### PR DESCRIPTION
The library status sheet's total size excludes files still being imported (their byte sizes aren't known yet), so the number could look misleadingly small after queuing an import. When viewing the sheet in size mode with pending imports, the Library section now shows a footer noting that total size does not reflect files pending import.
