### PR TITLE
fix(core,mobile): suppress DB suspension error from file status indicators

### DIFF
--- a/.changeset/hide-db-suspension-from-file-status.md
+++ b/.changeset/hide-db-suspension-from-file-status.md
@@ -1,0 +1,6 @@
+---
+core: patch
+mobile: patch
+---
+
+Fixed an issue where file status indicators showed a "Database is suspended" error after the app was backgrounded during an upload or download.

--- a/apps/mobile/src/db/index.ts
+++ b/apps/mobile/src/db/index.ts
@@ -1,21 +1,13 @@
 import type { DatabaseAdapter, SQLParam, SQLRunResult } from '@siastorage/core/adapters'
 import type { MigrationProgressHandler } from '@siastorage/core/db'
 import { runMigrations } from '@siastorage/core/db'
+import { DatabaseSuspendedError } from '@siastorage/core/lib/errors'
 import { Mutex } from '@siastorage/core/lib/mutex'
 import { logger } from '@siastorage/logger'
 import * as SQLite from 'expo-sqlite'
 import { Platform } from 'react-native'
 import { getSharedDbDirectory } from '../lib/sharedContainer'
 import { migrations } from './migrations'
-
-// Thrown when a query is issued while the suspension gate is closed.
-// Callers that need to wait for resume call waitUntilDbActive() first.
-export class DatabaseSuspendedError extends Error {
-  constructor() {
-    super('Database is suspended for background transition')
-    this.name = 'DatabaseSuspendedError'
-  }
-}
 
 // Suspension lifecycle state. The DB connection stays open across
 // suspension; iOS exempts SQLite files (recognized by magic bytes) from

--- a/apps/mobile/src/db/suspension.test.ts
+++ b/apps/mobile/src/db/suspension.test.ts
@@ -1,6 +1,6 @@
+import { DatabaseSuspendedError } from '@siastorage/core/lib/errors'
 import {
   closeDb,
-  DatabaseSuspendedError,
   database,
   db,
   dbInitialized,

--- a/packages/core/src/app/namespaces/downloads.ts
+++ b/packages/core/src/app/namespaces/downloads.ts
@@ -4,7 +4,7 @@ import type { StorageAdapter } from '../../adapters/storage'
 import { DEFAULT_MAX_DOWNLOADS, MAX_AUTO_DOWNLOAD_QUEUE } from '../../config'
 import * as ops from '../../db/operations'
 import type { LocalObject } from '../../encoding/localObject'
-import { getErrorMessage, isAbortError } from '../../lib/errors'
+import { getErrorMessage, isAbortError, isSuspendedDbError } from '../../lib/errors'
 import { SlotPool } from '../../lib/slotPool'
 import type { FsIOAdapter } from '../../services/fsFileUri'
 import type { AppCaches, AppService } from '../service'
@@ -123,6 +123,13 @@ export function buildDownloadsNamespace(
       update(fileId, { status: 'done', progress: 1 })
     } catch (e) {
       if (isAbortError(e)) return
+      if (isSuspendedDbError(e)) {
+        // Unlike abort (where cancel() pre-cleans), suspension leaves a
+        // stale 'downloading' entry — clear it so the indicator falls
+        // back, and rethrow so the caller can retry on resume.
+        remove(fileId)
+        throw e
+      }
       if (!controller.signal.aborted) {
         update(fileId, { status: 'error', error: getErrorMessage(e) })
       }
@@ -156,6 +163,11 @@ export function buildDownloadsNamespace(
       remove(id)
     } catch (e) {
       if (isAbortError(e)) return
+      if (isSuspendedDbError(e)) {
+        // See execute() above — clear the stale entry, rethrow for retry.
+        remove(id)
+        throw e
+      }
       if (!controller.signal.aborted) {
         update(id, { status: 'error', error: getErrorMessage(e) })
       }

--- a/packages/core/src/lib/errors.test.ts
+++ b/packages/core/src/lib/errors.test.ts
@@ -1,4 +1,10 @@
-import { AbortError, getErrorMessage, isAbortError } from './errors'
+import {
+  AbortError,
+  DatabaseSuspendedError,
+  getErrorMessage,
+  isAbortError,
+  isSuspendedDbError,
+} from './errors'
 
 describe('AbortError', () => {
   it('has name AbortError and default message', () => {
@@ -47,6 +53,43 @@ describe('isAbortError', () => {
     expect(isAbortError(undefined)).toBe(false)
     expect(isAbortError('AbortError')).toBe(false)
     expect(isAbortError(42)).toBe(false)
+  })
+})
+
+describe('DatabaseSuspendedError', () => {
+  it('has name DatabaseSuspendedError and a fixed message', () => {
+    const e = new DatabaseSuspendedError()
+    expect(e.name).toBe('DatabaseSuspendedError')
+    expect(e.message).toBe('Database is suspended for background transition')
+    expect(e).toBeInstanceOf(Error)
+  })
+})
+
+describe('isSuspendedDbError', () => {
+  it('true for our DatabaseSuspendedError class', () => {
+    expect(isSuspendedDbError(new DatabaseSuspendedError())).toBe(true)
+  })
+
+  // IPC-reconstructed copies lose the prototype chain but keep `name`.
+  it('true for plain Error with name DatabaseSuspendedError', () => {
+    const e = new Error('reconstructed across IPC')
+    e.name = 'DatabaseSuspendedError'
+    expect(isSuspendedDbError(e)).toBe(true)
+  })
+
+  it('false for an unrelated Error', () => {
+    expect(isSuspendedDbError(new Error('boom'))).toBe(false)
+  })
+
+  it('false for AbortError', () => {
+    expect(isSuspendedDbError(new AbortError())).toBe(false)
+  })
+
+  it('false for null, undefined, strings, numbers', () => {
+    expect(isSuspendedDbError(null)).toBe(false)
+    expect(isSuspendedDbError(undefined)).toBe(false)
+    expect(isSuspendedDbError('DatabaseSuspendedError')).toBe(false)
+    expect(isSuspendedDbError(42)).toBe(false)
   })
 })
 

--- a/packages/core/src/lib/errors.ts
+++ b/packages/core/src/lib/errors.ts
@@ -24,6 +24,22 @@ export function isAbortError(e: unknown): boolean {
   return false
 }
 
+/** Thrown by the mobile DB adapter when the suspension gate is closed. */
+export class DatabaseSuspendedError extends Error {
+  constructor() {
+    super('Database is suspended for background transition')
+    this.name = 'DatabaseSuspendedError'
+  }
+}
+
+/**
+ * True for DatabaseSuspendedError. Name-matched (not instanceof) so it
+ * survives reconstruction across the AppService IPC boundary.
+ */
+export function isSuspendedDbError(e: unknown): boolean {
+  return e instanceof Error && e.name === 'DatabaseSuspendedError'
+}
+
 /**
  * Best-effort human-readable message extraction from an unknown thrown value.
  * Returns Error.message for Error instances, string values as-is, and the

--- a/packages/core/src/services/uploader.ts
+++ b/packages/core/src/services/uploader.ts
@@ -19,7 +19,7 @@ import {
 } from '../config'
 import { encodeFileMetadata } from '../encoding/fileMetadata'
 import type { LocalObject } from '../encoding/localObject'
-import { getErrorMessage } from '../lib/errors'
+import { getErrorMessage, isSuspendedDbError } from '../lib/errors'
 import { sealPinnedObject } from '../lib/localObjects'
 import { retry } from '../lib/retry'
 import { SlotPool } from '../lib/slotPool'
@@ -297,7 +297,7 @@ export class UploadManager {
       })
 
       for (const entry of batch.files) {
-        this.app.uploads.setError(entry.fileId, message)
+        this.failEntry(entry.fileId, e, message)
       }
     } finally {
       this.uploadingBatch = null
@@ -415,6 +415,19 @@ export class UploadManager {
     return new Promise<void>((resolve) => {
       this._resumeResolve = resolve
     })
+  }
+
+  /**
+   * Real failure → setError (shown on the status pill). DB suspension →
+   * remove the entry so pollDB can re-register it on resume (getActiveIds
+   * would otherwise exclude it).
+   */
+  private failEntry(fileId: string, error: unknown, message: string): void {
+    if (isSuspendedDbError(error)) {
+      this.app.uploads.remove(fileId)
+    } else {
+      this.app.uploads.setError(fileId, message)
+    }
   }
 
   get currentBatch(): {
@@ -684,7 +697,7 @@ export class UploadManager {
         fileId: entry.fileId,
         error: e as Error,
       })
-      this.app.uploads.setError(entry.fileId, message)
+      this.failEntry(entry.fileId, e, message)
       // Keep this.packer / this.batch alive — the SDK leaves the packer
       // usable after add() errors, so subsequent entries continue in the
       // same batch instead of orphaning already-successful adds.
@@ -803,7 +816,7 @@ export class UploadManager {
           fileId: entry.fileId,
           error: e as Error,
         })
-        this.app.uploads.setError(entry.fileId, message)
+        this.failEntry(entry.fileId, e, message)
         // Abandon the rest of this window on first error; the loop below
         // attaches .catch so skipped in-flight promises don't surface as
         // unhandled rejections. Keep this.packer / this.batch alive — the
@@ -1102,7 +1115,7 @@ export class UploadManager {
               fileId: entry.fileId,
               error: e as Error,
             })
-            this.app.uploads.setError(entry.fileId, message)
+            this.failEntry(entry.fileId, e, message)
             return { type: 'error', fileId: entry.fileId }
           }
         }),


### PR DESCRIPTION
Each file in the library has a status pill that turns red on upload or download failure. The uploader and downloader were treating the database's brief refusal during backgrounding as a real failure — so files came back to the foreground showing "Database is suspended for background transition" as if something had broken. They now recognize the suspension error specifically and drop it quietly, so the file is just re-queued when the app returns.

In addition, the downstack change should make this error almost never occur going forward.
