### PR TITLE
perf(core,mobile): correct file types from magic bytes

### DIFF
--- a/.changeset/mime-bytes-first-priority.md
+++ b/.changeset/mime-bytes-first-priority.md
@@ -1,0 +1,6 @@
+---
+core: patch
+mobile: patch
+---
+
+Recognize files by their magic bytes instead of trusting a misleading filename extension, so a `.heic`-named file that's actually JPEG is identified as JPEG everywhere `type` is surfaced.

--- a/.changeset/thumb-scanner-self-heal-type.md
+++ b/.changeset/thumb-scanner-self-heal-type.md
@@ -1,0 +1,6 @@
+---
+mobile: patch
+core: patch
+---
+
+The thumbnail scanner now self-heals files whose recorded type disagrees with their actual content: the file is renamed on disk and the record updated, so other devices receive the fix on the next sync.

--- a/apps/integration/test/adapters/fs.ts
+++ b/apps/integration/test/adapters/fs.ts
@@ -44,6 +44,24 @@ export function createFsAdapter(params: { tempDir: string }) {
       nodeFs.writeFileSync(fp, buf)
       return { uri: `file://${fp}`, size: buf.byteLength }
     },
+    async renameToType(file, newType) {
+      const oldFp = fsFilePath(file.id, file.type)
+      const newFp = fsFilePath(file.id, newType)
+      if (oldFp === newFp) return { uri: `file://${oldFp}` }
+      if (!nodeFs.existsSync(oldFp)) {
+        if (nodeFs.existsSync(newFp)) return { uri: `file://${newFp}` }
+        throw new Error(`renameToType: neither ${oldFp} nor ${newFp} exists`)
+      }
+      if (nodeFs.existsSync(newFp)) {
+        try {
+          nodeFs.unlinkSync(newFp)
+        } catch {
+          // Best effort; rename below will throw if newFp still exists.
+        }
+      }
+      nodeFs.renameSync(oldFp, newFp)
+      return { uri: `file://${newFp}` }
+    },
     async list() {
       if (!nodeFs.existsSync(tempDir)) return []
       return nodeFs.readdirSync(tempDir) as string[]

--- a/apps/integration/test/adapters/fsIO.ts
+++ b/apps/integration/test/adapters/fsIO.ts
@@ -10,6 +10,9 @@ export function createMockFsIO(overrides?: Partial<FsIOAdapter>): FsIOAdapter {
       uri: 'file://thumb.webp',
       size: data.byteLength,
     }),
+    renameToType: async (file, newType) => ({
+      uri: `file://${file.id}.${newType.split('/').pop()}`,
+    }),
     list: async () => [],
     ensureDirectory: async () => {},
     ...overrides,

--- a/apps/mobile/src/adapters/fsIO.ts
+++ b/apps/mobile/src/adapters/fsIO.ts
@@ -78,6 +78,29 @@ export function createFsIOAdapter(): FsIOAdapter {
       const hash = await RNFS.hash(targetUri, 'sha256')
       return { uri: targetUri, size: stat.size, hash }
     },
+    async renameToType(file, newType) {
+      const oldUri = fsFileUri(file.id, file.type)
+      const newUri = fsFileUri(file.id, newType)
+      if (oldUri === newUri) return { uri: oldUri }
+      if (!(await RNFS.exists(oldUri))) {
+        // oldUri missing — only treat as success if newUri exists
+        // (idempotent retry), otherwise the caller will record a DB
+        // type for which no file is on disk.
+        if (await RNFS.exists(newUri)) return { uri: newUri }
+        throw new Error(`renameToType: neither ${oldUri} nor ${newUri} exists`)
+      }
+      if (await RNFS.exists(newUri)) {
+        // Swallow ENOENT if a concurrent scanner pass dropped the
+        // destination between our exists check and unlink.
+        try {
+          await RNFS.unlink(newUri)
+        } catch {
+          // Best effort; rename below will fail loudly if newUri remains.
+        }
+      }
+      await RNFS.moveFile(oldUri, newUri)
+      return { uri: newUri }
+    },
     async list() {
       if (!(await RNFS.exists(fsStorageDirectoryUri))) return []
       const entries = await RNFS.readDir(fsStorageDirectoryUri)

--- a/apps/mobile/src/managers/thumbnailScanner.test.ts
+++ b/apps/mobile/src/managers/thumbnailScanner.test.ts
@@ -596,6 +596,67 @@ describe('thumbnailScanner', () => {
   })
 })
 
+describe('thumbnailScanner type write-back', () => {
+  it('updates files.type when the magic-byte sniff disagrees with the declared type', async () => {
+    const now = Date.now()
+    await app().files.create({
+      id: 'file1',
+      name: 'photo.heic',
+      type: 'image/heic',
+      kind: 'file',
+      size: 1000,
+      hash: 'hash1',
+      createdAt: now,
+      updatedAt: now,
+      addedAt: now,
+      localId: 'local-file1',
+      trashedAt: null,
+      deletedAt: null,
+    })
+    await upsertFs('file1')
+    jest.spyOn(app().fs, 'detectMimeType').mockResolvedValue('image/jpeg')
+    const updateSpy = jest.spyOn(app().files, 'update')
+
+    await runThumbnailScanner()
+
+    const correction = updateSpy.mock.calls.find(([arg]) => arg.id === 'file1')
+    expect(correction).toBeDefined()
+    expect(correction?.[0]).toMatchObject({ id: 'file1', type: 'image/jpeg' })
+
+    const updated = await app().files.getById('file1')
+    expect(updated?.type).toBe('image/jpeg')
+  })
+
+  it('does not rewrite when declared and detected map to the same extension', async () => {
+    // image/dng and image/x-adobe-dng both -> .dng. Both are recognized
+    // MIMEs AND image/dng is in MOBILE_THUMBNAILABLE_TYPES, so the file
+    // reaches the per-candidate loop where shouldReplaceType runs.
+    const now = Date.now()
+    await app().files.create({
+      id: 'file1',
+      name: 'photo.dng',
+      type: 'image/dng',
+      kind: 'file',
+      size: 1000,
+      hash: 'hash1',
+      createdAt: now,
+      updatedAt: now,
+      addedAt: now,
+      localId: 'local-file1',
+      trashedAt: null,
+      deletedAt: null,
+    })
+    await upsertFs('file1')
+    jest.spyOn(app().fs, 'detectMimeType').mockResolvedValue('image/x-adobe-dng')
+    const updateSpy = jest.spyOn(app().files, 'update')
+
+    await runThumbnailScanner()
+
+    const correction = updateSpy.mock.calls.find(([arg]) => arg.id === 'file1')
+    expect(correction).toBeUndefined()
+  })
+})
+
 describe('thumbnailScanner idle backoff', () => {
   beforeEach(() => {
     resetThumbnailScannerBackoff()

--- a/packages/core/src/app/namespaces/db.ts
+++ b/packages/core/src/app/namespaces/db.ts
@@ -130,6 +130,7 @@ export function buildDbNamespaces(
       })
       return result
     },
+    renameToType: (file, newType) => fsIO.renameToType(file, newType),
     listFiles: () => fsIO.list(),
     ensureStorageDirectory: () => fsIO.ensureDirectory(),
     detectMimeType: async (path) => {

--- a/packages/core/src/app/service.ts
+++ b/packages/core/src/app/service.ts
@@ -452,6 +452,8 @@ export interface AppService {
       file: { id: string; type: string },
       sourceUri: string,
     ): Promise<{ uri: string; size: number; hash: string }>
+    /** Renames the on-disk path to match a new mime type. Call before persisting `type`. */
+    renameToType(file: { id: string; type: string }, newType: string): Promise<{ uri: string }>
     /** Detects the MIME type of a file at the given path. */
     detectMimeType(path: string): Promise<string | null>
     /** Lists all filenames in the managed storage directory. */

--- a/packages/core/src/lib/detectMimeType.test.ts
+++ b/packages/core/src/lib/detectMimeType.test.ts
@@ -41,16 +41,19 @@ describe('detectMimeType', () => {
     expect(detectMimeType({ bytes: pdfBytes })).toBe('application/pdf')
   })
 
-  it('prioritizes providedType over extension', () => {
-    expect(detectMimeType({ providedType: 'image/png', fileName: 'photo.jpg' })).toBe('image/png')
-  })
-
-  it('prioritizes extension over bytes', () => {
+  it('prioritizes bytes over a misleading extension', () => {
+    // .heic filename, JPEG bytes — common iOS export case where the
+    // file was auto-converted to JPEG but the filename kept .heic.
     const jpegBytes = new Uint8Array([0xff, 0xd8, 0xff, 0xe0])
-    expect(detectMimeType({ fileName: 'image.png', bytes: jpegBytes })).toBe('image/png')
+    expect(detectMimeType({ fileName: 'photo.heic', bytes: jpegBytes })).toBe('image/jpeg')
   })
 
-  it('prioritizes providedType over extension over bytes', () => {
+  it('prioritizes bytes over a misleading providedType', () => {
+    const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+    expect(detectMimeType({ providedType: 'image/jpeg', bytes: pngBytes })).toBe('image/png')
+  })
+
+  it('prioritizes bytes over extension over providedType', () => {
     const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
     expect(
       detectMimeType({
@@ -58,7 +61,18 @@ describe('detectMimeType', () => {
         fileName: 'photo.jpg',
         bytes: pngBytes,
       }),
-    ).toBe('video/mp4')
+    ).toBe('image/png')
+  })
+
+  it('falls back to extension when bytes are unrecognized', () => {
+    const garbage = new Uint8Array([0x00, 0x01, 0x02, 0x03])
+    expect(detectMimeType({ fileName: 'doc.pdf', bytes: garbage })).toBe('application/pdf')
+  })
+
+  it('falls back to providedType when bytes and extension fail', () => {
+    expect(detectMimeType({ providedType: 'image/jpeg', fileName: 'no-extension' })).toBe(
+      'image/jpeg',
+    )
   })
 
   it('returns application/octet-stream when no signals are provided', () => {

--- a/packages/core/src/lib/detectMimeType.ts
+++ b/packages/core/src/lib/detectMimeType.ts
@@ -256,9 +256,9 @@ export function detectMimeTypeFromBytes(bytes: Uint8Array): string | null {
 
 /**
  * Unified MIME type detection with priority chain:
- * 1. providedType if recognized
+ * 1. Magic bytes (ground truth — wins over a misleading extension)
  * 2. Extension from fileName
- * 3. Magic bytes
+ * 3. providedType if recognized
  * 4. Fallback: application/octet-stream
  *
  * Synchronous, pure, no I/O. Callers read bytes themselves.
@@ -268,8 +268,9 @@ export function detectMimeType(opts: {
   fileName?: string | null
   bytes?: Uint8Array | null
 }): string {
-  if (opts.providedType && isMimeType(opts.providedType)) {
-    return opts.providedType
+  if (opts.bytes) {
+    const fromBytes = detectMimeTypeFromBytes(opts.bytes)
+    if (fromBytes) return fromBytes
   }
 
   if (opts.fileName) {
@@ -277,9 +278,8 @@ export function detectMimeType(opts: {
     if (fromExt) return fromExt
   }
 
-  if (opts.bytes) {
-    const fromBytes = detectMimeTypeFromBytes(opts.bytes)
-    if (fromBytes) return fromBytes
+  if (opts.providedType && isMimeType(opts.providedType)) {
+    return opts.providedType
   }
 
   return 'application/octet-stream'

--- a/packages/core/src/services/fsFileUri.ts
+++ b/packages/core/src/services/fsFileUri.ts
@@ -26,6 +26,15 @@ export type FsIOAdapter = FsFileUriAdapter & {
     file: { id: string; type: string },
     sourceUri: string,
   ): Promise<{ uri: string; size: number; hash: string }>
+  /**
+   * Move a file's on-disk path to match a new mime type. No-op when
+   * extensions match. **Overwrites** any existing file at the destination
+   * — callers must ensure the destination is safe to replace. The
+   * scanner's self-heal path guarantees this because the destination is
+   * derived from file ID + new type, which only collides for files being
+   * explicitly corrected.
+   */
+  renameToType(file: { id: string; type: string }, newType: string): Promise<{ uri: string }>
   list(): Promise<string[]>
   ensureDirectory(): Promise<void>
 }

--- a/packages/core/src/services/thumbnailScanner.test.ts
+++ b/packages/core/src/services/thumbnailScanner.test.ts
@@ -1,0 +1,29 @@
+import { shouldReplaceType } from './thumbnailScanner'
+
+describe('shouldReplaceType', () => {
+  it('returns false when declared and detected match', () => {
+    expect(shouldReplaceType('image/jpeg', 'image/jpeg')).toBe(false)
+  })
+
+  it('returns false when detected is not a recognized MIME type', () => {
+    expect(shouldReplaceType('image/jpeg', 'application/x-not-a-mime')).toBe(false)
+  })
+
+  it('returns true when declared is application/octet-stream and detected is recognized', () => {
+    expect(shouldReplaceType('application/octet-stream', 'image/jpeg')).toBe(true)
+  })
+
+  it('returns true when declared is not a recognized MIME type', () => {
+    expect(shouldReplaceType('application/x-not-a-mime', 'image/jpeg')).toBe(true)
+  })
+
+  it('returns false when declared and detected map to the same extension (sniffer drift)', () => {
+    // audio/mp4 and audio/x-m4a both -> .m4a — common drift between
+    // sniffers that disagree on the alias for an MPEG-4 audio container.
+    expect(shouldReplaceType('audio/mp4', 'audio/x-m4a')).toBe(false)
+  })
+
+  it('returns true when declared and detected map to different extensions', () => {
+    expect(shouldReplaceType('image/heic', 'image/jpeg')).toBe(true)
+  })
+})

--- a/packages/core/src/services/thumbnailScanner.ts
+++ b/packages/core/src/services/thumbnailScanner.ts
@@ -1,6 +1,7 @@
 import { logger } from '@siastorage/logger'
 import type { ThumbnailResult } from '../adapters/thumbnail'
 import type { AppService } from '../app/service'
+import { extFromMime, isMimeType } from '../lib/fileTypes'
 import { raceWithAbort } from '../lib/timeout'
 import { uniqueId } from '../lib/uniqueId'
 import { yieldToEventLoop } from '../lib/yieldToEventLoop'
@@ -16,6 +17,78 @@ async function writeThumbnailToStorage(
     return app.fs.adoptFile(thumbInfo, result.savedUri)
   }
   return app.fs.writeFileData(thumbInfo, result.data)
+}
+
+/**
+ * True when a magic-byte sniff should overwrite the stored `type`.
+ * Blocks rewrites between MIMEs that share an extension to avoid
+ * sniffer-drift flapping (e.g. image/dng vs image/x-adobe-dng).
+ */
+export function shouldReplaceType(declared: string, detected: string): boolean {
+  if (declared === detected) return false
+  if (!isMimeType(detected)) return false
+  if (declared === 'application/octet-stream') return true
+  if (!isMimeType(declared)) return true
+  const declaredExt = extFromMime(declared)
+  const detectedExt = extFromMime(detected)
+  // Defensive: if either side falls back to `.bin` (extFromMime's default
+  // for any MIME without an explicit case), we don't know if they collide
+  // on disk — err on the side of rewriting to the recognized type.
+  if (declaredExt === '.bin' || detectedExt === '.bin') return true
+  return declaredExt !== detectedExt
+}
+
+/**
+ * Apply a type correction: update the DB first, then rename the on-disk
+ * file (storage path is derived from `type`). Returns the new URI.
+ *
+ * DB-first ordering: the SQL write is the cheap, atomic step; the FS
+ * rename is the risky one. If the rename throws, we roll the DB back to
+ * the old type so the on-disk file (still at the old path) stays
+ * findable by the next scan, which can retry the correction cleanly.
+ */
+async function correctType(
+  app: AppService,
+  fileId: string,
+  oldType: string,
+  newType: string,
+): Promise<string> {
+  logger.info('thumbnailer', 'type_corrected', {
+    fileId,
+    storedType: oldType,
+    detectedType: newType,
+  })
+  await app.files.update({ id: fileId, type: newType })
+  try {
+    const renamed = await app.fs.renameToType({ id: fileId, type: oldType }, newType)
+    return renamed.uri
+  } catch (e) {
+    // Best-effort rollback so the DB stays consistent with disk.
+    await app.files.update({ id: fileId, type: oldType }).catch(() => {})
+    throw e
+  }
+}
+
+/**
+ * Detect + correct (if needed) once per file, before iterating sizes.
+ * Returns the post-correction type and source URI for per-size calls,
+ * so they don't redundantly re-detect or re-correct.
+ */
+async function prepareForCandidate(
+  app: AppService,
+  fileId: string,
+  fileType: string,
+  sourceUri: string,
+): Promise<{ actualType: string; effectiveSourceUri: string }> {
+  const detectedType = await app.fs.detectMimeType(sourceUri)
+  let effectiveSourceUri = sourceUri
+  if (detectedType && shouldReplaceType(fileType, detectedType)) {
+    effectiveSourceUri = await correctType(app, fileId, fileType, detectedType)
+  }
+  return {
+    actualType: detectedType ?? fileType,
+    effectiveSourceUri,
+  }
 }
 
 export type ThumbnailCandidateRow = {
@@ -184,24 +257,34 @@ export class ThumbnailScanner {
         missingSizes,
       })
 
-      if (fileRecord.type?.startsWith('image/') && missingSizes.length > 1) {
+      // Detect + self-heal type once per file, before iterating sizes,
+      // so subsequent per-size calls don't redundantly re-detect and
+      // re-correct (which would log + write to the DB N times).
+      const { actualType, effectiveSourceUri } = await prepareForCandidate(
+        app,
+        fileRecord.id,
+        fileRecord.type,
+        sourceUri,
+      )
+
+      if (actualType.startsWith('image/') && missingSizes.length > 1) {
         await this.ensureThumbnailsBatch({
           fileId: fileRecord.id,
           fileHash: fileRecord.hash,
-          fileType: fileRecord.type,
+          fileType: actualType,
           fileLocalId: fileRecord.localId,
           sizes: missingSizes,
-          sourceUri,
+          sourceUri: effectiveSourceUri,
         })
       } else {
         for (const size of missingSizes) {
           await this.ensureThumbnailForSize({
             fileId: fileRecord.id,
             fileHash: fileRecord.hash,
-            fileType: fileRecord.type,
+            fileType: actualType,
             fileLocalId: fileRecord.localId,
             size,
-            sourceUri,
+            sourceUri: effectiveSourceUri,
           })
         }
       }
@@ -214,25 +297,17 @@ export class ThumbnailScanner {
     const app = this.getApp()
     const { fileId, fileHash, fileType, size, sourceUri } = params
 
-    const detectedType = await app.fs.detectMimeType(sourceUri)
-    const actualType = detectedType ?? fileType
-
-    if (detectedType && detectedType !== fileType) {
-      logger.warn('thumbnailer', 'type_mismatch', {
-        fileId,
-        storedType: fileType,
-        detectedType,
-        sourceUri,
-      })
-    }
+    // Caller (runScan / generateThumbnailsForFile) is responsible for
+    // running detect+correct via prepareForCandidate, so `fileType` here
+    // is already the post-correction type.
+    const actualType = fileType
 
     if (!actualType || !app.thumbnails.allowedTypes.includes(actualType)) {
       logger.error('thumbnailer', 'unsupported_format', {
         fileId,
         fileHash,
         size,
-        storedType: fileType,
-        detectedType,
+        type: actualType,
         sourceUri,
       })
       this.markFileErrored(fileId)
@@ -242,8 +317,7 @@ export class ThumbnailScanner {
     logger.debug('thumbnailer', 'source_uri', {
       fileId,
       uri: sourceUri,
-      storedType: fileType,
-      detectedType,
+      type: actualType,
     })
 
     let result: ThumbnailResult
@@ -258,8 +332,7 @@ export class ThumbnailScanner {
         fileId,
         fileHash,
         size,
-        storedType: fileType,
-        detectedType,
+        type: actualType,
         sourceUri,
         error: e as Error,
       })
@@ -315,8 +388,7 @@ export class ThumbnailScanner {
         fileId,
         fileHash,
         size,
-        storedType: fileType,
-        detectedType,
+        type: actualType,
         sourceUri,
         error: e as Error,
       })
@@ -336,10 +408,9 @@ export class ThumbnailScanner {
     const app = this.getApp()
     const { fileId, fileHash, fileType, sizes, sourceUri } = params
 
-    const detectedType = await app.fs.detectMimeType(sourceUri)
-    const actualType = detectedType ?? fileType
-
-    if (!actualType || !app.thumbnails.allowedTypes.includes(actualType)) {
+    // Caller is responsible for running detect+correct via prepareForCandidate,
+    // so `fileType` here is already the post-correction type.
+    if (!fileType || !app.thumbnails.allowedTypes.includes(fileType)) {
       this.markFileErrored(fileId)
       return
     }
@@ -528,6 +599,15 @@ export class ThumbnailScanner {
             missingSizes: missingSizes.join(','),
           })
 
+          // Detect + self-heal type once per candidate, before the size
+          // loop, so we don't redundantly re-correct on every size.
+          const { actualType, effectiveSourceUri } = await prepareForCandidate(
+            app,
+            c.id,
+            c.type,
+            sourceUri,
+          )
+
           for (const size of missingSizes) {
             // Exit early on suspension so the DB can close promptly.
             if (signal?.aborted || producedCount >= MAX_THUMBS_PER_TICK) break
@@ -543,10 +623,10 @@ export class ThumbnailScanner {
               this.ensureThumbnailForSize({
                 fileId: c.id,
                 fileHash: c.hash,
-                fileType: c.type,
+                fileType: actualType,
                 fileLocalId: c.localId,
                 size,
-                sourceUri,
+                sourceUri: effectiveSourceUri,
               }),
               signal,
             )

--- a/packages/node-adapters/src/fsIO.ts
+++ b/packages/node-adapters/src/fsIO.ts
@@ -49,6 +49,32 @@ export function createNodeFsIO(filesDir: string): FsIOAdapter {
       return { uri: target, size: buf.byteLength }
     },
 
+    async renameToType(file, newType) {
+      const oldPath = filePath(file.id, file.type)
+      const newPath = filePath(file.id, newType)
+      if (oldPath === newPath) return { uri: oldPath }
+      try {
+        await fs.access(oldPath)
+      } catch {
+        // oldPath missing — only treat as success if newPath exists
+        // (idempotent retry after a partial rename), otherwise the
+        // caller will record a DB type for which no file is on disk.
+        try {
+          await fs.access(newPath)
+          return { uri: newPath }
+        } catch {
+          throw new Error(`renameToType: neither ${oldPath} nor ${newPath} exists`)
+        }
+      }
+      try {
+        await fs.unlink(newPath)
+      } catch (e: any) {
+        if (e?.code !== 'ENOENT') throw e
+      }
+      await fs.rename(oldPath, newPath)
+      return { uri: newPath }
+    },
+
     async list() {
       try {
         return await fs.readdir(filesDir)


### PR DESCRIPTION
The app was trusting filename extensions over a file's actual signature, so a .heic-named JPEG (a common artifact of shared iOS exports) ended up routed and stored as HEIC and got re-sniffed on every thumbnail tick. detectMimeType now prefers magic bytes over extension and providedType, and the thumbnail scanner self-heals any disagreement it spots by renaming the on-disk file and updating the DB.

https://github.com/SiaFoundation/sia-storage-app/issues/690