### PR TITLE
perf(core): batch thumbnail size lookups per scanner page

### DIFF
--- a/.changeset/batch-thumbnail-size-queries.md
+++ b/.changeset/batch-thumbnail-size-queries.md
@@ -1,0 +1,5 @@
+---
+core: patch
+---
+
+Batch thumbnail-size lookups in the scanner from one query per candidate to one per page.

--- a/packages/core/src/app/namespaces/db.ts
+++ b/packages/core/src/app/namespaces/db.ts
@@ -480,6 +480,7 @@ export function buildDbNamespaces(
       getByFileIdAndSize: (fileId, size) => ops.queryThumbnailByFileIdAndSize(db, fileId, size),
       getInfoForFiles: (fileIds) => ops.queryThumbnailFileInfoByFileIds(db, fileIds),
       getSizesForFile: (fileId) => ops.queryThumbnailSizesForFileId(db, fileId),
+      getSizesForFiles: (fileIds) => ops.queryThumbnailSizesForFileIds(db, fileIds),
       existsForFileAndSize: (fileId, size) =>
         ops.queryThumbnailExistsForFileIdAndSize(db, fileId, size),
       queryCandidatePage: (pageSize, cursor, allowedTypes) =>

--- a/packages/core/src/app/service.ts
+++ b/packages/core/src/app/service.ts
@@ -343,6 +343,8 @@ export interface AppService {
     ): Promise<{ id: string; type: string; localId: string | null }[]>
     /** Returns all available thumbnail sizes for a file. */
     getSizesForFile(fileId: string): Promise<ThumbSize[]>
+    /** Returns a map of fileId → available thumbnail sizes for a batch of files. */
+    getSizesForFiles(fileIds: string[]): Promise<Map<string, ThumbSize[]>>
     /** Returns whether a thumbnail exists for a given file and size. */
     existsForFileAndSize(fileId: string, size: ThumbSize): Promise<boolean>
     /** Returns a page of candidate originals that still need thumbnails generated. */

--- a/packages/core/src/db/operations/index.ts
+++ b/packages/core/src/db/operations/index.ts
@@ -180,6 +180,7 @@ export {
   queryThumbnailByFileIdAndSize,
   queryThumbnailScanProgress,
   queryThumbnailSizesForFileId,
+  queryThumbnailSizesForFileIds,
   queryThumbnailsByFileId,
   type ThumbnailCandidateRow,
 } from './thumbnails'

--- a/packages/core/src/db/operations/thumbnails.test.ts
+++ b/packages/core/src/db/operations/thumbnails.test.ts
@@ -8,6 +8,7 @@ import {
   queryThumbnailFileInfoByFileIds,
   queryThumbnailScanProgress,
   queryThumbnailSizesForFileId,
+  queryThumbnailSizesForFileIds,
   queryThumbnailsByFileId,
 } from './thumbnails'
 
@@ -87,6 +88,27 @@ describe('queryThumbnailSizesForFileId', () => {
     await createTestFile('f1')
     const sizes = await queryThumbnailSizesForFileId(db(), 'f1')
     expect(sizes).toEqual([])
+  })
+})
+
+describe('queryThumbnailSizesForFileIds', () => {
+  it('returns a map of fileId to sorted sizes for each file', async () => {
+    await createTestFile('f1')
+    await createTestFile('f2')
+    await createTestFile('f3')
+    await createThumbnail('t1', 'f1', 512)
+    await createThumbnail('t2', 'f1', 64)
+    await createThumbnail('t3', 'f2', 64)
+
+    const sizes = await queryThumbnailSizesForFileIds(db(), ['f1', 'f2', 'f3'])
+    expect(sizes.get('f1')).toEqual([64, 512])
+    expect(sizes.get('f2')).toEqual([64])
+    expect(sizes.get('f3')).toEqual([])
+  })
+
+  it('returns an empty map when given no fileIds', async () => {
+    const sizes = await queryThumbnailSizesForFileIds(db(), [])
+    expect(sizes.size).toBe(0)
   })
 })
 

--- a/packages/core/src/db/operations/thumbnails.ts
+++ b/packages/core/src/db/operations/thumbnails.ts
@@ -41,6 +41,28 @@ export async function queryThumbnailSizesForFileId(
     .sort((a, b) => a - b)
 }
 
+export async function queryThumbnailSizesForFileIds(
+  db: DatabaseAdapter,
+  fileIds: string[],
+): Promise<Map<string, ThumbSize[]>> {
+  const result = new Map<string, ThumbSize[]>()
+  if (fileIds.length === 0) return result
+  const ph = fileIds.map(() => '?').join(',')
+  const rows = await db.getAllAsync<{ thumbForId: string; thumbSize: number | null }>(
+    `SELECT thumbForId, thumbSize FROM files WHERE thumbForId IN (${ph})`,
+    ...fileIds,
+  )
+  for (const id of fileIds) result.set(id, [])
+  for (const r of rows) {
+    if (typeof r.thumbSize !== 'number') continue
+    if (!ThumbSizes.includes(r.thumbSize as ThumbSize)) continue
+    const list = result.get(r.thumbForId)
+    if (list) list.push(r.thumbSize as ThumbSize)
+  }
+  for (const list of result.values()) list.sort((a, b) => a - b)
+  return result
+}
+
 export async function queryThumbnailExistsForFileIdAndSize(
   db: DatabaseAdapter,
   fileId: string,

--- a/packages/core/src/services/thumbnailScanner.ts
+++ b/packages/core/src/services/thumbnailScanner.ts
@@ -202,11 +202,6 @@ export class ThumbnailScanner {
     const app = this.getApp()
     const { fileId, fileHash, fileType, size, sourceUri } = params
 
-    const exactExists = await app.thumbnails.existsForFileAndSize(fileId, size)
-    if (exactExists) {
-      return { status: 'exists' }
-    }
-
     const detectedType = await app.fs.detectMimeType(sourceUri)
     const actualType = detectedType ?? fileType
 
@@ -476,6 +471,8 @@ export class ThumbnailScanner {
         const batch = await this.queryCandidateOriginals(25, processedThisRun)
         if (batch.length === 0) break
 
+        const sizesByFileId = await app.thumbnails.getSizesForFiles(batch.map((c) => c.id))
+
         for (const c of batch) {
           if (signal?.aborted) break
           if (producedCount >= MAX_THUMBS_PER_TICK) break
@@ -491,8 +488,7 @@ export class ThumbnailScanner {
           }
 
           summary.processedCandidates += 1
-          // Determine missing sizes for this original so we don't attempt existing ones.
-          const existingSizes = await app.thumbnails.getSizesForFile(c.id)
+          const existingSizes = sizesByFileId.get(c.id) ?? []
           const missingSizes = ThumbSizes.filter((s) => !existingSizes.includes(s))
           if (missingSizes.length === 0) {
             summary.skippedFullyCovered.push({ fileId: c.id, hash: c.hash })


### PR DESCRIPTION
During heavy processing the scanner was issuing one getSizesForFile per candidate plus a redundant existsForFileAndSize per requested size, saturating the SQLite queue with tiny reads. It now prefetches a fileId → sizes map once per 25-file page and computes missing sizes from that map, dropping the redundant existence check.



https://github.com/SiaFoundation/sia-storage-app/issues/690