### PR TITLE
fix(core,mobile): reconcile file size from real bytes instead of picker metadata

### DIFF
--- a/.changeset/reconcile-file-size.md
+++ b/.changeset/reconcile-file-size.md
@@ -1,0 +1,6 @@
+---
+core: patch
+mobile: patch
+---
+
+File sizes now reflect the real file length. The size read at import is often wrong on Android; it's corrected to the real on-disk size after copy, then again from the size the SDK reports when the upload finishes, and any already-wrong sizes heal as files sync down.

--- a/apps/integration/test/size-reconcile.test.ts
+++ b/apps/integration/test/size-reconcile.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Size reconciliation: a size recorded wrong at import (Android often reports
+ * the wrong size) is corrected to the real length after copy, and again from
+ * the SDK at upload.
+ */
+
+import { extFromMime } from '@siastorage/core/lib/fileTypes'
+import { createEmptyIndexerStorage } from '@siastorage/sdk-mock'
+import * as crypto from 'crypto'
+import * as nodeFs from 'fs'
+import * as path from 'path'
+import { createTestApp, waitForCondition } from './app'
+
+describe('Size reconcile', () => {
+  it('copyFile corrects files.size to the real on-disk length without bumping updatedAt', async () => {
+    const app = createTestApp(createEmptyIndexerStorage())
+    await app.start()
+
+    // A real source file of known size.
+    const content = crypto.randomBytes(4096)
+    const sourcePath = path.join(app.tempDir, 'source.bin')
+    nodeFs.writeFileSync(sourcePath, content)
+
+    // Placeholder created with a wrong size.
+    const now = Date.now()
+    await app.app.files.create({
+      id: 'sz-1',
+      name: 'big.bin',
+      type: 'application/octet-stream',
+      kind: 'file',
+      size: 1,
+      hash: '',
+      createdAt: now,
+      updatedAt: now,
+      localId: null,
+      addedAt: now,
+      trashedAt: null,
+      deletedAt: null,
+    })
+    const before = await app.getFileById('sz-1')
+    expect(before!.size).toBe(1)
+
+    // Copy the real file into local storage.
+    await app.app.fs.copyFile({ id: 'sz-1', type: 'application/octet-stream' }, sourcePath)
+
+    // files.size is corrected to the real length, fs.size agrees, and updatedAt
+    // is untouched.
+    const after = await app.getFileById('sz-1')
+    expect(after!.size).toBe(content.length)
+    expect(after!.updatedAt).toBe(before!.updatedAt)
+    const fsMeta = await app.app.fs.readMeta('sz-1')
+    expect(fsMeta!.size).toBe(content.length)
+
+    await app.shutdown()
+  })
+
+  it('upload pins the SDK size, correcting a mis-recorded size at the source and on sync', async () => {
+    const indexerStorage = createEmptyIndexerStorage()
+    const appA = createTestApp(indexerStorage)
+    const appB = createTestApp(indexerStorage)
+    await appA.start()
+    await appB.start()
+
+    // A file with a wrong recorded size but larger real content, written to its
+    // storage path so the uploader reads the true bytes.
+    const type = 'application/octet-stream'
+    const ext = extFromMime(type)
+    const content = crypto.randomBytes(2048)
+    const hash = crypto.createHash('sha256').update(content).digest('hex')
+    nodeFs.writeFileSync(path.join(appA.tempDir, `wrongsize${ext}`), content)
+    const now = Date.now()
+    await appA.app.files.create({
+      id: 'wrongsize',
+      name: 'wrong.bin',
+      type,
+      kind: 'file',
+      size: 1,
+      hash,
+      createdAt: now,
+      updatedAt: now,
+      localId: null,
+      addedAt: now,
+      trashedAt: null,
+      deletedAt: null,
+    })
+    await appA.app.fs.upsertMeta({ fileId: 'wrongsize', size: 1, addedAt: now, usedAt: now })
+
+    await appA.waitForNoActiveUploads()
+
+    // Upload corrected the size from the SDK, so the local row is right...
+    const onA = await appA.getFileById('wrongsize')
+    expect(onA!.size).toBe(content.length)
+
+    // ...and the uploaded metadata carries it, so B receives it correct.
+    await waitForCondition(async () => (await appB.getFileById('wrongsize')) != null, {
+      timeout: 15_000,
+      message: 'B sees the file',
+    })
+    const onB = await appB.getFileById('wrongsize')
+    expect(onB!.size).toBe(content.length)
+
+    await appA.shutdown()
+    await appB.shutdown()
+  }, 60_000)
+})

--- a/apps/mobile/src/lib/assetImports.ts
+++ b/apps/mobile/src/lib/assetImports.ts
@@ -504,6 +504,8 @@ export async function importAssets(
             addedAt: now,
             type,
             kind: 'file' as const,
+            // Provisional: Android often reports the wrong size at import.
+            // Corrected after copy (fs.copyFile) and again from the SDK at upload.
             size: a.size ?? 0,
             hash: '',
             trashedAt: null,

--- a/packages/core/src/app/namespaces/db.ts
+++ b/packages/core/src/app/namespaces/db.ts
@@ -100,6 +100,10 @@ export function buildDbNamespaces(
         addedAt: previous?.addedAt ?? Date.now(),
         usedAt: opts?.usedAt ?? Date.now(),
       })
+      // Android often reports the wrong size at import; correct it to the real
+      // on-disk length after the copy. updatedAt is preserved so this size fix
+      // can't trip sync-up.
+      await ops.updateFile(db, { id: file.id, size: result.size }, { includeUpdatedAt: true })
       return result.uri
     },
     writeFileData: async (file, data) => {

--- a/packages/core/src/services/syncDownEvents.ts
+++ b/packages/core/src/services/syncDownEvents.ts
@@ -364,11 +364,17 @@ async function processBatch(
         })
       }
       const localObject = sealPinnedObject(existing.id, indexerURL, object, appKey)
+      // Heal a wrong stored size from the SDK's size (local-only, no sync-up).
+      const realSize = Number(object.size())
       const isRemoteNewer = metadata.updatedAt >= existing.updatedAt
       const mergedMetadata = isRemoteNewer ? toFileRecordFields(metadata) : {}
       prepared.push({
         kind: 'update',
-        fileRecord: { ...existing, ...mergedMetadata },
+        fileRecord: {
+          ...existing,
+          ...mergedMetadata,
+          ...(realSize > 0 ? { size: realSize } : {}),
+        },
         localObject,
         fileId: existing.id,
         tags: metadata.tags,
@@ -386,10 +392,12 @@ async function processBatch(
         })
       }
       const localObject = sealPinnedObject(fileId, indexerURL, object, appKey)
+      const realSize = Number(object.size())
       prepared.push({
         kind: 'create',
         fileRecord: {
           ...toFileRecordFields(metadata),
+          ...(realSize > 0 ? { size: realSize } : {}),
           id: fileId,
           localId: null,
           addedAt: Date.now(),

--- a/packages/core/src/services/uploader.ts
+++ b/packages/core/src/services/uploader.ts
@@ -1098,7 +1098,13 @@ export class UploadManager {
               })
               return { type: 'deleted', fileId: entry.fileId }
             }
-            pinnedObject.updateMetadata(encodeFileMetadata(metadata))
+            // Prefer the SDK's calculated size as the source of truth, in case
+            // it differs from the recorded file-system size.
+            const sdkSize = Number(pinnedObject.size())
+            const size = sdkSize > 0 ? sdkSize : metadata.size
+            pinnedObject.updateMetadata(
+              encodeFileMetadata(size === metadata.size ? metadata : { ...metadata, size }),
+            )
             await retry('pinObject', () => sdk.pinObject(pinnedObject), 3, 1000)
 
             const appKey = sdk.appKey()
@@ -1109,7 +1115,7 @@ export class UploadManager {
             return {
               type: 'success',
               fileId: entry.fileId,
-              size: entry.size,
+              size,
               localObject,
             }
           } catch (e) {
@@ -1154,8 +1160,16 @@ export class UploadManager {
       // commit on the same side of the suspend gate.
       await this.app.db.waitUntilActive()
       const now = Date.now()
+      // Persist the SDK size in the same bump so the local row matches what we
+      // sent up.
+      const sizeByFileId = new Map(
+        results.flatMap((r) => (r.type === 'success' ? [[r.fileId, r.size] as const] : [])),
+      )
       await this.app.files.updateMany(
-        successfulFileIds.map((id) => ({ id, updatedAt: now })),
+        successfulFileIds.map((id) => {
+          const size = sizeByFileId.get(id)
+          return size === undefined ? { id, updatedAt: now } : { id, updatedAt: now, size }
+        }),
         { includeUpdatedAt: true, skipCurrentRecalc: true },
       )
     }


### PR DESCRIPTION
The file size recorded at import comes from the OS picker, which Android frequently reports wrong (a 642 MB video logged as 18.7 MB), and that bad number was both shown in the UI and baked into the metadata pinned to the indexer. The size is now corrected to the real on-disk length right after the copy, and again from the SDK's authoritative size when the upload finishes so the stored metadata is right at the source; existing wrong sizes heal from the object's own size as files sync down.
