### PR TITLE
perf(core,mobile): skip thumbnail scan for metadata-only files; add idle backoff

### DIFF
--- a/.changeset/thumb-idle-backoff.md
+++ b/.changeset/thumb-idle-backoff.md
@@ -1,0 +1,6 @@
+---
+core: patch
+mobile: patch
+---
+
+Reduced battery use during idle gallery viewing by skipping thumbnail-scanner work for files whose originals aren't yet downloaded and slowing the scanner's polling cadence after several quiet ticks.

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,11 +12,11 @@ runs:
   using: composite
   steps:
     - name: Setup Node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version-file: .node-version
     - name: Setup Bun
-      uses: oven-sh/setup-bun@v2
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       with:
         bun-version: ${{ inputs.bun_version }}
     - name: Install dependencies

--- a/apps/integration/test/app.ts
+++ b/apps/integration/test/app.ts
@@ -607,6 +607,14 @@ export function createTestApp(
         localId: null,
         ...record,
       } as Parameters<AppService['files']['create']>[0])
+      if (record.kind === 'file') {
+        await appService.fs.upsertMeta({
+          fileId: record.id,
+          size: record.size,
+          addedAt: now,
+          usedAt: now,
+        })
+      }
     },
 
     async addFiles(fileFactories) {

--- a/apps/mobile/src/managers/importScanner.ts
+++ b/apps/mobile/src/managers/importScanner.ts
@@ -7,6 +7,7 @@ import { getMimeType } from '../lib/fileTypes'
 import { getMediaLibraryUri } from '../lib/mediaLibrary'
 import { app } from '../stores/appService'
 import { isBgTaskActive } from './bgTaskContext'
+import { triggerThumbnailScanner } from './thumbnailScanner'
 
 const scanner = new ImportScanner()
 
@@ -44,7 +45,11 @@ async function computeMaxDeferred(): Promise<number> {
 export async function runImportScanner(signal?: AbortSignal): Promise<ImportScannerResult> {
   ensureInitialized()
   const maxDeferred = await computeMaxDeferred()
-  return scanner.runScan(signal, getMediaLibraryUri, maxDeferred)
+  const result = await scanner.runScan(signal, getMediaLibraryUri, maxDeferred)
+  if (result.finalized > 0) {
+    triggerThumbnailScanner()
+  }
+  return result
 }
 
 export function getImportBackoffEntries() {

--- a/apps/mobile/src/managers/thumbnailScanner.test.ts
+++ b/apps/mobile/src/managers/thumbnailScanner.test.ts
@@ -1,7 +1,17 @@
 import { ThumbSizes } from '@siastorage/core/types'
 import { initializeDB, resetDb } from '../db'
 import { app } from '../stores/appService'
-import { getThumbnailScanner, runThumbnailScanner } from './thumbnailScanner'
+import {
+  getThumbnailScanner,
+  nextIdleInterval,
+  resetThumbnailScannerBackoff,
+  runThumbnailScanner,
+} from './thumbnailScanner'
+
+async function upsertFs(id: string): Promise<void> {
+  const now = Date.now()
+  await app().fs.upsertMeta({ fileId: id, size: 1000, addedAt: now, usedAt: now })
+}
 
 let getFsFileUriMock: jest.SpyInstance
 let generateMock: jest.SpyInstance
@@ -51,6 +61,7 @@ describe('thumbnailScanner', () => {
       trashedAt: null,
       deletedAt: null,
     })
+    await upsertFs('file1')
     getFsFileUriMock.mockResolvedValue(null)
     const result = await runThumbnailScanner()
     expect(result.skippedNoSource).toEqual([{ fileId: 'file1', hash: 'hash1' }])
@@ -82,6 +93,7 @@ describe('thumbnailScanner', () => {
       trashedAt: null,
       deletedAt: null,
     })
+    await upsertFs('file1')
     for (const size of ThumbSizes) {
       await app().files.create({
         id: `thumb-${size}`,
@@ -133,6 +145,7 @@ describe('thumbnailScanner', () => {
       trashedAt: null,
       deletedAt: null,
     })
+    await upsertFs('file1')
     for (const size of ThumbSizes) {
       if (size === 64) continue
       await app().files.create({
@@ -193,6 +206,7 @@ describe('thumbnailScanner', () => {
         trashedAt: null,
         deletedAt: null,
       })
+      await upsertFs(id)
     }
 
     for (let i = 0; i < 10; i++) {
@@ -211,6 +225,7 @@ describe('thumbnailScanner', () => {
         trashedAt: null,
         deletedAt: null,
       })
+      await upsertFs(id)
       for (const size of ThumbSizes) {
         await app().files.create({
           id: `${id}-thumb-${size}`,
@@ -245,6 +260,7 @@ describe('thumbnailScanner', () => {
       trashedAt: null,
       deletedAt: null,
     })
+    await upsertFs('eligible-1')
 
     getFsFileUriMock.mockImplementation(async ({ id }: { id: string }) => {
       if (noSourceIds.has(id)) return null
@@ -279,6 +295,7 @@ describe('thumbnailScanner', () => {
       trashedAt: null,
       deletedAt: null,
     })
+    await upsertFs('file1')
     await app().files.create({
       id: 'thumb-64',
       name: 'thumbnail.webp',
@@ -326,6 +343,7 @@ describe('thumbnailScanner', () => {
       trashedAt: null,
       deletedAt: null,
     })
+    await upsertFs('video1')
 
     const result = await runThumbnailScanner()
 
@@ -394,6 +412,7 @@ describe('thumbnailScanner', () => {
         trashedAt: null,
         deletedAt: null,
       })
+      await upsertFs(`file${i}`)
     }
     getFsFileUriMock.mockResolvedValue('file://test.jpg')
     const result = await runThumbnailScanner()
@@ -416,6 +435,7 @@ describe('thumbnailScanner', () => {
       trashedAt: null,
       deletedAt: null,
     })
+    await upsertFs('file1')
     getFsFileUriMock.mockResolvedValue('file://test.jpg')
     generateMock.mockRejectedValue(new Error('Failed to get size'))
     const result = await runThumbnailScanner()
@@ -443,6 +463,7 @@ describe('thumbnailScanner', () => {
       trashedAt: null,
       deletedAt: null,
     })
+    await upsertFs('file1')
     getFsFileUriMock.mockResolvedValue('file://test.jpg')
 
     const ac = new AbortController()
@@ -470,6 +491,7 @@ describe('thumbnailScanner', () => {
         trashedAt: null,
         deletedAt: null,
       })
+      await upsertFs(`file${i}`)
     }
     getFsFileUriMock.mockResolvedValue('file://test.jpg')
 
@@ -502,6 +524,7 @@ describe('thumbnailScanner', () => {
       trashedAt: null,
       deletedAt: null,
     })
+    await upsertFs('file1')
     getFsFileUriMock.mockResolvedValue('file://test.jpg')
     generateMock.mockRejectedValue(new Error('Manipulation failed'))
     const result = await runThumbnailScanner()
@@ -513,5 +536,56 @@ describe('thumbnailScanner', () => {
     })
     const sizes = await app().thumbnails.getSizesForFile('file1')
     expect(sizes).not.toContain(64)
+  })
+
+  it('does not return metadata-only files (no fs row) as candidates', async () => {
+    const now = Date.now()
+    await app().files.create({
+      id: 'meta-only',
+      name: 'meta.jpg',
+      type: 'image/jpeg',
+      kind: 'file',
+      size: 1000,
+      hash: 'hash-meta',
+      createdAt: now,
+      updatedAt: now,
+      addedAt: now,
+      localId: null,
+      trashedAt: null,
+      deletedAt: null,
+    })
+    // Note: no upsertFs — this is the metadata-only case.
+
+    const result = await runThumbnailScanner()
+
+    expect(result.processedCandidates).toBe(0)
+    expect(result.attempts).toHaveLength(0)
+    expect(result.skippedNoSource).toHaveLength(0)
+    expect(result.produced).toHaveLength(0)
+    // getFileUri is not consulted because the file never reaches the per-file loop.
+    expect(getFsFileUriMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('thumbnailScanner idle backoff', () => {
+  beforeEach(() => {
+    resetThumbnailScannerBackoff()
+  })
+
+  it('returns no override before the threshold', () => {
+    expect(nextIdleInterval(0)).toBeUndefined()
+    expect(nextIdleInterval(1)).toBeUndefined()
+    expect(nextIdleInterval(2)).toBeUndefined()
+  })
+
+  it('returns the backoff interval at 3 consecutive zero ticks', () => {
+    expect(nextIdleInterval(3)).toBe(30_000)
+    expect(nextIdleInterval(4)).toBe(30_000)
+    expect(nextIdleInterval(5)).toBe(30_000)
+  })
+
+  it('returns the steady interval at 6 consecutive zero ticks', () => {
+    expect(nextIdleInterval(6)).toBe(60_000)
+    expect(nextIdleInterval(50)).toBe(60_000)
   })
 })

--- a/apps/mobile/src/managers/thumbnailScanner.ts
+++ b/apps/mobile/src/managers/thumbnailScanner.ts
@@ -9,6 +9,15 @@ import { app } from '../stores/appService'
 
 const scanner = new ThumbnailScanner()
 
+// After this many consecutive ticks with zero candidates, the scanner
+// slows its polling cadence. Reset on triggerNow / new imports.
+const IDLE_BACKOFF_THRESHOLD = 3
+const IDLE_BACKOFF_INTERVAL_MS = 30_000
+const IDLE_STEADY_INTERVAL_MS = 60_000
+const IDLE_STEADY_THRESHOLD = 6
+
+let consecutiveZeroTicks = 0
+
 export function getThumbnailScanner(): ThumbnailScanner {
   ensureInitialized()
   return scanner
@@ -17,6 +26,10 @@ export function getThumbnailScanner(): ThumbnailScanner {
 function ensureInitialized(): void {
   if (scanner.isInitialized()) return
   scanner.initialize(app())
+}
+
+export function resetThumbnailScannerBackoff(): void {
+  consecutiveZeroTicks = 0
 }
 
 export async function runThumbnailScanner(signal?: AbortSignal): Promise<ThumbnailScannerResult> {
@@ -29,7 +42,25 @@ export async function runThumbnailScanner(signal?: AbortSignal): Promise<Thumbna
   return result
 }
 
-async function run(signal: AbortSignal): Promise<void> {
+function resultSawWork(result: ThumbnailScannerResult): boolean {
+  return (
+    result.processedCandidates > 0 ||
+    result.produced.length > 0 ||
+    result.attempts.length > 0 ||
+    result.skippedNoSource.length > 0 ||
+    result.skippedFullyCovered.length > 0 ||
+    result.skippedErrorCooldown.length > 0 ||
+    result.errors.length > 0
+  )
+}
+
+export function nextIdleInterval(zeroTicks: number): number | undefined {
+  if (zeroTicks >= IDLE_STEADY_THRESHOLD) return IDLE_STEADY_INTERVAL_MS
+  if (zeroTicks >= IDLE_BACKOFF_THRESHOLD) return IDLE_BACKOFF_INTERVAL_MS
+  return undefined
+}
+
+async function run(signal: AbortSignal): Promise<number | void> {
   // Hard gate: hold off for the entire initial sync window so we don't
   // generate thumbs locally for files whose remote thumbnails are about
   // to land in the same catch-up.
@@ -43,11 +74,24 @@ async function run(signal: AbortSignal): Promise<void> {
     logger.debug('thumbnailScanner', 'skipped', { reason: 'syncing_down' })
     return
   }
-  await runThumbnailScanner(signal)
+  const result = await runThumbnailScanner(signal)
+  if (resultSawWork(result)) {
+    consecutiveZeroTicks = 0
+    return
+  }
+  consecutiveZeroTicks++
+  return nextIdleInterval(consecutiveZeroTicks)
 }
 
-export const { init: initThumbnailScanner } = createServiceInterval({
+const scannerInterval = createServiceInterval({
   name: 'thumbnailScanner',
   worker: run,
   interval: THUMBNAIL_SCANNER_INTERVAL,
 })
+
+export const initThumbnailScanner = scannerInterval.init
+
+export function triggerThumbnailScanner(): void {
+  resetThumbnailScannerBackoff()
+  scannerInterval.triggerNow()
+}

--- a/packages/core/src/db/operations/thumbnails.test.ts
+++ b/packages/core/src/db/operations/thumbnails.test.ts
@@ -1,4 +1,5 @@
 import { insertFile } from './files'
+import { upsertFsMeta } from './fs'
 import { db, setupTestDb, teardownTestDb } from './test-setup'
 import {
   queryBestThumbnailByFileId,
@@ -28,6 +29,7 @@ async function createTestFile(id: string, overrides?: Record<string, any>) {
     deletedAt: null,
     ...overrides,
   })
+  await upsertFsMeta(db(), { fileId: id, size: 100, addedAt: 1000, usedAt: 1000 })
 }
 
 async function createThumbnail(id: string, parentId: string, thumbSize: 64 | 512) {

--- a/packages/core/src/db/operations/thumbnails.ts
+++ b/packages/core/src/db/operations/thumbnails.ts
@@ -122,6 +122,7 @@ export async function queryThumbnailCandidatePage(
   return db.getAllAsync<ThumbnailCandidateRow>(
     `SELECT f.id, f.hash, f.type, f.localId, f.createdAt
      FROM files f
+     INNER JOIN fs fsm ON fsm.fileId = f.id
      LEFT JOIN files t
        ON t.thumbForId = f.id
       AND t.thumbSize IN (${ThumbSizes.join(',')})


### PR DESCRIPTION
The thumbnail scanner runs as a 5-second background tick from app startup, and on a quiet device it was walking the full candidate set every tick and producing nothing because the SQL didn't require the original to be locally present — metadata-only rows synced from other devices reappeared as candidates forever. The candidate query now joins through fs so metadata-only files are filtered at SQL, and after three consecutive empty ticks the scanner stretches its cadence to 30 s then 60 s, resetting on imports and explicit triggers.



https://github.com/SiaFoundation/sia-storage-app/issues/690