### PR TITLE
fix(mobile): scroll PDFs vertically on Android in the file viewer

### DIFF
--- a/.changeset/pdf-scroll-android.md
+++ b/.changeset/pdf-scroll-android.md
@@ -1,0 +1,5 @@
+---
+'@siastorage/mobile': patch
+---
+
+Fix PDF scrolling on Android. PDF documents can now be scrolled vertically in the file viewer; previously the swipe-to-navigate gesture prevented scrolling.

--- a/apps/mobile/src/components/MediaConsumers/PDFViewer.tsx
+++ b/apps/mobile/src/components/MediaConsumers/PDFViewer.tsx
@@ -1,4 +1,4 @@
-import { StyleSheet, useWindowDimensions, View, type ViewStyle } from 'react-native'
+import { Platform, StyleSheet, useWindowDimensions, View, type ViewStyle } from 'react-native'
 import { Gesture, GestureDetector } from 'react-native-gesture-handler'
 import Pdf from 'react-native-pdf'
 import Animated, { runOnJS } from 'react-native-reanimated'
@@ -37,17 +37,30 @@ export function PDFViewer({ source, style, onSwipeLeft, onSwipeRight }: Props) {
     .activeOffsetX(-15)
     .failOffsetY([-15, 15])
 
+  const pdf = (
+    <Pdf
+      fitPolicy={2}
+      maxScale={8}
+      minScale={1}
+      source={{ uri: source }}
+      style={styles.pdf}
+      trustAllCerts={false}
+      enableAntialiasing
+    />
+  )
+
   return (
     <View style={[styles.container, style]}>
-      <Pdf
-        fitPolicy={2}
-        maxScale={8}
-        minScale={1}
-        source={{ uri: source }}
-        style={styles.pdf}
-        trustAllCerts={false}
-        enableAntialiasing
-      />
+      {/* Android: wrap the native PDF view in Gesture.Native() so it can claim
+          vertical scroll/pan touches alongside the carousel's horizontal pan
+          gesture. Without it, RNGH swallows the touches at the root and the PDF
+          won't scroll. Not needed on iOS, where native scroll cooperation works
+          out of the box. */}
+      {Platform.OS === 'android' ? (
+        <GestureDetector gesture={Gesture.Native()}>{pdf}</GestureDetector>
+      ) : (
+        pdf
+      )}
       {/* Left edge swipe zone */}
       <GestureDetector gesture={leftEdgeGesture}>
         <Animated.View style={[styles.edgeZone, styles.leftEdge]} />


### PR DESCRIPTION
On Android, PDFs opened in the file viewer couldn't be scrolled because the surrounding carousel's gesture handler swallowed the touches at the root before the native PDF view ever saw them — iOS was unaffected. The fix wraps the native PDF view in a `Gesture.Native()` detector on Android only, letting it claim vertical scroll touches alongside the carousel's horizontal swipe-to-navigate gesture.