### PR TITLE
fix(mobile): redesign init error screen actions

### DIFF
--- a/.changeset/init-error-screen-actions.md
+++ b/.changeset/init-error-screen-actions.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Redesign the initialization error screen with clearer recovery options: restart, clear and re-sync local data, email the team, and a separated clear-and-sign-out at the bottom. Pre-onboarding the recovery options collapse to a single "Clear local data" action.

--- a/apps/mobile/src/components/AppSplash.tsx
+++ b/apps/mobile/src/components/AppSplash.tsx
@@ -5,16 +5,14 @@ import {
   useSyncGateStatus,
   useSyncState,
 } from '@siastorage/core/stores'
-import { TriangleAlertIcon } from 'lucide-react-native'
 import { useEffect } from 'react'
-import { Alert, StyleSheet, Text, View } from 'react-native'
+import { StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
-import { resetApp } from '../managers/app'
 import { acquireAutoKeepAwake, releaseAutoKeepAwake } from '../managers/autoKeepAwake'
 import { palette } from '../styles/colors'
+import { AppSplashError } from './AppSplashError'
 import BlocksGrid from './BlocksGrid'
 import BlocksLoader from './BlocksLoader'
-import { Button } from './Button'
 
 function useSyncProgress() {
   const { data } = useSyncState()
@@ -50,36 +48,7 @@ export function AppSplash() {
       />
       <View style={[styles.centerWrap, { paddingTop: top + 12, paddingBottom: bottom + 12 }]}>
         {initializationError && currentStep ? (
-          <View style={styles.errorWrap}>
-            <View style={styles.errorIconWrap}>
-              <TriangleAlertIcon size={48} color={palette.red[500]} />
-            </View>
-            <Text style={styles.errorTitle}>{currentStep.label}</Text>
-            <Text style={styles.errorMessage}>{currentStep.message}</Text>
-            <Text style={styles.errorHint}>
-              Please report this issue to the team or restart the app to try again.
-            </Text>
-            <Button
-              variant="danger"
-              style={styles.resetButton}
-              onPress={() => {
-                Alert.alert(
-                  'Reset Application',
-                  'This will delete all local metadata. This cannot be undone.',
-                  [
-                    { text: 'Cancel', style: 'cancel' },
-                    {
-                      text: 'Permanently reset',
-                      style: 'destructive',
-                      onPress: () => resetApp(),
-                    },
-                  ],
-                )
-              }}
-            >
-              Reset application
-            </Button>
-          </View>
+          <AppSplashError step={currentStep} />
         ) : (
           <View style={styles.waitingWrap}>
             <BlocksLoader colorStart={1} size={20} />
@@ -153,35 +122,5 @@ const styles = StyleSheet.create({
     height: '100%',
     borderRadius: 2,
     backgroundColor: palette.gray[400],
-  },
-  errorWrap: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 8,
-    maxWidth: '80%',
-  },
-  errorIconWrap: {
-    paddingBottom: 8,
-  },
-  errorTitle: {
-    color: 'white',
-    fontSize: 20,
-    fontWeight: '700',
-  },
-  errorMessage: {
-    color: palette.red[500],
-    fontSize: 14,
-    textAlign: 'center',
-    lineHeight: 20,
-  },
-  errorHint: {
-    color: palette.gray[400],
-    fontSize: 13,
-    textAlign: 'center',
-    lineHeight: 18,
-  },
-  resetButton: {
-    marginTop: 16,
-    alignSelf: 'stretch',
   },
 })

--- a/apps/mobile/src/components/AppSplashError.tsx
+++ b/apps/mobile/src/components/AppSplashError.tsx
@@ -1,0 +1,151 @@
+import type { InitStep } from '@siastorage/core/app'
+import { useHasOnboarded } from '@siastorage/core/stores'
+import { Alert, Platform, StyleSheet, Text, View } from 'react-native'
+import { LINKS } from '../config/links'
+import { openExternalURL } from '../lib/inAppBrowser'
+import {
+  promptClearAndResync,
+  promptClearAndSignOut,
+  promptClearLocalData,
+} from '../lib/resetPrompts'
+import { palette } from '../styles/colors'
+import { InsetGroupLink, InsetGroupSection } from './InsetGroup'
+
+const RESTART_INSTRUCTIONS =
+  Platform.OS === 'ios'
+    ? 'Swipe up from the bottom of the screen and pause, then swipe up on the Sia Storage card to close it. Open Sia Storage again from your home screen.'
+    : 'Open the recent apps view, swipe the Sia Storage card away, then tap the app icon to open it again.'
+
+function promptRestart() {
+  Alert.alert('How to restart Sia Storage', RESTART_INSTRUCTIONS, [{ text: 'Got it' }])
+}
+
+// Linking.openURL rejects when the user cancels the iOS "Open in Mail?" prompt,
+// or when no mail app is configured. Either way, nothing to do.
+function emailSupport() {
+  openExternalURL(`mailto:${LINKS.supportEmail}`).catch(() => {})
+}
+
+export function AppSplashError({ step }: { step: InitStep }) {
+  const hasOnboarded = useHasOnboarded()
+
+  return (
+    <View style={styles.errorWrap}>
+      <View style={styles.card}>
+        <View style={styles.cardContent}>
+          <View style={styles.headerBlock}>
+            <Text style={styles.errorTitle}>Something went wrong</Text>
+            {/* Cap at 4 lines so a verbose error can't push the recovery
+                actions off-screen. */}
+            <Text style={styles.errorMessage} numberOfLines={4} ellipsizeMode="tail">
+              {step.message}
+            </Text>
+          </View>
+
+          <InsetGroupSection footer="Closing and reopening Sia Storage may fix your issue.">
+            <InsetGroupLink label="Close and restart" onPress={promptRestart} showChevron={false} />
+          </InsetGroupSection>
+
+          {hasOnboarded ? (
+            <InsetGroupSection footer="If restarting doesn't help, try clearing and re-syncing your local data.">
+              <InsetGroupLink
+                label="Clear local data and resync"
+                onPress={promptClearAndResync}
+                showChevron={false}
+              />
+            </InsetGroupSection>
+          ) : (
+            <InsetGroupSection footer="If restarting doesn't help, try clearing your local data.">
+              <InsetGroupLink
+                label="Clear local data"
+                onPress={promptClearLocalData}
+                destructive
+                showChevron={false}
+              />
+            </InsetGroupSection>
+          )}
+
+          <InsetGroupSection footer="If neither of those help, let us know what error you're running into.">
+            <InsetGroupLink label="Email the team" onPress={emailSupport} showChevron={false} />
+          </InsetGroupSection>
+
+          {hasOnboarded ? (
+            // Visually separated from the recovery actions above — not part
+            // of the "try this to fix it" flow, just available if the user
+            // wants to sign out at the same time as wiping data.
+            <>
+              <View style={styles.signOutDivider} />
+              {/* Pull up to neutralize part of InsetGroupSection's default
+                  marginBottom — keeps the bottom of the card snug under the
+                  sign-out button. */}
+              <View style={styles.signOutSection}>
+                <InsetGroupSection>
+                  <InsetGroupLink
+                    label="Clear local data and sign out"
+                    onPress={promptClearAndSignOut}
+                    destructive
+                    showChevron={false}
+                  />
+                </InsetGroupSection>
+              </View>
+            </>
+          ) : null}
+        </View>
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  // Negative horizontal margin extends the card past the parent splash's
+  // 20px paddingHorizontal so the band runs edge-to-edge like the
+  // onboarding welcome screen.
+  errorWrap: {
+    alignSelf: 'stretch',
+    marginHorizontal: -20,
+  },
+  card: {
+    width: '100%',
+    paddingTop: 32,
+    paddingBottom: 4,
+    backgroundColor: '#000',
+    borderTopWidth: 1,
+    borderBottomWidth: 1,
+    borderColor: palette.gray[800],
+  },
+  // Caps content width so InsetGroup rows don't stretch into uselessly long
+  // bars on tablets / large devices. The card band stays full-bleed.
+  cardContent: {
+    width: '100%',
+    maxWidth: 520,
+    alignSelf: 'center',
+  },
+  headerBlock: {
+    paddingHorizontal: 20,
+    marginBottom: 28,
+  },
+  errorTitle: {
+    color: 'white',
+    fontSize: 26,
+    fontWeight: '700',
+    letterSpacing: -0.4,
+    textAlign: 'center',
+  },
+  errorMessage: {
+    color: palette.gray[200],
+    fontSize: 15,
+    lineHeight: 22,
+    textAlign: 'center',
+    marginTop: 12,
+  },
+  signOutDivider: {
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: palette.gray[800],
+    marginHorizontal: 16,
+    marginTop: 8,
+    marginBottom: 24,
+  },
+  signOutSection: {
+    marginBottom: -8,
+  },
+})

--- a/apps/mobile/src/lib/resetPrompts.ts
+++ b/apps/mobile/src/lib/resetPrompts.ts
@@ -1,0 +1,53 @@
+import { Alert } from 'react-native'
+import { resetLocalDataAndResync, resetLocalDataAndSignOut } from '../managers/app'
+
+export function promptClearAndResync() {
+  Alert.alert(
+    'Clear local data and resync',
+    'Rebuilds your library from your indexer. Any files still importing or uploading will be lost. Your account stays signed in.',
+    [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Clear and resync',
+        style: 'destructive',
+        onPress: () => void resetLocalDataAndResync(),
+      },
+    ],
+  )
+}
+
+export function promptClearAndSignOut() {
+  Alert.alert(
+    'Clear local data and sign out',
+    'Wipes your local library and signs you out. Any files still importing or uploading will be lost. You will need your recovery phrase to sign back in.',
+    [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Clear and sign out',
+        style: 'destructive',
+        onPress: () => void resetLocalDataAndSignOut(),
+      },
+    ],
+  )
+}
+
+/**
+ * Pre-onboarding equivalent: there's no indexer to resync from and no
+ * account to sign out of, so both keep variants collapse to a single
+ * "clear everything and start over" action. Uses the sign-out path
+ * (keepAuth=false) so nothing carries over into a fresh onboarding.
+ */
+export function promptClearLocalData() {
+  Alert.alert(
+    'Clear local data',
+    'Wipes any local data and starts over. You will return to the welcome screen.',
+    [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Clear',
+        style: 'destructive',
+        onPress: () => void resetLocalDataAndSignOut(),
+      },
+    ],
+  )
+}

--- a/apps/mobile/src/screens/MenuScreen.tsx
+++ b/apps/mobile/src/screens/MenuScreen.tsx
@@ -15,8 +15,8 @@ import { SettingsSyncPhotos } from '../components/SettingsSyncPhotos'
 import { LINKS } from '../config/links'
 import { useMenuHeader } from '../hooks/useMenuHeader'
 import { openExternalURL } from '../lib/inAppBrowser'
+import { promptClearAndResync, promptClearAndSignOut } from '../lib/resetPrompts'
 import { useToast } from '../lib/toastContext'
-import { resetLocalDataAndResync, resetLocalDataAndSignOut } from '../managers/app'
 import type { MenuStackParamList } from '../stacks/types'
 import { reconnectIndexer, useIsConnected } from '../stores/sdk'
 import { toggleKeepAwake, useKeepAwake } from '../stores/settings'
@@ -42,36 +42,6 @@ function promptDeleteAccount(indexerURL: string) {
     { text: 'Cancel', style: 'cancel' },
     { text: 'Continue to Website', onPress: () => void openExternalURL(targetURL) },
   ])
-}
-
-function promptResync() {
-  Alert.alert(
-    'Clear local data and resync',
-    'This wipes your locally cached metadata and re-downloads everything from your indexer. Your account stays signed in.',
-    [
-      { text: 'Cancel', style: 'cancel' },
-      {
-        text: 'Clear and resync',
-        style: 'destructive',
-        onPress: () => void resetLocalDataAndResync(),
-      },
-    ],
-  )
-}
-
-function promptSignOut() {
-  Alert.alert(
-    'Clear local data and sign out',
-    'This wipes all local data and signs you out. You will need your recovery phrase to sign back in.',
-    [
-      { text: 'Cancel', style: 'cancel' },
-      {
-        text: 'Clear and sign out',
-        style: 'destructive',
-        onPress: () => void resetLocalDataAndSignOut(),
-      },
-    ],
-  )
 }
 
 type Props = NativeStackScreenProps<MenuStackParamList, 'MenuHome'>
@@ -202,16 +172,16 @@ export function MenuScreen({ navigation }: Props) {
       <InsetGroupSection header="Danger zone">
         <InsetGroupLink
           label="Clear local data and resync"
-          description="Re-downloads metadata from your indexer. You stay signed in."
+          description="Rebuilds your library from your indexer. Pending uploads are lost. You stay signed in."
           destructive
-          onPress={promptResync}
+          onPress={promptClearAndResync}
           showChevron={false}
         />
         <InsetGroupLink
           label="Clear local data and sign out"
-          description="Signs you out. You'll need your recovery phrase to sign back in."
+          description="Signs you out and clears your library. Pending uploads are lost. You'll need your recovery phrase to sign back in."
           destructive
-          onPress={promptSignOut}
+          onPress={promptClearAndSignOut}
           showChevron={false}
         />
         <InsetGroupLink


### PR DESCRIPTION
When app initialization failed (which should never happen), the splash screen's only action was a destructive "Reset application" button that signed users out, even though a force-quit usually clears the transient suspension error that triggered the screen. The error view now provides a set of suggestions covering restart, resync, and contact.