### PR TITLE
fix(mobile): stop the custom indexer field from clearing and lock it to https

### DIFF
--- a/.changeset/indexer-input-https.md
+++ b/.changeset/indexer-input-https.md
@@ -1,0 +1,5 @@
+---
+'@siastorage/mobile': patch
+---
+
+Fix the custom indexer field clearing itself as you typed, and lock the protocol to https. The URL field now shows a fixed `https://` prefix so you only enter the host, and any pasted protocol is stripped.

--- a/apps/mobile/src/components/IndexerSelector.tsx
+++ b/apps/mobile/src/components/IndexerSelector.tsx
@@ -1,5 +1,7 @@
 import { DEFAULT_INDEXER_URL } from '@siastorage/core/config'
+import { LockIcon } from 'lucide-react-native'
 import { Pressable, StyleSheet, Text, TextInput, View } from 'react-native'
+import { stripProtocol } from '../lib/indexerURL'
 import { colors, palette } from '../styles/colors'
 import { InfoCard } from './InfoCard'
 
@@ -9,12 +11,16 @@ type IndexerSelectorProps = {
   hasErrored?: boolean
 }
 
+// The protocol is locked to https, so values here are host-only — compare and
+// select against the default with its protocol stripped to match.
+const DEFAULT_INDEXER_HOST = stripProtocol(DEFAULT_INDEXER_URL)
+
 export function IndexerSelector({ value, onChangeText, hasErrored = false }: IndexerSelectorProps) {
   const trimmedValue = value.trim()
-  const isUsingCustomProvider = trimmedValue !== DEFAULT_INDEXER_URL
+  const isUsingCustomProvider = trimmedValue !== DEFAULT_INDEXER_HOST
 
   const handleSelectDefault = () => {
-    onChangeText(DEFAULT_INDEXER_URL)
+    onChangeText(DEFAULT_INDEXER_HOST)
   }
 
   const handleUseCustom = () => {
@@ -64,16 +70,22 @@ export function IndexerSelector({ value, onChangeText, hasErrored = false }: Ind
         {isUsingCustomProvider ? (
           <View style={styles.inputWrap}>
             <Text style={styles.inputLabel}>Indexer URL</Text>
-            <TextInput
-              style={styles.textInput}
-              placeholder="https://sia.storage"
-              placeholderTextColor={palette.gray[400]}
-              keyboardType="url"
-              autoCorrect={false}
-              autoCapitalize="none"
-              value={value}
-              onChangeText={onChangeText}
-            />
+            <View style={styles.inputRow}>
+              <View style={styles.inputPrefix}>
+                <LockIcon color={palette.gray[400]} size={13} />
+                <Text style={styles.inputPrefixText}>https://</Text>
+              </View>
+              <TextInput
+                style={styles.textInputField}
+                placeholder="your-indexer.com"
+                placeholderTextColor={palette.gray[400]}
+                keyboardType="url"
+                autoCorrect={false}
+                autoCapitalize="none"
+                value={value}
+                onChangeText={onChangeText}
+              />
+            </View>
           </View>
         ) : null}
       </InfoCard>
@@ -131,11 +143,29 @@ const styles = StyleSheet.create({
     fontSize: 13,
     fontWeight: '600',
   },
-  textInput: {
-    color: colors.textPrimary,
+  inputRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
     backgroundColor: palette.gray[950],
     borderRadius: 8,
     paddingHorizontal: 12,
+  },
+  inputPrefix: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingRight: 8,
+    marginRight: 8,
+    borderRightWidth: 1,
+    borderRightColor: palette.gray[800],
+  },
+  inputPrefixText: {
+    color: palette.gray[400],
+    fontSize: 16,
+  },
+  textInputField: {
+    flex: 1,
+    color: colors.textPrimary,
     paddingVertical: 12,
     fontSize: 16,
   },

--- a/apps/mobile/src/hooks/useChangeIndexer.test.tsx
+++ b/apps/mobile/src/hooks/useChangeIndexer.test.tsx
@@ -1,0 +1,74 @@
+import { act, renderHook } from '@testing-library/react-native'
+import { buildIndexerURL, stripProtocol } from '../lib/indexerURL'
+import { useChangeIndexer } from './useChangeIndexer'
+
+jest.mock('@siastorage/core/stores', () => ({
+  useIndexerURL: () => ({ data: '' }),
+}))
+
+jest.mock('../lib/toastContext', () => ({
+  useToast: () => ({ show: jest.fn() }),
+}))
+
+jest.mock('../stores/sdk', () => ({
+  authenticateIndexer: jest.fn(),
+}))
+
+describe('indexer URL helpers', () => {
+  it('strips any leading scheme and whitespace, leaving the host', () => {
+    expect(stripProtocol('  https://example.com  ')).toBe('example.com')
+    expect(stripProtocol('http://example.com')).toBe('example.com')
+    expect(stripProtocol('HTTPS://Example.com')).toBe('Example.com')
+    expect(stripProtocol('ftp://example.com')).toBe('example.com')
+    expect(stripProtocol('example.com')).toBe('example.com')
+    expect(stripProtocol('https:// example.com ')).toBe('example.com')
+    expect(stripProtocol('')).toBe('')
+  })
+
+  it('collapses an accidentally repeated scheme rather than leaking one through', () => {
+    expect(stripProtocol('https://https://example.com')).toBe('example.com')
+    expect(stripProtocol('https://https://https://example.com')).toBe('example.com')
+  })
+
+  it('always builds an https URL from a host', () => {
+    expect(buildIndexerURL('example.com')).toBe('https://example.com')
+    expect(buildIndexerURL('http://example.com')).toBe('https://example.com')
+    expect(buildIndexerURL('ftp://example.com')).toBe('https://example.com')
+    expect(buildIndexerURL('https://example.com:9999/path')).toBe('https://example.com:9999/path')
+  })
+
+  it('returns an empty string when no host has been entered', () => {
+    expect(buildIndexerURL('')).toBe('')
+    expect(buildIndexerURL('   ')).toBe('')
+    expect(buildIndexerURL('https://')).toBe('')
+  })
+})
+
+describe('useChangeIndexer', () => {
+  it('keeps onChangeText stable across renders so typing does not clear the field', () => {
+    // Regression: OnboardingAdvancedIndexerScreen resets the field in a focus
+    // effect keyed on this callback. If the reference changed on every render,
+    // the effect re-ran on each keystroke and wiped the input as the user typed.
+    const { result, rerender } = renderHook(() => useChangeIndexer())
+    const first = result.current.newIndexerInputProps.onChangeText
+
+    act(() => {
+      result.current.newIndexerInputProps.onChangeText('h')
+    })
+    rerender({})
+
+    expect(result.current.newIndexerInputProps.onChangeText).toBe(first)
+    expect(result.current.newIndexerInputProps.value).toBe('h')
+  })
+
+  it('strips a pasted protocol from the input and resolves a full https URL', () => {
+    const { result } = renderHook(() => useChangeIndexer())
+
+    act(() => {
+      result.current.newIndexerInputProps.onChangeText('https://my-indexer.com')
+    })
+
+    expect(result.current.newIndexerInputProps.value).toBe('my-indexer.com')
+    expect(result.current.indexerURL).toBe('https://my-indexer.com')
+  })
+})

--- a/apps/mobile/src/hooks/useChangeIndexer.tsx
+++ b/apps/mobile/src/hooks/useChangeIndexer.tsx
@@ -1,5 +1,6 @@
 import { useIndexerURL } from '@siastorage/core/stores'
 import { useCallback, useState } from 'react'
+import { buildIndexerURL, stripProtocol } from '../lib/indexerURL'
 import { useToast } from '../lib/toastContext'
 import { authenticateIndexer } from '../stores/sdk'
 import { useInputValue } from './useInputValue'
@@ -25,19 +26,31 @@ export type ConnectResult =
 export function useChangeIndexer() {
   const [isWaiting, setIsWaiting] = useState(false)
   const [hasErrored, setHasErrored] = useState(false)
-  const indexerURL = useIndexerURL()
+  const storedIndexerURL = useIndexerURL()
   const toast = useToast()
 
-  const newIndexerInputProps = useInputValue({
-    value: indexerURL.data ?? '',
+  // The input holds only the host — the https:// protocol is locked in the UI.
+  const rawInput = useInputValue({
+    value: stripProtocol(storedIndexerURL.data ?? ''),
   })
+
+  // Strip any protocol the user pastes so the field never duplicates https://.
+  // rawInput.onChangeText is setState, stable across renders, so this wrapper
+  // stays stable too — callers depend on it to reset the field without it
+  // changing identity on every keystroke (which would re-clear as you type).
+  const setInput = rawInput.onChangeText
+  const onChangeText = useCallback((text: string) => setInput(stripProtocol(text)), [setInput])
+  const newIndexerInputProps = { value: rawInput.value, onChangeText }
+
+  // The full https URL to validate, auth against, and persist.
+  const indexerURL = buildIndexerURL(rawInput.value)
 
   /**
    * Attempts connection to the selected indexer.
    * Returns result indicating whether already connected, needs mnemonic, or errored.
    */
   const connectToIndexer = useCallback(async (): Promise<ConnectResult> => {
-    const newUrl = newIndexerInputProps.value
+    const newUrl = indexerURL
     setHasErrored(false)
     setIsWaiting(true)
     const isValid = validateURL(newUrl)
@@ -62,11 +75,12 @@ export function useChangeIndexer() {
       return { status: 'connected' }
     }
     return { status: 'needsMnemonic' }
-  }, [newIndexerInputProps.value, toast])
+  }, [indexerURL, toast])
 
   return {
     newIndexerInputProps,
     connectToIndexer,
+    indexerURL,
     isWaiting,
     hasErrored,
   }

--- a/apps/mobile/src/lib/indexerURL.ts
+++ b/apps/mobile/src/lib/indexerURL.ts
@@ -1,0 +1,22 @@
+// Indexers are always reached over https — indexd assumes https:// for its
+// signature and exposing an indexer over http is unsafe. We lock the protocol
+// in the UI and only ever store/auth an https URL, so the user types just the
+// host (and we strip any protocol they happen to paste in).
+
+/**
+ * Remove any leading scheme(s) (https://, http://, ftp://, …) and surrounding
+ * whitespace, leaving the host. The `+` collapses an accidentally repeated
+ * prefix (e.g. a pasted "https://https://host") rather than leaking one through.
+ */
+export function stripProtocol(value: string) {
+  return value
+    .trim()
+    .replace(/^([a-z][a-z0-9+.-]*:\/\/)+/i, '')
+    .trim()
+}
+
+/** Build the full https URL from a host, or '' when no host has been entered. */
+export function buildIndexerURL(value: string) {
+  const host = stripProtocol(value)
+  return host ? `https://${host}` : ''
+}

--- a/apps/mobile/src/screens/OnboardingAdvancedIndexerScreen.tsx
+++ b/apps/mobile/src/screens/OnboardingAdvancedIndexerScreen.tsx
@@ -1,6 +1,6 @@
 import { useFocusEffect, useNavigation } from '@react-navigation/native'
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack'
-import { ArrowLeftIcon } from 'lucide-react-native'
+import { ArrowLeftIcon, LockIcon } from 'lucide-react-native'
 import { useCallback, useState } from 'react'
 import { Linking, Pressable, StyleSheet, Text, TextInput, View } from 'react-native'
 import { KeyboardAwareScrollView, KeyboardProvider } from 'react-native-keyboard-controller'
@@ -19,14 +19,19 @@ import { colors, palette } from '../styles/colors'
 export default function OnboardingAdvancedIndexerScreen() {
   const nav = useNavigation<NativeStackNavigationProp<OnboardingStackParamList>>()
   const { top, bottom } = useSafeAreaInsets()
-  const { newIndexerInputProps, connectToIndexer, isWaiting, hasErrored } = useChangeIndexer()
+  const { newIndexerInputProps, connectToIndexer, indexerURL, isWaiting, hasErrored } =
+    useChangeIndexer()
   const [isNavigating, setIsNavigating] = useState(false)
 
+  // Reset the field each time the screen is focused so the user starts fresh.
+  // Depend on the stable onChangeText only — depending on the whole props object
+  // re-ran this on every keystroke, clearing the input as the user typed.
+  const resetInput = newIndexerInputProps.onChangeText
   useFocusEffect(
     useCallback(() => {
       setIsNavigating(false)
-      newIndexerInputProps.onChangeText('')
-    }, [newIndexerInputProps]),
+      resetInput('')
+    }, [resetInput]),
   )
 
   const trimmedValue = newIndexerInputProps.value.trim()
@@ -39,7 +44,6 @@ export default function OnboardingAdvancedIndexerScreen() {
   }
 
   const handleContinue = async () => {
-    const indexerURL = newIndexerInputProps.value.trim()
     const result = await connectToIndexer()
     if (result.status === 'connected') {
       setIsNavigating(true)
@@ -125,17 +129,23 @@ export default function OnboardingAdvancedIndexerScreen() {
               ) : null}
 
               <Text style={styles.inputLabel}>Your Indexer URL</Text>
-              <TextInput
-                testID="advanced-indexer-url-input"
-                style={styles.textInput}
-                placeholder="https://"
-                placeholderTextColor={palette.gray[400]}
-                keyboardType="url"
-                autoCorrect={false}
-                autoCapitalize="none"
-                value={newIndexerInputProps.value}
-                onChangeText={newIndexerInputProps.onChangeText}
-              />
+              <View style={styles.inputRow}>
+                <View style={styles.inputPrefix}>
+                  <LockIcon color={palette.gray[400]} size={13} />
+                  <Text style={styles.inputPrefixText}>https://</Text>
+                </View>
+                <TextInput
+                  testID="advanced-indexer-url-input"
+                  style={styles.textInputField}
+                  placeholder="your-indexer.com"
+                  placeholderTextColor={palette.gray[400]}
+                  keyboardType="url"
+                  autoCorrect={false}
+                  autoCapitalize="none"
+                  value={newIndexerInputProps.value}
+                  onChangeText={newIndexerInputProps.onChangeText}
+                />
+              </View>
             </View>
           )}
         </KeyboardAwareScrollView>
@@ -223,11 +233,32 @@ const styles = StyleSheet.create({
     fontWeight: '600',
   },
 
-  textInput: {
-    color: colors.textPrimary,
+  inputRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
     backgroundColor: palette.gray[950],
     borderRadius: 8,
     paddingHorizontal: 12,
+  },
+
+  inputPrefix: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingRight: 8,
+    marginRight: 8,
+    borderRightWidth: 1,
+    borderRightColor: palette.gray[800],
+  },
+
+  inputPrefixText: {
+    color: palette.gray[400],
+    fontSize: 16,
+  },
+
+  textInputField: {
+    flex: 1,
+    color: colors.textPrimary,
     paddingVertical: 12,
     fontSize: 16,
   },

--- a/apps/mobile/src/screens/OnboardingWelcomeScreen.tsx
+++ b/apps/mobile/src/screens/OnboardingWelcomeScreen.tsx
@@ -26,7 +26,7 @@ const contentFadeDurationMs = 600
 export default function OnboardingWelcomeScreen() {
   const nav = useNavigation<NativeStackNavigationProp<OnboardingStackParamList>>()
   const { top, bottom } = useSafeAreaInsets()
-  const { newIndexerInputProps, connectToIndexer, isWaiting } = useChangeIndexer()
+  const { connectToIndexer, indexerURL, isWaiting } = useChangeIndexer()
   const [isNavigating, setIsNavigating] = useState(false)
 
   const gridOpacity = useRef(new Animated.Value(1)).current
@@ -65,7 +65,6 @@ export default function OnboardingWelcomeScreen() {
   }, [gridOpacity, contentOpacity])
 
   const handleSignIn = async () => {
-    const indexerURL = newIndexerInputProps.value.trim()
     const result = await connectToIndexer()
     if (result.status === 'connected') {
       setIsNavigating(true)

--- a/apps/mobile/src/screens/SwitchIndexerScreen.tsx
+++ b/apps/mobile/src/screens/SwitchIndexerScreen.tsx
@@ -12,22 +12,22 @@ import { palette } from '../styles/colors'
 type Props = NativeStackScreenProps<SwitchIndexerStackParamList, 'SwitchIndexerHome'>
 
 export function SwitchIndexerScreen({ navigation }: Props) {
-  const { newIndexerInputProps, connectToIndexer, isWaiting, hasErrored } = useChangeIndexer()
+  const { newIndexerInputProps, connectToIndexer, indexerURL, isWaiting, hasErrored } =
+    useChangeIndexer()
 
-  const trimmedValue = newIndexerInputProps.value.trim()
-  const isInputEmpty = trimmedValue.length === 0
+  const isInputEmpty = newIndexerInputProps.value.trim().length === 0
 
   const handleContinue = useCallback(async () => {
     const result = await connectToIndexer()
     if (result.status === 'connected') {
       // Already registered with this indexer, skip to finished.
-      navigation.navigate('SwitchFinished', { indexerURL: trimmedValue })
+      navigation.navigate('SwitchFinished', { indexerURL })
     } else if (result.status === 'needsMnemonic') {
       // Need mnemonic entry.
-      navigation.navigate('SwitchRecoveryPhrase', { indexerURL: trimmedValue })
+      navigation.navigate('SwitchRecoveryPhrase', { indexerURL })
     }
     // If error, stay on screen, error already shown via toast.
-  }, [connectToIndexer, trimmedValue, navigation])
+  }, [connectToIndexer, indexerURL, navigation])
 
   if (isWaiting) {
     return (


### PR DESCRIPTION
Android users reported the custom indexer URL field wiping itself on every keystroke (a focus effect keyed on an unstable callback re-ran and cleared the input as they typed), making it impossible to enter a custom indexer at all. This fixes the field so typing sticks, and reframes the input around a locked `https://` prefix shown in the UI: users now enter just the host, any scheme they paste is stripped, and the connection always resolves to an `https://` URL — matching indexd's assumption that indexers are reached over https.
