### PR TITLE
feat(mobile): show device photo-library thumbnails in galleries during import

### DIFF
--- a/.changeset/os-thumbnail-gallery-preview.md
+++ b/.changeset/os-thumbnail-gallery-preview.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Photo and video thumbnails now appear immediately from your device's photo library while files are still importing, instead of a blank placeholder until each file finishes copying.

--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -67,6 +67,7 @@ export default {
     plugins: [
       'expo-secure-store',
       'expo-sqlite',
+      'expo-image',
       ['./plugins/ios-target-16'],
       './plugins/android-gradle-cache',
       'expo-video',

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -54,6 +54,7 @@
     "expo-dev-client": "55.0.11",
     "expo-document-picker": "55.0.8",
     "expo-file-system": "55.0.10",
+    "expo-image": "55.0.11",
     "expo-image-manipulator": "55.0.9",
     "expo-keep-awake": "55.0.4",
     "expo-linear-gradient": "55.0.8",

--- a/apps/mobile/src/components/FileThumbnail.tsx
+++ b/apps/mobile/src/components/FileThumbnail.tsx
@@ -1,4 +1,5 @@
 import type { FileRecord, ThumbSize } from '@siastorage/core/types'
+import { Image } from 'expo-image'
 import {
   FileAudioIcon,
   FileIcon,
@@ -7,8 +8,8 @@ import {
   ImageIcon,
   PlayIcon,
 } from 'lucide-react-native'
-import { Image, StyleSheet, View } from 'react-native'
-import { useBestThumbnailUri } from '../hooks/useBestThumbnail'
+import { StyleSheet, View } from 'react-native'
+import { useThumbnailUri } from '../hooks/useBestThumbnail'
 import { palette } from '../styles/colors'
 
 export function FileThumbnail({
@@ -22,12 +23,21 @@ export function FileThumbnail({
   iconSize?: number
   iconColor?: string
 }) {
-  const bestThumb = useBestThumbnailUri(file, thumbSize)
+  // Real cached thumb when present, else the device photo-library tile while
+  // importing. onError fires only for the OS fallback, which marks the asset
+  // unrenderable so the cell drops to the icon and stops retrying.
+  const { uri, isOsFallback, onOsError } = useThumbnailUri(file, thumbSize)
 
   if (file.type?.includes('image')) {
-    const thumbUri = bestThumb.data
-    if (thumbUri) {
-      return <Image source={{ uri: thumbUri }} style={styles.thumbnailImage} />
+    if (uri) {
+      return (
+        <Image
+          source={uri}
+          style={styles.thumbnailImage}
+          recyclingKey={file.id}
+          onError={isOsFallback ? onOsError : undefined}
+        />
+      )
     }
     return (
       <View style={styles.thumbnailImage}>
@@ -43,13 +53,14 @@ export function FileThumbnail({
     )
   }
   if (file.type?.includes('video')) {
-    const thumbUri = bestThumb.data
     return (
       <View style={styles.thumbnailImage}>
-        {thumbUri ? (
+        {uri ? (
           <Image
-            source={{ uri: thumbUri }}
+            source={uri}
             style={[{ position: 'absolute' }, styles.thumbnailImage]}
+            recyclingKey={file.id}
+            onError={isOsFallback ? onOsError : undefined}
           />
         ) : null}
         <PlayIcon size={iconSize} color={iconColor} />

--- a/apps/mobile/src/hooks/useBestThumbnail.ts
+++ b/apps/mobile/src/hooks/useBestThumbnail.ts
@@ -3,6 +3,7 @@ import type { FileRecord, ThumbSize } from '@siastorage/core/types'
 import { useEffect } from 'react'
 import useSWR from 'swr'
 import { useFileStatus } from '../lib/file'
+import { getOsThumbnailUri } from '../lib/mediaLibrary'
 import { useDownload } from '../managers/downloader'
 import { app } from '../stores/appService'
 import { useFsFileUri } from '../stores/fs'
@@ -43,4 +44,44 @@ export function useBestThumbnailUri(file?: FileRecord, thumbSize: ThumbSize = 51
   // Get the URI via app.caches.fsFileUri which receives synchronous pushes from
   // copyFileToFs — no async gap between download completing and URI appearing.
   return useFsFileUri(thumbRecord.data ?? undefined)
+}
+
+export type ResolvedThumbnail = {
+  /** URI to render, or null when only the placeholder icon should show. */
+  uri: string | null
+  /** True when `uri` is an OS photo-library tile rather than a real thumb. */
+  isOsFallback: boolean
+  /** Call from the image's `onError` while an OS fallback is showing. */
+  onOsError: () => void
+}
+
+/**
+ * Resolves what a file's thumbnail cell should render: the real cached
+ * `kind='thumb'` when present, otherwise the OS photo-library tile while the
+ * file is still importing and has a source asset (`localId`).
+ *
+ * The OS lookup is gated on the real thumb being absent, so files that
+ * already have a thumbnail never touch the photo library. A failed lookup
+ * (deleted asset, no cached tile) — whether it fails at resolution or at
+ * image load (`onOsError`) — is cached as null and never retried; the
+ * asset's URI is stable, so there is nothing to revalidate.
+ */
+export function useThumbnailUri(file?: FileRecord, thumbSize: ThumbSize = 512): ResolvedThumbnail {
+  const best = useBestThumbnailUri(file, thumbSize)
+  const localId = file?.localId ?? null
+  const osKey = !best.data && localId ? (['os-thumb-uri', localId] as const) : null
+  const { data: osUri, mutate: mutateOs } = useSWR(osKey, () => getOsThumbnailUri(localId), {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+    revalidateIfStale: false,
+  })
+
+  const osFallbackUri = best.data ? null : (osUri ?? null)
+  return {
+    uri: best.data ?? osFallbackUri,
+    isOsFallback: !!osFallbackUri,
+    onOsError: () => {
+      mutateOs(null, { revalidate: false })
+    },
+  }
 }

--- a/apps/mobile/src/lib/mediaLibrary.ts
+++ b/apps/mobile/src/lib/mediaLibrary.ts
@@ -1,6 +1,7 @@
 import type { ResolveLocalIdResult } from '@siastorage/core/services/importScanner'
 import { logger } from '@siastorage/logger'
 import * as MediaLibrary from 'expo-media-library'
+import { Platform } from 'react-native'
 
 const resolved = (uri: string): ResolveLocalIdResult => ({ status: 'resolved', uri })
 const deleted: ResolveLocalIdResult = { status: 'deleted' }
@@ -119,6 +120,38 @@ function resolveAssetDisplay(asset: MediaLibrary.AssetInfo | null): ResolveLocal
   if (!asset) return deleted
   const uri = normalizeUri(asset.localUri) ?? asset.uri ?? null
   return uri ? resolved(uri) : unavailable
+}
+
+/**
+ * Resolve a media-library localId to a URI that expo-image can render as a
+ * thumbnail, without triggering an iCloud download.
+ *
+ * iOS: the PHAsset localIdentifier wrapped as a `ph://` URI. expo-image's
+ * PhotoKit loader serves a cache-sized tile sized to the view — no full
+ * decode, no network. Built synchronously, no native round-trip.
+ *
+ * Android: MediaStore only exposes a renderable URI via getAssetInfoAsync.
+ * The options are ignored on Android (no network occurs), so this is a
+ * local MediaStore query returning a `content://` (or `file://`) URI.
+ *
+ * Returns null when there is no localId or the asset can't be resolved.
+ * Display only — these URIs are not readable bytes; use getMediaLibraryUri
+ * for hashing/copying/upload.
+ */
+export async function getOsThumbnailUri(localId: string | null): Promise<string | null> {
+  if (!localId) return null
+  if (Platform.OS === 'ios') {
+    return localId.startsWith('ph://') ? localId : `ph://${localId}`
+  }
+  try {
+    const asset = await MediaLibrary.getAssetInfoAsync(localId, {
+      shouldDownloadFromNetwork: false,
+    })
+    return asset?.uri ?? null
+  } catch (e) {
+    logger.debug('mediaLibrary', 'os_thumb_uri_failed', { localId, error: e as Error })
+    return null
+  }
 }
 
 /**

--- a/bun.lock
+++ b/bun.lock
@@ -94,6 +94,7 @@
         "expo-dev-client": "55.0.11",
         "expo-document-picker": "55.0.8",
         "expo-file-system": "55.0.10",
+        "expo-image": "55.0.11",
         "expo-image-manipulator": "55.0.9",
         "expo-keep-awake": "55.0.4",
         "expo-linear-gradient": "55.0.8",
@@ -1331,6 +1332,8 @@
     "expo-file-system": ["expo-file-system@55.0.10", "", { "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-ysFdVdUgtfj2ApY0Cn+pBg+yK4xp+SNwcaH8j2B91JJQ4OXJmnyCSmrNZYz7J4mdYVuv2GzxIP+N/IGlHQG3Yw=="],
 
     "expo-font": ["expo-font@55.0.4", "", { "dependencies": { "fontfaceobserver": "^2.1.0" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-ZKeGTFffPygvY5dM/9ATM2p7QDkhsaHopH7wFAWgP2lKzqUMS9B/RxCvw5CaObr9Ro7x9YptyeRKX2HmgmMfrg=="],
+
+    "expo-image": ["expo-image@55.0.11", "", { "dependencies": { "sf-symbols-typescript": "^2.2.0" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*", "react-native-web": "*" }, "optionalPeers": ["react-native-web"] }, "sha512-PVIBYQJW/h1f6Zb9xnoWlgfqyOPVm2yb6eo6ZogaKbvMrhb/Q/fiERbagi4oqmR6IPljWPEpkXXQyFBUh7TjpQ=="],
 
     "expo-image-loader": ["expo-image-loader@55.0.0", "", { "peerDependencies": { "expo": "*" } }, "sha512-NOjp56wDrfuA5aiNAybBIjqIn1IxKeGJ8CECWZncQ/GzjZfyTYAHTCyeApYkdKkMBLHINzI4BbTGSlbCa0fXXQ=="],
 


### PR DESCRIPTION
Freshly imported photos and videos have no thumbnail until they are copied in - for an archive sync this can be a while due to upload backpressure, so gallery cells sit blank with a placeholder icon, which looks confusing and empty. Mirroring how the file viewer already renders the OS asset directly for pending imports, the cell now shows an OS thumb when no app thumb exists yet.