### PR TITLE
fix(core,mobile): stop marking in-flight picker imports as lost

### DIFF
--- a/.changeset/import-orphan-race.md
+++ b/.changeset/import-orphan-race.md
@@ -1,0 +1,6 @@
+---
+core: patch
+mobile: patch
+---
+
+Fixed picker imports occasionally getting permanently marked as "File unavailable" right after a successful import. The import scanner could race the background copy and mark just-inserted placeholders lost before their bytes had landed.

--- a/apps/mobile/src/lib/assetImports.test.ts
+++ b/apps/mobile/src/lib/assetImports.test.ts
@@ -1,4 +1,5 @@
 import { db, initializeDB, resetDb } from '../db'
+import { markImportCopyComplete, markImportCopyStarted } from '../managers/importScanner'
 import { app } from '../stores/appService'
 import { copyFileToFs } from '../stores/fs'
 import { calculateContentHash } from './contentHash'
@@ -17,6 +18,8 @@ jest.mock('../managers/thumbnailer', () => ({
 }))
 jest.mock('../managers/importScanner', () => ({
   triggerImportScanner: jest.fn(),
+  markImportCopyStarted: jest.fn(),
+  markImportCopyComplete: jest.fn(),
 }))
 jest.mock('./fileTypes', () => {
   const actual = jest.requireActual('./fileTypes')
@@ -557,6 +560,121 @@ describe('importAssets — picker / camera / share intent', () => {
       const result = await copyPromise
       expect(result).toEqual({ copied: 2, failed: 1 })
       expect(events).toEqual([1, 3])
+    })
+
+    it('registers every placeholder before any await after createMany', async () => {
+      // Regression: the scanner runs on a 3s autotick and can fire while
+      // importAssets is still awaiting tag assignment, optimize, or
+      // getByIds. If marks are placed only inside copyAssets, the scanner
+      // sees the placeholders with no fs row and no localId during that
+      // window and writes lostReason permanently. Registration must happen
+      // synchronously after createMany resolves.
+      const optimizeSpy = jest.spyOn(app(), 'optimize')
+
+      const assets = [
+        {
+          id: undefined,
+          name: 'a.txt',
+          size: 1,
+          sourceUri: 'file:///tmp/a.txt',
+          type: 'text/plain',
+          timestamp: '2024-06-01',
+        },
+        {
+          id: undefined,
+          name: 'b.txt',
+          size: 2,
+          sourceUri: 'file:///tmp/b.txt',
+          type: 'text/plain',
+          timestamp: '2024-06-01',
+        },
+      ]
+
+      const { files, copyPromise } = await importAssets(assets)
+      await copyPromise
+
+      const startedIds = jest.mocked(markImportCopyStarted).mock.calls.map((c) => c[0])
+      expect(startedIds).toEqual(files.map((f) => f.id))
+
+      // Every mark must precede optimize (the first await after createMany).
+      const optimizeOrder = optimizeSpy.mock.invocationCallOrder[0]
+      for (const markOrder of jest.mocked(markImportCopyStarted).mock.invocationCallOrder) {
+        expect(markOrder).toBeLessThan(optimizeOrder)
+      }
+    })
+
+    it('releases marks when setup fails between createMany and copyAssets', async () => {
+      // If anything between the mark and the copy dispatch throws,
+      // copyAssets never runs and its per-file finally cannot release
+      // the marks. importAssets must release them itself so future
+      // scanner ticks can clean up the now-orphaned placeholders.
+      jest.spyOn(app(), 'optimize').mockRejectedValueOnce(new Error('boom'))
+
+      const assets = [
+        {
+          id: undefined,
+          name: 'a.txt',
+          size: 1,
+          sourceUri: 'file:///tmp/a.txt',
+          type: 'text/plain',
+          timestamp: '2024-06-01',
+        },
+      ]
+
+      await expect(importAssets(assets)).rejects.toThrow('boom')
+
+      const startedIds = jest
+        .mocked(markImportCopyStarted)
+        .mock.calls.map((c) => c[0])
+        .sort()
+      const completedIds = jest
+        .mocked(markImportCopyComplete)
+        .mock.calls.map((c) => c[0])
+        .sort()
+      expect(startedIds.length).toBe(1)
+      expect(completedIds).toEqual(startedIds)
+    })
+
+    it('clears each registration as its copy resolves (success and failure both unregister)', async () => {
+      jest
+        .mocked(copyFileToFs)
+        .mockResolvedValueOnce('/local/ok')
+        .mockRejectedValueOnce(new Error('disk full'))
+
+      const assets = [
+        {
+          id: undefined,
+          name: 'ok.txt',
+          size: 1,
+          sourceUri: 'file:///tmp/ok.txt',
+          type: 'text/plain',
+          timestamp: '2024-06-01',
+        },
+        {
+          id: undefined,
+          name: 'bad.txt',
+          size: 2,
+          sourceUri: 'file:///tmp/bad.txt',
+          type: 'text/plain',
+          timestamp: '2024-06-01',
+        },
+      ]
+
+      const { files, copyPromise } = await importAssets(assets)
+      await copyPromise
+
+      const startedIds = jest
+        .mocked(markImportCopyStarted)
+        .mock.calls.map((c) => c[0])
+        .sort()
+      const completedIds = jest
+        .mocked(markImportCopyComplete)
+        .mock.calls.map((c) => c[0])
+        .sort()
+      const expectedIds = files.map((f) => f.id).sort()
+
+      expect(startedIds).toEqual(expectedIds)
+      expect(completedIds).toEqual(expectedIds)
     })
 
     it('reports totalBytes as the sum of placeholder sizes', async () => {

--- a/apps/mobile/src/lib/assetImports.ts
+++ b/apps/mobile/src/lib/assetImports.ts
@@ -27,7 +27,11 @@ import { yieldToEventLoop } from '@siastorage/core/lib/yieldToEventLoop'
 import type { FileRecord } from '@siastorage/core/types'
 import { logger } from '@siastorage/logger'
 import RNFS from 'react-native-fs'
-import { triggerImportScanner } from '../managers/importScanner'
+import {
+  markImportCopyComplete,
+  markImportCopyStarted,
+  triggerImportScanner,
+} from '../managers/importScanner'
 import { generateThumbnails } from '../managers/thumbnailer'
 import { app } from '../stores/appService'
 import { copyFileToFs } from '../stores/fs'
@@ -486,46 +490,61 @@ export async function importAssets(
   )
 
   const insertedIds = candidates.map((c) => c.placeholder.id)
+  // Register synchronously, before the next await. The scanner runs on
+  // its own 3s tick and would otherwise see these placeholders with no
+  // fs row and no localId during the tag/optimize/getByIds awaits below
+  // and mark them lost. copyAssets clears each ID in its per-file finally.
+  for (const id of insertedIds) markImportCopyStarted(id)
 
-  if (assignTagName && insertedIds.length > 0) {
-    await app().tags.addToFiles(insertedIds, assignTagName)
+  let copyDispatched = false
+  try {
+    if (assignTagName && insertedIds.length > 0) {
+      await app().tags.addToFiles(insertedIds, assignTagName)
+    }
+
+    await app().optimize()
+
+    // Preserve candidate order in the returned array.
+    let files: FileRecord[] = []
+    if (insertedIds.length > 0) {
+      const fetched = await app().files.getByIds(insertedIds)
+      const byId = new Map(fetched.map((f) => [f.id, f]))
+      files = insertedIds.map((id) => byId.get(id)).filter((f): f is FileRecord => !!f)
+    }
+
+    // Each copy dispatches to a native RNFS thread that holds the source
+    // URI open once it starts reading, so ephemeral picker/share URIs are
+    // captured before the caller can do anything else. The native thread
+    // freezes with the process on iOS suspension and thaws on resume. If
+    // iOS terminates rather than suspends, the import is lost — the
+    // import-progress modal warns the user not to close the app.
+    const copyPromise = copyAssets(
+      candidates.map((c) => ({
+        id: c.placeholder.id,
+        type: c.placeholder.type,
+        size: c.placeholder.size,
+        sourceUri: c.sourceUri,
+      })),
+      onCopyProgress,
+    )
+    copyDispatched = true
+
+    triggerImportScanner()
+    const totalBytes = candidates.reduce((s, c) => s + c.placeholder.size, 0)
+    return { files, newVersionCount, totalBytes, copyPromise }
+  } finally {
+    if (!copyDispatched) {
+      for (const id of insertedIds) markImportCopyComplete(id)
+    }
   }
-
-  await app().optimize()
-
-  // Preserve candidate order in the returned array.
-  let files: FileRecord[] = []
-  if (insertedIds.length > 0) {
-    const fetched = await app().files.getByIds(insertedIds)
-    const byId = new Map(fetched.map((f) => [f.id, f]))
-    files = insertedIds.map((id) => byId.get(id)).filter((f): f is FileRecord => !!f)
-  }
-
-  // Each copy dispatches to a native RNFS thread that holds the source
-  // URI open once it starts reading, so ephemeral picker/share URIs are
-  // captured before the caller can do anything else. The native thread
-  // freezes with the process on iOS suspension and thaws on resume. If
-  // iOS terminates rather than suspends, the import is lost — the
-  // import-progress modal warns the user not to close the app.
-  const copyPromise = copyAssets(
-    candidates.map((c) => ({
-      id: c.placeholder.id,
-      type: c.placeholder.type,
-      size: c.placeholder.size,
-      sourceUri: c.sourceUri,
-    })),
-    onCopyProgress,
-  )
-
-  triggerImportScanner()
-  const totalBytes = candidates.reduce((s, c) => s + c.placeholder.size, 0)
-  return { files, newVersionCount, totalBytes, copyPromise }
 }
 
 async function copyAssets(
   copies: { id: string; type: string; size: number; sourceUri: string }[],
   onProgress?: (bytes: number) => void,
 ): Promise<{ copied: number; failed: number }> {
+  // IDs are already registered by importAssets right after createMany;
+  // we only clear them here as each copy resolves.
   let copied = 0
   let failed = 0
   for (const { id, type, size, sourceUri } of copies) {
@@ -539,6 +558,8 @@ async function copyAssets(
         fileId: id,
         error: e as Error,
       })
+    } finally {
+      markImportCopyComplete(id)
     }
   }
   triggerImportScanner()

--- a/apps/mobile/src/managers/importScanner.ts
+++ b/apps/mobile/src/managers/importScanner.ts
@@ -80,3 +80,11 @@ export function retryAllImportFiles(): void {
   scanner.clearAllBackoff()
   triggerImportScanner()
 }
+
+export function markImportCopyStarted(fileId: string): void {
+  scanner.markCopyStarted(fileId)
+}
+
+export function markImportCopyComplete(fileId: string): void {
+  scanner.markCopyComplete(fileId)
+}

--- a/packages/core/src/services/importScanner.test.ts
+++ b/packages/core/src/services/importScanner.test.ts
@@ -325,8 +325,31 @@ describe('ImportScanner', () => {
       expect(mock.app.files.updateMany).not.toHaveBeenCalled()
     })
 
-    it('marks orphan file (no local file, no localId) as lost', async () => {
+    it('does not mark orphan files as lost while their copy is in flight (picker import race)', async () => {
+      // Regression: Phase 2 used to mark every freshly-inserted picker
+      // placeholder lost because it saw "no local file + no localId". The
+      // partial DB update path never clears lostReason, so the file was
+      // permanently stuck behind a red "File unavailable" icon even after
+      // the copy completed. copyAssets now registers each ID before its
+      // first await, and Phase 2 skips in-flight IDs.
+      mock.addFile('inflight-picker')
+      scanner.markCopyStarted('inflight-picker')
+
+      const result = await scanner.runScan()
+
+      expect(result.lost).toBe(0)
+      expect(result.skipped).toBe(1)
+      expect(mock.app.files.updateMany).not.toHaveBeenCalled()
+    })
+
+    it('marks orphan file as lost once its in-flight copy clears (genuine orphan)', async () => {
+      // After copyAssets finishes (success or failure) it calls
+      // markCopyComplete. If the placeholder still has no local copy and
+      // no localId at that point, no recovery path remains and the file
+      // is surfaced to the UI on a subsequent scanner tick.
       mock.addFile('f7')
+      scanner.markCopyStarted('f7')
+      scanner.markCopyComplete('f7')
 
       const result = await scanner.runScan()
 
@@ -334,6 +357,23 @@ describe('ImportScanner', () => {
       expect(mock.app.files.updateMany).toHaveBeenCalledWith([
         expect.objectContaining({
           id: 'f7',
+          lostReason: 'No local file or source available',
+        }),
+      ])
+    })
+
+    it('marks orphan file as lost when never registered (app-killed-mid-import)', async () => {
+      // If the app crashed before copyAssets could mark the ID, the
+      // in-flight set is empty on next launch. The scanner cleans up the
+      // unrecoverable placeholder so the user sees the failure.
+      mock.addFile('f-crashed')
+
+      const result = await scanner.runScan()
+
+      expect(result.lost).toBe(1)
+      expect(mock.app.files.updateMany).toHaveBeenCalledWith([
+        expect.objectContaining({
+          id: 'f-crashed',
           lostReason: 'No local file or source available',
         }),
       ])

--- a/packages/core/src/services/importScanner.ts
+++ b/packages/core/src/services/importScanner.ts
@@ -34,6 +34,11 @@ export type GetMimeType = (opts: { name?: string; uri?: string }) => Promise<str
 export class ImportScanner {
   private app: AppService | null = null
   private processingFiles = new Set<string>()
+  // IDs whose bytes are mid-copy by importAssets's copyAssets. Phase 2's
+  // orphan branch would otherwise mark these lost while the copy is still
+  // streaming. The set is empty on restart, so a placeholder whose copy
+  // never resumed is correctly surfaced as lost on the next tick.
+  private inFlightCopies = new Set<string>()
   private backoff = new BackoffTracker()
   private _calculateContentHash: CalculateContentHash | null = null
   private _getMimeType: GetMimeType | null = null
@@ -53,6 +58,7 @@ export class ImportScanner {
     this._calculateContentHash = null
     this._getMimeType = null
     this.processingFiles.clear()
+    this.inFlightCopies.clear()
     this.backoff.reset()
   }
 
@@ -62,6 +68,14 @@ export class ImportScanner {
 
   isFileBeingProcessed(fileId: string): boolean {
     return this.processingFiles.has(fileId)
+  }
+
+  markCopyStarted(fileId: string): void {
+    this.inFlightCopies.add(fileId)
+  }
+
+  markCopyComplete(fileId: string): void {
+    this.inFlightCopies.delete(fileId)
   }
 
   /** Returns all backoff entries for UI display. */
@@ -102,7 +116,9 @@ export class ImportScanner {
    * on subsequent ticks until their backoff expires (5m → 15m → 60m cap).
    *
    * Files that cannot be recovered (deleted from device, no local file
-   * and no localId) are marked with lostReason for the UI.
+   * and no localId) are marked with lostReason for the UI. Placeholders
+   * registered in inFlightCopies are skipped — picker imports are still
+   * streaming their bytes there.
    */
   async runScan(
     signal?: AbortSignal,
@@ -303,6 +319,14 @@ export class ImportScanner {
                 fileId: file.id,
               })
               this.backoff.recordSkip(file.id, 'No resolver available')
+              result.skipped++
+              continue
+            }
+
+            if (this.inFlightCopies.has(file.id)) {
+              logger.debug('importScanner', 'orphan_inflight', {
+                fileId: file.id,
+              })
               result.skipped++
               continue
             }


### PR DESCRIPTION
The import scanner was racing copyAssets and writing lostReason on picker placeholders before their bytes landed, leaving uploaded files permanently stuck behind a red "File unavailable" icon. copyAssets now registers each ID with the scanner before its first await and clears it in a finally; Phase 2's orphan branch skips registered IDs. Fixes https://github.com/SiaFoundation/sia-storage-app/issues/695