### PR TITLE
fix(mobile): dedup archive photos already synced from another device

### DIFF
--- a/.changeset/archive-cross-device-dedup.md
+++ b/.changeset/archive-cross-device-dedup.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Photo archive sync no longer re-imports photos already in your library, including ones uploaded from another device or restored by re-syncing this device.

--- a/apps/mobile/src/lib/assetImports.test.ts
+++ b/apps/mobile/src/lib/assetImports.test.ts
@@ -1307,4 +1307,185 @@ describe('catalogAssets — deferred bulk catalog for archive sync', () => {
     const dirs = await app().directories.getAll()
     expect(row?.directoryId).toBe(dirs[0].id)
   })
+
+  describe('dedup against synced-down rows (localId=NULL)', () => {
+    async function setupImportDir() {
+      await app().settings.setPhotoImportDirectory('Camera Roll')
+      const dir = await app().directories.getOrCreateAtPath('Camera Roll')
+      return dir.id
+    }
+
+    async function seedInDir(
+      dirId: string,
+      fields: {
+        id: string
+        name: string
+        createdAt: number
+        localId: string | null
+        trashedAt?: number | null
+      },
+    ) {
+      await app().files.create({
+        id: fields.id,
+        name: fields.name,
+        size: 0,
+        createdAt: fields.createdAt,
+        updatedAt: fields.createdAt,
+        type: 'image/jpeg',
+        kind: 'file',
+        localId: fields.localId,
+        hash: '',
+        addedAt: fields.createdAt,
+        trashedAt: fields.trashedAt ?? null,
+        deletedAt: null,
+      })
+      await app().directories.moveFiles([fields.id], dirId)
+    }
+
+    function asset(name: string, createdAt: number, id?: string) {
+      return {
+        id,
+        name,
+        sourceUri: `file:///${name}`,
+        type: 'image/jpeg',
+        timestamp: new Date(createdAt).toISOString(),
+      }
+    }
+
+    it('dedups a candidate that matches a synced-down row by (name, createdAt)', async () => {
+      const dirId = await setupImportDir()
+      await seedInDir(dirId, {
+        id: 'synced-down',
+        name: 'IMG_0042.HEIC',
+        createdAt: 1_710_000_000_000,
+        localId: null,
+      })
+      const { newCount, existingCount } = await catalogAssets(
+        [asset('IMG_0042.HEIC', 1_710_000_000_000, 'L_new')],
+        'file',
+        { addToImportDirectory: true },
+      )
+      expect(newCount).toBe(0)
+      expect(existingCount).toBe(1)
+      const rows = await app().files.query({ order: 'ASC' })
+      expect(rows.map((r) => r.id)).toEqual(['synced-down'])
+    })
+
+    // Asymmetric rule: when the existing row already has a localId, the
+    // new dedup doesn't fire. Same-device siblings sharing (name, time)
+    // — e.g., OEM camera bursts that reuse filenames at second precision
+    // — insert as distinct rows. (Same-name files in the same folder
+    // still collapse to a single visible row downstream; not changed by
+    // this dedup.)
+    it('does not block same-device siblings when the existing row has a localId', async () => {
+      const dirId = await setupImportDir()
+      await seedInDir(dirId, {
+        id: 'sibling-1',
+        name: '20240115_142345.jpg',
+        createdAt: 1_710_000_000_000,
+        localId: 'local_1',
+      })
+      const siblings = Array.from({ length: 4 }, (_, i) =>
+        asset('20240115_142345.jpg', 1_710_000_000_000, `local_${i + 2}`),
+      )
+      const { newCount } = await catalogAssets(siblings, 'file', { addToImportDirectory: true })
+      expect(newCount).toBe(4)
+      const rows = await app().files.query({ order: 'ASC', includeOldVersions: true })
+      expect(rows.map((r) => r.localId).sort()).toEqual([
+        'local_1',
+        'local_2',
+        'local_3',
+        'local_4',
+        'local_5',
+      ])
+    })
+
+    // Same captureTime, different filenames (e.g. an iPhone Live Photo's
+    // .HEIC + .MOV pair): both import — name disambiguates.
+    it('imports both when names differ at the same captureTime', async () => {
+      await setupImportDir()
+      const ts = 1_710_000_000_000
+      const { newCount } = await catalogAssets(
+        [asset('IMG_0042.HEIC', ts, 'still'), asset('IMG_0042.MOV', ts, 'motion')],
+        'file',
+        { addToImportDirectory: true },
+      )
+      expect(newCount).toBe(2)
+    })
+
+    // Same name, different captureTime (AirDrop name clash, iPhone
+    // counter wraparound): import proceeds — createdAt disambiguates.
+    it('imports as distinct when name matches but createdAt differs', async () => {
+      const dirId = await setupImportDir()
+      await seedInDir(dirId, {
+        id: 'mine',
+        name: 'IMG_0042.HEIC',
+        createdAt: 1_700_000_000_000,
+        localId: 'mine_localId',
+      })
+      const { newCount } = await catalogAssets(
+        [asset('IMG_0042.HEIC', 1_710_000_000_000, 'other_localId')],
+        'file',
+        { addToImportDirectory: true },
+      )
+      expect(newCount).toBe(1)
+    })
+
+    it('does not block re-import when the matching synced-down row is trashed', async () => {
+      const dirId = await setupImportDir()
+      await seedInDir(dirId, {
+        id: 'synced-down-trashed',
+        name: 'IMG_0042.HEIC',
+        createdAt: 1_710_000_000_000,
+        localId: null,
+        trashedAt: 1_710_000_500_000,
+      })
+      const { newCount } = await catalogAssets(
+        [asset('IMG_0042.HEIC', 1_710_000_000_000, 'L_new')],
+        'file',
+        { addToImportDirectory: true },
+      )
+      expect(newCount).toBe(1)
+    })
+
+    it('does not match synced-down rows in a different directory', async () => {
+      await setupImportDir()
+      const otherDir = await app().directories.getOrCreateAtPath('Trip 2024')
+      await seedInDir(otherDir.id, {
+        id: 'in-other-dir',
+        name: 'IMG_0042.HEIC',
+        createdAt: 1_710_000_000_000,
+        localId: null,
+      })
+      const { newCount } = await catalogAssets(
+        [asset('IMG_0042.HEIC', 1_710_000_000_000, 'L_new')],
+        'file',
+        { addToImportDirectory: true },
+      )
+      expect(newCount).toBe(1)
+    })
+
+    // Documents a known limitation: when both rows carry non-null
+    // localIds (e.g. Android factory reset rotated the MediaStore id),
+    // the asymmetric rule doesn't fire and a duplicate row inserts.
+    // Hashes are computed at scanner finalize but aren't used for
+    // dedup today — a future hash-dedup pass there could recover this.
+    it('inserts a duplicate when both rows have non-null but rotated localIds', async () => {
+      const dirId = await setupImportDir()
+      await seedInDir(dirId, {
+        id: 'pre-rotation',
+        name: '20240115_142345.jpg',
+        createdAt: 1_710_000_000_000,
+        localId: 'old_id',
+      })
+      const { newCount } = await catalogAssets(
+        [asset('20240115_142345.jpg', 1_710_000_000_000, 'new_id')],
+        'file',
+        { addToImportDirectory: true },
+      )
+      expect(newCount).toBe(1)
+      const rows = await app().files.query({ order: 'ASC', includeOldVersions: true })
+      expect(rows).toHaveLength(2)
+    })
+  })
 })

--- a/apps/mobile/src/lib/assetImports.ts
+++ b/apps/mobile/src/lib/assetImports.ts
@@ -354,21 +354,81 @@ export async function catalogAssets(
 
   if (signal?.aborted) return { newCount: 0, existingCount: 0 }
 
-  const localIds = candidates.filter((f) => f.localId).map((f) => f.localId!)
+  // Catch-up dedup for rows that arrived via sync-down (no localId) or
+  // had their localId nulled by a re-sync (reinstall, restore, sign out
+  // and back in). When the archive walk later sees the same photo on
+  // the camera roll, the existing row has no localId to match against,
+  // so localId-based dedup misses.
+  // (name, createdAt) is the cheapest stable identity available without
+  // reading bytes; the query is directory-scoped via getCurrentByNames-
+  // InDirectory, so the same photo in a different folder is unaffected.
+  //
+  // Same-name files in the same folder collapse to one visible row
+  // elsewhere in the app, so distinct files that share a filename end
+  // up as a single entry regardless of what this dedup decides. See
+  // "Known limits" below for the future-work shape.
+  //
+  // Asymmetric: only fires against rows where existing.localId IS NULL,
+  // so same-device siblings sharing (name, captureTime) — e.g., OEM
+  // camera bursts that reuse filenames at second precision — aren't
+  // blocked by this rule. (They still collapse downstream via the
+  // existing (name, dir) version-grouping; not changed here.)
+  //
+  // Known limits — two separate problems that both need future work:
+  //  (1) Identity — recognizing the same file across devices or after
+  //      a re-sync. (name, createdAt) is what we can compute upfront
+  //      without reading bytes. It misses for iOS assets whose
+  //      filenames are storage UUIDs that differ per device (common
+  //      for iCloud-restored or shared assets).
+  //  (2) Name collisions on insert — once a file is decided to be
+  //      new, it's stored under the filename the OS reported. If two
+  //      distinct files happen to share that filename in the same
+  //      folder (counter wraparound, AirDrop name clashes, OEM burst
+  //      siblings), they collapse to one visible row downstream even
+  //      though identity correctly flagged them as different.
+  //
+  // (1) takes stronger upfront identity — native modules surfacing
+  // stable cloud IDs or fingerprints. (2) takes uniquifying the name
+  // at import time so distinct files don't merge in storage. SHA-256
+  // hashes are computed at finalize but aren't used for dedup yet;
+  // they'd address (1), not (2).
+  const namesToCheck = Array.from(new Set(candidates.map((c) => c.name)))
+  const existingByName =
+    namesToCheck.length > 0
+      ? await app().files.getCurrentByNamesInDirectory(namesToCheck, importDirectoryId)
+      : []
+  const syncedDownKeys = new Set<string>()
+  for (const f of existingByName) {
+    if (f.localId === null) {
+      syncedDownKeys.add(`${f.name}\x00${f.createdAt}`)
+    }
+  }
+  const dedupedCandidates = candidates.filter(
+    (c) => !syncedDownKeys.has(`${c.name}\x00${c.createdAt}`),
+  )
+  const syncedDownDuplicateCount = candidates.length - dedupedCandidates.length
+
+  const localIds = dedupedCandidates.filter((f) => f.localId).map((f) => f.localId!)
   const existingFiles = localIds.length > 0 ? await app().files.getByLocalIds(localIds) : []
-  const existingLocalIds = new Set(existingFiles.map((f) => f.localId))
-  const existingCount = existingLocalIds.size
+  const localIdDuplicateCount = new Set(existingFiles.map((f) => f.localId)).size
+  const existingCount = localIdDuplicateCount + syncedDownDuplicateCount
   const newCount = candidates.length - existingCount
 
   logger.debug('catalogAssets', 'result', {
     count: candidates.length,
     newCount,
     existingCount,
+    syncedDownDuplicateCount,
   })
+  if (syncedDownDuplicateCount > 0) {
+    logger.info('catalogAssets', 'dedup_by_name_and_time', {
+      count: syncedDownDuplicateCount,
+    })
+  }
 
   if (signal?.aborted) return { newCount: 0, existingCount: 0 }
 
-  await app().files.createMany(candidates, {
+  await app().files.createMany(dedupedCandidates, {
     conflictClause: 'OR IGNORE',
     directoryId: importDirectoryId,
   })


### PR DESCRIPTION
When a photo's row arrived via sync-down or had its localId nulled by a re-sync (reinstall, restore, sign-out), the row has no localId — so the archive walk's localId-based dedup misses and the whole library gets re-imported as new versions. The walk now also matches null-localId rows by (name, createdAt); name collisions make this imperfect, but the app already has filename-collision behavior downstream, and this helps with the re-sync-everything case for now.

https://github.com/SiaFoundation/sia-storage-app/issues/699