### PR TITLE
fix(mobile): improve recovery phrase onboarding UX and tone

### DIFF
--- a/.changeset/recovery-phrase-ux.md
+++ b/.changeset/recovery-phrase-ux.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Improved recovery phrase onboarding with softer tone, distinct new vs returning user experience, and fixed 24-word placeholder

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -90,6 +90,7 @@
     "react-native-share": "12.2.5",
     "react-native-sia": "0.14.0",
     "react-native-svg": "15.15.3",
+    "react-native-view-shot": "^5.1.0",
     "react-native-webview": "13.16.0",
     "react-native-worklets": "0.7.2",
     "swr": "2.4.1",

--- a/apps/mobile/src/components/RecoveryPhraseInput.tsx
+++ b/apps/mobile/src/components/RecoveryPhraseInput.tsx
@@ -18,7 +18,7 @@ export function RecoveryPhraseInput({
   normalizedValue,
   validationError,
   editable = true,
-  placeholder = 'Enter your 12 or 24 word recovery phrase',
+  placeholder = '12 word recovery phrase',
 }: RecoveryPhraseInputProps) {
   return (
     <>

--- a/apps/mobile/src/screens/OnboardingRecoveryPhraseScreen.tsx
+++ b/apps/mobile/src/screens/OnboardingRecoveryPhraseScreen.tsx
@@ -4,9 +4,10 @@ import { useNavigation, useRoute } from '@react-navigation/native'
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack'
 import { logger } from '@siastorage/logger'
 import { ArrowLeftIcon } from 'lucide-react-native'
-import { useEffect, useState } from 'react'
-import { Platform, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native'
+import { useEffect, useRef, useState } from 'react'
+import { Image, Platform, Pressable, Share, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
+import ViewShot, { type ViewShotRef } from 'react-native-view-shot'
 import BlocksGrid from '../components/BlocksGrid'
 import BlocksShape, { BLOCK_COLORS } from '../components/BlocksShape'
 import { Button } from '../components/Button'
@@ -30,11 +31,13 @@ export default function OnboardingRecoveryPhraseScreen() {
   const [ackSaved, setAckSaved] = useState(false)
   const [mode, setMode] = useState<'generated' | 'manual'>('generated')
   const [manualPhrase, setManualPhrase] = useState('')
+  const [previewUri, setPreviewUri] = useState<string | null>(null)
 
   const { normalizedManualPhrase, isManualPhraseValid, manualValidationError } =
     useRecoveryPhraseValidation(manualPhrase)
 
   const { register, isSubmitting } = useRecoveryPhraseRegistration()
+  const cardRef = useRef<ViewShotRef>(null)
 
   // Abort any in-flight auth poll and clear pending state before leaving.
   const handleBack = () => {
@@ -44,10 +47,13 @@ export default function OnboardingRecoveryPhraseScreen() {
   }
 
   // Ensure onboarding starts with a fresh app key and no stale mnemonic
-  // hash to validate against.
+  // hash to validate against. Auto-generate a recovery phrase.
   useEffect(() => {
     app().auth.clearMnemonicHash()
     app().auth.clearAppKeys()
+    app()
+      .auth.generateRecoveryPhrase()
+      .then((phrase) => setRecoveryPhrase(phrase))
   }, [])
 
   const handleContinue = async () => {
@@ -64,14 +70,37 @@ export default function OnboardingRecoveryPhraseScreen() {
     }
   }
 
-  const makeNewRecoveryPhrase = async () => {
-    const phrase = await app().auth.generateRecoveryPhrase()
-    setRecoveryPhrase(phrase)
-    setAckSaved(false)
+  const handlePreview = async () => {
+    try {
+      const uri = await cardRef.current?.capture?.()
+      if (uri) {
+        setPreviewUri(uri)
+      }
+    } catch (err) {
+      logger.error('onboarding', 'recovery_phrase_preview_error', {
+        error: err as Error,
+      })
+    }
+  }
+
+  const handleShare = async () => {
+    if (previewUri) {
+      try {
+        const result = await Share.share({ url: previewUri })
+        if (result.action === Share.sharedAction) {
+          toast.show('Image saved')
+          setPreviewUri(null)
+        }
+      } catch (err) {
+        logger.error('onboarding', 'recovery_phrase_share_error', {
+          error: err as Error,
+        })
+      }
+    }
   }
 
   const canContinue =
-    mode === 'generated' ? Boolean(recoveryPhrase) && ackSaved : isManualPhraseValid && ackSaved
+    mode === 'generated' ? Boolean(recoveryPhrase) && ackSaved : isManualPhraseValid
 
   return (
     <SafeAreaView style={styles.screen}>
@@ -84,124 +113,173 @@ export default function OnboardingRecoveryPhraseScreen() {
         inset={{ top, bottom }}
         style={StyleSheet.absoluteFillObject}
       />
-      <Pressable
-        testID="recovery-back-button"
-        onPress={handleBack}
-        style={[styles.backButton, { top: top + 12 }]}
-        accessibilityRole="button"
-        accessibilityLabel="Back"
-      >
-        <ArrowLeftIcon color={palette.gray[50]} size={22} />
-      </Pressable>
-      <View style={[styles.centerWrap, { paddingTop: top, paddingBottom: bottom }]}>
-        <View style={styles.card}>
-          <View style={styles.titleRow}>
-            <View style={{ width: 16, height: 16, marginRight: 8 }}>
-              <BlocksShape
-                shape="block1"
-                origin={{ x: 0, y: 0 }}
-                tileSize={16}
-                style={{ position: 'relative', width: 16, height: 16 }}
-                palette={[BLOCK_COLORS[1]]}
-                ringStart={0}
-              />
-            </View>
-            <Text testID="recovery-title" style={styles.title}>
-              Recovery Phrase
-            </Text>
+      {previewUri ? (
+        <>
+          <Image
+            source={{ uri: previewUri }}
+            style={StyleSheet.absoluteFillObject}
+            resizeMode="cover"
+          />
+          <Pressable
+            testID="recovery-preview-back"
+            onPress={() => setPreviewUri(null)}
+            style={[styles.backButton, { top: top + 12 }]}
+            accessibilityRole="button"
+            accessibilityLabel="Back"
+          >
+            <ArrowLeftIcon color={palette.gray[50]} size={22} />
+          </Pressable>
+          <View style={[styles.previewFooter, { paddingBottom: bottom + 12 }]}>
+            <Button testID="recovery-share-button" onPress={handleShare}>
+              Save
+            </Button>
           </View>
+        </>
+      ) : (
+        <>
+          <Pressable
+            testID="recovery-back-button"
+            onPress={handleBack}
+            style={[styles.backButton, { top: top + 12 }]}
+            accessibilityRole="button"
+            accessibilityLabel="Back"
+          >
+            <ArrowLeftIcon color={palette.gray[50]} size={22} />
+          </Pressable>
+          <View style={[styles.centerWrap, { paddingTop: top, paddingBottom: bottom }]}>
+            <View style={styles.card}>
+              <View style={styles.titleRow}>
+                <View style={{ width: 16, height: 16, marginRight: 8 }}>
+                  <BlocksShape
+                    shape="block1"
+                    origin={{ x: 0, y: 0 }}
+                    tileSize={16}
+                    style={{ position: 'relative', width: 16, height: 16 }}
+                    palette={[BLOCK_COLORS[1]]}
+                    ringStart={0}
+                  />
+                </View>
+                <Text testID="recovery-title" style={styles.title}>
+                  {mode === 'generated' ? 'Recovery Phrase' : 'Welcome Back'}
+                </Text>
+              </View>
 
-          <Text style={styles.subtitle}>
-            Your recovery phrase is the only way to access your data. Write it down and store it
-            somewhere safe. If you lose it, your files cannot be recovered.
-          </Text>
+              <Text style={styles.subtitle}>
+                {mode === 'generated'
+                  ? 'This is the key to your account. Save it somewhere safe. It cannot be recovered if lost.'
+                  : 'To restore your account, enter your 12 word recovery phrase below.'}
+              </Text>
 
-          {mode === 'generated' ? (
-            <>
-              <View style={styles.phraseBox}>
-                <ScrollView
-                  showsVerticalScrollIndicator={false}
-                  keyboardShouldPersistTaps="handled"
-                >
-                  <Text
-                    testID="recovery-phrase-text"
-                    style={recoveryPhrase ? styles.phraseText : styles.phrasePlaceholder}
-                    selectable={!!recoveryPhrase}
+              {mode === 'generated' ? (
+                <>
+                  <View style={styles.phraseBox}>
+                    <Text testID="recovery-phrase-text" style={styles.phraseText} selectable>
+                      {recoveryPhrase}
+                    </Text>
+                  </View>
+
+                  <View style={styles.actionsRow}>
+                    <Button
+                      testID="recovery-save-button"
+                      variant="secondary"
+                      onPress={handlePreview}
+                      style={styles.button}
+                      disabled={!recoveryPhrase}
+                    >
+                      Save Image
+                    </Button>
+                    <Button
+                      testID="recovery-copy-button"
+                      variant="secondary"
+                      onPress={() => {
+                        Clipboard.setString(recoveryPhrase)
+                        toast.show('Copied')
+                      }}
+                      style={styles.button}
+                      disabled={!recoveryPhrase}
+                    >
+                      Copy Text
+                    </Button>
+                  </View>
+
+                  <Pressable testID="recovery-toggle-manual" onPress={() => setMode('manual')}>
+                    <Text style={styles.toggleText}>Already have a recovery phrase?</Text>
+                  </Pressable>
+                </>
+              ) : (
+                <>
+                  <RecoveryPhraseInput
+                    value={manualPhrase}
+                    onChangeText={setManualPhrase}
+                    isValid={isManualPhraseValid}
+                    normalizedValue={normalizedManualPhrase}
+                    validationError={manualValidationError}
+                    editable={!isSubmitting}
+                  />
+
+                  <Pressable
+                    testID="recovery-toggle-generated"
+                    onPress={() => setMode('generated')}
                   >
-                    {recoveryPhrase || "Tap 'Generate new key' to create your recovery phrase"}
-                  </Text>
-                </ScrollView>
-              </View>
-
-              <View style={styles.actionsRow}>
-                <Button
-                  testID="recovery-generate-button"
-                  variant="secondary"
-                  onPress={makeNewRecoveryPhrase}
-                  style={styles.button}
-                >
-                  Generate new key
-                </Button>
-                <Button
-                  testID="recovery-copy-button"
-                  variant="secondary"
-                  onPress={() => {
-                    Clipboard.setString(recoveryPhrase)
-                    toast.show('Copied')
-                  }}
-                  style={styles.button}
-                >
-                  Copy
-                </Button>
-              </View>
-
-              <Pressable testID="recovery-toggle-manual" onPress={() => setMode('manual')}>
-                <Text style={styles.toggleText}>Already have a recovery phrase?</Text>
-              </Pressable>
-            </>
-          ) : (
-            <>
-              <RecoveryPhraseInput
-                value={manualPhrase}
-                onChangeText={setManualPhrase}
-                isValid={isManualPhraseValid}
-                normalizedValue={normalizedManualPhrase}
-                validationError={manualValidationError}
-                editable={!isSubmitting}
-              />
-
-              <Pressable testID="recovery-toggle-generated" onPress={() => setMode('generated')}>
-                <Text style={styles.toggleText}>Generate a new recovery phrase instead.</Text>
-              </Pressable>
-            </>
-          )}
-        </View>
-      </View>
-
-      <View style={[styles.footer, { paddingBottom: bottom }]}>
-        <Pressable
-          testID="recovery-checkbox"
-          onPress={() => setAckSaved((v) => !v)}
-          style={styles.checkboxRow}
-          accessibilityRole="checkbox"
-          accessibilityState={{ checked: ackSaved }}
-        >
-          <View style={[styles.checkboxBox, ackSaved && styles.checkboxBoxChecked]}>
-            {ackSaved ? <Text style={styles.checkMark}>✓</Text> : null}
+                    <Text style={styles.toggleText}>Generate a new recovery phrase instead.</Text>
+                  </Pressable>
+                </>
+              )}
+            </View>
           </View>
-          <Text style={styles.checkboxLabel}>
-            I have recorded my recovery phrase somewhere safe.
-          </Text>
-        </Pressable>
 
-        <Button
-          testID="recovery-continue-button"
-          onPress={handleContinue}
-          disabled={!canContinue || isSubmitting}
-        >
-          {isSubmitting ? 'Connecting...' : 'Continue'}
-        </Button>
-      </View>
+          <View style={[styles.footer, { paddingBottom: bottom }]}>
+            {mode === 'generated' ? (
+              <Pressable
+                testID="recovery-checkbox"
+                onPress={() => setAckSaved((v) => !v)}
+                style={styles.checkboxRow}
+                accessibilityRole="checkbox"
+                accessibilityState={{ checked: ackSaved }}
+              >
+                <View style={[styles.checkboxBox, ackSaved && styles.checkboxBoxChecked]}>
+                  {ackSaved ? <Text style={styles.checkMark}>✓</Text> : null}
+                </View>
+                <Text style={styles.checkboxLabel}>
+                  I have recorded my recovery phrase somewhere safe.
+                </Text>
+              </Pressable>
+            ) : null}
+
+            <Button
+              testID="recovery-continue-button"
+              onPress={handleContinue}
+              disabled={!canContinue || isSubmitting}
+            >
+              {isSubmitting ? 'Connecting...' : 'Continue'}
+            </Button>
+          </View>
+        </>
+      )}
+      <ViewShot ref={cardRef} options={{ format: 'png', quality: 1 }} style={styles.hiddenCard}>
+        <View style={styles.exportCard}>
+          <BlocksGrid
+            cols={5}
+            rows={8}
+            tileScale={0.12}
+            animation="none"
+            opacity={0.25}
+            style={StyleSheet.absoluteFillObject}
+          />
+          <View style={styles.exportLogoWrap}>
+            <Image
+              source={require('../../assets/sia-storage-dark.png')}
+              style={styles.exportLogo}
+              resizeMode="contain"
+            />
+          </View>
+          <View style={styles.exportPhraseWrap}>
+            <View style={styles.exportPhraseBox}>
+              <Text style={styles.exportPhraseText}>{recoveryPhrase}</Text>
+            </View>
+          </View>
+        </View>
+      </ViewShot>
     </SafeAreaView>
   )
 }
@@ -245,7 +323,6 @@ const styles = StyleSheet.create({
   subtitle: { color: palette.gray[300], fontSize: 14 },
 
   phraseBox: {
-    height: 90,
     paddingHorizontal: 12,
     paddingVertical: 14,
     justifyContent: 'center',
@@ -257,7 +334,7 @@ const styles = StyleSheet.create({
   phraseText: {
     color: palette.gray[100],
     fontSize: 14,
-    lineHeight: 20,
+    lineHeight: 22,
     fontFamily: Platform.select({
       ios: 'Menlo',
       android: 'monospace',
@@ -265,20 +342,75 @@ const styles = StyleSheet.create({
     }),
   },
 
-  phrasePlaceholder: {
-    color: palette.gray[500],
-    fontSize: 14,
-    lineHeight: 20,
-  },
-
   actionsRow: { flexDirection: 'row', gap: 12 },
-  button: { flex: 1 },
+  button: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: palette.gray[700],
+  },
 
   toggleText: {
     color: palette.gray[400],
     fontSize: 13,
     textAlign: 'center',
     textDecorationLine: 'underline',
+  },
+
+  previewFooter: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    paddingHorizontal: 20,
+  },
+
+  hiddenCard: {
+    position: 'absolute',
+    left: -9999,
+  },
+  exportCard: {
+    width: 390,
+    height: 844,
+    paddingHorizontal: 32,
+    backgroundColor: '#000',
+    alignItems: 'center',
+    overflow: 'hidden',
+  },
+  exportLogoWrap: {
+    position: 'absolute',
+    top: '25%',
+    alignItems: 'center',
+    width: '100%',
+  },
+  exportPhraseWrap: {
+    position: 'absolute',
+    top: '50%',
+    left: 0,
+    right: 0,
+    paddingHorizontal: 32,
+  },
+  exportLogo: {
+    width: 270,
+    height: 270 * (84 / 325),
+  },
+  exportPhraseBox: {
+    paddingHorizontal: 20,
+    paddingVertical: 20,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: palette.gray[700],
+    backgroundColor: '#000',
+  },
+  exportPhraseText: {
+    color: palette.gray[100],
+    fontSize: 18,
+    lineHeight: 28,
+    textAlign: 'center',
+    fontFamily: Platform.select({
+      ios: 'Menlo',
+      android: 'monospace',
+      default: 'monospace',
+    }),
   },
 
   footer: {

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "siastorage",
@@ -131,6 +130,7 @@
         "react-native-share": "12.2.5",
         "react-native-sia": "0.14.0",
         "react-native-svg": "15.15.3",
+        "react-native-view-shot": "^5.1.0",
         "react-native-webview": "13.16.0",
         "react-native-worklets": "0.7.2",
         "swr": "2.4.1",
@@ -1074,6 +1074,8 @@
 
     "base-64": ["base-64@0.1.0", "", {}, "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="],
 
+    "base64-arraybuffer": ["base64-arraybuffer@1.0.2", "", {}, "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ=="],
+
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.0", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA=="],
@@ -1179,6 +1181,8 @@
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "crypto-js": ["crypto-js@4.2.0", "", {}, "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="],
+
+    "css-line-break": ["css-line-break@2.1.0", "", { "dependencies": { "utrie": "^1.0.2" } }, "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w=="],
 
     "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
 
@@ -1481,6 +1485,8 @@
     "html-encoding-sniffer": ["html-encoding-sniffer@3.0.0", "", { "dependencies": { "whatwg-encoding": "^2.0.0" } }, "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA=="],
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
+
+    "html2canvas": ["html2canvas@1.4.1", "", { "dependencies": { "css-line-break": "^2.1.0", "text-segmentation": "^1.0.3" } }, "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
@@ -1976,6 +1982,8 @@
 
     "react-native-svg": ["react-native-svg@15.15.3", "", { "dependencies": { "css-select": "^5.1.0", "css-tree": "^1.1.3", "warn-once": "0.1.1" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-/k4KYwPBLGcx2f5d4FjE+vCScK7QOX14cl2lIASJ28u4slHHtIhL0SZKU7u9qmRBHxTCKPoPBtN6haT1NENJNA=="],
 
+    "react-native-view-shot": ["react-native-view-shot@5.1.0", "", { "dependencies": { "html2canvas": "^1.4.1" }, "peerDependencies": { "react": ">=18.0.0", "react-native": ">=0.76.0" } }, "sha512-JZgElCD82aO+hejIF/leUzI7JufL9mgJ6ChzGWIcdZ2ajpaEvvSnvIcw0qD32XWkrbId8wfSbyz/4u/ulTQzQA=="],
+
     "react-native-webview": ["react-native-webview@13.16.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0", "invariant": "2.2.4" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-Nh13xKZWW35C0dbOskD7OX01nQQavOzHbCw9XoZmar4eXCo7AvrYJ0jlUfRVVIJzqINxHlpECYLdmAdFsl9xDA=="],
 
     "react-native-worklets": ["react-native-worklets@0.7.2", "", { "dependencies": { "@babel/plugin-transform-arrow-functions": "7.27.1", "@babel/plugin-transform-class-properties": "7.27.1", "@babel/plugin-transform-classes": "7.28.4", "@babel/plugin-transform-nullish-coalescing-operator": "7.27.1", "@babel/plugin-transform-optional-chaining": "7.27.1", "@babel/plugin-transform-shorthand-properties": "7.27.1", "@babel/plugin-transform-template-literals": "7.27.1", "@babel/plugin-transform-unicode-regex": "7.27.1", "@babel/preset-typescript": "7.27.1", "convert-source-map": "2.0.0", "semver": "7.7.3" }, "peerDependencies": { "@babel/core": "*", "react": "*", "react-native": "*" } }, "sha512-DuLu1kMV/Uyl9pQHp3hehAlThoLw7Yk2FwRTpzASOmI+cd4845FWn3m2bk9MnjUw8FBRIyhwLqYm2AJaXDXsog=="],
@@ -2152,6 +2160,8 @@
 
     "test-exclude": ["test-exclude@6.0.0", "", { "dependencies": { "@istanbuljs/schema": "^0.1.2", "glob": "^7.1.4", "minimatch": "^3.0.4" } }, "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w=="],
 
+    "text-segmentation": ["text-segmentation@1.0.3", "", { "dependencies": { "utrie": "^1.0.2" } }, "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw=="],
+
     "throat": ["throat@5.0.0", "", {}, "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA=="],
 
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
@@ -2219,6 +2229,8 @@
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "utils-merge": ["utils-merge@1.0.1", "", {}, "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="],
+
+    "utrie": ["utrie@1.0.2", "", { "dependencies": { "base64-arraybuffer": "^1.0.2" } }, "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw=="],
 
     "uuid": ["uuid@7.0.3", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="],
 


### PR DESCRIPTION
This removes the manual recovery phrase generation option and auto generates the recovery phrase on mount. Removed "24 word" referencene and added a "save image" feature that allows them to safe that recovery phrase as picture wherever they want through the share sheet.

One bit of feedback I did not change is the checkbox and having to tap that to proceed forward. I think this is our forever rebuttal to "I lost my recovery phrase," so I'm hesitant to give that up and then see "well I didn't realize it was that important."