### PR TITLE
fix(core,mobile): keep upload finalize DB writes resumable across iOS suspend

### DIFF
--- a/.changeset/finalize-bump-gate.md
+++ b/.changeset/finalize-bump-gate.md
@@ -1,0 +1,6 @@
+---
+core: patch
+mobile: patch
+---
+
+Fixed an upload race that could leave some files unsynced. Helps with https://github.com/SiaFoundation/sia-storage-app/issues/688.

--- a/apps/mobile/src/managers/uploader.test.ts
+++ b/apps/mobile/src/managers/uploader.test.ts
@@ -33,7 +33,7 @@ import {
 import type { ShardProgress } from '@siastorage/core/adapters'
 import { type UploaderAdapters, UploadManager } from '@siastorage/core/services/uploader'
 import type { PackedUploadInterface, PinnedObjectInterface, SdkInterface } from 'react-native-sia'
-import { initializeDB, resetDb } from '../db'
+import { initializeDB, resetDb, resumeDb, suspendDb } from '../db'
 import { app, internal } from '../stores/appService'
 import { getActiveUploads } from '../stores/uploads'
 import type { FileEntry } from './uploader'
@@ -214,6 +214,9 @@ describe('UploadManager', () => {
     jest.useRealTimers()
     await resetDb()
     resetUploadsStore()
+    // clearAllMocks() wipes call history but leaves spy implementations
+    // in place — restore here so per-test spies don't leak across tests.
+    jest.restoreAllMocks()
   })
 
   describe('__testProcessFiles (test helper)', () => {
@@ -501,6 +504,69 @@ describe('UploadManager', () => {
       await manager.__testProcessFiles([createFileEntry('file2')])
 
       expect(mockSdk.uploadPacked).toHaveBeenCalledTimes(2)
+    })
+
+    describe('iOS suspend gates', () => {
+      it('waits for the DB gate before each post-pin finalize write', async () => {
+        const entry = await createTestFile('gate-order')
+        manager.initialize(app(), internal(), defaultAdapters())
+        mockPacker.finalize.mockResolvedValueOnce([mockPinnedObject])
+
+        const events: string[] = []
+        jest
+          .spyOn(app().db, 'waitUntilActive')
+          .mockImplementation(async () => void events.push('wait'))
+        jest
+          .spyOn(app().localObjects, 'upsertMany')
+          .mockImplementation(async () => void events.push('upsert'))
+        jest
+          .spyOn(app().files, 'updateMany')
+          .mockImplementation(async () => void events.push('update'))
+
+        await manager.__testProcessFiles([entry])
+        await manager.flush()
+
+        // entry gate, [pin pool], gate, upsert, gate, update. Removing
+        // either post-pool gate lets a mid-finalize suspend orphan the
+        // updatedAt bump.
+        expect(events).toEqual(['wait', 'wait', 'upsert', 'wait', 'update'])
+      })
+
+      it('still bumps updatedAt when the DB suspends after the localObject upsert', async () => {
+        const entry = await createTestFile('mid-finalize-suspend')
+        // Anchor updatedAt to 1 so the bump's Date.now() is unambiguously
+        // greater — fake-timer ticks would otherwise collide.
+        const originalUpdatedAt = 1
+        await app().files.update(
+          { id: entry.fileId, updatedAt: originalUpdatedAt },
+          { includeUpdatedAt: true, skipInvalidation: true },
+        )
+        manager.initialize(app(), internal(), defaultAdapters())
+        mockPacker.finalize.mockResolvedValueOnce([mockPinnedObject])
+
+        // Suspend the moment upsertMany lands, resume on a real timer.
+        // Without the gate before files.updateMany, the bump would
+        // fast-reject and the file would stay at updatedAt=1.
+        const originalUpsert = app().localObjects.upsertMany.bind(app().localObjects)
+        jest.spyOn(app().localObjects, 'upsertMany').mockImplementation(async (...args) => {
+          const result = await originalUpsert(...args)
+          suspendDb()
+          setTimeout(() => resumeDb(), 0)
+          return result
+        })
+
+        await manager.__testProcessFiles([entry])
+        const flushPromise = manager.flush()
+        await jest.advanceTimersByTimeAsync(10)
+        await flushPromise
+
+        const after = await app().files.getById(entry.fileId)
+        expect(after?.updatedAt).toBeGreaterThan(originalUpdatedAt)
+        const localObjects = await app().localObjects.getForFile(entry.fileId)
+        expect(localObjects).toHaveLength(1)
+        // Entry only clears on a successful finalize.
+        expect(app().uploads.getEntry(entry.fileId)).toBeUndefined()
+      })
     })
   })
 

--- a/packages/core/src/services/uploader.ts
+++ b/packages/core/src/services/uploader.ts
@@ -1122,10 +1122,13 @@ export class UploadManager {
       ),
     )
 
-    // Phase 2: Batch DB write
+    // Phase 2: Batch DB write. Re-gate: Phase 1's pin pool yields
+    // across pinObject awaits, so the entry gate can be stale before
+    // we reach these writes. Same for the updatedAt bump below.
     const localObjects = results
       .filter((r): r is Extract<PinResult, { type: 'success' }> => r.type === 'success')
       .map((r) => r.localObject)
+    await this.app.db.waitUntilActive()
     await this.app.localObjects.upsertMany(localObjects, {
       skipInvalidation: true,
     })
@@ -1144,6 +1147,9 @@ export class UploadManager {
       .filter((r) => r.type !== 'error' && r.type !== 'missing')
       .map((r) => r.fileId)
     if (successfulFileIds.length > 0) {
+      // Re-gate (see upsert above): the bump and the upsert must
+      // commit on the same side of the suspend gate.
+      await this.app.db.waitUntilActive()
       const now = Date.now()
       await this.app.files.updateMany(
         successfulFileIds.map((id) => ({ id, updatedAt: now })),


### PR DESCRIPTION
If iOS suspended the app mid-upload, a file could end up marked synced on the uploading device but invisible to your other devices until something else (like renaming it) forced another sync. Finalize now waits for the app to resume before finishing, so the upload either fully lands or fully retries.
