### PR TITLE
feat(mobile): add import buttons to library empty state and default to media tab

### DIFF
--- a/.changeset/library-empty-state-buttons.md
+++ b/.changeset/library-empty-state-buttons.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Added import photo library and add files buttons to the library empty state, defaulted to media tab, and reordered tab bar

--- a/apps/mobile/src/components/LibraryTabBar.tsx
+++ b/apps/mobile/src/components/LibraryTabBar.tsx
@@ -24,7 +24,7 @@ type Props = {
 }
 
 const INSET = 4
-const TABS: ActiveLibraryTab[] = ['files', 'tags', 'media']
+const TABS: ActiveLibraryTab[] = ['media', 'files', 'tags']
 
 export function LibraryTabBar({
   activeTab,
@@ -74,6 +74,14 @@ export function LibraryTabBar({
         ) : null}
         <Pressable
           accessibilityRole="tab"
+          accessibilityState={{ selected: activeTab === 'media' }}
+          onPress={() => onChangeTab('media')}
+          style={styles.segment}
+        >
+          <ImageIcon size={20} color={mediaColor} />
+        </Pressable>
+        <Pressable
+          accessibilityRole="tab"
           accessibilityState={{ selected: activeTab === 'files' }}
           onPress={() => onChangeTab('files')}
           style={styles.segment}
@@ -87,14 +95,6 @@ export function LibraryTabBar({
           style={styles.segment}
         >
           <TagIcon size={20} color={tagsColor} />
-        </Pressable>
-        <Pressable
-          accessibilityRole="tab"
-          accessibilityState={{ selected: activeTab === 'media' }}
-          onPress={() => onChangeTab('media')}
-          style={styles.segment}
-        >
-          <ImageIcon size={20} color={mediaColor} />
         </Pressable>
       </View>
       <FloatingPill style={styles.actions}>

--- a/apps/mobile/src/screens/LibraryScreen.tsx
+++ b/apps/mobile/src/screens/LibraryScreen.tsx
@@ -13,6 +13,7 @@ import type { FileRecord } from '@siastorage/core/types'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { ActivityIndicator, Animated, StyleSheet, Text, View } from 'react-native'
 import { AddFileActionSheet } from '../components/AddFileActionSheet'
+import { ArchiveSyncModal } from '../components/ArchiveSyncModal'
 import { CreateDirectorySheet } from '../components/CreateDirectorySheet'
 import { CreateTagSheet } from '../components/CreateTagSheet'
 import { DirectoriesGrid } from '../components/DirectoriesGrid'
@@ -67,7 +68,7 @@ export function LibraryScreen({ route, navigation }: Props) {
   const fileCount = useLibraryCount()
   const mediaCount = useMediaCount()
   const activeTabSetting = useActiveLibraryTab()
-  const activeTab: ActiveLibraryTab = activeTabSetting.data ?? 'files'
+  const activeTab: ActiveLibraryTab = activeTabSetting.data ?? 'media'
   const handleChangeTab = useCallback((tab: ActiveLibraryTab) => {
     void app().settings.setActiveLibraryTab(tab)
   }, [])
@@ -77,6 +78,7 @@ export function LibraryScreen({ route, navigation }: Props) {
     return files.data?.find((f) => f.id === openFileId) ?? null
   })
   const [isCarouselZoomed, setIsCarouselZoomed] = useState(false)
+  const [archiveModalVisible, setArchiveModalVisible] = useState(false)
   const [isCarouselDetail, setIsCarouselDetail] = useState(false)
   const [isDraggingToDismiss, setIsDraggingToDismiss] = useState(false)
   const fadeAnim = useRef(new Animated.Value(0)).current
@@ -315,11 +317,16 @@ export function LibraryScreen({ route, navigation }: Props) {
       ) : (
         <EmptyState
           image={require('../../assets/image-stack.png')}
-          title="Add files to get started"
-          message="Files are sharded and encrypted and synced directly to the Sia host network."
+          title="No files yet"
+          message="Add files to start building your library."
+          action={{ label: 'Import Photo Library', onPress: () => setArchiveModalVisible(true) }}
         />
       )}
       <AddFileActionSheet />
+      <ArchiveSyncModal
+        visible={archiveModalVisible}
+        onRequestClose={() => setArchiveModalVisible(false)}
+      />
       <CreateDirectorySheet onCreated={handleDirectoryCreated} />
       <CreateTagSheet />
       <LibraryStatusSheet />

--- a/packages/core/src/app/namespaces/settings.ts
+++ b/packages/core/src/app/namespaces/settings.ts
@@ -51,7 +51,7 @@ export function buildSettingsNamespace(
     setStatusDisplayMode: (v) => setStr('statusDisplayMode', v),
     getPhotoImportDirectory: () => getStr('photoImportDirectory', 'Media'),
     setPhotoImportDirectory: (v) => setStr('photoImportDirectory', v),
-    getActiveLibraryTab: () => getStr('activeLibraryTab', 'files'),
+    getActiveLibraryTab: () => getStr('activeLibraryTab', 'media'),
     setActiveLibraryTab: async (v) => {
       caches.settings.set(v, 'activeLibraryTab')
       await storage.setItem('activeLibraryTab', v)


### PR DESCRIPTION
Verified that we do save view type preference on change. I also changed the media empty state to align exactly with the files view in term of icon, short blurb, then only one same-styled "Import photo library" button.