### PR TITLE
feat(mobile): add "Save to device" export option on Android

### DIFF
--- a/.changeset/android-save-to-device.md
+++ b/.changeset/android-save-to-device.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Android now has a "Save to device" option in the file actions menu. It opens the system folder picker so you can choose where the file is saved — the Android share sheet has no built-in save target like the iOS "Save to Files" option.

--- a/apps/mobile/src/components/FileActionsSheet.tsx
+++ b/apps/mobile/src/components/FileActionsSheet.tsx
@@ -7,6 +7,7 @@ import {
   FolderIcon,
   HeartIcon,
   LinkIcon,
+  SaveIcon,
   ShareIcon,
   TagIcon,
   Trash2Icon,
@@ -87,9 +88,10 @@ function SingleFileActionsSheet({
   const status = useFileStatus(file ?? undefined)
   const isOpen = useSheetOpen(sheetName)
 
-  const { handleShareFile, handleShareURL, canShare } = useShareAction({
-    fileId,
-  })
+  const { handleShareFile, handleShareURL, handleSaveToDevice, canShare, canSaveToDevice } =
+    useShareAction({
+      fileId,
+    })
   const favorite = useIsFavorite(isOpen ? fileId : null)
 
   const handleToggleFavorite = useCallback(async () => {
@@ -156,6 +158,15 @@ function SingleFileActionsSheet({
       >
         Export file
       </ActionSheetButton>
+      {canSaveToDevice && (
+        <ActionSheetButton
+          variant="primary"
+          icon={<SaveIcon size={18} />}
+          onPress={handlePressAndClose(handleSaveToDevice)}
+        >
+          Save to device
+        </ActionSheetButton>
+      )}
       {status.data?.canDownload && (
         <ActionSheetButton
           variant="primary"

--- a/apps/mobile/src/hooks/useShareAction.tsx
+++ b/apps/mobile/src/hooks/useShareAction.tsx
@@ -1,8 +1,13 @@
 import Clipboard from '@react-native-clipboard/clipboard'
 import { getErrorMessage } from '@siastorage/core/lib/errors'
+import { extFromMime } from '@siastorage/core/lib/fileTypes'
 import { useFileDetails, useSdk } from '@siastorage/core/stores'
 import { logger } from '@siastorage/logger'
+// oxlint-disable-next-line no-restricted-imports -- pickDirectoryAsync is async and createFile only creates an empty SAF document; the bytes are streamed natively by blob-util below
+import { Directory, type File } from 'expo-file-system'
 import { useCallback } from 'react'
+import { Platform } from 'react-native'
+import ReactNativeBlobUtil from 'react-native-blob-util'
 import Share from 'react-native-share'
 import { useFileStatus } from '../lib/file'
 import { useToast } from '../lib/toastContext'
@@ -51,9 +56,48 @@ export function useShareAction({ fileId }: { fileId: string }) {
     }
   }, [file, status.data?.fileUri])
 
+  // Android's system share sheet has no "Save to Files" target like iOS,
+  // so we surface an explicit save action: the user picks a destination
+  // folder in the system (SAF) picker and we stream the file into it.
+  const handleSaveToDevice = useCallback(async () => {
+    if (!file) return
+    if (!file.type) return
+    if (!status.data?.fileUri) return
+
+    let directory: Directory
+    try {
+      directory = await Directory.pickDirectoryAsync()
+    } catch (e) {
+      if (getErrorMessage(e, '').includes('cancelled')) return
+      logger.error('shareAction', 'save_to_device_pick_failed', { error: e as Error })
+      toast.show('Failed to save file')
+      return
+    }
+
+    let target: File | null = null
+    try {
+      // createFile makes an empty SAF document; blob-util then streams the
+      // bytes into its content URI off the JS thread (expo-file-system's
+      // own copy() is sync JSI and would block on large files).
+      target = directory.createFile(file.name ?? `${file.id}${extFromMime(file.type)}`, file.type)
+      await ReactNativeBlobUtil.MediaCollection.writeToMediafile(target.uri, status.data.fileUri)
+      toast.show('File saved')
+    } catch (e) {
+      try {
+        target?.delete()
+      } catch {
+        // Best effort — at worst an empty document is left behind.
+      }
+      logger.error('shareAction', 'save_to_device_failed', { error: e as Error })
+      toast.show('Failed to save file')
+    }
+  }, [file, status.data?.fileUri, toast])
+
   return {
     canShare: status.data?.canShare,
+    canSaveToDevice: Platform.OS === 'android' && !!status.data?.fileUri,
     handleShareURL,
     handleShareFile,
+    handleSaveToDevice,
   }
 }


### PR DESCRIPTION
Android users had no way to export a file to their device storage: the app's only export path is the system share sheet, which on Android lists only apps — unlike iOS, where the sheet has a built-in "Save to Files" target. The file actions menu now offers "Save to device" on Android (when a local copy exists), which opens the system folder picker and streams the file natively into the chosen destination, handling picker cancellation silently and cleaning up the empty target document if the write fails.