### PR TITLE
fix(mobile): picker import perf + scanner race fixes

### DIFF
--- a/.changeset/copy-assets-parallel.md
+++ b/.changeset/copy-assets-parallel.md
@@ -1,0 +1,5 @@
+---
+'@siastorage/mobile': patch
+---
+
+Picker imports copy files in parallel (up to 4 at a time, bounded by total bytes in flight) instead of one at a time. Cloud sources like Google Drive in particular finish significantly faster.

--- a/.changeset/copy-assets-parallel.md
+++ b/.changeset/copy-assets-parallel.md
@@ -1,5 +1,5 @@
 ---
-'@siastorage/mobile': patch
+mobile: patch
 ---
 
 Picker imports copy files in parallel (up to 4 at a time, bounded by total bytes in flight) instead of one at a time. Cloud sources like Google Drive in particular finish significantly faster.

--- a/.changeset/import-scanner-drain-mode.md
+++ b/.changeset/import-scanner-drain-mode.md
@@ -1,0 +1,5 @@
+---
+'@siastorage/mobile': patch
+---
+
+Imports finish faster — the import scanner now drains pending hashes back-to-back instead of waiting 3 seconds between batches of 20.

--- a/.changeset/import-scanner-drain-mode.md
+++ b/.changeset/import-scanner-drain-mode.md
@@ -1,5 +1,5 @@
 ---
-'@siastorage/mobile': patch
+mobile: patch
 ---
 
 Imports finish faster — the import scanner now drains pending hashes back-to-back instead of waiting 3 seconds between batches of 20.

--- a/.changeset/import-scanner-orphan-recheck-and-heal.md
+++ b/.changeset/import-scanner-orphan-recheck-and-heal.md
@@ -1,0 +1,5 @@
+---
+'@siastorage/core': patch
+---
+
+Import scanner re-checks the fs row before marking a placeholder lost, and clears any stale "lost" reason when a file is successfully hashed.

--- a/.changeset/import-scanner-orphan-recheck-and-heal.md
+++ b/.changeset/import-scanner-orphan-recheck-and-heal.md
@@ -1,5 +1,5 @@
 ---
-'@siastorage/core': patch
+core: patch
 ---
 
 Import scanner re-checks the fs row before marking a placeholder lost, and clears any stale "lost" reason when a file is successfully hashed.

--- a/.changeset/import-scanner-skip-lost-placeholders.md
+++ b/.changeset/import-scanner-skip-lost-placeholders.md
@@ -1,0 +1,5 @@
+---
+core: patch
+---
+
+Fix the import scanner re-selecting `lostReason`-marked placeholders on every tick, which caused a cascade of library-cache invalidations. `FileQueryOpts` gains a `lostReasonIsNull` flag used by the scanner's phase 2 query; successful finalize clears `lostReason` so a recovered row can leave the Unavailable tab.

--- a/.changeset/library-fs-exists-join.md
+++ b/.changeset/library-fs-exists-join.md
@@ -1,6 +1,6 @@
 ---
-'@siastorage/core': patch
-'@siastorage/mobile': patch
+core: patch
+mobile: patch
 ---
 
 `queryLibrary` now returns an `fsExists` flag per row via LEFT JOIN, and the file-list fetcher primes the per-fileId fs URI cache. List-row `useFsFileUri` hooks no longer fan out into one SELECT + `RNFS.stat` per visible row.

--- a/.changeset/library-fs-exists-join.md
+++ b/.changeset/library-fs-exists-join.md
@@ -1,0 +1,6 @@
+---
+'@siastorage/core': patch
+'@siastorage/mobile': patch
+---
+
+`queryLibrary` now returns an `fsExists` flag per row via LEFT JOIN, and the file-list fetcher primes the per-fileId fs URI cache. List-row `useFsFileUri` hooks no longer fan out into one SELECT + `RNFS.stat` per visible row.

--- a/.changeset/library-isfavorite-join.md
+++ b/.changeset/library-isfavorite-join.md
@@ -1,0 +1,5 @@
+---
+'@siastorage/core': patch
+---
+
+`queryLibrary` now returns an `isFavorite` flag per row via LEFT JOIN, and the file-list fetcher primes the per-fileId favorites cache. List-row `useIsFavorite` hooks no longer fan out into one `SELECT FROM file_tags` per visible row.

--- a/.changeset/library-isfavorite-join.md
+++ b/.changeset/library-isfavorite-join.md
@@ -1,5 +1,5 @@
 ---
-'@siastorage/core': patch
+core: patch
 ---
 
 `queryLibrary` now returns an `isFavorite` flag per row via LEFT JOIN, and the file-list fetcher primes the per-fileId favorites cache. List-row `useIsFavorite` hooks no longer fan out into one `SELECT FROM file_tags` per visible row.

--- a/.changeset/picker-import-mark-inflight-before-insert.md
+++ b/.changeset/picker-import-mark-inflight-before-insert.md
@@ -1,0 +1,5 @@
+---
+'@siastorage/mobile': patch
+---
+
+Picker imports no longer race the scanner's orphan branch during the initial INSERT, preventing files that copied successfully from being marked with a stale "lost" reason.

--- a/.changeset/picker-import-mark-inflight-before-insert.md
+++ b/.changeset/picker-import-mark-inflight-before-insert.md
@@ -1,5 +1,5 @@
 ---
-'@siastorage/mobile': patch
+mobile: patch
 ---
 
 Picker imports no longer race the scanner's orphan branch during the initial INSERT, preventing files that copied successfully from being marked with a stale "lost" reason.

--- a/.changeset/service-interval-rerun-flag.md
+++ b/.changeset/service-interval-rerun-flag.md
@@ -1,5 +1,5 @@
 ---
-'@siastorage/core': patch
+core: patch
 ---
 
 `ServiceScheduler.triggerNow()` no longer drops requests that arrive while a tick is running — the request defers to fire immediately after the in-flight tick completes.

--- a/.changeset/service-interval-rerun-flag.md
+++ b/.changeset/service-interval-rerun-flag.md
@@ -1,0 +1,5 @@
+---
+'@siastorage/core': patch
+---
+
+`ServiceScheduler.triggerNow()` no longer drops requests that arrive while a tick is running — the request defers to fire immediately after the in-flight tick completes.

--- a/apps/mobile/src/hooks/useBestThumbnail.ts
+++ b/apps/mobile/src/hooks/useBestThumbnail.ts
@@ -40,7 +40,7 @@ export function useBestThumbnailUri(file?: FileRecord, thumbSize: ThumbSize = 51
     download()
   }, [isInitializing, isConnected, thumbRecord.data, status.data, download])
 
-  // Get the URI via fsFileUriCache which receives synchronous pushes from
+  // Get the URI via app.caches.fsFileUri which receives synchronous pushes from
   // copyFileToFs — no async gap between download completing and URI appearing.
   return useFsFileUri(thumbRecord.data ?? undefined)
 }

--- a/apps/mobile/src/lib/assetImports.test.ts
+++ b/apps/mobile/src/lib/assetImports.test.ts
@@ -724,7 +724,7 @@ describe('importAssets — picker / camera / share intent', () => {
   })
 
   describe('scanner integration', () => {
-    it('triggers the import scanner so hashing starts promptly', async () => {
+    it('triggers the import scanner once the copy loop finishes', async () => {
       const { triggerImportScanner } = require('../managers/importScanner')
       const assets = [
         {
@@ -737,7 +737,8 @@ describe('importAssets — picker / camera / share intent', () => {
         },
       ]
 
-      await importAssets(assets)
+      const { copyPromise } = await importAssets(assets)
+      await copyPromise
       expect(triggerImportScanner).toHaveBeenCalled()
     })
   })

--- a/apps/mobile/src/lib/assetImports.test.ts
+++ b/apps/mobile/src/lib/assetImports.test.ts
@@ -562,14 +562,13 @@ describe('importAssets — picker / camera / share intent', () => {
       expect(events).toEqual([1, 3])
     })
 
-    it('registers every placeholder before any await after createMany', async () => {
-      // Regression: the scanner runs on a 3s autotick and can fire while
-      // importAssets is still awaiting tag assignment, optimize, or
-      // getByIds. If marks are placed only inside copyAssets, the scanner
-      // sees the placeholders with no fs row and no localId during that
-      // window and writes lostReason permanently. Registration must happen
-      // synchronously after createMany resolves.
-      const optimizeSpy = jest.spyOn(app(), 'optimize')
+    it('registers every placeholder before createMany commits the rows', async () => {
+      // insertManyFiles commits its INSERTs individually; a scanner tick
+      // that lands mid-INSERT could see a row with no fs row, no localId,
+      // and no in-flight marker, and flag it lost. markImportCopyStarted
+      // must run before createMany so every committed row is protected
+      // from the first instant it becomes visible.
+      const createManySpy = jest.spyOn(app().files, 'createMany')
 
       const assets = [
         {
@@ -596,10 +595,9 @@ describe('importAssets — picker / camera / share intent', () => {
       const startedIds = jest.mocked(markImportCopyStarted).mock.calls.map((c) => c[0])
       expect(startedIds).toEqual(files.map((f) => f.id))
 
-      // Every mark must precede optimize (the first await after createMany).
-      const optimizeOrder = optimizeSpy.mock.invocationCallOrder[0]
+      const createOrder = createManySpy.mock.invocationCallOrder[0]
       for (const markOrder of jest.mocked(markImportCopyStarted).mock.invocationCallOrder) {
-        expect(markOrder).toBeLessThan(optimizeOrder)
+        expect(markOrder).toBeLessThan(createOrder)
       }
     })
 

--- a/apps/mobile/src/lib/assetImports.test.ts
+++ b/apps/mobile/src/lib/assetImports.test.ts
@@ -468,14 +468,14 @@ describe('importAssets — picker / camera / share intent', () => {
         settled = true
       })
 
+      // Both copies dispatch in parallel up to the concurrency cap.
       await new Promise((r) => setTimeout(r, 0))
       expect(settled).toBe(false)
-      expect(releasers).toHaveLength(1)
+      expect(releasers).toHaveLength(2)
 
       releasers[0]()
       await new Promise((r) => setTimeout(r, 0))
       expect(settled).toBe(false)
-      expect(releasers).toHaveLength(2)
 
       releasers[1]()
       const result = await copyPromise
@@ -695,6 +695,102 @@ describe('importAssets — picker / camera / share intent', () => {
         },
       ])
       expect(totalBytes).toBe(35)
+    })
+  })
+
+  describe('bounded concurrency', () => {
+    const MB = 1024 * 1024
+
+    function makeAssets(count: number, sizeBytes: number) {
+      return Array.from({ length: count }, (_, i) => ({
+        id: undefined as string | undefined,
+        name: `f${i}.bin`,
+        size: sizeBytes,
+        sourceUri: `file:///tmp/f${i}.bin`,
+        type: 'application/octet-stream',
+        timestamp: '2024-06-01',
+      }))
+    }
+
+    /**
+     * Stubs `copyFileToFs` with deferred promises, tracks peak
+     * concurrency, and drains pending copies in waves. Each invocation
+     * parks on a promise resolved by the next `releaseNext()` call.
+     */
+    function deferredCopyStub() {
+      const pending: Array<() => void> = []
+      let inFlight = 0
+      let peakInFlight = 0
+      jest.mocked(copyFileToFs).mockImplementation(() => {
+        inFlight++
+        if (inFlight > peakInFlight) peakInFlight = inFlight
+        return new Promise<string>((resolve) => {
+          pending.push(() => {
+            inFlight--
+            resolve('/local/x')
+          })
+        })
+      })
+      return {
+        pending,
+        peak: () => peakInFlight,
+        async drain() {
+          // Release whatever is currently pending and yield so the
+          // dispatcher can fill in the next wave. Repeat until empty.
+          while (pending.length > 0) {
+            const wave = pending.splice(0)
+            for (const r of wave) r()
+            await new Promise((r) => setTimeout(r, 0))
+          }
+        },
+      }
+    }
+
+    it('caps concurrent copies at 4 even with a large queue', async () => {
+      const stub = deferredCopyStub()
+      const { copyPromise } = await importAssets(makeAssets(10, 1 * MB))
+
+      // Drain microtasks so the dispatcher fills up to its cap.
+      await new Promise((r) => setTimeout(r, 0))
+      expect(copyFileToFs).toHaveBeenCalledTimes(4)
+      expect(stub.peak()).toBe(4)
+
+      await stub.drain()
+      await copyPromise
+      // Final peak across the whole run is still bounded by the cap.
+      expect(stub.peak()).toBe(4)
+      expect(copyFileToFs).toHaveBeenCalledTimes(10)
+    })
+
+    it('blocks new dispatch when adding the next file would exceed the byte budget', async () => {
+      // Each 6 MB; budget is 16 MB. The first file dispatches regardless
+      // (deadlock guard). The second adds to 12 MB. A third would push to
+      // 18 MB > 16 MB, so the dispatcher must wait. Peak in flight = 2.
+      const stub = deferredCopyStub()
+      const { copyPromise } = await importAssets(makeAssets(5, 6 * MB))
+
+      await new Promise((r) => setTimeout(r, 0))
+      expect(stub.peak()).toBe(2)
+      expect(copyFileToFs).toHaveBeenCalledTimes(2)
+
+      await stub.drain()
+      await copyPromise
+      expect(stub.peak()).toBe(2)
+      expect(copyFileToFs).toHaveBeenCalledTimes(5)
+    })
+
+    it('runs a single oversized file alone without deadlocking', async () => {
+      // 50 MB > 16 MB budget; the "first file regardless of size" carve-out
+      // must let it run alone, otherwise it'd never start.
+      const stub = deferredCopyStub()
+      const { copyPromise } = await importAssets(makeAssets(1, 50 * MB))
+
+      await new Promise((r) => setTimeout(r, 0))
+      expect(copyFileToFs).toHaveBeenCalledTimes(1)
+      expect(stub.peak()).toBe(1)
+
+      await stub.drain()
+      await copyPromise
     })
   })
 

--- a/apps/mobile/src/lib/assetImports.ts
+++ b/apps/mobile/src/lib/assetImports.ts
@@ -591,7 +591,12 @@ export async function importAssets(
     )
     copyDispatched = true
 
-    triggerImportScanner()
+    // No scanner trigger here. copyAssets dispatches copies in parallel
+    // with bounded concurrency; a tick now would find no fs rows to
+    // finalize and only contend with the placeholder INSERT and the first
+    // wave of RNFS.copyFile calls. copyAssets triggers the scanner once
+    // at the end of its loop, and the regular interval picks up files as
+    // they land.
     const totalBytes = candidates.reduce((s, c) => s + c.placeholder.size, 0)
     return { files, newVersionCount, totalBytes, copyPromise }
   } finally {

--- a/apps/mobile/src/lib/assetImports.ts
+++ b/apps/mobile/src/lib/assetImports.ts
@@ -542,22 +542,24 @@ export async function importAssets(
     0,
   )
 
-  await app().files.createMany(
-    candidates.map((c) => c.placeholder),
-    {
-      directoryId: destinationDirectoryId,
-    },
-  )
-
   const insertedIds = candidates.map((c) => c.placeholder.id)
-  // Register synchronously, before the next await. The scanner runs on
-  // its own 3s tick and would otherwise see these placeholders with no
-  // fs row and no localId during the tag/optimize/getByIds awaits below
-  // and mark them lost. copyAssets clears each ID in its per-file finally.
+  // Mark in-flight BEFORE createMany. insertManyFiles commits its INSERTs
+  // individually, so a scanner tick mid-INSERT would otherwise see
+  // partially-committed placeholders with no fs row, no localId, and no
+  // in-flight marker, and mark them lost. copyAssets clears each ID in
+  // its per-file finally; the finally below releases all of them if
+  // setup aborts before the copy loop takes ownership.
   for (const id of insertedIds) markImportCopyStarted(id)
 
   let copyDispatched = false
   try {
+    await app().files.createMany(
+      candidates.map((c) => c.placeholder),
+      {
+        directoryId: destinationDirectoryId,
+      },
+    )
+
     if (assignTagName && insertedIds.length > 0) {
       await app().tags.addToFiles(insertedIds, assignTagName)
     }

--- a/apps/mobile/src/lib/assetImports.ts
+++ b/apps/mobile/src/lib/assetImports.ts
@@ -606,29 +606,67 @@ export async function importAssets(
   }
 }
 
+// Bounded concurrency for picker copies.
+//
+// Each content:// URI takes ~500-1000ms of ContentResolver round-trip
+// (on Drive, the on-demand cloud fetch dominates) regardless of file
+// size, so a serial loop spends most of its time waiting. File sizes
+// are known upfront from the picker, so we run multiple copies in
+// parallel gated by both count and total bytes in flight. A single
+// file larger than the byte budget runs alone (no deadlock).
+const COPY_MAX_CONCURRENCY = 4
+const COPY_MAX_BYTES_IN_FLIGHT = 16 * 1024 * 1024
+
 async function copyAssets(
   copies: { id: string; type: string; size: number; sourceUri: string }[],
   onProgress?: (bytes: number) => void,
 ): Promise<{ copied: number; failed: number }> {
-  // IDs are already registered by importAssets right after createMany;
-  // we only clear them here as each copy resolves.
+  // IDs are already registered by importAssets before createMany; we
+  // only clear them here as each copy resolves (success or failure).
   let copied = 0
   let failed = 0
-  for (const { id, type, size, sourceUri } of copies) {
+
+  const runOne = async (entry: (typeof copies)[number]) => {
     try {
-      await copyFileToFs({ id, type }, sourceUri)
+      await copyFileToFs({ id: entry.id, type: entry.type }, entry.sourceUri)
       copied += 1
-      onProgress?.(size)
+      onProgress?.(entry.size)
     } catch (e) {
       failed += 1
       logger.warn('importAssets', 'copy_failed', {
-        fileId: id,
+        fileId: entry.id,
         error: e as Error,
       })
     } finally {
-      markImportCopyComplete(id)
+      markImportCopyComplete(entry.id)
     }
   }
+
+  let nextIndex = 0
+  let bytesInFlight = 0
+  const inFlight = new Map<number, Promise<void>>()
+
+  while (nextIndex < copies.length || inFlight.size > 0) {
+    while (nextIndex < copies.length && inFlight.size < COPY_MAX_CONCURRENCY) {
+      const next = copies[nextIndex]
+      // Allow the first concurrent file regardless of size; otherwise a
+      // single oversized file would deadlock.
+      if (inFlight.size > 0 && bytesInFlight + next.size > COPY_MAX_BYTES_IN_FLIGHT) {
+        break
+      }
+      const i = nextIndex++
+      bytesInFlight += next.size
+      const p = runOne(next).finally(() => {
+        inFlight.delete(i)
+        bytesInFlight -= next.size
+      })
+      inFlight.set(i, p)
+    }
+    if (inFlight.size > 0) {
+      await Promise.race(inFlight.values())
+    }
+  }
+
   triggerImportScanner()
   return { copied, failed }
 }

--- a/apps/mobile/src/managers/fsOrphanScanner.ts
+++ b/apps/mobile/src/managers/fsOrphanScanner.ts
@@ -4,7 +4,6 @@ import type { OrphanScannerResult } from '@siastorage/core/services'
 import { runOrphanScanner } from '@siastorage/core/services'
 import { logger } from '@siastorage/logger'
 import { app } from '../stores/appService'
-import { fsFileUriCache } from '../stores/fs'
 import { isBgTaskActive } from './bgTaskContext'
 
 const flight = new SingleInit()
@@ -46,7 +45,7 @@ export async function runFsOrphanScanner(options?: {
     options?.signal?.addEventListener('abort', onExternalAbort)
     try {
       const result = await runOrphanScanner(app(), options?.onProgress, activeController.signal)
-      fsFileUriCache.invalidateAll()
+      app().caches.fsFileUri.invalidateAll()
       // Don't advance lastRun on abort — the scan didn't complete, so the
       // throttle gate should let the next attempt through instead of skipping it.
       if (activeController.signal.aborted) {

--- a/apps/mobile/src/managers/importScanner.ts
+++ b/apps/mobile/src/managers/importScanner.ts
@@ -68,10 +68,11 @@ async function run(signal: AbortSignal): Promise<number | undefined> {
     return
   }
   const result = await runImportScanner(signal)
-  // Drain mode: if this tick finalized files (or files are mid-copy,
-  // surfaced as skipped via the in-flight set), more work is likely
-  // pending — re-run immediately instead of waiting the full interval.
-  if (result.finalized > 0 || result.skipped > 0) {
+  // Drain mode: if this tick finalized files, more work is likely
+  // pending behind MAX_PER_TICK — re-run immediately. Skip-only ticks
+  // (e.g., waiting on in-flight picker copies) fall back to the
+  // regular interval.
+  if (result.finalized > 0) {
     return 0
   }
   return undefined

--- a/apps/mobile/src/managers/importScanner.ts
+++ b/apps/mobile/src/managers/importScanner.ts
@@ -56,7 +56,7 @@ export function getImportBackoffEntries() {
   return scanner.getBackoffEntries()
 }
 
-async function run(signal: AbortSignal): Promise<void> {
+async function run(signal: AbortSignal): Promise<number | undefined> {
   // BGAppRefreshTask still enforces iOS's 80%/60s CPU monitor; hashing
   // here can trip cpu_resource_fatal. See bgTaskContext.ts.
   if (isBgTaskActive('BGAppRefreshTask')) {
@@ -67,7 +67,14 @@ async function run(signal: AbortSignal): Promise<void> {
     logger.debug('importScanner', 'skipped', { reason: 'sync_gate_active' })
     return
   }
-  await runImportScanner(signal)
+  const result = await runImportScanner(signal)
+  // Drain mode: if this tick finalized files (or files are mid-copy,
+  // surfaced as skipped via the in-flight set), more work is likely
+  // pending — re-run immediately instead of waiting the full interval.
+  if (result.finalized > 0 || result.skipped > 0) {
+    return 0
+  }
+  return undefined
 }
 
 export const { init: initImportScanner, triggerNow: triggerImportScanner } = createServiceInterval({

--- a/apps/mobile/src/stores/fs.ts
+++ b/apps/mobile/src/stores/fs.ts
@@ -1,10 +1,6 @@
-import { swrCacheBy } from '@siastorage/core/stores'
 import { logger } from '@siastorage/logger'
 import useSWR from 'swr'
 import { app } from './appService'
-
-/** Local filesystem URI for a file, keyed by file ID. */
-export const fsFileUriCache = swrCacheBy<string | null>()
 
 export type FsFileInfo = {
   id: string
@@ -13,7 +9,7 @@ export type FsFileInfo = {
 
 export async function removeFsFile(file: FsFileInfo): Promise<void> {
   await app().fs.removeFile(file)
-  await fsFileUriCache.set(null, file.id)
+  await app().caches.fsFileUri.set(null, file.id)
 }
 
 /**
@@ -27,12 +23,12 @@ export async function removeFsFile(file: FsFileInfo): Promise<void> {
 export async function copyFileToFs(file: FsFileInfo, sourceUri: string): Promise<string> {
   logger.debug('fs', 'copy_file', { fileId: file.id, sourceUri })
   const uri = await app().fs.copyFile(file, sourceUri)
-  await fsFileUriCache.set(uri, file.id)
+  await app().caches.fsFileUri.set(uri, file.id)
   return uri
 }
 
 export function useFsFileUri(file?: FsFileInfo) {
-  return useSWR(file ? fsFileUriCache.key(file.id) : null, () => {
+  return useSWR(file ? app().caches.fsFileUri.key(file.id) : null, () => {
     return file ? app().fs.getFileUri(file) : null
   })
 }

--- a/packages/core/src/app/ipcProxy.ts
+++ b/packages/core/src/app/ipcProxy.ts
@@ -121,6 +121,7 @@ export function createRemoteAppService(
       best: swrCacheBy(),
       byFileId: swrCacheBy(),
     },
+    fsFileUri: swrCacheBy<string | null>(),
     libraryVersion: createLibraryVersionCache(),
     settings: swrCacheBy(),
     sync: swrCacheBy(),

--- a/packages/core/src/app/namespaces/db.ts
+++ b/packages/core/src/app/namespaces/db.ts
@@ -86,6 +86,7 @@ export function buildDbNamespaces(
     trashedCachedFiles: (limit) => ops.queryTrashedCachedFiles(db, limit),
     findOrphanedFileIds: (fileIds) => ops.queryOrphanedFileIds(db, fileIds),
     getFileUri: (file) => getFsFileUri(db, file, fsIO),
+    uri: (file) => fsIO.uri(file.id, file.type),
     removeFile,
     copyFile: async (file, sourceUri, opts) => {
       const result = await fsIO.copy(file, sourceUri)

--- a/packages/core/src/app/namespaces/index.ts
+++ b/packages/core/src/app/namespaces/index.ts
@@ -56,6 +56,7 @@ export function createAppService(adapters: AppServiceAdapters): AppServiceResult
       best: swrCacheBy(),
       byFileId: swrCacheBy(),
     },
+    fsFileUri: swrCacheBy<string | null>(),
     libraryVersion: createLibraryVersionCache(),
     settings: swrCacheBy(),
     sync: swrCacheBy(),

--- a/packages/core/src/app/service.ts
+++ b/packages/core/src/app/service.ts
@@ -63,6 +63,10 @@ export interface AppCaches {
     best: SwrCacheBy
     byFileId: SwrCacheBy
   }
+  /** Per-fileId local URI (`file://…` when on disk, null when not).
+   *  Primed by useFileList from the LEFT JOIN flag so list-row
+   *  useFsFileUri hooks short-circuit. */
+  fsFileUri: SwrCacheBy<string | null>
   libraryVersion: LibraryVersionCache
   settings: SwrCacheBy
   sync: SwrCacheBy
@@ -168,10 +172,13 @@ export interface AppService {
     queryCount(opts: FileQueryOpts): Promise<number>
     /** Returns count and total size for files matching the query. */
     queryStats(opts: FileQueryOpts): Promise<{ count: number; totalBytes: number }>
-    /** Queries file rows for library display. */
+    /** Queries file rows for library display. Each row includes
+     *  isFavorite and fsExists flags (0|1) computed via LEFT JOINs so
+     *  list-row hooks short-circuit instead of issuing one SELECT
+     *  per visible row. */
     queryLibrary(
       opts: LibraryQueryParams & { limit?: number; offset?: number },
-    ): Promise<FileRecordRow[]>
+    ): Promise<Array<FileRecordRow & { isFavorite: number; fsExists: number }>>
     /** Creates a file, optionally with a local object. */
     create(
       record: Omit<FileRecord, 'objects'>,
@@ -438,6 +445,11 @@ export interface AppService {
     findOrphanedFileIds(fileIds: string[]): Promise<Set<string>>
     /** Returns the local file URI if the file exists on disk, or null. */
     getFileUri(file: { id: string; type: string }): Promise<string | null>
+    /** Returns the predicted local file URI for an id+type pair, with
+     *  no disk check or side effects. Callers that already know the file
+     *  is on disk (e.g., the library fetcher priming the fs URI cache)
+     *  use this to avoid the stat round trip getFileUri performs. */
+    uri(file: { id: string; type: string }): string
     /** Removes a local file from disk. */
     removeFile(file: { id: string; type: string }): Promise<void>
     /** Copies a file from the source URI into managed storage; returns the new URI. */

--- a/packages/core/src/db/operations/files.test.ts
+++ b/packages/core/src/db/operations/files.test.ts
@@ -479,6 +479,49 @@ describe('queryFiles', () => {
     })
     expect(all).toHaveLength(3)
   })
+
+  it('filters by lostReasonIsNull when set', async () => {
+    await insertFile(db(), makeFileRecord('clean'))
+    await insertFile(
+      db(),
+      makeFileRecord('lost', { lostReason: 'Source photo deleted from device' }),
+    )
+    const results = await queryFiles(db(), {
+      order: 'ASC',
+      lostReasonIsNull: true,
+    })
+    expect(results.map((r) => r.id)).toEqual(['clean'])
+  })
+
+  it('does not filter lostReason by default', async () => {
+    await insertFile(db(), makeFileRecord('clean'))
+    await insertFile(
+      db(),
+      makeFileRecord('lost', { lostReason: 'Source photo deleted from device' }),
+    )
+    const results = await queryFiles(db(), { order: 'ASC' })
+    expect(results.map((r) => r.id).sort()).toEqual(['clean', 'lost'])
+  })
+
+  it('combines lostReasonIsNull with hashEmpty for the placeholder selector', async () => {
+    // Mirrors importScanner Phase 2: hash='' AND lostReason IS NULL —
+    // terminally lost placeholders must not re-enter the candidate pool.
+    await insertFile(db(), makeFileRecord('placeholder', { hash: '' }))
+    await insertFile(
+      db(),
+      makeFileRecord('placeholder-lost', {
+        hash: '',
+        lostReason: 'Source photo deleted from device',
+      }),
+    )
+    await insertFile(db(), makeFileRecord('finalized', { hash: 'sha256:abc' }))
+    const results = await queryFiles(db(), {
+      order: 'ASC',
+      hashEmpty: true,
+      lostReasonIsNull: true,
+    })
+    expect(results.map((r) => r.id)).toEqual(['placeholder'])
+  })
 })
 
 describe('updateFile edge cases', () => {

--- a/packages/core/src/db/operations/files.ts
+++ b/packages/core/src/db/operations/files.ts
@@ -238,6 +238,13 @@ export type FileQueryOpts = {
   includeDeleted?: boolean
   hashEmpty?: boolean
   hashNotEmpty?: boolean
+  /**
+   * Restrict to rows whose lostReason is NULL. Default: no filter.
+   * importScanner sets this to keep terminally-lost placeholders out of
+   * its candidate pool — they're already surfaced in the UI's Unavailable
+   * tab and never become hashable without external action.
+   */
+  lostReasonIsNull?: boolean
 }
 
 function buildFileRecordsQuery(
@@ -263,6 +270,7 @@ function buildFileRecordsQuery(
     includeDeleted,
     hashEmpty,
     hashNotEmpty,
+    lostReasonIsNull,
   } = opts
   const sortColumn: FileRecordCursorColumn = orderBy ?? 'createdAt'
 
@@ -283,6 +291,10 @@ function buildFileRecordsQuery(
 
   if (hashNotEmpty) {
     whereClauses.push(`${tableAlias}.hash != ''`)
+  }
+
+  if (lostReasonIsNull) {
+    whereClauses.push(`${tableAlias}.lostReason IS NULL`)
   }
 
   if (after) {

--- a/packages/core/src/db/operations/library.ts
+++ b/packages/core/src/db/operations/library.ts
@@ -1,5 +1,6 @@
 import type { DatabaseAdapter } from '../../adapters/db'
 import type { FileRecordRow } from '../../types/files'
+import { SYSTEM_TAGS } from './tags'
 
 export type SortBy = 'NAME' | 'DATE' | 'ADDED' | 'SIZE'
 export type SortDir = 'ASC' | 'DESC'
@@ -323,7 +324,7 @@ export async function querySortedFileIds(
 export async function queryLibraryFiles(
   db: DatabaseAdapter,
   opts: LibraryQueryParams & { limit?: number; offset?: number },
-): Promise<FileRecordRow[]> {
+): Promise<Array<FileRecordRow & { isFavorite: number; fsExists: number }>> {
   const { limit, offset, ...queryOpts } = opts
   const {
     where,
@@ -341,11 +342,22 @@ export async function queryLibraryFiles(
     pageClause = ` LIMIT ${limit | 0}`
   }
 
-  return db.getAllAsync<FileRecordRow>(
-    `SELECT id, name, size, createdAt, updatedAt, type, kind, localId, hash, addedAt, thumbForId, thumbSize, trashedAt, deletedAt
+  // LEFT JOINs surface flags per row without per-row fan-out during list
+  // render. useFileList primes the per-fileId favorites and fs URI caches
+  // from these flags so list-row useIsFavorite and useFsFileUri hooks
+  // short-circuit instead of issuing one SELECT per visible row.
+  return db.getAllAsync<FileRecordRow & { isFavorite: number; fsExists: number }>(
+    `SELECT files.id, files.name, files.size, files.createdAt, files.updatedAt, files.type, files.kind,
+            files.localId, files.hash, files.addedAt, files.thumbForId, files.thumbSize,
+            files.trashedAt, files.deletedAt,
+            (file_tags.fileId IS NOT NULL) AS isFavorite,
+            (fs.fileId IS NOT NULL) AS fsExists
      FROM files
+     LEFT JOIN file_tags ON file_tags.fileId = files.id AND file_tags.tagId = ?
+     LEFT JOIN fs ON fs.fileId = files.id
      ${where}
      ORDER BY ${orderExpr}${pageClause}`,
+    SYSTEM_TAGS.favorites.id,
     ...queryParams,
   )
 }

--- a/packages/core/src/lib/serviceInterval.test.ts
+++ b/packages/core/src/lib/serviceInterval.test.ts
@@ -1,0 +1,111 @@
+import { ServiceScheduler } from './serviceInterval'
+
+describe('ServiceScheduler', () => {
+  beforeEach(() => jest.useFakeTimers())
+  afterEach(() => jest.useRealTimers())
+
+  it('queues a re-run when triggerNow arrives during a running tick', async () => {
+    const scheduler = new ServiceScheduler()
+    let resolveFirst: (() => void) | undefined
+    const worker = jest.fn(() => {
+      if (worker.mock.calls.length === 1) {
+        return new Promise<void>((resolve) => {
+          resolveFirst = resolve
+        })
+      }
+      return undefined
+    })
+
+    const { init, triggerNow } = scheduler.createInterval({
+      name: 'test',
+      worker,
+      interval: 60_000,
+    })
+    init()
+    // init() scheduled the first tick via setTimeout(interval). Fire it.
+    triggerNow()
+    await Promise.resolve()
+    expect(worker).toHaveBeenCalledTimes(1)
+
+    // Tick 1 is pending — this trigger should defer, not overlap.
+    triggerNow()
+    await Promise.resolve()
+    expect(worker).toHaveBeenCalledTimes(1)
+
+    // Resolve tick 1; the finally must immediately invoke tick 2 (no timer wait).
+    resolveFirst!()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(worker).toHaveBeenCalledTimes(2)
+
+    await scheduler.shutdown()
+  })
+
+  it('honors a worker that returns 0 by skipping the interval delay', async () => {
+    const scheduler = new ServiceScheduler()
+    let callCount = 0
+    const worker = jest.fn(() => {
+      callCount++
+      // First call returns 0 (drain mode); second returns undefined (back to interval).
+      return callCount === 1 ? 0 : undefined
+    })
+
+    const { init } = scheduler.createInterval({
+      name: 'test',
+      worker,
+      interval: 60_000,
+    })
+    init()
+
+    // First tick fires after the initial interval.
+    await jest.advanceTimersByTimeAsync(60_000)
+    expect(worker).toHaveBeenCalledTimes(1)
+
+    // Worker returned 0 — the next tick must schedule a 0ms timer. Drain it.
+    await jest.advanceTimersByTimeAsync(1)
+    expect(worker).toHaveBeenCalledTimes(2)
+
+    // Worker now returned undefined, so the NEXT timer is interval-sized.
+    // Confirm no further fire happens until we advance the full interval.
+    await jest.advanceTimersByTimeAsync(1000)
+    expect(worker).toHaveBeenCalledTimes(2)
+
+    await scheduler.shutdown()
+  })
+
+  it('drops nothing across rapid triggerNow + worker-return-0 alternation', async () => {
+    // Combined-path sanity: external trigger lands during a productive
+    // tick. Verify both the rerun flag and the return-0 mechanism end
+    // up firing the worker exactly the number of times we asked for.
+    const scheduler = new ServiceScheduler()
+    let resolveFirst: (() => void) | undefined
+    const worker = jest.fn(() => {
+      if (worker.mock.calls.length === 1) {
+        return new Promise<void>((resolve) => {
+          resolveFirst = resolve
+        })
+      }
+      return undefined
+    })
+
+    const { init, triggerNow } = scheduler.createInterval({
+      name: 'test',
+      worker,
+      interval: 60_000,
+    })
+    init()
+    triggerNow()
+    await Promise.resolve()
+    triggerNow()
+    triggerNow()
+    triggerNow()
+    resolveFirst!()
+    await Promise.resolve()
+    await Promise.resolve()
+    // Only one rerun is queued regardless of how many times triggerNow fires
+    // during the in-flight tick (the flag is a bool, not a counter).
+    expect(worker).toHaveBeenCalledTimes(2)
+
+    await scheduler.shutdown()
+  })
+})

--- a/packages/core/src/lib/serviceInterval.ts
+++ b/packages/core/src/lib/serviceInterval.ts
@@ -42,6 +42,7 @@ export class ServiceScheduler {
     triggerNow: () => void
   } {
     let running = false
+    let rerunRequested = false
     let runTick: (() => void) | null = null
 
     const init = () => {
@@ -56,6 +57,7 @@ export class ServiceScheduler {
       // Increment the token to invalidate any previously scheduled or in-flight ticks.
       const token = (existing?.token ?? 0) + 1
       running = false
+      rerunRequested = false
       this.schedulerStateMap.set(name, {
         token,
         timeoutId: null,
@@ -90,7 +92,15 @@ export class ServiceScheduler {
           }
         } finally {
           running = false
-          scheduleNextRun(nextInterval)
+          // A triggerNow that arrived while we were running deferred
+          // itself instead of being dropped — honor it now, bypassing
+          // the interval delay (unless the scheduler is paused).
+          if (rerunRequested && !this.paused) {
+            rerunRequested = false
+            runTick!()
+          } else {
+            scheduleNextRun(nextInterval)
+          }
         }
       }
 
@@ -115,7 +125,13 @@ export class ServiceScheduler {
 
     const triggerNow = () => {
       const current = this.schedulerStateMap.get(name)
-      if (!current || !runTick || running) return
+      if (!current || !runTick) return
+      if (running) {
+        // Defer; the finally above will honor the flag immediately
+        // after the in-flight tick completes.
+        rerunRequested = true
+        return
+      }
       if (current.timeoutId) {
         clearTimeout(current.timeoutId)
         current.timeoutId = null

--- a/packages/core/src/services/importScanner.test.ts
+++ b/packages/core/src/services/importScanner.test.ts
@@ -34,8 +34,10 @@ function createMockApp(): MockHelper {
           if (!opts.includeTrashed && file.trashedAt) continue
           if (!opts.includeDeleted && file.deletedAt) continue
           if (opts.hashEmpty && file.hash !== '') continue
+          if (opts.hashNotEmpty && file.hash === '') continue
           if (opts.fileExistsLocally === true && !fsFiles.has(file.id)) continue
           if (opts.fileExistsLocally === false && fsFiles.has(file.id)) continue
+          if (opts.lostReasonIsNull && file.lostReason != null) continue
           results.push({ ...file, objects: {} })
         }
         results.sort((a: any, b: any) =>
@@ -375,6 +377,91 @@ describe('ImportScanner', () => {
         expect.objectContaining({
           id: 'f-crashed',
           lostReason: 'No local file or source available',
+        }),
+      ])
+    })
+
+    it('rechecks the fs row before marking lost (query/await race)', async () => {
+      // Phase 2's candidate query captures state at query-start; a copy
+      // can land between then and the orphan check (fs row written,
+      // in-flight marker cleared). The recheck via app.fs.readMeta
+      // catches that and Phase 1 finalizes the file next tick.
+      mock.addFile('f-late')
+      // No in-flight marker (cleared during the await) and no fsFiles
+      // entry (query saw the row as no-local-file), but fsMeta is set —
+      // the just-completed copy wrote the fs row.
+      mock.fsMeta.set('f-late', { fileId: 'f-late', size: 100, addedAt: 1, usedAt: 1 })
+
+      const result = await scanner.runScan()
+
+      expect(result.lost).toBe(0)
+      expect(result.skipped).toBe(1)
+      expect(mock.app.files.updateMany).not.toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ lostReason: expect.any(String) })]),
+      )
+    })
+
+    it('does not re-pick deleted placeholders on subsequent ticks', async () => {
+      // Regression for the loop that wrote 18,687 localId_not_resolved
+      // logs over 937 ticks (~20/tick) on a device with 20 lost rows.
+      // After tick 1 marks them lost, the placeholder selector must
+      // exclude them via lostReason IS NULL.
+      for (let i = 0; i < 20; i++) {
+        mock.addFile(`d${i}`, { localId: `ph://gone-${i}` })
+      }
+      const resolveLocalId = jest.fn(
+        async (): Promise<ResolveLocalIdResult> => ({ status: 'deleted' }),
+      )
+
+      const r1 = await scanner.runScan(undefined, resolveLocalId)
+      expect(r1.lost).toBe(20)
+      expect(resolveLocalId).toHaveBeenCalledTimes(20)
+      expect(mock.caches.library.invalidateAll).toHaveBeenCalledTimes(1)
+
+      jest.clearAllMocks()
+      const r2 = await scanner.runScan(undefined, resolveLocalId)
+      expect(r2.lost).toBe(0)
+      expect(r2.skipped).toBe(0)
+      expect(r2.failed).toBe(0)
+      expect(resolveLocalId).not.toHaveBeenCalled()
+      expect(mock.app.files.updateMany).not.toHaveBeenCalled()
+      expect(mock.caches.library.invalidateAll).not.toHaveBeenCalled()
+    })
+
+    it('does not re-pick orphan placeholders on subsequent ticks', async () => {
+      // Same loop, orphan branch: no localId and the in-flight set is
+      // empty. After tick 1 marks them lost, tick 2 must be a no-op.
+      mock.addFile('orphan-1')
+      mock.addFile('orphan-2')
+
+      const r1 = await scanner.runScan()
+      expect(r1.lost).toBe(2)
+
+      jest.clearAllMocks()
+      const r2 = await scanner.runScan()
+      expect(r2.lost).toBe(0)
+      expect(r2.skipped).toBe(0)
+      expect(r2.failed).toBe(0)
+      expect(mock.app.files.updateMany).not.toHaveBeenCalled()
+      expect(mock.caches.library.invalidateAll).not.toHaveBeenCalled()
+    })
+
+    it('clears lostReason when a previously-lost row finalizes via phase 1', async () => {
+      // Recovery: a row marked lost on a prior tick later gains a local
+      // file (no flow does this today, but defense in depth). Phase 1
+      // does not filter on lostReason, so it finalizes the row and
+      // clears the marker on the same pass — the row leaves the
+      // Unavailable tab without any external intervention.
+      mock.addFile('recovered', { lostReason: 'No local file or source available' })
+      mock.addLocalFile('recovered', '/local/recovered.jpg')
+
+      const result = await scanner.runScan()
+
+      expect(result.finalized).toBe(1)
+      expect(mock.app.files.updateMany).toHaveBeenCalledWith([
+        expect.objectContaining({
+          id: 'recovered',
+          lostReason: null,
         }),
       ])
     })

--- a/packages/core/src/services/importScanner.ts
+++ b/packages/core/src/services/importScanner.ts
@@ -150,6 +150,9 @@ export class ImportScanner {
 
       // Phase 1: files already on disk, just need hashing.
       if (!signal?.aborted) {
+        // No lostReasonIsNull filter: a row with local bytes but a stale
+        // lostReason (no flow today, but defense in depth) should finalize
+        // here and clear the marker on the same pass.
         const localCandidates = await app.files.query({
           hashEmpty: true,
           fileExistsLocally: true,
@@ -227,6 +230,7 @@ export class ImportScanner {
         const deferredCandidates = await app.files.query({
           hashEmpty: true,
           fileExistsLocally: false,
+          lostReasonIsNull: true,
           includeThumbnails: true,
           includeOldVersions: true,
           limit: deferredLimit,
@@ -331,7 +335,26 @@ export class ImportScanner {
               continue
             }
 
-            logger.debug('importScanner', 'orphan', { fileId: file.id })
+            // Phase 2's query captured state at query-start time. A
+            // file's copy can finish during that await: fs row gets
+            // written and markImportCopyComplete fires, so we'd mark a
+            // succeeded file as lost. Recheck the fs row freshly and
+            // let Phase 1 pick it up on the next tick.
+            const freshMeta = await app.fs.readMeta(file.id)
+            if (freshMeta) {
+              logger.debug('importScanner', 'orphan_recheck_safe', {
+                fileId: file.id,
+              })
+              result.skipped++
+              continue
+            }
+
+            logger.warn('importScanner', 'orphan_lost', {
+              fileId: file.id,
+              name: file.name,
+              type: file.type,
+              localId: file.localId,
+            })
             lostUpdates.push({
               id: file.id,
               lostReason: 'No local file or source available',
@@ -353,6 +376,9 @@ export class ImportScanner {
       // Per-file disk copies are done; gate the batch DB writes so
       // suspend in the gap can't leave a finalized-on-disk file stuck
       // with an empty hash/size/type row that no scanner re-picks up.
+      // lostReason: null clears any prior terminal marker so a row that
+      // becomes recoverable (no flow does this today) leaves the
+      // Unavailable tab without external intervention.
       if (updates.length > 0) {
         await app.db.waitUntilActive()
         await app.files.updateMany(
@@ -361,6 +387,10 @@ export class ImportScanner {
             hash: u.hash,
             size: u.size,
             type: u.type,
+            // A file we just hashed isn't lost. Clear any stale
+            // lostReason left by a prior tick's orphan branch racing a
+            // mid-flight copy.
+            lostReason: null,
           })),
         )
       }

--- a/packages/core/src/stores/library.test.ts
+++ b/packages/core/src/stores/library.test.ts
@@ -1,0 +1,72 @@
+import type { AppService } from '../app/service'
+import { primeListRowCaches } from './library'
+
+// Cache key parity tests — the literals used here must match the
+// keys read by the consumer hooks (`useIsFavorite` and `useFsFileUri`).
+// If those hook key formats change without updating the primer, the
+// optimization silently degrades to per-row fetcher fan-out.
+//   - `favorite/${id}` → `packages/core/src/stores/tags.ts` `useIsFavorite`
+//   - `${id}` (raw id) → `apps/mobile/src/stores/fs.ts`     `useFsFileUri`
+
+type CacheSpy = {
+  set: jest.Mock
+}
+
+function makeApp(): { app: AppService; tags: CacheSpy; fsFileUri: CacheSpy; uri: jest.Mock } {
+  const tags: CacheSpy = { set: jest.fn() }
+  const fsFileUri: CacheSpy = { set: jest.fn() }
+  const uri = jest.fn((file: { id: string; type: string }) => `/predicted/${file.id}.bin`)
+  const app = {
+    caches: { tags, fsFileUri },
+    fs: { uri },
+  } as unknown as AppService
+  return { app, tags, fsFileUri, uri }
+}
+
+function row(id: string, isFavorite: 0 | 1, fsExists: 0 | 1) {
+  return {
+    id,
+    name: `${id}.jpg`,
+    type: 'image/jpeg',
+    kind: 'file',
+    size: 100,
+    hash: 'sha256:x',
+    createdAt: 1,
+    updatedAt: 1,
+    addedAt: 1,
+    localId: null,
+    trashedAt: null,
+    deletedAt: null,
+    lostReason: null,
+    isFavorite,
+    fsExists,
+  } as unknown as Parameters<typeof primeListRowCaches>[1][number]
+}
+
+describe('primeListRowCaches', () => {
+  it('writes the favorite cache with the same key shape `useIsFavorite` reads', () => {
+    const { app, tags } = makeApp()
+    primeListRowCaches(app, [row('f1', 1, 0)])
+    expect(tags.set).toHaveBeenCalledWith(true, 'favorite/f1')
+  })
+
+  it('writes false to the favorite cache when the join column is 0', () => {
+    const { app, tags } = makeApp()
+    primeListRowCaches(app, [row('f1', 0, 0)])
+    expect(tags.set).toHaveBeenCalledWith(false, 'favorite/f1')
+  })
+
+  it('writes the predicted URI to fsFileUri keyed by raw file id when fsExists=1', () => {
+    const { app, fsFileUri, uri } = makeApp()
+    primeListRowCaches(app, [row('f1', 0, 1)])
+    expect(uri).toHaveBeenCalledWith({ id: 'f1', type: 'image/jpeg' })
+    expect(fsFileUri.set).toHaveBeenCalledWith('/predicted/f1.bin', 'f1')
+  })
+
+  it('writes null to fsFileUri when fsExists=0 (no stat call)', () => {
+    const { app, fsFileUri, uri } = makeApp()
+    primeListRowCaches(app, [row('f1', 0, 0)])
+    expect(fsFileUri.set).toHaveBeenCalledWith(null, 'f1')
+    expect(uri).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/stores/library.ts
+++ b/packages/core/src/stores/library.ts
@@ -1,12 +1,33 @@
 import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'react'
 import useSWR from 'swr'
 import useSWRInfinite from 'swr/infinite'
+import type { AppService } from '../app/service'
 import { useApp } from '../app/context'
 import type { LibraryQueryParams, SortBy, SortDir } from '../db/operations'
 import { transformRow } from '../db/operations'
-import type { FileRecord } from '../types/files'
+import type { FileRecord, FileRecordRow } from '../types/files'
 
 const PAGE_SIZE = 40
+
+type LibraryRow = FileRecordRow & { isFavorite: number; fsExists: number }
+
+/**
+ * Populate per-row SWR caches from the joined columns returned by
+ * `queryLibrary`. Each list row component then renders its
+ * `useIsFavorite` and `useFsFileUri` from cache instead of firing its
+ * own query. `fsExists` priming trusts the DB row; `useFsFileUri`'s
+ * fetcher self-heals on disk drift, and the staleness window is at
+ * most one library invalidation cycle.
+ */
+export function primeListRowCaches(app: AppService, rows: LibraryRow[]): void {
+  for (const row of rows) {
+    app.caches.tags.set(!!row.isFavorite, `favorite/${row.id}`)
+    app.caches.fsFileUri.set(
+      row.fsExists ? app.fs.uri({ id: row.id, type: row.type }) : null,
+      row.id,
+    )
+  }
+}
 
 /** Parameters for querying a paginated, sortable, and filterable file list. */
 export type FileListParams = {
@@ -68,6 +89,8 @@ export function useFileList(params: FileListParams) {
       limit: PAGE_SIZE,
       offset: pageIndex * PAGE_SIZE,
     })
+
+    primeListRowCaches(app, rows)
 
     const fileIds = rows.map((r) => r.id)
     const objectsByFile = await app.localObjects.getRefsForFiles(fileIds)


### PR DESCRIPTION
Batch of optimizations and fixes from manual testing of file imports on Android.

- Picker imports were slow because each Drive content:// URI costs ~500–1000ms in ContentResolver round-trips. Copies now run in parallel with a 4-way cap and 16MB in-flight byte budget.
- Library list fired a per-row favorite lookup and fs-URI stat, 80 extra calls per 40-row page, which get queued on the single SQLite connection. queryLibrary now LEFT JOINs file_tags and fs; the list primes the row SWR caches so useIsFavorite and useFsFileUri resolve from cache.
- Import scanner slept 3s between productive ticks. Productive ticks now return 0 to refire immediately, and a triggerNow arriving mid-tick queues a re-run instead of being dropped.
- Copied picker files showed as Unavailable because the scanner raced the placeholder INSERT and copy completion, stamping a stale lostReason. Now: mark in-flight before INSERT, recheck app.fs.readMeta in the orphan branch, clear lostReason on successful hash, and filter terminally-lost rows out of phase 2.
