### PR TITLE
fix(mobile,core): exclude thumbnails from status-line file counts

### DIFF
--- a/.changeset/status-line-exclude-thumbnails.md
+++ b/.changeset/status-line-exclude-thumbnails.md
@@ -1,0 +1,6 @@
+---
+'@siastorage/mobile': patch
+'@siastorage/core': patch
+---
+
+Exclude thumbnails from the file count in the status line. "Encrypting N files" / "Uploading N files" / "Importing N files" now count only real files, not the thumbnails generated alongside them. Thumbnails still upload — when only thumbnails remain, the status line keeps showing the state without a number.

--- a/apps/mobile/src/hooks/useAppStatus.tsx
+++ b/apps/mobile/src/hooks/useAppStatus.tsx
@@ -62,26 +62,37 @@ export function useAppStatus(): AppStatus {
   }
 
   if (uploadsProgress.show) {
-    const { packerCount, pendingCount, percentDecimal } = uploadsProgress
+    const { packerCount, packerFileCount, pendingFileCount, percentDecimal } = uploadsProgress
     if (packerCount > 0) {
-      const plural = packerCount === 1 ? 'file' : 'files'
       const isUploading = percentDecimal > 0
       const verb = isUploading ? 'Uploading' : 'Encrypting'
       const hint = isUploading ? (compactUploadPercent(percentDecimal) ?? undefined) : undefined
+      // When real files are in flight, show the count. When only thumbnails
+      // remain (packerFileCount === 0), keep the state but drop the number —
+      // thumbnails still upload, but counting them confuses the user.
+      const plural = packerFileCount === 1 ? 'file' : 'files'
+      const message =
+        packerFileCount > 0 ? `${verb} ${packerFileCount.toLocaleString()} ${plural}` : verb
       return {
         visible: true,
         icon: <CloudUploadIcon size={18} color={palette.blue[400]} />,
-        message: `${verb} ${packerCount.toLocaleString()} ${plural}`,
+        message,
         hint,
         animate: true,
         level: 'info',
       }
     }
-    const plural = pendingCount === 1 ? 'file' : 'files'
+    // Pending branch: same treatment — number excludes thumbnails, but the
+    // state stays visible while only thumbnails are pending.
+    const plural = pendingFileCount === 1 ? 'file' : 'files'
+    const message =
+      pendingFileCount > 0
+        ? `Importing ${pendingFileCount.toLocaleString()} ${plural}`
+        : 'Importing'
     return {
       visible: true,
       icon: <CloudUploadIcon size={18} color={palette.blue[400]} />,
-      message: `Importing ${pendingCount.toLocaleString()} ${plural}`,
+      message,
       animate: true,
       level: 'info',
     }

--- a/apps/mobile/src/stores/files.ts
+++ b/apps/mobile/src/stores/files.ts
@@ -79,7 +79,16 @@ export function useFileCountLocal(params: { localOnly: boolean }, config?: SWRCo
   return useSWR([...key, params], () => getFileCountLocal(params), config)
 }
 
-export async function getFileStatsLocal(params: { localOnly: boolean }) {
+export async function getFileStatsLocal(params: {
+  localOnly: boolean
+  /**
+   * Whether to count thumbnails. Defaults to true so storage/backup surfaces
+   * (the library status sheet, the background-upload work-remaining gate) keep
+   * counting thumbnails as pending work. Pass false for user-facing file
+   * counts that should exclude thumbnails (the status line).
+   */
+  includeThumbnails?: boolean
+}) {
   const currentIndexerURL = await app().settings.getIndexerURL()
   return app().files.queryStats({
     order: 'ASC',
@@ -88,11 +97,14 @@ export async function getFileStatsLocal(params: { localOnly: boolean }) {
       isPinned: !params.localOnly,
     },
     fileExistsLocally: true,
-    includeThumbnails: true,
+    includeThumbnails: params.includeThumbnails ?? true,
   })
 }
 
-export function useFileStatsLocal(params: { localOnly: boolean }, config?: SWRConfiguration) {
+export function useFileStatsLocal(
+  params: { localOnly: boolean; includeThumbnails?: boolean },
+  config?: SWRConfiguration,
+) {
   const key = app().caches.library.key('localStats')
   return useSWR([...key, params], () => getFileStatsLocal(params), config)
 }

--- a/apps/mobile/src/stores/uploads.test.tsx
+++ b/apps/mobile/src/stores/uploads.test.tsx
@@ -1,0 +1,62 @@
+import { AppProvider } from '@siastorage/core/app'
+import { renderHook, waitFor } from '@testing-library/react-native'
+import type { ReactNode } from 'react'
+import { initializeDB, resetDb } from '../db'
+import { app } from './appService'
+import { useUploadProgress } from './uploads'
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <AppProvider value={app()}>{children}</AppProvider>
+}
+
+describe('useUploadProgress', () => {
+  beforeEach(async () => {
+    await initializeDB()
+  })
+
+  afterEach(async () => {
+    app().uploads.clear()
+    await resetDb()
+    jest.clearAllMocks()
+  })
+
+  test('excludes thumbnails from the active file count', async () => {
+    app().uploads.register({
+      id: 'photo',
+      size: 1000,
+      kind: 'file',
+      status: 'uploading',
+      progress: 0,
+    })
+    app().uploads.register({
+      id: 'thumb-512',
+      size: 50,
+      kind: 'thumb',
+      status: 'uploading',
+      progress: 0,
+    })
+    app().uploads.register({
+      id: 'thumb-64',
+      size: 10,
+      kind: 'thumb',
+      status: 'uploading',
+      progress: 0,
+    })
+
+    const { result } = renderHook(() => useUploadProgress(), { wrapper })
+
+    await waitFor(() => expect(result.current.packerCount).toBe(3))
+    // Total stays at 3 (all three still upload); the user-facing count is just
+    // the one real file.
+    expect(result.current.packerFileCount).toBe(1)
+  })
+
+  test('counts an upload with no kind as a real file', async () => {
+    app().uploads.register({ id: 'legacy', size: 1000, status: 'uploading', progress: 0 })
+
+    const { result } = renderHook(() => useUploadProgress(), { wrapper })
+
+    await waitFor(() => expect(result.current.packerCount).toBe(1))
+    expect(result.current.packerFileCount).toBe(1)
+  })
+})

--- a/apps/mobile/src/stores/uploads.ts
+++ b/apps/mobile/src/stores/uploads.ts
@@ -58,28 +58,50 @@ export function useActiveUploads(): UploadState[] {
 
 export function useUploadProgress(): {
   show: boolean
+  /** Total active uploads, including thumbnails — drives whether to show a state. */
   packerCount: number
+  /** Active uploads that are real files (excludes thumbnails) — drives the count. */
+  packerFileCount: number
+  /** Total pending (importing + local-only) including thumbnails — drives show. */
   pendingCount: number
+  /** Pending real files (excludes thumbnails) — drives the count. */
+  pendingFileCount: number
   percentDecimal: number
 } {
   const enabled = useAutoScanUploads()
-  const activeUploads = useActiveUploads()
-  const localOnlyStats = useFileStatsLocal({ localOnly: true })
-  const importingCountQuery = useFileCountImporting()
   const isEnabled = enabled.data ?? false
+  // When auto-scan is off the status line never shows, so skip the DB queries
+  // entirely rather than fetching counts we'll discard.
+  const pausedWhenDisabled = { isPaused: () => !isEnabled }
+  const activeUploads = useActiveUploads()
+  // Total local-only count includes thumbnails (keeps the indicator visible
+  // while only thumbnails remain); the files-only count drives the number.
+  const localOnlyStats = useFileStatsLocal({ localOnly: true }, pausedWhenDisabled)
+  const localOnlyFileStats = useFileStatsLocal(
+    { localOnly: true, includeThumbnails: false },
+    pausedWhenDisabled,
+  )
+  const importingCountQuery = useFileCountImporting(pausedWhenDisabled)
   const packerUploads = activeUploads.filter((u) => ACTIVE_STATUSES.includes(u.status))
   const packerCount = packerUploads.length
+  const packerFileCount = packerUploads.filter((u) => u.kind !== 'thumb').length
   const packerTotalBytes = packerUploads.reduce((s, u) => s + u.size, 0)
   const packerWeightedProgress = packerUploads.reduce((s, u) => s + u.progress * u.size, 0)
   const percentDecimal = packerTotalBytes > 0 ? packerWeightedProgress / packerTotalBytes : 0
+  // importingCount (empty-hash records) is already files-only — thumbnails are
+  // generated with their hash, so they never sit in the importing state.
   const importingCount = importingCountQuery.data ?? 0
   const localOnlyCount = localOnlyStats.data?.count ?? 0
+  const localOnlyFileCount = localOnlyFileStats.data?.count ?? 0
   const pendingCount = importingCount + localOnlyCount
+  const pendingFileCount = importingCount + localOnlyFileCount
 
   return {
     show: isEnabled && (packerCount > 0 || pendingCount > 0),
     packerCount,
+    packerFileCount,
     pendingCount,
+    pendingFileCount,
     percentDecimal,
   }
 }

--- a/packages/core/src/app/namespaces/uploads.ts
+++ b/packages/core/src/app/namespaces/uploads.ts
@@ -46,8 +46,8 @@ export function buildUploadsNamespace(caches: AppCaches): AppService['uploads'] 
     },
     registerMany: (entries) => {
       const next = { ...state.uploads }
-      for (const { id, size } of entries) {
-        next[id] = { id, size, status: 'queued', progress: 0 }
+      for (const { id, size, kind } of entries) {
+        next[id] = { id, size, kind, status: 'queued', progress: 0 }
       }
       state = { uploads: next }
       caches.uploads.invalidateAll()

--- a/packages/core/src/app/service.ts
+++ b/packages/core/src/app/service.ts
@@ -12,7 +12,7 @@ import type {
 } from '../db/operations'
 import type { LocalObject, LocalObjectRef } from '../encoding/localObject'
 import type { SyncUpCursor } from '../services/syncUpMetadata'
-import type { FileMetadata, FileRecord, FileRecordRow, ThumbSize } from '../types/files'
+import type { FileKind, FileMetadata, FileRecord, FileRecordRow, ThumbSize } from '../types/files'
 import type {
   ConnectionState,
   DownloadEntry,
@@ -717,7 +717,7 @@ export interface AppService {
     /** Removes all upload entries. */
     clear(): void
     /** Registers multiple upload entries as queued. */
-    registerMany(entries: Array<{ id: string; size: number }>): void
+    registerMany(entries: Array<{ id: string; size: number; kind?: FileKind }>): void
     /** Sets upload status, clearing any previous error. No-op if entry does not exist. */
     setStatus(id: string, status: UploadStatus): void
     /** Marks an upload as failed with an error message. */

--- a/packages/core/src/app/stores.ts
+++ b/packages/core/src/app/stores.ts
@@ -1,3 +1,5 @@
+import type { FileKind } from '../types/files'
+
 /** Lifecycle stage of the sync gate overlay shown during initial catch-up. */
 export type SyncGateStatus = 'idle' | 'pending' | 'active' | 'dismissed'
 
@@ -24,6 +26,13 @@ export type UploadStatus = 'queued' | 'packing' | 'packed' | 'uploading' | 'done
 export type UploadEntry = {
   id: string
   name?: string
+  /**
+   * Record kind: 'file' for a real user file, 'thumb' for a generated
+   * thumbnail. Thumbnails are still uploaded, but they're excluded from
+   * user-facing file counts (the status line) since counting them inflates
+   * the number in a way that confuses users.
+   */
+  kind?: FileKind
   /** File size in bytes. */
   size: number
   /** Upload progress from 0 to 1. */

--- a/packages/core/src/services/uploader.ts
+++ b/packages/core/src/services/uploader.ts
@@ -206,7 +206,9 @@ export class UploadManager {
 
   /** Add files to the explicit queue and wake the loop. */
   enqueue(files: FileEntry[]): void {
-    this.app.uploads.registerMany(files.map((f) => ({ id: f.fileId, size: f.size })))
+    this.app.uploads.registerMany(
+      files.map((f) => ({ id: f.fileId, size: f.size, kind: f.file.kind })),
+    )
     this.explicitQueue.push(...files)
     this.wake()
   }
@@ -490,7 +492,9 @@ export class UploadManager {
    * async loop. Allows deterministic control over file order and timing.
    */
   async __testProcessFiles(files: FileEntry[]): Promise<void> {
-    this.app.uploads.registerMany(files.map((f) => ({ id: f.fileId, size: f.size })))
+    this.app.uploads.registerMany(
+      files.map((f) => ({ id: f.fileId, size: f.size, kind: f.file.kind })),
+    )
     for (const file of files) {
       await this.processEntry(file)
     }
@@ -921,7 +925,9 @@ export class UploadManager {
       }
 
       if (newEntries.length > 0) {
-        this.app.uploads.registerMany(newEntries.map((e) => ({ id: e.fileId, size: e.size })))
+        this.app.uploads.registerMany(
+          newEntries.map((e) => ({ id: e.fileId, size: e.size, kind: e.file.kind })),
+        )
         this.polledFiles.push(...newEntries)
       }
 


### PR DESCRIPTION
The status line counted auto-generated thumbnails as if they were files, so backing up a single photo could read "Uploading 3 files" and leave users confused about what was actually happening. It now counts only real files in the "Encrypting/Uploading/Importing N files" message; thumbnails still upload, but when they're all that's left the status keeps showing activity without a misleading count.
