### PR TITLE
fix(core,mobile): close suspend-time orphan-commit races

### DIFF
--- a/.changeset/suspend-writable-guards.md
+++ b/.changeset/suspend-writable-guards.md
@@ -1,0 +1,6 @@
+---
+core: patch
+mobile: patch
+---
+
+Fixed iOS suspend-time races that could leave an upload, sync-up, download, import, thumbnail, or share-sheet add half-applied.

--- a/apps/mobile/src/adapters/uploader.ts
+++ b/apps/mobile/src/adapters/uploader.ts
@@ -1,14 +1,9 @@
 import type { UploaderAdapters } from '@siastorage/core/app'
-import { db } from '../db'
 import { createFileReader } from '../lib/fileReader'
 
 export function createUploaderAdapters(): UploaderAdapters {
   return {
     createFileReader: (uri) => createFileReader(uri),
     progressScheduler: (cb) => requestAnimationFrame(cb),
-    // Surface the DB gate so saveBatchObjects can wait for resume
-    // before issuing finalize reads/writes (otherwise pin progress
-    // is dropped on the floor when finalize fires post-suspend).
-    db: db(),
   }
 }

--- a/apps/mobile/src/components/FileImport/index.tsx
+++ b/apps/mobile/src/components/FileImport/index.tsx
@@ -211,6 +211,9 @@ export function FileImport({
       logger.info('FileImport', 'importing_file', { id: sharedFile.data.id })
 
       const localObject = await app().shares.pin(shareUrl, sharedFile.data.id)
+      // Indexer pin is done; gate so files.create can't fast-reject and
+      // leave the user's share missing from their library.
+      await app().db.waitUntilActive()
       await app().files.create(sharedFile.data, localObject)
 
       toast.show('File added')

--- a/apps/mobile/src/db/index.ts
+++ b/apps/mobile/src/db/index.ts
@@ -8,9 +8,8 @@ import { Platform } from 'react-native'
 import { getSharedDbDirectory } from '../lib/sharedContainer'
 import { migrations } from './migrations'
 
-// Thrown by the adapter when a query is issued while the suspension gate
-// is closed. Reads and writes both reject — callers that want to wait for
-// the gate to open should call waitForDbActive() before issuing the query.
+// Thrown when a query is issued while the suspension gate is closed.
+// Callers that need to wait for resume call waitUntilDbActive() first.
 export class DatabaseSuspendedError extends Error {
   constructor() {
     super('Database is suspended for background transition')
@@ -18,44 +17,29 @@ export class DatabaseSuspendedError extends Error {
   }
 }
 
-// Suspension lifecycle state. The DB connection is NEVER closed across
-// suspension; this flag only gates JS-side dispatch. iOS recognizes
-// SQLite databases by the file-header magic bytes and exempts processes
-// holding file locks on recognized SQLite files from the 0xDEAD10CC
-// kill — so leaving the connection open is safe as long as no write or
-// fsync is in flight at suspension time (which the suspension manager's
-// drain ensures).
+// Suspension lifecycle state. The DB connection stays open across
+// suspension; iOS exempts SQLite files (recognized by magic bytes) from
+// the 0xDEAD10CC kill as long as no write/fsync is mid-flight — the
+// drain ensures that.
 //
-// States:
 // - 'active':     queries flow normally.
-// - 'suspending': all queries reject fast with DatabaseSuspendedError.
-//                 Callers that want to retry on resume should await
-//                 waitForDbActive() BEFORE issuing the query — never
-//                 inside an open transaction's fn (would deadlock with
-//                 the suspension manager waiting on the txMutex holder).
-// - 'closed':     handle destroyed, reopen imminent — both reads and
-//                 writes park on activeWaiters. This is the load-bearing
-//                 case for picker / share-intent callbacks that fire
-//                 during the ~80ms reopen window. The current suspend
-//                 flow does NOT close the DB, so this state is only
-//                 reachable from resetDb (manual reset from settings).
+// - 'suspending': queries fast-reject; callers that need to wait for
+//                 resume call waitUntilDbActive() BEFORE the query.
+//                 Calling it inside withTransactionAsync's fn deadlocks
+//                 the drain (txMutex held while waiting).
+// - 'closed':     handle destroyed, reopen imminent — queries park.
+//                 Today only reachable via resetDb (manual reset).
 type DbState = 'active' | 'suspending' | 'closed'
 
 let state: DbState = 'active'
 
-// Queue of callers parked inside waitForActive(). Drained by resumeDb()
-// when state returns to 'active'. Only populated under 'closed' state
-// (parking) or via the public waitForDbActive() helper.
+// Callers parked inside enterGate() or waitUntilDbActive(). Drained by
+// resumeDb() when state returns to 'active'.
 let activeWaiters: Array<() => void> = []
 
-// Safety valve: if resume never fires (app stuck in broken state), don't
-// let parked waiters pile up forever. 30s is well past any realistic iOS
-// thaw or Android foreground transition.
+// Safety valve for a resume that never fires.
 const WAIT_TIMEOUT_MS = 30_000
 
-// Pushes resolveOnce onto activeWaiters and arms a 30s safety-valve
-// rejection. Used by both the internal 'closed'-state parking and the
-// public waitForDbActive helper.
 function parkUntilActive(): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     let settled = false
@@ -75,37 +59,30 @@ function parkUntilActive(): Promise<void> {
   })
 }
 
-function waitForActive(_intent: 'read' | 'write'): Promise<void> {
+// Per-query gate. Fast-rejects during 'suspending' so in-flight
+// transactions release the txMutex and let the drain finish; parking
+// here would deadlock (fn awaits the parked write → mutex never
+// releases → inflightCount stays high).
+function enterGate(_intent: 'read' | 'write'): Promise<void> {
   if (state === 'active') return Promise.resolve()
-  // 'suspending': both intents reject fast. Parking writes here used to
-  // deadlock the suspension drain — a transaction's fn would park its
-  // inner write, fn would await forever, txMutex holder wouldn't release,
-  // and inflightCount stayed high so waitForQueriesIdle never resolved.
-  // Callers that need wait-for-resume semantics call waitForDbActive()
-  // BEFORE entering withTransactionAsync.
   if (state === 'suspending') {
     return Promise.reject(new DatabaseSuspendedError())
   }
-  // 'closed': park both intents. Picker / share-intent callbacks during
-  // a reopen window need their INSERTs to land against the new handle.
-  // Only reachable today via resetDb (manual settings reset).
+  // 'closed': park so picker / share-intent callbacks land their
+  // INSERTs against the new handle after reopen.
   return parkUntilActive()
 }
 
 /**
- * Resolves when the DB gate is open ('active'). Call this BEFORE issuing
- * a sequence of queries that should run on the same side of the gate
- * (e.g. upload finalize: getMetadata → pinObject → upsertMany).
+ * Resolves when state returns to 'active'. Call BEFORE any sequence of
+ * reads/writes that must land on the same side of the suspend gate —
+ * typically right after an irrecoverable network or filesystem commit.
  *
- * If state is already 'active', resolves synchronously. Otherwise, parks
- * on activeWaiters until resumeDb() fires the queue. Bounded by the
- * same 30s safety valve as the internal waitForActive.
- *
- * Do NOT call from inside withTransactionAsync's fn — by then the
- * txMutex is held and the suspension manager can't drain. Wrap the
- * whole logical operation (txn included) in waitForDbActive instead.
+ * Do NOT call from inside withTransactionAsync's fn — the txMutex is
+ * held by then and the drain can't finish. Gate the whole logical
+ * operation (txn included) instead.
  */
-export function waitForDbActive(): Promise<void> {
+export function waitUntilDbActive(): Promise<void> {
   if (state === 'active') return Promise.resolve()
   return parkUntilActive()
 }
@@ -146,25 +123,21 @@ export function getWalPath(): string {
   return `${dbDirectory}/${dbName}-wal`
 }
 
-// Called by the suspension manager as the first step when the app backgrounds.
-// After this, queries through db() reject fast with DatabaseSuspendedError.
-// Callers that need wait-for-resume semantics should await waitForDbActive()
-// BEFORE issuing the query.
+// First step when the app backgrounds. Queries through db() then
+// fast-reject; callers that want to wait for resume call
+// waitUntilDbActive() BEFORE issuing the query.
 export function suspendDb(): void {
   state = 'suspending'
   logger.debug('db', 'suspended')
 }
 
-// Called by the suspension manager when the app foregrounds. Flips state
-// back to active and drains any waiters parked via waitForDbActive() (or,
-// in the dead-code-but-defensive 'closed' path, internal waitForActive
-// writes parked during reopen).
+// Called on foreground. Drains waiters parked via waitUntilDbActive()
+// or the 'closed'-state enterGate path.
 //
-// Do NOT reset inflightCount here. Queries dispatched BEFORE the gate
-// already incremented inflight via trackStart; their .finally(trackEnd)
-// is still pending. Resetting here would let those late trackEnd calls
-// drive inflightCount negative, pinning waitForQueriesIdle non-zero and
-// making the next suspend's drain loop spin until MAX_DRAIN_MS.
+// Do NOT reset inflightCount: queries dispatched BEFORE the gate already
+// incremented inflight, and their pending trackEnd calls would drive
+// the count negative — pinning waitForQueriesIdle and stalling the next
+// drain until MAX_DRAIN_MS.
 export function resumeDb(): void {
   state = 'active'
   const waiters = activeWaiters
@@ -442,7 +415,7 @@ class MobileDbAdapter implements DatabaseAdapter {
       }).finally(trackEnd)
     }
     if (state === 'active') return dispatch()
-    return waitForActive(intent).then(dispatch)
+    return enterGate(intent).then(dispatch)
   }
 
   getAllAsync<T>(sql: string, ...params: SQLParam[]): Promise<T[]> {
@@ -483,11 +456,11 @@ class MobileDbAdapter implements DatabaseAdapter {
         .finally(trackEnd)
     }
     if (state === 'active') return dispatch()
-    return waitForActive('write').then(dispatch)
+    return enterGate('write').then(dispatch)
   }
 
-  waitForActive(): Promise<void> {
-    return waitForDbActive()
+  waitUntilActive(): Promise<void> {
+    return waitUntilDbActive()
   }
 }
 

--- a/apps/mobile/src/db/suspension.test.ts
+++ b/apps/mobile/src/db/suspension.test.ts
@@ -11,7 +11,7 @@ import {
   resumeDb,
   setJournalMode,
   suspendDb,
-  waitForDbActive,
+  waitUntilDbActive,
   waitForQueriesIdle,
   withRecovery,
 } from '.'
@@ -75,10 +75,8 @@ describe('query gating', () => {
   })
 
   it('runAsync rejects fast during suspending', async () => {
-    // Writes used to park here, but parking inside a transaction would
-    // deadlock with the suspension manager's drain. Now all queries
-    // reject during 'suspending' — callers that need wait-for-resume
-    // semantics must call waitForDbActive() BEFORE issuing the query.
+    // Parking writes here would deadlock the drain via the txMutex —
+    // callers that need wait-for-resume call waitUntilDbActive() first.
     suspendDb()
     await expect(db().runAsync('CREATE TABLE IF NOT EXISTS test (id TEXT)')).rejects.toThrow(
       DatabaseSuspendedError,
@@ -133,14 +131,14 @@ describe('query gating', () => {
     await queryPromise
   })
 
-  it('waitForDbActive resolves immediately when active', async () => {
-    await waitForDbActive()
+  it('waitUntilDbActive resolves immediately when active', async () => {
+    await waitUntilDbActive()
   })
 
-  it('waitForDbActive parks during suspending and resolves on resume', async () => {
+  it('waitUntilDbActive parks during suspending and resolves on resume', async () => {
     suspendDb()
     let settled = false
-    const wait = waitForDbActive().then(() => {
+    const wait = waitUntilDbActive().then(() => {
       settled = true
     })
     await Promise.resolve()
@@ -150,11 +148,11 @@ describe('query gating', () => {
     expect(settled).toBe(true)
   })
 
-  it('waitForDbActive rejects after the safety-valve timeout', async () => {
+  it('waitUntilDbActive rejects after the safety-valve timeout', async () => {
     jest.useFakeTimers()
     try {
       suspendDb()
-      const wait = waitForDbActive()
+      const wait = waitUntilDbActive()
       wait.catch(() => {})
       jest.advanceTimersByTime(30_000)
       await expect(wait).rejects.toThrow(DatabaseSuspendedError)
@@ -380,10 +378,8 @@ describe('full suspend/resume cycle', () => {
     expect(await duringClosed).toEqual([{ v: 2 }])
   })
 
-  it('writes during suspending reject fast; callers wait via waitForDbActive before issuing', async () => {
+  it('writes during suspending reject fast; callers wait via waitUntilDbActive before issuing', async () => {
     suspendDb()
-    // Direct write during gate now rejects (used to park). Callers that
-    // need wait-for-resume must call waitForDbActive() first.
     await expect(db().runAsync('CREATE TABLE IF NOT EXISTS t (id TEXT)')).rejects.toThrow(
       DatabaseSuspendedError,
     )
@@ -391,7 +387,7 @@ describe('full suspend/resume cycle', () => {
     // Caller-side gate: wait, then issue. The write succeeds after resume.
     let writeSettled = false
     const guarded = (async () => {
-      await waitForDbActive()
+      await waitUntilDbActive()
       await db().runAsync('CREATE TABLE IF NOT EXISTS t2 (id TEXT)')
       writeSettled = true
     })()

--- a/packages/core/src/adapters/db.ts
+++ b/packages/core/src/adapters/db.ts
@@ -16,7 +16,7 @@ export interface SQLRunResult {
  * | runAsync          | yes      | all             |
  * | execAsync         | yes      | all             |
  * | withTransactionAsync | yes   | all             |
- * | waitForActive     | no       | mobile only     |
+ * | waitUntilActive   | no       | mobile only     |
  * | finalize          | no       | node-adapters   |
  * | close             | no       | node-adapters   |
  */
@@ -28,16 +28,17 @@ export interface DatabaseAdapter {
   withTransactionAsync(fn: () => Promise<void>): Promise<void>
 
   /**
-   * Resolves once the DB is in a state where queries can dispatch (not
-   * suspended). Mobile uses this to let multi-step services pause cleanly
-   * across the iOS background gate. Call BEFORE the operation begins —
-   * never inside `withTransactionAsync`'s fn, which would deadlock against
-   * the suspension manager waiting on the txMutex.
+   * Resolves when the suspension gate is open. Call BEFORE any sequence
+   * of reads/writes that must run on the same side of the iOS background
+   * gate — typically right after an irrecoverable network/FS commit.
+   * Never call from inside `withTransactionAsync`'s fn (would deadlock
+   * the drain against the txMutex).
    *
-   * Adapters that don't gate (Node, web, tests) omit this. Callers must
-   * tolerate `undefined` as "no waiting needed."
+   * Barrier, not a lease: a re-suspend mid-query still interrupts. This
+   * only closes the gap between an irrecoverable commit and its DB
+   * record. Adapters that don't gate (Node, web, tests) omit it.
    */
-  waitForActive?(): Promise<void>
+  waitUntilActive?(): Promise<void>
 
   /**
    * Refreshes query planner stats and (for WAL adapters) truncates the WAL.

--- a/packages/core/src/app/namespaces/db.ts
+++ b/packages/core/src/app/namespaces/db.ts
@@ -57,9 +57,13 @@ export function buildDbNamespaces(
   | 'hosts'
   | 'account'
   | 'optimize'
+  | 'db'
 > {
   async function removeFile(file: { id: string; type: string }) {
     await fsIO.remove(file.id, file.type)
+    // Disk delete is done; gate so the fsMeta delete doesn't fast-reject
+    // and leave a row pointing at a missing file.
+    await db.waitUntilActive?.()
     await ops.deleteFsMeta(db, file.id)
   }
 
@@ -85,6 +89,9 @@ export function buildDbNamespaces(
     removeFile,
     copyFile: async (file, sourceUri, opts) => {
       const result = await fsIO.copy(file, sourceUri)
+      // Disk copy is done; gate so the read+upsert below can't leave
+      // the file invisible to cache eviction.
+      await db.waitUntilActive?.()
       const previous = await ops.readFsMeta(db, file.id)
       await ops.upsertFsMeta(db, {
         fileId: file.id,
@@ -101,6 +108,8 @@ export function buildDbNamespaces(
       if (adapters?.crypto) {
         hash = await adapters.crypto.sha256(data)
       }
+      // See copyFile above — disk write is done; gate the fsMeta upsert.
+      await db.waitUntilActive?.()
       await ops.upsertFsMeta(db, {
         fileId: file.id,
         size: result.size,

--- a/packages/core/src/app/namespaces/downloads.ts
+++ b/packages/core/src/app/namespaces/downloads.ts
@@ -111,6 +111,9 @@ export function buildDownloadsNamespace(
 
       if (controller.signal.aborted) return
 
+      // Bytes are on disk; gate so the fsMeta upsert doesn't fast-reject
+      // and leave the file invisible to the cache-eviction LRU.
+      await db.waitUntilActive?.()
       await ops.upsertFsMeta(db, {
         fileId,
         size: file.size,

--- a/packages/core/src/app/namespaces/index.ts
+++ b/packages/core/src/app/namespaces/index.ts
@@ -133,6 +133,9 @@ export function createAppService(adapters: AppServiceAdapters): AppServiceResult
     optimize: async () => {
       await adapters.db.execAsync('PRAGMA optimize')
     },
+    db: {
+      waitUntilActive: () => adapters.db.waitUntilActive?.() ?? Promise.resolve(),
+    },
     ...buildDbNamespaces(adapters.db, caches, uploadsNamespace, adapters.fsIO, {
       crypto: adapters.crypto,
       thumbnail: adapters.thumbnail,

--- a/packages/core/src/app/service.ts
+++ b/packages/core/src/app/service.ts
@@ -83,6 +83,16 @@ export interface AppService {
    * through finalizeAsync under concurrent reader load.
    */
   optimize(): Promise<void>
+  /** Database lifecycle hooks. */
+  db: {
+    /**
+     * Resolves when the DB suspension gate is open. Call right after an
+     * irrecoverable network/FS commit and before the DB sequence that
+     * records it, so an iOS suspend landing in the gap can't orphan the
+     * prior commit. No-op on adapters that don't gate (Node, web, tests).
+     */
+    waitUntilActive(): Promise<void>
+  }
   /** Tag operations: create, query, and manage file tags. */
   tags: {
     /** Returns all tags with their associated file counts. */

--- a/packages/core/src/services/importScanner.test.ts
+++ b/packages/core/src/services/importScanner.test.ts
@@ -22,6 +22,9 @@ function createMockApp(): MockHelper {
   }
 
   const app: any = {
+    db: {
+      waitUntilActive: jest.fn(async () => {}),
+    },
     files: {
       query: jest.fn(async (opts: any) => {
         const excludeSet = new Set(opts.excludeIds ?? [])

--- a/packages/core/src/services/importScanner.ts
+++ b/packages/core/src/services/importScanner.ts
@@ -326,7 +326,11 @@ export class ImportScanner {
         }
       }
 
+      // Per-file disk copies are done; gate the batch DB writes so
+      // suspend in the gap can't leave a finalized-on-disk file stuck
+      // with an empty hash/size/type row that no scanner re-picks up.
       if (updates.length > 0) {
+        await app.db.waitUntilActive()
         await app.files.updateMany(
           updates.map((u) => ({
             id: u.id,
@@ -338,6 +342,7 @@ export class ImportScanner {
       }
 
       if (lostUpdates.length > 0) {
+        await app.db.waitUntilActive()
         await app.files.updateMany(
           lostUpdates.map((u) => ({
             id: u.id,

--- a/packages/core/src/services/syncUpMetadata.ts
+++ b/packages/core/src/services/syncUpMetadata.ts
@@ -68,6 +68,9 @@ async function tryWithLog<T>(
  * Suspension signal policy: accepts AbortSignal. DB-holding loop —
  * reads remote metadata and writes local DB. Checks signal at exit
  * points so a mid-batch abort doesn't issue queries after the gate.
+ * Waits for the DB gate before the first remote call so a tombstone
+ * delete that already succeeded on the indexer doesn't lose its
+ * local cleanup write.
  */
 export async function syncUpMetadataBatch(
   batchSize: number,
@@ -81,6 +84,8 @@ export async function syncUpMetadataBatch(
     app.sync.setState({ isSyncingUp: false })
     return
   }
+  if (signal.aborted) return
+  await app.db.waitUntilActive()
   if (signal.aborted) return
 
   const sdk = internal.requireSdk()

--- a/packages/core/src/services/thumbnailScanner.ts
+++ b/packages/core/src/services/thumbnailScanner.ts
@@ -269,6 +269,9 @@ export class ThumbnailScanner {
       const copied = await app.fs.writeFileData(thumbFileInfo, result.data)
 
       const now = Date.now()
+      // Thumb is on disk; gate so files.create can't fast-reject and
+      // leave a thumb with fsMeta but no files row.
+      await app.db.waitUntilActive()
       await app.files.create({
         id: thumbId,
         name: 'thumbnail.webp',
@@ -358,6 +361,9 @@ export class ThumbnailScanner {
           result.data,
         )
         const now = Date.now()
+        // See ensureThumbnail above — gate the files.create that follows
+        // an on-disk commit.
+        await app.db.waitUntilActive()
         await app.files.create({
           id: thumbId,
           name: 'thumbnail.webp',

--- a/packages/core/src/services/uploader.ts
+++ b/packages/core/src/services/uploader.ts
@@ -1,5 +1,4 @@
 import { logger } from '@siastorage/logger'
-import type { DatabaseAdapter } from '../adapters/db'
 import type { Reader } from '../adapters/fs'
 import type { PackedUploadRef, PinnedObjectRef, ShardProgress } from '../adapters/sdk'
 import type { AppService, AppServiceInternal } from '../app/service'
@@ -62,14 +61,6 @@ export function calculateAllFileProgress(
 export interface UploaderAdapters {
   createFileReader: (uri: string) => Reader
   progressScheduler?: (cb: () => void) => void
-  /**
-   * Optional gate handle for the underlying DB. If provided, multi-step
-   * operations like batch finalize will await the gate before doing DB
-   * work — avoiding fast-reject during iOS suspend that would otherwise
-   * drop network-side pin progress on the floor. Shaped as a subset of
-   * DatabaseAdapter so callers can pass the adapter directly.
-   */
-  db?: { waitForActive?: DatabaseAdapter['waitForActive'] }
 }
 
 /** A file queued for upload with its resolved URI and size. */
@@ -1052,15 +1043,10 @@ export class UploadManager {
     const sdk = this.internal.requireSdk()
     const indexerURL = await this.app.settings.getIndexerURL()
 
-    // Wait for the DB gate to open before any of the per-file pin/save
-    // work begins. saveBatchObjects can fire long after a slab upload
-    // completes — including across an iOS suspend cycle — and Phase 1's
-    // first call (getMetadata) would otherwise reject with
-    // DatabaseSuspendedError, dropping the network-side pin work on the
-    // floor. Calling waitForActive() here pauses finalize at the gate
-    // boundary instead of failing through it. No-op on adapters that
-    // don't implement the method (Node tests, web).
-    await this.adapters.db?.waitForActive?.()
+    // Slab upload is done; gate before the pin/save phases so a
+    // mid-flight suspend can't reject the first DB call and drop the
+    // network-side pin work on the floor.
+    await this.app.db.waitUntilActive()
 
     type PinResult =
       | {


### PR DESCRIPTION
Lots of code paths do network or disk work and then write a DB row to remember it. If iOS suspended between those two steps the DB refused the write. Each path now waits for the DB to reactivate before writing so the entire operation is more likely to succeed.