### PR TITLE
fix(core): upload only current file versions, not superseded ones

### DIFF
--- a/.changeset/upload-current-versions-only.md
+++ b/.changeset/upload-current-versions-only.md
@@ -1,0 +1,5 @@
+---
+core: patch
+---
+
+Upload only current versions. Superseded versions and their thumbnails are no longer uploaded, matching the upload stats counts which already track current versions only.

--- a/apps/integration/test/app.ts
+++ b/apps/integration/test/app.ts
@@ -514,13 +514,15 @@ export function createTestApp(
             (u) => u.status !== 'error' && u.status !== 'done',
           )
           if (active.length > 0) return false
+          // Mirror the uploader's scope: it only uploads current versions, so a
+          // superseded version that never uploaded isn't "pending" — counting
+          // it here would never drain.
           const pending = await appService.files.query({
             limit: 1,
             order: 'ASC',
             pinned: { indexerURL: INDEXER_URL, isPinned: false },
             fileExistsLocally: true,
             includeThumbnails: true,
-            includeOldVersions: true,
             includeTrashed: true,
             includeDeleted: true,
           })

--- a/apps/integration/test/version-sync.test.ts
+++ b/apps/integration/test/version-sync.test.ts
@@ -462,8 +462,11 @@ describe('Version Sync', () => {
     await appA.start()
     await appB.start()
 
-    // Device A creates v1 and v2 via app flow — both devices sync
+    // Device A creates v1 then v2 via app flow. Each is uploaded while it's the
+    // current version (the uploader skips superseded versions), so both reach
+    // the indexer and sync to B.
     await addVersionFile(appA, 'conc-v1', 'shared.txt')
+    await appA.waitForNoActiveUploads()
     await addVersionFile(appA, 'conc-v2', 'shared.txt')
     await appA.waitForNoActiveUploads()
     await waitForCondition(async () => (await appB.getFiles()).length === 2, {
@@ -476,9 +479,10 @@ describe('Version Sync', () => {
     await appB.app.files.trashFile('conc-v1')
     expect(await appB.app.library.fileCount()).toBe(0)
 
-    // Device A creates v3 and v4 through the full app flow
-    // (create record + write file data + fs metadata → upload manager → sync-up)
+    // Device A creates v3 then v4 through the full app flow, uploading each
+    // while current so both reach the indexer.
     await addVersionFile(appA, 'conc-v3', 'shared.txt')
+    await appA.waitForNoActiveUploads()
     await addVersionFile(appA, 'conc-v4', 'shared.txt')
     await appA.waitForNoActiveUploads()
     await waitForCondition(async () => (await appA.getFiles()).length === 4, {
@@ -527,8 +531,10 @@ describe('Version Sync', () => {
     await appB.start()
     await appC.start()
 
-    // Device A creates v1 and v2 via app flow — all three sync
+    // Device A creates v1 then v2 via app flow, uploading each while current so
+    // both reach the indexer and sync to all three devices.
     await addVersionFile(appA, 'tri-v1', 'notes.txt')
+    await appA.waitForNoActiveUploads()
     await addVersionFile(appA, 'tri-v2', 'notes.txt')
     await appA.waitForNoActiveUploads()
     await waitForCondition(async () => (await appC.getFiles()).length === 2, {
@@ -583,5 +589,45 @@ describe('Version Sync', () => {
     await appA.shutdown()
     await appB.shutdown()
     await appC.shutdown()
+  }, 60_000)
+
+  it('superseded-before-upload version stays local; only the current version converges', async () => {
+    // The uploader backs up current versions only. A version superseded before
+    // it uploads never reaches the indexer: it stays a local-only history entry
+    // on the device that made it, while every device still converges on the
+    // same current version.
+    const indexerStorage = createEmptyIndexerStorage()
+    const appA = createTestApp(indexerStorage)
+    const appB = createTestApp(indexerStorage)
+    await appA.start()
+    await appB.start()
+
+    // A creates v1 then v2 while disconnected, so v1 is superseded before any
+    // upload runs (the uploader's pollDB skips work while disconnected).
+    appA.setConnected(false)
+    await addVersionFile(appA, 'loc-v1', 'doc.txt')
+    await addVersionFile(appA, 'loc-v2', 'doc.txt')
+    appA.setConnected(true)
+
+    // Only the current version (v2) uploads and reaches B.
+    await appA.waitForNoActiveUploads()
+    await waitForCondition(async () => (await appB.getFileById('loc-v2')) != null, {
+      timeout: 15_000,
+      message: 'B sees the current version',
+    })
+
+    // B converged on the current version only — it never saw the superseded v1.
+    expect(await appB.getFileById('loc-v1')).toBeNull()
+    expect(await appB.app.library.fileCount()).toBe(1)
+    const histB = await appB.app.files.getVersionHistory('doc.txt', null)
+    expect(histB.map((f) => f.id)).toEqual(['loc-v2'])
+
+    // A keeps v1 as a local-only history entry. Version history is
+    // newest-first, so v1 is ordered after the current v2.
+    const histA = await appA.app.files.getVersionHistory('doc.txt', null)
+    expect(histA.map((f) => f.id)).toEqual(['loc-v2', 'loc-v1'])
+
+    await appA.shutdown()
+    await appB.shutdown()
   }, 60_000)
 })

--- a/packages/core/src/services/uploader.ts
+++ b/packages/core/src/services/uploader.ts
@@ -899,6 +899,10 @@ export class UploadManager {
     try {
       const activeIds = this.app.uploads.getActiveIds()
       const indexerURL = await this.app.settings.getIndexerURL()
+      // Back up current versions only. Omitting includeOldVersions excludes
+      // superseded (current=0) files and orphan thumbnails (whose original is no
+      // longer current), so we don't re-upload stale duplicates — and the
+      // uploader's scope matches the stats sheet, which counts current=1 only.
       const candidateFiles = await this.app.files.query({
         limit: 200,
         order: 'ASC',
@@ -907,7 +911,6 @@ export class UploadManager {
         hashNotEmpty: true,
         excludeIds: activeIds.length > 0 ? activeIds : undefined,
         includeThumbnails: true,
-        includeOldVersions: true,
       })
 
       const newEntries: FileEntry[] = []


### PR DESCRIPTION
The uploader was uploading old versions of files that had already been superseded. This scopes uploads to current versions only, along with their thumbnails.
