### PR TITLE
perf(core,mobile): adopt thumbnail files natively instead of base64 round-trip

### DIFF
--- a/.changeset/thumb-native-move.md
+++ b/.changeset/thumb-native-move.md
@@ -1,0 +1,6 @@
+---
+mobile: patch
+core: patch
+---
+
+Thumbnail generation is now faster and uses less memory, especially when processing many images at once.

--- a/apps/mobile/jest.setup.cjs
+++ b/apps/mobile/jest.setup.cjs
@@ -55,6 +55,7 @@ const rnfsHash = jest.fn()
 const rnfsMkdir = jest.fn().mockResolvedValue(undefined)
 const rnfsWriteFile = jest.fn().mockResolvedValue(undefined)
 const rnfsCopyFile = jest.fn().mockResolvedValue(undefined)
+const rnfsMoveFile = jest.fn().mockResolvedValue(undefined)
 const rnfsUnlink = jest.fn().mockResolvedValue(undefined)
 jest.mock('react-native-fs', () => ({
   __esModule: true,
@@ -68,6 +69,7 @@ jest.mock('react-native-fs', () => ({
     mkdir: rnfsMkdir,
     writeFile: rnfsWriteFile,
     copyFile: rnfsCopyFile,
+    moveFile: rnfsMoveFile,
     unlink: rnfsUnlink,
   },
 }))
@@ -81,6 +83,7 @@ global.__rnfs = {
   rnfsMkdir,
   rnfsWriteFile,
   rnfsCopyFile,
+  rnfsMoveFile,
   rnfsUnlink,
 }
 

--- a/apps/mobile/src/adapters/fsIO.test.ts
+++ b/apps/mobile/src/adapters/fsIO.test.ts
@@ -6,15 +6,19 @@ jest.mock('react-native-fs', () => ({
   exists: jest.fn(),
   unlink: jest.fn(),
   copyFile: jest.fn(),
+  moveFile: jest.fn(),
   writeFile: jest.fn(),
   mkdir: jest.fn(),
   readDir: jest.fn(),
+  hash: jest.fn(),
 }))
 
 const statMock = jest.mocked(RNFS.stat)
 const existsMock = jest.mocked(RNFS.exists)
 const unlinkMock = jest.mocked(RNFS.unlink)
 const copyFileMock = jest.mocked(RNFS.copyFile)
+const moveFileMock = jest.mocked(RNFS.moveFile)
+const hashMock = jest.mocked(RNFS.hash)
 
 function mockStatResult(size: number): RNFS.StatResult {
   return {
@@ -123,5 +127,43 @@ describe('fsIO adapter copy()', () => {
     await adapter.copy(file, 'file:///tmp/clean.png')
     expect(unlinkMock).toHaveBeenCalledTimes(1)
     expect(copyFileMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('fsIO adapter adoptFile()', () => {
+  const adapter = createFsIOAdapter()
+  const file = { id: 'file1', type: 'image/webp' }
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    existsMock.mockImplementation(async (path: string) => {
+      if (path.endsWith('/files')) return true
+      return false
+    })
+    moveFileMock.mockResolvedValue(undefined)
+    statMock.mockResolvedValue(mockStatResult(2048))
+    hashMock.mockResolvedValue('deadbeef')
+  })
+
+  it('moves the file natively, stats it, and returns a sha256 hash', async () => {
+    if (!adapter.adoptFile) throw new Error('adoptFile missing')
+    const result = await adapter.adoptFile(file, 'file:///tmp/abc.webp')
+    expect(moveFileMock).toHaveBeenCalledWith('/tmp/abc.webp', expect.any(String))
+    expect(hashMock).toHaveBeenCalledWith(expect.any(String), 'sha256')
+    expect(result).toMatchObject({ size: 2048, hash: 'deadbeef' })
+  })
+
+  it('removes an existing target before moving', async () => {
+    existsMock.mockResolvedValue(true)
+    if (!adapter.adoptFile) throw new Error('adoptFile missing')
+    await adapter.adoptFile(file, 'file:///tmp/abc.webp')
+    expect(unlinkMock).toHaveBeenCalledTimes(1)
+    expect(moveFileMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('decodes percent-encoded file:// source URIs', async () => {
+    if (!adapter.adoptFile) throw new Error('adoptFile missing')
+    await adapter.adoptFile(file, 'file:///tmp/some%20file.webp')
+    expect(moveFileMock).toHaveBeenCalledWith('/tmp/some file.webp', expect.any(String))
   })
 })

--- a/apps/mobile/src/adapters/fsIO.ts
+++ b/apps/mobile/src/adapters/fsIO.ts
@@ -65,6 +65,19 @@ export function createFsIOAdapter(): FsIOAdapter {
       const stat = await RNFS.stat(targetUri)
       return { uri: targetUri, size: stat.size }
     },
+    async adoptFile(file, sourceUri) {
+      const targetUri = fsFileUri(file.id, file.type)
+      if (!(await RNFS.exists(fsStorageDirectoryUri))) {
+        await RNFS.mkdir(fsStorageDirectoryUri)
+      }
+      if (await RNFS.exists(targetUri)) {
+        await RNFS.unlink(targetUri)
+      }
+      await RNFS.moveFile(fileUriToPath(sourceUri), targetUri)
+      const stat = await RNFS.stat(targetUri)
+      const hash = await RNFS.hash(targetUri, 'sha256')
+      return { uri: targetUri, size: stat.size, hash }
+    },
     async list() {
       if (!(await RNFS.exists(fsStorageDirectoryUri))) return []
       const entries = await RNFS.readDir(fsStorageDirectoryUri)

--- a/apps/mobile/src/adapters/thumbnail.ts
+++ b/apps/mobile/src/adapters/thumbnail.ts
@@ -1,8 +1,6 @@
 import type { ThumbnailAdapter, ThumbnailResult } from '@siastorage/core/adapters'
 import type { MimeType } from '@siastorage/core/lib/fileTypes'
 import type { ThumbSize } from '@siastorage/core/types'
-// oxlint-disable-next-line no-restricted-imports -- File constructor + .bytes() (async)
-import { File } from 'expo-file-system'
 import { ImageManipulator, SaveFormat } from 'expo-image-manipulator'
 import * as VideoThumbnails from 'expo-video-thumbnails'
 import { Image } from 'react-native'
@@ -29,7 +27,7 @@ async function resizeToWebP(
   inputUri: string,
   maxSize: number,
   skipOrientationDetection?: boolean,
-): Promise<{ result: ThumbnailResult; savedUri: string }> {
+): Promise<{ savedUri: string; mimeType: string }> {
   const ctx = ImageManipulator.manipulate(inputUri)
 
   let isPortrait: boolean
@@ -72,15 +70,7 @@ async function resizeToWebP(
     compress: 0.8,
     format: SaveFormat.WEBP,
   })
-  const file = new File(saved.uri)
-  const data = await file.bytes()
-  return {
-    result: {
-      data: data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength),
-      mimeType: 'image/webp',
-    },
-    savedUri: saved.uri,
-  }
+  return { savedUri: saved.uri, mimeType: 'image/webp' }
 }
 
 // Image MIMEs that ImageIO (iOS) and BitmapFactory (Android) can decode.
@@ -121,8 +111,7 @@ export function createMobileThumbnailAdapter(): ThumbnailAdapter {
   return {
     thumbnailableTypes: MOBILE_THUMBNAILABLE_TYPES,
     async generateImageThumbnail(sourcePath: string, targetSize: number): Promise<ThumbnailResult> {
-      const { result } = await resizeToWebP(sourcePath, targetSize as ThumbSize)
-      return result
+      return resizeToWebP(sourcePath, targetSize as ThumbSize)
     },
 
     async generateImageThumbnails(
@@ -135,12 +124,12 @@ export function createMobileThumbnailAdapter(): ThumbnailAdapter {
       let inputUri = sourcePath
       let skipDetection = false
       for (const size of sorted) {
-        const { result, savedUri } = await resizeToWebP(inputUri, size, skipDetection)
+        const result = await resizeToWebP(inputUri, size, skipDetection)
         results.set(size, result)
         // Subsequent smaller sizes resize from the larger result.
         // That file is already correctly oriented and much smaller,
         // so decoding it is essentially free.
-        inputUri = savedUri
+        inputUri = result.savedUri
         skipDetection = true
       }
 
@@ -152,8 +141,7 @@ export function createMobileThumbnailAdapter(): ThumbnailAdapter {
         time: 1000,
         quality: 0.8,
       })
-      const { result } = await resizeToWebP(thumb.uri, targetSize as ThumbSize)
-      return result
+      return resizeToWebP(thumb.uri, targetSize as ThumbSize)
     },
   }
 }

--- a/apps/mobile/src/managers/thumbnailScanner.test.ts
+++ b/apps/mobile/src/managers/thumbnailScanner.test.ts
@@ -538,6 +538,35 @@ describe('thumbnailScanner', () => {
     expect(sizes).not.toContain(64)
   })
 
+  it('routes savedUri results through fs.adoptFile (no JS-side bytes)', async () => {
+    const now = Date.now()
+    await app().files.create({
+      id: 'file1',
+      name: 'test.jpg',
+      type: 'image/jpeg',
+      kind: 'file',
+      size: 1000,
+      hash: 'hash1',
+      createdAt: now,
+      updatedAt: now,
+      addedAt: now,
+      localId: 'local-file1',
+      trashedAt: null,
+      deletedAt: null,
+    })
+    await upsertFs('file1')
+    getFsFileUriMock.mockResolvedValue('file://test.jpg')
+    const adoptSpy = jest
+      .spyOn(app().fs, 'adoptFile')
+      .mockResolvedValue({ uri: 'file://target.webp', size: 200, hash: 'thumb-hash' })
+    generateMock.mockResolvedValue({ savedUri: 'file:///tmp/sized.webp', mimeType: 'image/webp' })
+
+    const result = await runThumbnailScanner()
+    const producedSizes = result.produced.map((p) => p.size).sort((a, b) => a - b)
+    expect(producedSizes).toEqual([...ThumbSizes].sort((a, b) => a - b))
+    expect(adoptSpy).toHaveBeenCalledTimes(ThumbSizes.length)
+  })
+
   it('does not return metadata-only files (no fs row) as candidates', async () => {
     const now = Date.now()
     await app().files.create({

--- a/packages/core/src/adapters/thumbnail.ts
+++ b/packages/core/src/adapters/thumbnail.ts
@@ -1,7 +1,13 @@
-export interface ThumbnailResult {
-  data: ArrayBuffer
-  mimeType: string
-}
+// Adapters return one of two shapes:
+//   - `data`: bytes in memory (e.g. node-adapters/sharp), written via
+//     `app.fs.writeFileData`.
+//   - `savedUri`: a path to the thumbnail already on disk (e.g. mobile/
+//     expo-image-manipulator), moved into managed storage via `app.fs.adoptFile`.
+// Any FsIOAdapter paired with a thumbnail adapter that can return `savedUri`
+// MUST implement `adoptFile`; the scanner throws at runtime if it doesn't.
+export type ThumbnailResult =
+  | { data: ArrayBuffer; mimeType: string }
+  | { savedUri: string; mimeType: string }
 
 export interface ThumbnailAdapter {
   /**

--- a/packages/core/src/app/namespaces/db.ts
+++ b/packages/core/src/app/namespaces/db.ts
@@ -118,6 +118,18 @@ export function buildDbNamespaces(
       })
       return { uri: result.uri, size: result.size, hash }
     },
+    adoptFile: async (file, sourceUri) => {
+      if (!fsIO.adoptFile) throw new Error('adoptFile not implemented')
+      const result = await fsIO.adoptFile(file, sourceUri)
+      const now = Date.now()
+      await ops.upsertFsMeta(db, {
+        fileId: file.id,
+        size: result.size,
+        addedAt: now,
+        usedAt: now,
+      })
+      return result
+    },
     listFiles: () => fsIO.list(),
     ensureStorageDirectory: () => fsIO.ensureDirectory(),
     detectMimeType: async (path) => {

--- a/packages/core/src/app/service.ts
+++ b/packages/core/src/app/service.ts
@@ -1,4 +1,5 @@
 import type { Account, Host, ObjectsCursor, SdkAdapter } from '../adapters/sdk'
+import type { ThumbnailResult } from '../adapters/thumbnail'
 import type {
   Directory,
   DirectoryWithCount,
@@ -364,20 +365,11 @@ export interface AppService {
     /** Returns overall thumbnail scan progress (count of originals and thumbs). */
     queryProgress(allowedTypes: readonly string[]): Promise<{ originals: number; thumbs: number }>
     /** Generates a single image thumbnail at the given size. */
-    generate(
-      sourcePath: string,
-      targetSize: number,
-    ): Promise<{ data: ArrayBuffer; mimeType: string }>
+    generate(sourcePath: string, targetSize: number): Promise<ThumbnailResult>
     /** Generates image thumbnails at multiple sizes in one pass. */
-    generateBatch(
-      sourcePath: string,
-      sizes: number[],
-    ): Promise<Map<number, { data: ArrayBuffer; mimeType: string }>>
+    generateBatch(sourcePath: string, sizes: number[]): Promise<Map<number, ThumbnailResult>>
     /** Generates a video thumbnail at the given size. */
-    generateVideo(
-      sourcePath: string,
-      targetSize: number,
-    ): Promise<{ data: ArrayBuffer; mimeType: string }>
+    generateVideo(sourcePath: string, targetSize: number): Promise<ThumbnailResult>
   }
   /** Local object (remote reference) CRUD for file-to-indexer mappings. */
   localObjects: {
@@ -454,6 +446,11 @@ export interface AppService {
     writeFileData(
       file: { id: string; type: string },
       data: ArrayBuffer,
+    ): Promise<{ uri: string; size: number; hash: string }>
+    /** Moves an existing file into managed storage, hashes it natively, and upserts metadata. */
+    adoptFile(
+      file: { id: string; type: string },
+      sourceUri: string,
     ): Promise<{ uri: string; size: number; hash: string }>
     /** Detects the MIME type of a file at the given path. */
     detectMimeType(path: string): Promise<string | null>

--- a/packages/core/src/services/fsFileUri.ts
+++ b/packages/core/src/services/fsFileUri.ts
@@ -22,6 +22,10 @@ export type FsIOAdapter = FsFileUriAdapter & {
     file: { id: string; type: string },
     data: ArrayBuffer,
   ): Promise<{ uri: string; size: number }>
+  adoptFile?(
+    file: { id: string; type: string },
+    sourceUri: string,
+  ): Promise<{ uri: string; size: number; hash: string }>
   list(): Promise<string[]>
   ensureDirectory(): Promise<void>
 }

--- a/packages/core/src/services/thumbnailScanner.ts
+++ b/packages/core/src/services/thumbnailScanner.ts
@@ -1,10 +1,22 @@
 import { logger } from '@siastorage/logger'
+import type { ThumbnailResult } from '../adapters/thumbnail'
 import type { AppService } from '../app/service'
 import { raceWithAbort } from '../lib/timeout'
 import { uniqueId } from '../lib/uniqueId'
 import { yieldToEventLoop } from '../lib/yieldToEventLoop'
 import type { FileRecord, ThumbSize } from '../types/files'
 import { ThumbSizes } from '../types/files'
+
+async function writeThumbnailToStorage(
+  app: AppService,
+  thumbInfo: { id: string; type: string },
+  result: ThumbnailResult,
+): Promise<{ uri: string; size: number; hash: string }> {
+  if ('savedUri' in result) {
+    return app.fs.adoptFile(thumbInfo, result.savedUri)
+  }
+  return app.fs.writeFileData(thumbInfo, result.data)
+}
 
 export type ThumbnailCandidateRow = {
   id: string
@@ -234,7 +246,7 @@ export class ThumbnailScanner {
       detectedType,
     })
 
-    let result: { data: ArrayBuffer; mimeType: string }
+    let result: ThumbnailResult
     try {
       if (actualType?.startsWith('video/')) {
         result = await app.thumbnails.generateVideo(sourceUri, size)
@@ -261,7 +273,7 @@ export class ThumbnailScanner {
         id: thumbId,
         type: result.mimeType,
       }
-      const copied = await app.fs.writeFileData(thumbFileInfo, result.data)
+      const copied = await writeThumbnailToStorage(app, thumbFileInfo, result)
 
       const now = Date.now()
       // Thumb is on disk; gate so files.create can't fast-reject and
@@ -332,7 +344,7 @@ export class ThumbnailScanner {
       return
     }
 
-    let thumbnails: Map<number, { data: ArrayBuffer; mimeType: string }>
+    let thumbnails: Map<number, ThumbnailResult>
     try {
       thumbnails = await app.thumbnails.generateBatch(sourceUri, sizes)
     } catch (e) {
@@ -351,9 +363,10 @@ export class ThumbnailScanner {
       if (!result) continue
       try {
         const thumbId = uniqueId()
-        const copied = await app.fs.writeFileData(
+        const copied = await writeThumbnailToStorage(
+          app,
           { id: thumbId, type: result.mimeType },
-          result.data,
+          result,
         )
         const now = Date.now()
         // See ensureThumbnail above — gate the files.create that follows

--- a/packages/node-adapters/test/thumbnail.test.ts
+++ b/packages/node-adapters/test/thumbnail.test.ts
@@ -1,7 +1,13 @@
+import type { ThumbnailResult } from '@siastorage/core/adapters'
 import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
 import { createSharpThumbnailAdapter } from '../src/thumbnail-sharp'
+
+function dataOf(result: ThumbnailResult): ArrayBuffer {
+  if (!('data' in result)) throw new Error('expected ArrayBuffer result, got savedUri')
+  return result.data
+}
 
 let tempDir: string
 let adapter: ReturnType<typeof createSharpThumbnailAdapter>
@@ -35,19 +41,20 @@ beforeEach(() => {
 describe('generateImageThumbnail', () => {
   it('generates thumbnail at target size', async () => {
     const result = await adapter.generateImageThumbnail(testImagePath, 50)
-    expect(result.data.byteLength).toBeGreaterThan(0)
+    const data = dataOf(result)
+    expect(data.byteLength).toBeGreaterThan(0)
     expect(result.mimeType).toBe('image/webp')
 
     // Verify dimensions
     const sharp = require('sharp')
-    const meta = await sharp(Buffer.from(result.data)).metadata()
+    const meta = await sharp(Buffer.from(data)).metadata()
     expect(meta.width).toBeLessThanOrEqual(50)
     expect(meta.height).toBeLessThanOrEqual(50)
   })
 
   it('outputs WebP format', async () => {
     const result = await adapter.generateImageThumbnail(testImagePath, 50)
-    const buf = Buffer.from(result.data)
+    const buf = Buffer.from(dataOf(result))
     // WebP starts with RIFF....WEBP
     expect(buf.slice(0, 4).toString()).toBe('RIFF')
     expect(buf.slice(8, 12).toString()).toBe('WEBP')
@@ -56,14 +63,14 @@ describe('generateImageThumbnail', () => {
   it('does not enlarge beyond original size', async () => {
     const result = await adapter.generateImageThumbnail(testImagePath, 1000)
     const sharp = require('sharp')
-    const meta = await sharp(Buffer.from(result.data)).metadata()
+    const meta = await sharp(Buffer.from(dataOf(result))).metadata()
     expect(meta.width).toBeLessThanOrEqual(200)
     expect(meta.height).toBeLessThanOrEqual(150)
   })
 
   it('handles file:// prefix', async () => {
     const result = await adapter.generateImageThumbnail(`file://${testImagePath}`, 50)
-    expect(result.data.byteLength).toBeGreaterThan(0)
+    expect(dataOf(result).byteLength).toBeGreaterThan(0)
   })
 })
 
@@ -75,7 +82,7 @@ describe('generateImageThumbnails', () => {
     for (const size of sizes) {
       const result = results.get(size)
       expect(result).toBeDefined()
-      expect(result!.data.byteLength).toBeGreaterThan(0)
+      expect(dataOf(result!).byteLength).toBeGreaterThan(0)
       expect(result!.mimeType).toBe('image/webp')
     }
   })


### PR DESCRIPTION
Every produced thumb WebP was being read off disk into JS, base64-encoded, and re-written through RNFS — 200–800 ms of JS-thread CPU per tick during bursts, with no benefit since the file already existed on disk from ImageManipulator.saveAsync. ThumbnailResult is now a discriminated union of { data } or { savedUri }, the mobile adapter returns the saved path directly, and a new app.fs.adoptFile moves the file into managed storage and hashes it via RNFS.hash without crossing the bridge.



https://github.com/SiaFoundation/sia-storage-app/issues/690