### PR TITLE
fix(core,mobile): gate sync overlay on new files, not total events

### DIFF
--- a/.changeset/sync-gate-on-creates.md
+++ b/.changeset/sync-gate-on-creates.md
@@ -1,0 +1,6 @@
+---
+core: patch
+mobile: patch
+---
+
+The launch sync screen now stays hidden when it detects a catch-up is mostly file migrations rather than new files, so returning users don't wait through it.

--- a/apps/mobile/src/managers/syncDownEvents.test.ts
+++ b/apps/mobile/src/managers/syncDownEvents.test.ts
@@ -1,3 +1,4 @@
+import { SYNC_GATE_HYDRATION_MIN } from '@siastorage/core/config'
 import { encodeFileMetadata } from '@siastorage/core/encoding/fileMetadata'
 import type { LocalObject } from '@siastorage/core/encoding/localObject'
 import type { FileMetadata, FileRecord } from '@siastorage/core/types'
@@ -1451,6 +1452,140 @@ describe('syncDownEvents', () => {
       const aborted = new AbortController()
       aborted.abort()
       await run(aborted.signal)
+      expect(app().sync.getState().syncGateStatus).toBe('pending')
+    })
+
+    // Re-push existing seeded files (same metadata.id) with a newer updatedAt so
+    // they classify as updates (repairs), not creates.
+    function makeUpdateEvents(count: number, startId = 0) {
+      return Array.from({ length: count }, (_, i) => {
+        const id = `obj-gate-${startId + i}`
+        const metadata: FileMetadata = {
+          id: `file-gate-${startId + i}`,
+          name: `gate-${startId + i}.jpg`,
+          type: 'image/jpeg',
+          kind: 'file',
+          size: 100,
+          hash: `hash-gate-${startId + i}`,
+          createdAt: NOW_BASE + startId + i,
+          updatedAt: NOW_BASE + startId + i + 100_000,
+          thumbForId: undefined,
+          thumbSize: undefined,
+          trashedAt: null,
+        }
+        return makeObjectEvent({
+          id,
+          updatedAt: new Date(NOW_BASE + startId + i + 100_000),
+          object: makeMockPinnedObject(metadata, id),
+        })
+      })
+    }
+
+    function makeThumbEvents(count: number, startId = 0) {
+      return Array.from({ length: count }, (_, i) => {
+        const id = `obj-thumb-${startId + i}`
+        const metadata: FileMetadata = {
+          id: `thumb-${startId + i}`,
+          name: `thumb-${startId + i}.jpg`,
+          type: 'image/jpeg',
+          kind: 'thumb',
+          size: 100,
+          hash: `hash-thumb-${startId + i}`,
+          createdAt: NOW_BASE + startId + i,
+          updatedAt: NOW_BASE + startId + i,
+          thumbForId: `file-gate-${startId + i}`,
+          thumbSize: 64,
+          trashedAt: null,
+        }
+        return makeObjectEvent({
+          id,
+          updatedAt: new Date(NOW_BASE + startId + i),
+          object: makeMockPinnedObject(metadata, id),
+        })
+      })
+    }
+
+    // Populate the local library so subsequent runs see an established (not
+    // hydrating) library. Runs with the gate idle so seeding doesn't gate.
+    async function seedLibrary(count: number) {
+      app().sync.setState({ syncGateStatus: 'idle' })
+      internal().setSdk({
+        objectEvents: jest.fn().mockResolvedValueOnce(makeEvents(count)),
+        appKey: () => mockAppKey,
+      } as any)
+      await run(new AbortController().signal)
+      expect(await app().library.fileCount()).toBeGreaterThanOrEqual(SYNC_GATE_HYDRATION_MIN)
+    }
+
+    test('established library: repair-only catch-up dismisses without gating', async () => {
+      await seedLibrary(60)
+      app().sync.setState({ syncGateStatus: 'pending' })
+      internal().setSdk({
+        objectEvents: jest.fn().mockResolvedValueOnce(makeUpdateEvents(60)),
+        appKey: () => mockAppKey,
+      } as any)
+
+      await run(new AbortController().signal)
+      expect(app().sync.getState().syncGateStatus).toBe('dismissed')
+    })
+
+    test('established library: create-light batch dismisses past the old event threshold', async () => {
+      await seedLibrary(60)
+      app().sync.setState({ syncGateStatus: 'pending' })
+      // 5 new files + 30 repairs = 35 events. The old gate keyed on total events
+      // (>= 10) would activate; the new gate keys on the 5 creates and dismisses.
+      const events = [...makeEvents(5, 1000), ...makeUpdateEvents(30)]
+      internal().setSdk({
+        objectEvents: jest.fn().mockResolvedValueOnce(events),
+        appKey: () => mockAppKey,
+      } as any)
+
+      await run(new AbortController().signal)
+      expect(app().sync.getState().syncGateStatus).toBe('dismissed')
+    })
+
+    test('established library: a real influx of new files still gates', async () => {
+      await seedLibrary(60)
+      app().sync.setState({ syncGateStatus: 'pending' })
+      const events = makeEvents(15, 2000)
+      internal().setSdk({
+        objectEvents: jest.fn().mockResolvedValueOnce(events),
+        appKey: () => mockAppKey,
+      } as any)
+
+      await run(new AbortController().signal)
+      expect(app().sync.getState().syncGateStatus).toBe('active')
+    })
+
+    test('established library: thumbnail creates do not count toward the gate', async () => {
+      await seedLibrary(60)
+      app().sync.setState({ syncGateStatus: 'pending' })
+      // 20 thumbnail creates, no new files — must not gate.
+      internal().setSdk({
+        objectEvents: jest.fn().mockResolvedValueOnce(makeThumbEvents(20)),
+        appKey: () => mockAppKey,
+      } as any)
+
+      await run(new AbortController().signal)
+      expect(app().sync.getState().syncGateStatus).toBe('dismissed')
+    })
+
+    test('aborted mid-batch leaves the gate pending instead of dismissing', async () => {
+      await seedLibrary(60)
+      app().sync.setState({ syncGateStatus: 'pending' })
+      const controller = new AbortController()
+      // Abort during the fetch so the batch never commits: counts.fileCreates
+      // stays 0 and would read as create-light. The gate must stay 'pending'
+      // for the next run, not dismiss against an incomplete sync.
+      internal().setSdk({
+        objectEvents: jest.fn().mockImplementationOnce(async () => {
+          controller.abort()
+          return makeEvents(20, 3000)
+        }),
+        appKey: () => mockAppKey,
+      } as any)
+
+      await run(controller.signal)
       expect(app().sync.getState().syncGateStatus).toBe('pending')
     })
   })

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -84,8 +84,12 @@ export const TRASH_AUTO_PURGE_INTERVAL = minutesInMs(60) // 60 minutes
 export const DB_OPTIMIZE_INTERVAL = secondsInMs(60) // 60 seconds
 // Performance monitor logging interval.
 export const PERF_MONITOR_INTERVAL = secondsInMs(15)
-// Minimum events to activate the sync gate overlay during initial catch-up.
-export const SYNC_GATE_THRESHOLD = 10
+// New-file creates needed to show the sync gate for an established library.
+// A repair-only catch-up is all updates, so it stays under this.
+export const SYNC_GATE_CREATE_THRESHOLD = 10
+// Below this library size, a catch-up is treated as first-time hydration: the
+// gate holds until the queue drains instead of dismissing on a low create count.
+export const SYNC_GATE_HYDRATION_MIN = 50
 // Max concurrent pinObject calls during save phase.
 export const SAVE_BATCH_CONCURRENCY = 20
 // Delay before removing upload state after save, so cache invalidation

--- a/packages/core/src/services/syncDownEvents.ts
+++ b/packages/core/src/services/syncDownEvents.ts
@@ -1,7 +1,8 @@
 import { logger } from '@siastorage/logger'
 import type { PinnedObjectRef } from '../adapters/sdk'
 import type { AppService, AppServiceInternal } from '../app/service'
-import { SYNC_GATE_THRESHOLD } from '../config'
+import type { SyncGateStatus } from '../app/stores'
+import { SYNC_GATE_CREATE_THRESHOLD, SYNC_GATE_HYDRATION_MIN } from '../config'
 import {
   decodeFileMetadata,
   hasCompleteFileMetadata,
@@ -27,6 +28,26 @@ const batchSize = 500
 
 type Counts = {
   total: number
+  // New files only (thumbnails excluded); a metadata-repair wave is updates,
+  // so this stays low.
+  fileCreates: number
+}
+
+/**
+ * Gate status for a just-classified batch. Keyed on new files, not event count,
+ * so a catch-up that's only metadata repairs doesn't block a returning user.
+ * Latches once it leaves 'pending':
+ *   - established library: decided on the first batch
+ *   - near-empty library: keep holding while few new files have arrived
+ */
+function nextGateStatus(
+  current: SyncGateStatus,
+  fileCreates: number,
+  hydrating: boolean,
+): SyncGateStatus {
+  if (current !== 'pending') return current
+  if (fileCreates >= SYNC_GATE_CREATE_THRESHOLD) return 'active'
+  return hydrating ? 'pending' : 'dismissed'
 }
 
 // A "create" means no existing file record matches this object.
@@ -85,12 +106,21 @@ export async function syncDownEventsBatch(
 
   const sdk = internal.requireSdk()
 
-  const counts: Counts = { total: 0 }
+  const counts: Counts = { total: 0, fileCreates: 0 }
   let totalEventsFetched = 0
   let firstEventTime: number | undefined
   const now = Date.now()
 
   try {
+    // A near-empty library is being filled for the first time, so hold the gate
+    // until the catch-up finishes instead of dismissing early on a low new-file
+    // count. Only checked while the gate is pending. Computed inside the try so
+    // a fileCount() throw still reaches the finally that restores isSyncingDown.
+    const hydrating =
+      app.sync.getState().syncGateStatus === 'pending'
+        ? (await app.library.fileCount()) < SYNC_GATE_HYDRATION_MIN
+        : false
+
     while (true) {
       if (signal.aborted) break
       try {
@@ -110,11 +140,6 @@ export async function syncDownEventsBatch(
           })
         }
 
-        const gateStatus = app.sync.getState().syncGateStatus
-        if (gateStatus === 'pending' && totalEventsFetched >= SYNC_GATE_THRESHOLD) {
-          app.sync.setState({ syncGateStatus: 'active' })
-        }
-
         // If the batch size is 1, we are probably synced and repeatedly polling the last event.
         if (events.length === 1) {
           logger.debug('syncDownEvents', 'batch', { size: events.length })
@@ -125,6 +150,15 @@ export async function syncDownEventsBatch(
         const prevTotal = counts.total
         await processBatch(events, counts, signal, app, internal)
         const batchChanged = counts.total > prevTotal
+
+        // Move the gate now this batch is classified. Skip empty/aborted
+        // batches: fileCreates is final only after the commit, and an aborted
+        // run leaves the gate to `finally`, which preserves it across suspension.
+        if (!signal.aborted && totalEventsFetched > 1) {
+          const current = app.sync.getState().syncGateStatus
+          const next = nextGateStatus(current, counts.fileCreates, hydrating)
+          if (next !== current) app.sync.setState({ syncGateStatus: next })
+        }
 
         // Track the first event's timestamp for progress estimation.
         if (firstEventTime === undefined && events.length > 0) {
@@ -512,6 +546,7 @@ async function processBatch(
   // withTransaction can rerun the closure after reopening the DB handle,
   // and an in-closure `+=` would double-count on retry.
   counts.total += creates.length + updates.length + deletedFileIds.length
+  counts.fileCreates += creates.filter((e) => e.isFile).length
 
   // Filesystem cleanup runs after the transaction commits. FS isn't
   // transactional, and an orphan-on-disk after a committed delete is


### PR DESCRIPTION
The launch "Syncing your library" overlay triggered on the raw count of fetched sync events, so a wave of background file migrations (metadata updates to files the user already has) made returning users wait through it for zero new files. It now decides from the catch-up itself: a near-empty library holds the overlay until the initial fill finishes, while an established library reads the first batch and makes a best-case call — show the overlay if real new files are coming in, or dismiss it right away if the batch is only file migrations and let them reconcile in the background.
