### PR TITLE
feat(mobile): experiment with OS thumbnail cache

### DIFF
--- a/.changeset/os-thumb-capture.md
+++ b/.changeset/os-thumb-capture.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Archive sync now shows photo thumbnails right away instead of waiting for each file to fully copy. The thumbnails are read from the OS photo library's own cache, so the app doesn't have to do the heavy work of decoding each original photo.

--- a/apps/mobile/jest.config.cjs
+++ b/apps/mobile/jest.config.cjs
@@ -26,6 +26,7 @@ module.exports = {
     '^expo-media-library$': '<rootDir>/test/mocks/expo-media-library.ts',
     '^expo-keep-awake$': '<rootDir>/test/mocks/expo-keep-awake.ts',
     '^react-native-sia$': '<rootDir>/test/mocks/react-native-sia.ts',
+    '^sia-os-thumb$': '<rootDir>/test/mocks/sia-os-thumb.ts',
     '^\\.\\./lib/sharedContainer$': '<rootDir>/test/mocks/sharedContainer.ts',
     '^\\.\\./\\.\\./lib/sharedContainer$': '<rootDir>/test/mocks/sharedContainer.ts',
   },

--- a/apps/mobile/modules/sia-os-thumb/android/build.gradle
+++ b/apps/mobile/modules/sia-os-thumb/android/build.gradle
@@ -1,0 +1,30 @@
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+group = 'expo.modules.siaosthumb'
+version = '0.0.0'
+
+android {
+  namespace 'expo.modules.siaosthumb'
+
+  compileSdk rootProject.ext.compileSdkVersion
+
+  defaultConfig {
+    minSdk rootProject.ext.minSdkVersion
+    targetSdk rootProject.ext.targetSdkVersion
+  }
+
+  kotlinOptions {
+    jvmTarget = '17'
+  }
+
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_17
+    targetCompatibility JavaVersion.VERSION_17
+  }
+}
+
+dependencies {
+  implementation project(':expo-modules-core')
+  implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.kotlinVersion}"
+}

--- a/apps/mobile/modules/sia-os-thumb/android/src/main/AndroidManifest.xml
+++ b/apps/mobile/modules/sia-os-thumb/android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/apps/mobile/modules/sia-os-thumb/android/src/main/java/expo/modules/siaosthumb/SiaOsThumbModule.kt
+++ b/apps/mobile/modules/sia-os-thumb/android/src/main/java/expo/modules/siaosthumb/SiaOsThumbModule.kt
@@ -1,0 +1,64 @@
+package expo.modules.siaosthumb
+
+import android.content.ContentUris
+import android.graphics.Bitmap
+import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
+import android.util.Size
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+import java.io.File
+import java.io.FileOutputStream
+import java.util.UUID
+
+// Writes a system-cached MediaStore thumbnail to the app cache directory
+// and resolves with the resulting file:// path. ContentResolver.loadThumbnail
+// (API 29+) reads from MediaProvider's on-disk thumbnail cache; the system
+// process handles decode and resize. The JPEG encode and write run on the
+// AsyncFunction worker thread — no bytes cross the JS bridge.
+//
+// Returns null on API < 29 and on any failure — callers fall back to the
+// in-process resize path.
+class SiaOsThumbModule : Module() {
+  override fun definition() = ModuleDefinition {
+    Name("SiaOsThumb")
+
+    AsyncFunction("getOsThumbnail") { localId: String, targetSize: Double ->
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return@AsyncFunction null
+      val context = appContext.reactContext ?: return@AsyncFunction null
+      val uri = parseLocalId(localId) ?: return@AsyncFunction null
+
+      val bitmap: Bitmap = try {
+        context.contentResolver.loadThumbnail(
+          uri,
+          Size(targetSize.toInt(), targetSize.toInt()),
+          null,
+        )
+      } catch (_: Exception) {
+        return@AsyncFunction null
+      }
+
+      val cacheDir = File(context.cacheDir, "sia-os-thumb").apply { mkdirs() }
+      val file = File(cacheDir, "${uri.lastPathSegment}-${targetSize.toInt()}-${UUID.randomUUID()}.jpg")
+      try {
+        FileOutputStream(file).use { bitmap.compress(Bitmap.CompressFormat.JPEG, 85, it) }
+      } catch (_: Exception) {
+        return@AsyncFunction null
+      }
+
+      mapOf(
+        "uri" to Uri.fromFile(file).toString(),
+        "width" to bitmap.width,
+        "height" to bitmap.height,
+        "mimeType" to "image/jpeg",
+      )
+    }
+  }
+
+  private fun parseLocalId(localId: String): Uri? {
+    if (localId.startsWith("content://")) return Uri.parse(localId)
+    val id = localId.toLongOrNull() ?: return null
+    return ContentUris.withAppendedId(MediaStore.Files.getContentUri("external"), id)
+  }
+}

--- a/apps/mobile/modules/sia-os-thumb/expo-module.config.json
+++ b/apps/mobile/modules/sia-os-thumb/expo-module.config.json
@@ -1,0 +1,9 @@
+{
+  "platforms": ["apple", "android"],
+  "apple": {
+    "modules": ["SiaOsThumbModule"]
+  },
+  "android": {
+    "modules": ["expo.modules.siaosthumb.SiaOsThumbModule"]
+  }
+}

--- a/apps/mobile/modules/sia-os-thumb/index.ts
+++ b/apps/mobile/modules/sia-os-thumb/index.ts
@@ -1,0 +1,36 @@
+import { requireOptionalNativeModule } from 'expo'
+
+export type OsThumbResult = {
+  /** `file://` path to the JPEG the native side wrote to the app cache. */
+  uri: string
+  width: number
+  height: number
+  mimeType: 'image/jpeg'
+}
+
+type NativeModule = {
+  getOsThumbnail(localId: string, targetSize: number): Promise<OsThumbResult | null>
+}
+
+const native = requireOptionalNativeModule<NativeModule>('SiaOsThumb')
+
+/**
+ * Writes a system-cached thumbnail of a media-library asset to the app cache
+ * directory and returns its `file://` path. iOS reads from the Photos
+ * framework's thumbnail cache via PHImageManager (fastFormat, exact, no iCloud
+ * fetch); Android reads from MediaProvider via ContentResolver.loadThumbnail
+ * (API 29+). Decode/scale and the disk write all run in the OS media daemon
+ * and native side — no bytes ever cross the JS bridge.
+ *
+ * Returns null when the asset doesn't exist, the platform can't fulfill the
+ * request (cloud-only on Android, permission revoked, API < 29 on Android,
+ * native module absent), or anything else short of a genuine programming bug.
+ * Callers fall back to the in-process resizeToWebP path on null.
+ */
+export async function getOsThumbnail(
+  localId: string,
+  targetSize: number,
+): Promise<OsThumbResult | null> {
+  if (!native) return null
+  return native.getOsThumbnail(localId, targetSize)
+}

--- a/apps/mobile/modules/sia-os-thumb/ios/SiaOsThumb.podspec
+++ b/apps/mobile/modules/sia-os-thumb/ios/SiaOsThumb.podspec
@@ -1,0 +1,26 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name           = 'SiaOsThumb'
+  s.version        = package['version']
+  s.summary        = 'Reads system-cached PHAsset thumbnails via PHImageManager.'
+  s.description    = 'Local Expo module that wraps PHImageManager.requestImage with fastFormat/exact/no-network so the archive-walk thumbnail pipeline can use OS-cached tiles instead of decoding full assets in-process.'
+  s.license        = { :type => 'MIT' }
+  s.author         = { 'sia-storage-app' => 'noreply@sia.tech' }
+  s.homepage       = 'https://github.com/SiaFoundation/sia-storage-app'
+  s.platforms      = { :ios => '15.1' }
+  s.swift_version  = '5.9'
+  s.source         = { :path => '.' }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+    'SWIFT_COMPILATION_MODE' => 'wholemodule'
+  }
+
+  s.source_files = '**/*.{h,m,swift}'
+end

--- a/apps/mobile/modules/sia-os-thumb/ios/SiaOsThumbModule.swift
+++ b/apps/mobile/modules/sia-os-thumb/ios/SiaOsThumbModule.swift
@@ -1,0 +1,73 @@
+import ExpoModulesCore
+import Photos
+import UIKit
+
+// Writes a system-cached PHAsset thumbnail to the app cache directory and
+// resolves with the resulting file:// path. PHImageManager dispatches the
+// work to photolibraryd; with deliveryMode=.fastFormat, resizeMode=.exact,
+// and isNetworkAccessAllowed=false the call returns a cached tile sized to
+// the request without decoding the full asset and without iCloud network.
+// The JPEG encode and write also happen on a global queue — no bytes
+// touch the JS thread.
+//
+// Returns nil for any expected failure (asset deleted, permission revoked,
+// cached tile unavailable) — callers fall back to the in-process resize.
+public class SiaOsThumbModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("SiaOsThumb")
+
+    AsyncFunction("getOsThumbnail") { (localId: String, targetSize: Double, promise: Promise) in
+      let identifier = localId.hasPrefix("ph://") ? String(localId.dropFirst(5)) : localId
+      let fetch = PHAsset.fetchAssets(withLocalIdentifiers: [identifier], options: nil)
+      guard let asset = fetch.firstObject else {
+        promise.resolve(nil)
+        return
+      }
+
+      let opts = PHImageRequestOptions()
+      opts.deliveryMode = .fastFormat
+      opts.resizeMode = .exact
+      opts.isNetworkAccessAllowed = false
+      opts.isSynchronous = false
+
+      let pixelSize = CGSize(width: targetSize, height: targetSize)
+
+      PHImageManager.default().requestImage(
+        for: asset,
+        targetSize: pixelSize,
+        contentMode: .aspectFill,
+        options: opts
+      ) { image, _ in
+        DispatchQueue.global(qos: .userInitiated).async {
+          guard let image = image,
+                let data = image.jpegData(compressionQuality: 0.85)
+          else {
+            promise.resolve(nil)
+            return
+          }
+          let cache = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("sia-os-thumb", isDirectory: true)
+          do {
+            try FileManager.default.createDirectory(at: cache, withIntermediateDirectories: true)
+          } catch {
+            promise.resolve(nil)
+            return
+          }
+          let file = cache.appendingPathComponent("\(identifier)-\(Int(targetSize))-\(UUID().uuidString).jpg")
+          do {
+            try data.write(to: file, options: .atomic)
+          } catch {
+            promise.resolve(nil)
+            return
+          }
+          promise.resolve([
+            "uri": file.absoluteString,
+            "width": Int(image.size.width),
+            "height": Int(image.size.height),
+            "mimeType": "image/jpeg",
+          ])
+        }
+      }
+    }
+  }
+}

--- a/apps/mobile/modules/sia-os-thumb/package.json
+++ b/apps/mobile/modules/sia-os-thumb/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "sia-os-thumb",
+  "version": "0.0.0",
+  "private": true,
+  "main": "index.ts",
+  "types": "index.ts"
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -92,6 +92,7 @@
     "react-native-svg": "15.15.3",
     "react-native-webview": "13.16.0",
     "react-native-worklets": "0.7.2",
+    "sia-os-thumb": "file:./modules/sia-os-thumb",
     "swr": "2.4.1",
     "zod": "4.3.6"
   },

--- a/apps/mobile/src/adapters/thumbnail.test.ts
+++ b/apps/mobile/src/adapters/thumbnail.test.ts
@@ -1,0 +1,38 @@
+import { getOsThumbnail } from 'sia-os-thumb'
+import { createMobileThumbnailAdapter } from './thumbnail'
+
+const getOsThumbnailMock = jest.mocked(getOsThumbnail)
+
+beforeEach(() => {
+  getOsThumbnailMock.mockReset()
+})
+
+describe('createMobileThumbnailAdapter generateImageThumbnails', () => {
+  it('returns OS-cached tiles for every size and skips the resize cascade', async () => {
+    getOsThumbnailMock.mockImplementation(async (_localId: string, size: number) => ({
+      uri: `file:///cache/${size}.jpg`,
+      width: size,
+      height: size,
+      mimeType: 'image/jpeg',
+    }))
+
+    const adapter = createMobileThumbnailAdapter()
+    const results = await adapter.generateImageThumbnails('file:///orig.jpg', [64, 512], {
+      localId: 'ph://abc',
+    })
+
+    expect(results.get(64)).toEqual({ savedUri: 'file:///cache/64.jpg', mimeType: 'image/jpeg' })
+    expect(results.get(512)).toEqual({ savedUri: 'file:///cache/512.jpg', mimeType: 'image/jpeg' })
+    expect(getOsThumbnailMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('skips the OS path entirely when localId is missing', async () => {
+    const adapter = createMobileThumbnailAdapter()
+    // sourcePath doesn't exist; the cascade will throw, which is fine —
+    // we only need to assert the OS path was never queried.
+    await expect(
+      adapter.generateImageThumbnails('file:///does-not-exist.jpg', [64, 512], { localId: null }),
+    ).rejects.toThrow()
+    expect(getOsThumbnailMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/mobile/src/adapters/thumbnail.ts
+++ b/apps/mobile/src/adapters/thumbnail.ts
@@ -4,6 +4,7 @@ import type { ThumbSize } from '@siastorage/core/types'
 import { ImageManipulator, SaveFormat } from 'expo-image-manipulator'
 import * as VideoThumbnails from 'expo-video-thumbnails'
 import { Image } from 'react-native'
+import { getOsThumbnail } from 'sia-os-thumb'
 
 function getImageSize(uri: string): Promise<{ width: number; height: number }> {
   return new Promise((resolve, reject) => {
@@ -107,23 +108,52 @@ const MOBILE_THUMBNAILABLE_TYPES: readonly string[] = [
   ...MOBILE_THUMBNAILABLE_VIDEO_TYPES,
 ]
 
+async function tryOsThumb(
+  localId: string | null | undefined,
+  size: number,
+): Promise<ThumbnailResult | null> {
+  if (!localId) return null
+  const r = await getOsThumbnail(localId, size)
+  if (!r) return null
+  return { savedUri: r.uri, mimeType: r.mimeType }
+}
+
 export function createMobileThumbnailAdapter(): ThumbnailAdapter {
   return {
     thumbnailableTypes: MOBILE_THUMBNAILABLE_TYPES,
-    async generateImageThumbnail(sourcePath: string, targetSize: number): Promise<ThumbnailResult> {
+    async generateImageThumbnail(
+      sourcePath: string,
+      targetSize: number,
+      opts?: { localId?: string | null },
+    ): Promise<ThumbnailResult> {
+      const os = await tryOsThumb(opts?.localId, targetSize)
+      if (os) return os
       return resizeToWebP(sourcePath, targetSize as ThumbSize)
     },
 
     async generateImageThumbnails(
       sourcePath: string,
       sizes: number[],
+      opts?: { localId?: string | null },
     ): Promise<Map<number, ThumbnailResult>> {
       const sorted = [...sizes].sort((a, b) => b - a)
       const results = new Map<number, ThumbnailResult>()
 
+      // First try every size via the OS path in parallel. Anything that
+      // returns null falls through to the resize cascade below.
+      const osResults = await Promise.all(
+        sorted.map((size) => tryOsThumb(opts?.localId, size).then((r) => ({ size, r }))),
+      )
+      const missing: number[] = []
+      for (const { size, r } of osResults) {
+        if (r) results.set(size, r)
+        else missing.push(size)
+      }
+      if (missing.length === 0) return results
+
       let inputUri = sourcePath
       let skipDetection = false
-      for (const size of sorted) {
+      for (const size of missing) {
         const result = await resizeToWebP(inputUri, size, skipDetection)
         results.set(size, result)
         // Subsequent smaller sizes resize from the larger result.

--- a/apps/mobile/src/lib/assetImports.ts
+++ b/apps/mobile/src/lib/assetImports.ts
@@ -32,6 +32,7 @@ import {
   markImportCopyStarted,
   triggerImportScanner,
 } from '../managers/importScanner'
+import { triggerOsThumbCapture } from '../managers/osThumbCapture'
 import { generateThumbnails } from '../managers/thumbnailer'
 import { app } from '../stores/appService'
 import { copyFileToFs } from '../stores/fs'
@@ -375,6 +376,7 @@ export async function catalogAssets(
   await app().optimize()
 
   triggerImportScanner()
+  triggerOsThumbCapture()
 
   return { newCount, existingCount }
 }

--- a/apps/mobile/src/managers/app.ts
+++ b/apps/mobile/src/managers/app.ts
@@ -20,6 +20,7 @@ import { runFsEvictionScanner } from './fsEvictionScanner'
 import { initAutoKeepAwake } from './autoKeepAwake'
 import { initImportScanner } from './importScanner'
 import { initLogRotation } from './logRotation'
+import { initOsThumbCapture } from './osThumbCapture'
 import { initPerfMonitor } from './perfMonitor'
 import { initSuspensionManager, teardownSuspensionManager } from './suspension'
 import { initSyncDownEvents, triggerSyncDownEvents } from './syncDownEvents'
@@ -128,6 +129,7 @@ export async function initApp(): Promise<void> {
         initDbOptimize()
         await activateSyncGate(app())
         initImportScanner()
+        initOsThumbCapture()
         initSyncDownEvents()
         triggerSyncDownEvents()
         initSyncNewPhotos()

--- a/apps/mobile/src/managers/osThumbCapture.ts
+++ b/apps/mobile/src/managers/osThumbCapture.ts
@@ -1,0 +1,205 @@
+import {
+  OS_THUMB_CAPTURE_BATCH,
+  OS_THUMB_CAPTURE_CONCURRENCY,
+  OS_THUMB_CAPTURE_INTERVAL,
+} from '@siastorage/core/config'
+import { BackoffTracker } from '@siastorage/core/lib/backoffTracker'
+import { createServiceInterval } from '@siastorage/core/lib/serviceInterval'
+import { uniqueId } from '@siastorage/core/lib/uniqueId'
+import type { FileRecord, ThumbSize } from '@siastorage/core/types'
+import { ThumbSizes } from '@siastorage/core/types'
+import { logger } from '@siastorage/logger'
+import { getOsThumbnail } from 'sia-os-thumb'
+import { app } from '../stores/appService'
+import { isBgTaskActive } from './bgTaskContext'
+
+const backoff = new BackoffTracker()
+
+type CapturedThumb = {
+  fileId: string
+  size: ThumbSize
+  record: Omit<FileRecord, 'objects'>
+}
+
+type CaptureFailure = 'os_null' | 'adopt_failed'
+type CaptureOutcome = { ok: true; thumb: CapturedThumb } | { ok: false; reason: CaptureFailure }
+
+async function captureOne(
+  fileId: string,
+  localId: string,
+  size: ThumbSize,
+  mimeFallback: string,
+): Promise<CaptureOutcome> {
+  // Native side does the IPC, decode, JPEG encode, and tmp-file write on
+  // background threads. We only orchestrate.
+  const r = await getOsThumbnail(localId, size)
+  if (!r) {
+    backoff.recordSkip(fileId, `os-thumb-null:${size}`)
+    return { ok: false, reason: 'os_null' }
+  }
+  try {
+    const thumbId = uniqueId()
+    // adoptFile = RNFS.moveFile + RNFS.hash, both native. No JS-thread bytes.
+    const adopted = await app().fs.adoptFile({ id: thumbId, type: r.mimeType }, r.uri)
+    const now = Date.now()
+    return {
+      ok: true,
+      thumb: {
+        fileId,
+        size,
+        record: {
+          id: thumbId,
+          name: 'thumbnail.jpg',
+          type: r.mimeType || mimeFallback,
+          kind: 'thumb',
+          size: adopted.size,
+          hash: `sha256:${adopted.hash}`,
+          createdAt: now,
+          updatedAt: now,
+          addedAt: now,
+          localId: null,
+          thumbForId: fileId,
+          thumbSize: size,
+          trashedAt: null,
+          deletedAt: null,
+        },
+      },
+    }
+  } catch (e) {
+    backoff.recordSkip(fileId, `adopt-failed:${size}`)
+    logger.warn('osThumbCapture', 'adopt_failed', {
+      fileId,
+      localId,
+      size,
+      error: e as Error,
+    })
+    return { ok: false, reason: 'adopt_failed' }
+  }
+}
+
+/**
+ * OS-thumb capture loop. Pulls files with a `localId` that still need
+ * thumbnails — including archive-walk placeholders whose bodies haven't
+ * been copied yet — and fetches the system-cached tile via PHImageManager
+ * (iOS) or ContentResolver.loadThumbnail (Android). Runs ahead of the
+ * `importScanner`'s body-copy backpressure: artifacts are tiny and aren't
+ * queued for upload until their parent file is finalized.
+ *
+ * Heavy work runs off the JS thread: photolibraryd / MediaProvider do the
+ * decode and scale; the native module's JPEG encode and tmp-file write run
+ * on background queues; `adoptFile` is native (RNFS.moveFile + RNFS.hash);
+ * the DB write is one batched `files.createMany` per tick. Failures land
+ * in a shared `BackoffTracker` and are excluded from subsequent queries.
+ */
+async function run(signal: AbortSignal): Promise<void> {
+  if (isBgTaskActive('BGAppRefreshTask')) {
+    logger.debug('osThumbCapture', 'skipped', { reason: 'bg_app_refresh_no_cpu_budget' })
+    return
+  }
+  if (app().sync.getState().syncGateStatus === 'active') {
+    logger.debug('osThumbCapture', 'skipped', { reason: 'sync_gate_active' })
+    return
+  }
+
+  const allowedTypes = app().thumbnails.allowedTypes
+  // PHImageManager / loadThumbnail handle still images natively; video is a
+  // separate code path on iOS and stays on the deferred scanner for now.
+  const imageTypes = allowedTypes.filter((t) => t.startsWith('image/'))
+  if (imageTypes.length === 0) return
+
+  const excludeIds = backoff.getExcludeIds()
+  const queryStart = Date.now()
+  const candidates = await app().thumbnails.queryMissingOsThumbCandidates(
+    OS_THUMB_CAPTURE_BATCH,
+    imageTypes,
+    excludeIds.length > 0 ? excludeIds : undefined,
+  )
+  const queryMs = Date.now() - queryStart
+  if (candidates.length === 0) {
+    logger.debug('osThumbCapture', 'idle', { excluded: excludeIds.length, queryMs })
+    return
+  }
+
+  const sizesByFileId = await app().thumbnails.getSizesForFiles(candidates.map((c) => c.id))
+
+  // Build a flat work list of (file × missing size) so the concurrency pool
+  // saturates regardless of per-file size shape (1 missing vs 2 missing).
+  type Job = { fileId: string; localId: string; size: ThumbSize; mimeFallback: string }
+  const jobs: Job[] = []
+  for (const c of candidates) {
+    const existing = sizesByFileId.get(c.id) ?? []
+    for (const size of ThumbSizes) {
+      if (!existing.includes(size)) {
+        jobs.push({ fileId: c.id, localId: c.localId, size, mimeFallback: c.type })
+      }
+    }
+  }
+  if (jobs.length === 0) return
+
+  // Concurrency pool: keeps OS_THUMB_CAPTURE_CONCURRENCY native calls in
+  // flight. Each call's wait happens out-of-process; in-process cost is a
+  // small JPEG encode + RNFS move + RNFS hash, all on native threads.
+  const captured: CapturedThumb[] = []
+  const failureCounts = { os_null: 0, adopt_failed: 0 }
+  const newlyExcluded = new Set<string>()
+  let cursor = 0
+  async function worker(): Promise<void> {
+    while (!signal.aborted) {
+      const idx = cursor++
+      if (idx >= jobs.length) return
+      const job = jobs[idx]
+      const outcome = await captureOne(job.fileId, job.localId, job.size, job.mimeFallback)
+      if (outcome.ok) {
+        captured.push(outcome.thumb)
+      } else {
+        failureCounts[outcome.reason] += 1
+        newlyExcluded.add(job.fileId)
+      }
+    }
+  }
+  const tickStart = Date.now()
+  await Promise.all(
+    Array.from({ length: Math.min(OS_THUMB_CAPTURE_CONCURRENCY, jobs.length) }, () => worker()),
+  )
+  const captureMs = Date.now() - tickStart
+  if (signal.aborted) return
+
+  if (captured.length > 0) {
+    await app().db.waitUntilActive()
+    await app().files.createMany(
+      captured.map((c) => c.record),
+      { conflictClause: 'OR IGNORE', skipCurrentRecalc: true },
+    )
+
+    const touchedFileIds = new Set(captured.map((c) => c.fileId))
+    for (const fileId of touchedFileIds) {
+      backoff.clear(fileId)
+      await app().caches.thumbnails.byFileId.invalidate(fileId)
+    }
+    for (const c of captured) {
+      await app().caches.thumbnails.best.invalidate(c.fileId, String(c.size))
+    }
+  }
+
+  const filesAttempted = new Set(jobs.map((j) => j.fileId)).size
+  const filesSucceeded = new Set(captured.map((c) => c.fileId)).size
+  logger.info('osThumbCapture', 'tick', {
+    files_attempted: filesAttempted,
+    files_succeeded: filesSucceeded,
+    files_newly_excluded: newlyExcluded.size,
+    jobs_total: jobs.length,
+    jobs_succeeded: captured.length,
+    jobs_failed_os_null: failureCounts.os_null,
+    jobs_failed_adopt: failureCounts.adopt_failed,
+    excluded_persistent: excludeIds.length,
+    query_ms: queryMs,
+    capture_ms: captureMs,
+  })
+}
+
+export const { init: initOsThumbCapture, triggerNow: triggerOsThumbCapture } =
+  createServiceInterval({
+    name: 'osThumbCapture',
+    worker: run,
+    interval: OS_THUMB_CAPTURE_INTERVAL,
+  })

--- a/apps/mobile/test/mocks/sia-os-thumb.ts
+++ b/apps/mobile/test/mocks/sia-os-thumb.ts
@@ -1,0 +1,4 @@
+// Shared via jest.config moduleNameMapper. Defaults to returning null so
+// production-shaped tests fall through to `resizeToWebP`; targeted unit
+// tests override the implementation via `jest.mocked(getOsThumbnail)`.
+export const getOsThumbnail = jest.fn<Promise<unknown>, [string, number]>(async () => null)

--- a/bun.lock
+++ b/bun.lock
@@ -133,6 +133,7 @@
         "react-native-svg": "15.15.3",
         "react-native-webview": "13.16.0",
         "react-native-worklets": "0.7.2",
+        "sia-os-thumb": "file:./modules/sia-os-thumb",
         "swr": "2.4.1",
         "zod": "4.3.6",
       },
@@ -2369,6 +2370,8 @@
     "@react-native/community-cli-plugin/metro-core": ["metro-core@0.83.5", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "lodash.throttle": "^4.1.1", "metro-resolver": "0.83.5" } }, "sha512-YcVcLCrf0ed4mdLa82Qob0VxYqfhmlRxUS8+TO4gosZo/gLwSvtdeOjc/Vt0pe/lvMNrBap9LlmvZM8FIsMgJQ=="],
 
     "@siastorage/mobile/background-time-remaining": ["background-time-remaining@file:apps/mobile/modules/background-time-remaining", {}],
+
+    "@siastorage/mobile/sia-os-thumb": ["sia-os-thumb@file:apps/mobile/modules/sia-os-thumb", {}],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
 

--- a/packages/core/src/adapters/thumbnail.ts
+++ b/packages/core/src/adapters/thumbnail.ts
@@ -9,6 +9,16 @@ export type ThumbnailResult =
   | { data: ArrayBuffer; mimeType: string }
   | { savedUri: string; mimeType: string }
 
+export interface ThumbnailOptions {
+  /**
+   * Media-library identifier when the source file originated from the OS
+   * photo library. Mobile uses this to fetch the system-cached thumbnail
+   * via PHImageManager (iOS) or ContentResolver.loadThumbnail (Android)
+   * instead of decoding the full source. CLI/desktop adapters ignore it.
+   */
+  localId?: string | null
+}
+
 export interface ThumbnailAdapter {
   /**
    * MIME types this adapter can decode into a thumbnail. The scanner uses
@@ -16,10 +26,19 @@ export interface ThumbnailAdapter {
    * get scanned on every cold start.
    */
   readonly thumbnailableTypes: readonly string[]
-  generateImageThumbnail(sourcePath: string, targetSize: number): Promise<ThumbnailResult>
+  generateImageThumbnail(
+    sourcePath: string,
+    targetSize: number,
+    opts?: ThumbnailOptions,
+  ): Promise<ThumbnailResult>
   generateImageThumbnails(
     sourcePath: string,
     sizes: number[],
+    opts?: ThumbnailOptions,
   ): Promise<Map<number, ThumbnailResult>>
-  generateVideoThumbnail(sourcePath: string, targetSize: number): Promise<ThumbnailResult>
+  generateVideoThumbnail(
+    sourcePath: string,
+    targetSize: number,
+    opts?: ThumbnailOptions,
+  ): Promise<ThumbnailResult>
 }

--- a/packages/core/src/app/namespaces/db.ts
+++ b/packages/core/src/app/namespaces/db.ts
@@ -498,18 +498,20 @@ export function buildDbNamespaces(
         ops.queryThumbnailExistsForFileIdAndSize(db, fileId, size),
       queryCandidatePage: (pageSize, cursor, allowedTypes) =>
         ops.queryThumbnailCandidatePage(db, pageSize, cursor, allowedTypes),
+      queryMissingOsThumbCandidates: (limit, allowedTypes, excludeIds) =>
+        ops.queryMissingOsThumbCandidates(db, limit, allowedTypes, excludeIds),
       queryProgress: (allowedTypes) => ops.queryThumbnailScanProgress(db, allowedTypes),
-      generate: (sourcePath, targetSize) => {
+      generate: (sourcePath, targetSize, opts) => {
         if (!adapters?.thumbnail) throw new Error('Thumbnail adapter not configured')
-        return adapters.thumbnail.generateImageThumbnail(sourcePath, targetSize)
+        return adapters.thumbnail.generateImageThumbnail(sourcePath, targetSize, opts)
       },
-      generateBatch: (sourcePath, sizes) => {
+      generateBatch: (sourcePath, sizes, opts) => {
         if (!adapters?.thumbnail) throw new Error('Thumbnail adapter not configured')
-        return adapters.thumbnail.generateImageThumbnails(sourcePath, sizes)
+        return adapters.thumbnail.generateImageThumbnails(sourcePath, sizes, opts)
       },
-      generateVideo: (sourcePath, targetSize) => {
+      generateVideo: (sourcePath, targetSize, opts) => {
         if (!adapters?.thumbnail) throw new Error('Thumbnail adapter not configured')
-        return adapters.thumbnail.generateVideoThumbnail(sourcePath, targetSize)
+        return adapters.thumbnail.generateVideoThumbnail(sourcePath, targetSize, opts)
       },
     },
     localObjects: {

--- a/packages/core/src/app/service.ts
+++ b/packages/core/src/app/service.ts
@@ -362,14 +362,45 @@ export interface AppService {
         createdAt: number
       }[]
     >
+    /**
+     * Returns files with a localId still missing one or more `ThumbSizes`
+     * thumbnails. Drives the OS-thumb capture scanner — includes archive-walk
+     * placeholders (hash='') so thumbnails can be produced ahead of the
+     * import scanner's body-copy backpressure. `excludeIds` lets callers
+     * skip files currently in backoff.
+     */
+    queryMissingOsThumbCandidates(
+      limit: number,
+      allowedTypes: readonly string[],
+      excludeIds?: readonly string[],
+    ): Promise<
+      {
+        id: string
+        type: string
+        localId: string
+        createdAt: number
+      }[]
+    >
     /** Returns overall thumbnail scan progress (count of originals and thumbs). */
     queryProgress(allowedTypes: readonly string[]): Promise<{ originals: number; thumbs: number }>
     /** Generates a single image thumbnail at the given size. */
-    generate(sourcePath: string, targetSize: number): Promise<ThumbnailResult>
+    generate(
+      sourcePath: string,
+      targetSize: number,
+      opts?: { localId?: string | null },
+    ): Promise<ThumbnailResult>
     /** Generates image thumbnails at multiple sizes in one pass. */
-    generateBatch(sourcePath: string, sizes: number[]): Promise<Map<number, ThumbnailResult>>
+    generateBatch(
+      sourcePath: string,
+      sizes: number[],
+      opts?: { localId?: string | null },
+    ): Promise<Map<number, ThumbnailResult>>
     /** Generates a video thumbnail at the given size. */
-    generateVideo(sourcePath: string, targetSize: number): Promise<ThumbnailResult>
+    generateVideo(
+      sourcePath: string,
+      targetSize: number,
+      opts?: { localId?: string | null },
+    ): Promise<ThumbnailResult>
   }
   /** Local object (remote reference) CRUD for file-to-indexer mappings. */
   localObjects: {

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -58,6 +58,19 @@ export const IMPORT_SCANNER_INTERVAL = secondsInMs(3) // 3 seconds
 export const IMPORT_SCANNER_BACKLOG_LIMIT = 50
 // Thumbnail scanner interval.
 export const THUMBNAIL_SCANNER_INTERVAL = secondsInMs(5) // 5 seconds
+// OS thumbnail capture scanner interval. Runs ahead of the body-copy
+// backpressure so archive-walk placeholders pick up their PHImageManager /
+// ContentResolver.loadThumbnail tiles immediately after cataloging.
+export const OS_THUMB_CAPTURE_INTERVAL = secondsInMs(1) // 1 second
+// Files processed per OS-thumb capture tick. The work is OS-IPC bound, not
+// CPU-bound, so the batch can be much wider than the import scanner's
+// body-copy throughput.
+export const OS_THUMB_CAPTURE_BATCH = 200
+// Concurrent (file × size) native calls in flight. Each call waits on
+// photolibraryd / MediaProvider IPC; in-process cost is a small JPEG encode
+// + disk write on a native background queue. Keeps the JS thread idle and
+// SQLite writer comfortable.
+export const OS_THUMB_CAPTURE_CONCURRENCY = 20
 // Maximum number of bytes to retain in the local file system before evicting.
 export const FS_MAX_BYTES = 4_000_000_000 // 4 GB
 // File system orphaned file cleanup frequency.

--- a/packages/core/src/db/operations/index.ts
+++ b/packages/core/src/db/operations/index.ts
@@ -174,6 +174,7 @@ export {
 } from './tags'
 export {
   queryBestThumbnailByFileId,
+  queryMissingOsThumbCandidates,
   queryThumbnailCandidatePage,
   queryThumbnailExistsForFileIdAndSize,
   queryThumbnailFileInfoByFileIds,
@@ -182,6 +183,7 @@ export {
   queryThumbnailSizesForFileId,
   queryThumbnailSizesForFileIds,
   queryThumbnailsByFileId,
+  type OsThumbCandidateRow,
   type ThumbnailCandidateRow,
 } from './thumbnails'
 export {

--- a/packages/core/src/db/operations/thumbnails.test.ts
+++ b/packages/core/src/db/operations/thumbnails.test.ts
@@ -3,6 +3,7 @@ import { upsertFsMeta } from './fs'
 import { db, setupTestDb, teardownTestDb } from './test-setup'
 import {
   queryBestThumbnailByFileId,
+  queryMissingOsThumbCandidates,
   queryThumbnailCandidatePage,
   queryThumbnailExistsForFileIdAndSize,
   queryThumbnailFileInfoByFileIds,
@@ -199,6 +200,51 @@ describe('queryThumbnailCandidatePage allowlist', () => {
     await createThumbnail('thumb64', 'jpeg', 64)
     await createThumbnail('thumb512', 'jpeg', 512)
     const rows = await queryThumbnailCandidatePage(db(), 10, undefined, DEFAULT_ALLOWED)
+    expect(rows).toEqual([])
+  })
+})
+
+describe('queryMissingOsThumbCandidates', () => {
+  it('returns files missing one or more ThumbSizes', async () => {
+    await createTestFile('partial')
+    await createThumbnail('partial-64', 'partial', 64)
+    await createTestFile('none')
+    await createTestFile('complete')
+    await createThumbnail('complete-64', 'complete', 64)
+    await createThumbnail('complete-512', 'complete', 512)
+
+    const rows = await queryMissingOsThumbCandidates(db(), 10, DEFAULT_ALLOWED)
+    expect(rows.map((r) => r.id).sort()).toEqual(['none', 'partial'])
+  })
+
+  it('skips files without a localId', async () => {
+    await createTestFile('hasLocal')
+    await createTestFile('noLocal', { localId: null })
+
+    const rows = await queryMissingOsThumbCandidates(db(), 10, DEFAULT_ALLOWED)
+    expect(rows.map((r) => r.id)).toEqual(['hasLocal'])
+  })
+
+  it('honours the type allowlist', async () => {
+    await createTestFile('jpeg', { type: 'image/jpeg' })
+    await createTestFile('mp4', { type: 'video/mp4' })
+    await createTestFile('raw', { type: 'image/x-canon-cr3' })
+
+    const rows = await queryMissingOsThumbCandidates(db(), 10, ['image/jpeg'])
+    expect(rows.map((r) => r.id)).toEqual(['jpeg'])
+  })
+
+  it('respects excludeIds', async () => {
+    await createTestFile('keep')
+    await createTestFile('skip')
+
+    const rows = await queryMissingOsThumbCandidates(db(), 10, DEFAULT_ALLOWED, ['skip'])
+    expect(rows.map((r) => r.id)).toEqual(['keep'])
+  })
+
+  it('returns empty when allowedTypes is empty', async () => {
+    await createTestFile('jpeg')
+    const rows = await queryMissingOsThumbCandidates(db(), 10, [])
     expect(rows).toEqual([])
   })
 })

--- a/packages/core/src/db/operations/thumbnails.ts
+++ b/packages/core/src/db/operations/thumbnails.ts
@@ -160,6 +160,53 @@ export async function queryThumbnailCandidatePage(
   )
 }
 
+export type OsThumbCandidateRow = {
+  id: string
+  type: string
+  localId: string
+  createdAt: number
+}
+
+/**
+ * Files with a `localId` that are still missing one or more `ThumbSizes`
+ * thumbnails, including archive-walk placeholders (hash=''). Drives the
+ * OS-thumb capture scanner, which can produce thumbnails ahead of the
+ * import-scanner body copy.
+ */
+export async function queryMissingOsThumbCandidates(
+  db: DatabaseAdapter,
+  limit: number,
+  allowedTypes: readonly string[],
+  excludeIds?: readonly string[],
+): Promise<OsThumbCandidateRow[]> {
+  if (allowedTypes.length === 0) return []
+  const typePlaceholders = allowedTypes.map(() => '?').join(',')
+  const params: (string | number)[] = [...allowedTypes]
+  let excludeClause = ''
+  if (excludeIds && excludeIds.length > 0) {
+    const excludePlaceholders = excludeIds.map(() => '?').join(',')
+    excludeClause = `AND f.id NOT IN (${excludePlaceholders})`
+    params.push(...excludeIds)
+  }
+  params.push(limit)
+  return db.getAllAsync<OsThumbCandidateRow>(
+    `SELECT f.id, f.type, f.localId, f.createdAt
+     FROM files f
+     LEFT JOIN files t
+       ON t.thumbForId = f.id
+      AND t.thumbSize IN (${ThumbSizes.join(',')})
+     WHERE f.localId IS NOT NULL
+       AND f.type IN (${typePlaceholders})
+       AND ${buildRecordFilter('f')}
+       ${excludeClause}
+     GROUP BY f.id
+     HAVING COUNT(DISTINCT t.thumbSize) < ${ThumbSizes.length}
+     ORDER BY f.createdAt DESC, f.id DESC
+     LIMIT ?`,
+    ...params,
+  )
+}
+
 export async function queryThumbnailScanProgress(
   db: DatabaseAdapter,
   allowedTypes: readonly string[],

--- a/packages/core/src/services/thumbnailScanner.ts
+++ b/packages/core/src/services/thumbnailScanner.ts
@@ -323,9 +323,13 @@ export class ThumbnailScanner {
     let result: ThumbnailResult
     try {
       if (actualType?.startsWith('video/')) {
-        result = await app.thumbnails.generateVideo(sourceUri, size)
+        result = await app.thumbnails.generateVideo(sourceUri, size, {
+          localId: params.fileLocalId,
+        })
       } else {
-        result = await app.thumbnails.generate(sourceUri, size)
+        result = await app.thumbnails.generate(sourceUri, size, {
+          localId: params.fileLocalId,
+        })
       }
     } catch (e) {
       logger.error('thumbnailer', 'source_prepare_error', {
@@ -417,7 +421,9 @@ export class ThumbnailScanner {
 
     let thumbnails: Map<number, ThumbnailResult>
     try {
-      thumbnails = await app.thumbnails.generateBatch(sourceUri, sizes)
+      thumbnails = await app.thumbnails.generateBatch(sourceUri, sizes, {
+        localId: params.fileLocalId,
+      })
     } catch (e) {
       logger.error('thumbnailer', 'batch_generate_error', {
         fileId,


### PR DESCRIPTION
Archive sync used to leave the gallery on file-type icons for while bodies trickled in under upload-backlog backpressure. Thumbnails are now pulled from the OS photo library's own cache at catalog time — out of process so the grid fills in immediately while body copies run independently.

