### PR TITLE
fix(mobile): restore iCloud photo preview in file viewer

### DIFF
--- a/.changeset/file-viewer-icloud-photo-preview.md
+++ b/.changeset/file-viewer-icloud-photo-preview.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Fixed iCloud-only photos failing to preview in the file viewer with a "No suitable image URL loader" error. The file viewer now pulls them from iCloud on demand when opened.

--- a/apps/mobile/src/lib/mediaLibrary.test.ts
+++ b/apps/mobile/src/lib/mediaLibrary.test.ts
@@ -1,5 +1,5 @@
 import * as MediaLibrary from 'expo-media-library'
-import { getMediaLibraryUri } from './mediaLibrary'
+import { getMediaLibraryDisplayUri, getMediaLibraryUri } from './mediaLibrary'
 
 jest.mock('expo-media-library', () => ({
   getAssetInfoAsync: jest.fn(),
@@ -119,5 +119,106 @@ describe('getMediaLibraryUri', () => {
 
       expect(await getMediaLibraryUri('ph://slowmo')).toEqual({ status: 'unavailable' })
     })
+  })
+})
+
+describe('getMediaLibraryDisplayUri', () => {
+  it('returns deleted for null localId', async () => {
+    expect(await getMediaLibraryDisplayUri(null)).toEqual({ status: 'deleted' })
+    expect(getAssetInfoAsyncMock).not.toHaveBeenCalled()
+  })
+
+  // Eager step: triggers iCloud download so iOS image previews work in
+  // FileViewer for assets not yet on disk.
+  it('requests with shouldDownloadFromNetwork=true and returns localUri', async () => {
+    getAssetInfoAsyncMock.mockResolvedValue({
+      localUri: 'file:///photos/IMG_001.jpg',
+    } as any)
+
+    expect(await getMediaLibraryDisplayUri('ph://icloud-photo')).toEqual({
+      status: 'resolved',
+      uri: 'file:///photos/IMG_001.jpg',
+    })
+    expect(getAssetInfoAsyncMock).toHaveBeenCalledWith('ph://icloud-photo', {
+      shouldDownloadFromNetwork: true,
+    })
+  })
+
+  it('normalizes localUri by stripping hash suffix', async () => {
+    getAssetInfoAsyncMock.mockResolvedValue({
+      localUri: 'file:///photos/IMG_001.jpg#hash-index',
+      uri: 'ph://asset-1',
+    } as any)
+
+    expect(await getMediaLibraryDisplayUri('ph://asset-1')).toEqual({
+      status: 'resolved',
+      uri: 'file:///photos/IMG_001.jpg',
+    })
+  })
+
+  // Eager fetch succeeded but no localUri (download didn't materialize a
+  // file). Fall through to asset.uri — ph:// on iOS for video, file://
+  // on Android.
+  it('falls back to asset.uri when eager fetch returns null localUri', async () => {
+    getAssetInfoAsyncMock.mockResolvedValue({
+      localUri: null,
+      uri: 'ph://asset-2/L0/001',
+    } as any)
+
+    expect(await getMediaLibraryDisplayUri('ph://asset-2')).toEqual({
+      status: 'resolved',
+      uri: 'ph://asset-2/L0/001',
+    })
+    expect(getAssetInfoAsyncMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns deleted when eager fetch returns null asset', async () => {
+    getAssetInfoAsyncMock.mockResolvedValue(null as any)
+
+    expect(await getMediaLibraryDisplayUri('ph://deleted')).toEqual({ status: 'deleted' })
+  })
+
+  // iOS: AVAssetExportSession throws on slow-mo / HEVC / edited iCloud
+  // videos. The retry without download grabs asset.uri (ph://) so AVPlayer
+  // can still play it via PHImageManager — this is the regression PR #665
+  // originally fixed and the reason we keep the fallback step.
+  it('retries without download and returns asset.uri when eager throws', async () => {
+    getAssetInfoAsyncMock
+      .mockRejectedValueOnce(new Error('ExportSessionFailedException'))
+      .mockResolvedValueOnce({
+        localUri: null,
+        uri: 'ph://slowmo/L0/001',
+      } as any)
+
+    expect(await getMediaLibraryDisplayUri('ph://slowmo')).toEqual({
+      status: 'resolved',
+      uri: 'ph://slowmo/L0/001',
+    })
+    expect(getAssetInfoAsyncMock).toHaveBeenCalledTimes(2)
+    expect(getAssetInfoAsyncMock).toHaveBeenNthCalledWith(2, 'ph://slowmo', {
+      shouldDownloadFromNetwork: false,
+    })
+  })
+
+  it('returns deleted when eager throws and retry returns null', async () => {
+    getAssetInfoAsyncMock
+      .mockRejectedValueOnce(new Error('Network error'))
+      .mockResolvedValueOnce(null as any)
+
+    expect(await getMediaLibraryDisplayUri('ph://gone')).toEqual({ status: 'deleted' })
+  })
+
+  it('returns deleted when both eager and retry throw', async () => {
+    getAssetInfoAsyncMock
+      .mockRejectedValueOnce(new Error('Network error'))
+      .mockRejectedValueOnce(new Error('Photos DB unavailable'))
+
+    expect(await getMediaLibraryDisplayUri('ph://broken')).toEqual({ status: 'deleted' })
+  })
+
+  it('returns unavailable when the fetch resolves with neither localUri nor asset.uri', async () => {
+    getAssetInfoAsyncMock.mockResolvedValue({ localUri: null, uri: null } as any)
+
+    expect(await getMediaLibraryDisplayUri('ph://no-uri')).toEqual({ status: 'unavailable' })
   })
 })

--- a/apps/mobile/src/lib/mediaLibrary.ts
+++ b/apps/mobile/src/lib/mediaLibrary.ts
@@ -78,12 +78,21 @@ export async function getMediaLibraryUri(localId: string | null): Promise<Resolv
 /**
  * Resolve a media library local ID to a URI a player can render.
  *
- * Prefers asset.localUri (file://) when available, falls back to asset.uri
- * (ph:// on iOS, file:// on Android). The ph:// fallback is what unblocks
- * slow-mo / HEVC / iCloud videos on iOS where AVAssetExportSession can't
- * produce a localUri, and any video on Android where expo-media-library's
+ * Two-step: first request with shouldDownloadFromNetwork to materialize
+ * a real file:// localUri (pulls iCloud-only assets on demand). If that
+ * throws or returns no localUri, retry without download and fall back to
+ * asset.uri (ph:// on iOS, file:// on Android).
+ *
+ * The eager step is what restores iOS image preview during import for
+ * iCloud-only photos. RN's stock <Image> (which ImageZoom wraps as
+ * Animated.Image) has no ph:// URL loader registered, so it needs a
+ * real file:// — libraries like expo-image / react-native-fast-image
+ * ship a PHAsset loader and would accept ph:// directly, but we don't
+ * use them today. The ph:// fallback below is what still unblocks
+ * slow-mo / HEVC / iCloud videos on iOS where AVAssetExportSession
+ * throws, and any video on Android where expo-media-library's
  * ExifInterface path is image-only. Video players resolve ph:// directly
- * via PHImageManager — no file on disk required.
+ * via PHImageManager.
  *
  * Display only. ph:// has no readable bytes, so do not use this for
  * hashing, copying, sharing, or upload — getMediaLibraryUri (above) is
@@ -93,9 +102,20 @@ export async function getMediaLibraryDisplayUri(
   localId: string | null,
 ): Promise<ResolveLocalIdResult> {
   if (!localId) return deleted
-  const asset = await MediaLibrary.getAssetInfoAsync(localId, {
-    shouldDownloadFromNetwork: false,
-  }).catch(() => null)
+  try {
+    return resolveAssetDisplay(
+      await MediaLibrary.getAssetInfoAsync(localId, { shouldDownloadFromNetwork: true }),
+    )
+  } catch {
+    return resolveAssetDisplay(
+      await MediaLibrary.getAssetInfoAsync(localId, {
+        shouldDownloadFromNetwork: false,
+      }).catch(() => null),
+    )
+  }
+}
+
+function resolveAssetDisplay(asset: MediaLibrary.AssetInfo | null): ResolveLocalIdResult {
   if (!asset) return deleted
   const uri = normalizeUri(asset.localUri) ?? asset.uri ?? null
   return uri ? resolved(uri) : unavailable


### PR DESCRIPTION
Regression from the recent file state machine refactor: Opening an iCloud-only photo during import was producing a "No suitable image URL loader found for ph://…" error because the viewer was handed a PHAsset identifier that React Native's stock <Image> can't load. The Photos display resolver is now two-step: it first asks for the asset with network download enabled so iCloud photos materialize a real file:// path, and falls back to the no-download ph:// URI only when the eager fetch throws (slow-mo / HEVC videos), where AVPlayer still resolves it natively.
