### PR TITLE
feat(mobile,core,cli): periodically prune unreferenced slabs to reclaim deleted-file storage

### DIFF
--- a/.changeset/auto-prune-slabs.md
+++ b/.changeset/auto-prune-slabs.md
@@ -1,0 +1,7 @@
+---
+'@siastorage/mobile': patch
+'@siastorage/core': patch
+'@siastorage/cli': patch
+---
+
+Periodically reclaim account storage left behind by deleted files. A background task calls the indexer's prune endpoint about once a day (and on app start/foreground, throttled).

--- a/apps/cli/src/daemon/scheduler.ts
+++ b/apps/cli/src/daemon/scheduler.ts
@@ -1,5 +1,6 @@
 import {
   DB_OPTIMIZE_INTERVAL,
+  PRUNE_SLABS_INTERVAL,
   SYNC_EVENTS_INTERVAL,
   SYNC_UP_METADATA_BATCH_SIZE,
   SYNC_UP_METADATA_CONCURRENCY,
@@ -9,6 +10,7 @@ import {
 } from '@siastorage/core/config'
 import { ServiceScheduler } from '@siastorage/core/lib/serviceInterval'
 import { LOG_ROTATION_INTERVAL, runLogRotation } from '@siastorage/core/services'
+import { runPruneSlabs } from '@siastorage/core/services/pruneSlabs'
 import { syncDownEventsBatch } from '@siastorage/core/services/syncDownEvents'
 import { syncUpMetadataBatch } from '@siastorage/core/services/syncUpMetadata'
 import { ThumbnailScanner } from '@siastorage/core/services/thumbnailScanner'
@@ -62,6 +64,11 @@ export function initializeScheduler(app: CliApp): { scheduler: ServiceScheduler 
       name: 'trashAutoPurge',
       interval: TRASH_AUTO_PURGE_INTERVAL,
       worker: () => app.service.files.autoPurgeWithCleanup(),
+    },
+    {
+      name: 'pruneSlabs',
+      interval: PRUNE_SLABS_INTERVAL,
+      worker: whenConnected(() => runPruneSlabs(app.service, app.internal)),
     },
     {
       name: 'logRotation',

--- a/apps/integration/test/adapters/upload.ts
+++ b/apps/integration/test/adapters/upload.ts
@@ -20,6 +20,7 @@ export function buildTestSdkAdapter(sdk: MockSdk, appKey: AppKeyRef): SdkAdapter
     downloadByObjectId: (id) => sdk.downloadByObjectId(id),
     hosts: async () => [],
     account: async () => ({ publicKey: '', storage: BigInt(0), app: null }) as any,
+    pruneSlabs: () => sdk.pruneSlabs(),
   }
 }
 

--- a/apps/integration/test/prune-slabs.test.ts
+++ b/apps/integration/test/prune-slabs.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Auto-prune: a background service periodically calls the indexer's prune
+ * endpoint to reclaim storage left behind by deleted files. It doesn't try to
+ * detect reclaimable storage first — the indexer does that as prune's first
+ * step — so the service just calls prune when connected.
+ */
+
+import { runPruneSlabs } from '@siastorage/core/services/pruneSlabs'
+import { createEmptyIndexerStorage } from '@siastorage/sdk-mock'
+import { createTestApp, type TestApp } from './app'
+
+describe('Prune slabs', () => {
+  let app: TestApp
+
+  beforeEach(async () => {
+    app = createTestApp(createEmptyIndexerStorage())
+    await app.start()
+  })
+
+  afterEach(async () => {
+    await app.shutdown()
+  })
+
+  it('calls the prune endpoint when connected', async () => {
+    await runPruneSlabs(app.app, app.internal)
+    expect(app.sdk.pruneSlabsCallCount).toBe(1)
+  })
+
+  it('does not call prune when disconnected', async () => {
+    app.setConnected(false)
+    await runPruneSlabs(app.app, app.internal)
+    expect(app.sdk.pruneSlabsCallCount).toBe(0)
+  })
+})

--- a/apps/mobile/src/adapters/sdk.ts
+++ b/apps/mobile/src/adapters/sdk.ts
@@ -107,4 +107,8 @@ export class MobileSdkAdapter implements SdkAdapter {
   async account(): Promise<Account> {
     return this.sdk.account() as Promise<Account>
   }
+
+  async pruneSlabs(): Promise<void> {
+    await this.sdk.pruneSlabs()
+  }
 }

--- a/apps/mobile/src/managers/app.ts
+++ b/apps/mobile/src/managers/app.ts
@@ -22,6 +22,7 @@ import { initAutoKeepAwake } from './autoKeepAwake'
 import { initImportScanner } from './importScanner'
 import { initLogRotation } from './logRotation'
 import { initPerfMonitor } from './perfMonitor'
+import { maybePruneSlabs, resetPruneThrottle } from './pruneSlabs'
 import { initSuspensionManager, teardownSuspensionManager } from './suspension'
 import { initSyncDownEvents, triggerSyncDownEvents } from './syncDownEvents'
 import { initSyncNewPhotos } from './syncNewPhotos'
@@ -135,6 +136,7 @@ export async function initApp(): Promise<void> {
         initBackgroundTasks()
         initSyncUpMetadata()
         initThumbnailScanner()
+        void maybePruneSlabs()
       },
     })
   }
@@ -223,6 +225,7 @@ async function clearAppState({ keepAuth }: { keepAuth: boolean }) {
 
   // Reset cursor caches.
   await resetPhotosArchiveCursor()
+  await resetPruneThrottle()
 
   // Pin every SWR slot to `undefined` for the reset window so useShowSplash
   // holds via its `hasOnboarded === undefined` clause — without this, sign-out

--- a/apps/mobile/src/managers/pruneSlabs.ts
+++ b/apps/mobile/src/managers/pruneSlabs.ts
@@ -1,0 +1,22 @@
+import { PRUNE_SLABS_INTERVAL } from '@siastorage/core/config'
+import { runPruneSlabs } from '@siastorage/core/services/pruneSlabs'
+import { app, internal } from '../stores/appService'
+
+/**
+ * Prune unreferenced slabs on app start and foreground, at most once per
+ * interval. The last-run time is persisted, so the throttle holds across app
+ * restarts. No standalone timer — the app is never foregrounded long enough to
+ * need one.
+ */
+export async function maybePruneSlabs(): Promise<void> {
+  if (!app().connection.getState().isConnected) return
+  const lastRun = await app().settings.getPruneSlabsLastRun()
+  if (Date.now() - lastRun < PRUNE_SLABS_INTERVAL) return
+  await app().settings.setPruneSlabsLastRun(Date.now())
+  await runPruneSlabs(app(), internal())
+}
+
+/** Clears the throttle so the next start/foreground prunes again (sign-out/reset). */
+export async function resetPruneThrottle(): Promise<void> {
+  await app().settings.setPruneSlabsLastRun(0)
+}

--- a/apps/mobile/src/managers/suspension.ts
+++ b/apps/mobile/src/managers/suspension.ts
@@ -29,6 +29,7 @@ import { resumeLogger } from '../stores/logs'
 import { cancelFsEvictionScanner, runFsEvictionScanner } from './fsEvictionScanner'
 import { cancelFsOrphanScanner } from './fsOrphanScanner'
 import { addLifecycleListener, getLifecycle } from './lifecycle'
+import { maybePruneSlabs } from './pruneSlabs'
 import { isArchiveWalkActive, pauseArchiveSync, resumeArchiveSync } from './syncPhotosArchive'
 import { getUploadManager } from './uploader'
 
@@ -100,6 +101,9 @@ const manager = createSuspensionManager(
         // Eviction's frequency gate short-circuits if it ran recently, so a
         // quick app-switch is cheap; a long suspension triggers a real pass.
         void runFsEvictionScanner()
+        // Prune unreferenced slabs on foreground (throttled to once per
+        // interval, no-op server-side when there's nothing to reclaim).
+        void maybePruneSlabs()
       },
     },
   },

--- a/packages/core/src/adapters/sdk.ts
+++ b/packages/core/src/adapters/sdk.ts
@@ -168,4 +168,10 @@ export interface SdkAdapter {
   downloadByObjectId(objectId: string): Promise<ArrayBuffer>
   hosts(): Promise<Host[]>
   account(): Promise<Account>
+  /**
+   * Unpins slabs no longer referenced by any object on the account,
+   * reclaiming the storage held by deleted objects. Blocks on a single
+   * indexer round-trip and resolves with no data on success.
+   */
+  pruneSlabs(): Promise<void>
 }

--- a/packages/core/src/app/namespaces/settings.ts
+++ b/packages/core/src/app/namespaces/settings.ts
@@ -93,6 +93,8 @@ export function buildSettingsNamespace(
     setFsEvictionLastRun: (v) => setNum('fsEvictionLastRun', v),
     getFsOrphanLastRun: () => getNum('fsOrphanLastRun', 0),
     setFsOrphanLastRun: (v) => setNum('fsOrphanLastRun', v),
+    getPruneSlabsLastRun: () => getNum('pruneSlabsLastRun', 0),
+    setPruneSlabsLastRun: (v) => setNum('pruneSlabsLastRun', v),
     getViewSettings: async () => {
       const raw = await storage.getItem('viewSettings')
       if (!raw) return {}

--- a/packages/core/src/app/service.ts
+++ b/packages/core/src/app/service.ts
@@ -664,6 +664,10 @@ export interface AppService {
     getFsOrphanLastRun(): Promise<number>
     /** Sets the timestamp of the last orphan cleanup run. */
     setFsOrphanLastRun(value: number): Promise<void>
+    /** Returns the timestamp of the last slab-prune run. */
+    getPruneSlabsLastRun(): Promise<number>
+    /** Sets the timestamp of the last slab-prune run. */
+    setPruneSlabsLastRun(value: number): Promise<void>
     /** Returns the persisted view settings (sort, layout, etc.). */
     getViewSettings(): Promise<Record<string, unknown>>
     /** Sets the view settings. */

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -76,6 +76,9 @@ export const SHARED_FILE_AUTO_DOWNLOAD_THRESHOLD = 5 * 1024 * 1024 // 5 MB
 export const TRASH_AUTO_PURGE_AGE = daysInMs(30) // 30 days
 // How often to check for trashed files to auto-purge.
 export const TRASH_AUTO_PURGE_INTERVAL = minutesInMs(60) // 60 minutes
+// How often to prune unreferenced slabs. Pruning is a slow indexer operation,
+// and even a no-op call runs a scan server-side, so keep the cadence slow.
+export const PRUNE_SLABS_INTERVAL = daysInMs(1)
 // SQLite PRAGMA optimize interval.
 export const DB_OPTIMIZE_INTERVAL = secondsInMs(60) // 60 seconds
 // Performance monitor logging interval.

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -14,6 +14,7 @@ export {
 } from './importScanner'
 export { LOG_ROTATION_INTERVAL, runLogRotation } from './logRotation'
 export { type OrphanScannerResult, runOrphanScanner } from './orphanScanner'
+export { runPruneSlabs } from './pruneSlabs'
 export { type SuspensionAdapters, createSuspensionManager } from './suspension'
 export { syncDownEventsBatch } from './syncDownEvents'
 export { diffFileMetadata, syncUpMetadataBatch } from './syncUpMetadata'

--- a/packages/core/src/services/pruneSlabs.ts
+++ b/packages/core/src/services/pruneSlabs.ts
@@ -1,0 +1,25 @@
+import { logger } from '@siastorage/logger'
+import type { AppService, AppServiceInternal } from '../app/service'
+
+/**
+ * Ask the indexer to unpin slabs no longer referenced by any object, reclaiming
+ * the storage that deleted files leave behind.
+ *
+ * We always call prune rather than checking first whether anything is
+ * reclaimable: the indexer runs that check as prune's first step and returns
+ * fast when there's nothing to do. A client-side size comparison can't work
+ * anyway — the account reports slab capacity, not file bytes — so callers just
+ * keep the cadence slow.
+ */
+export async function runPruneSlabs(app: AppService, internal: AppServiceInternal): Promise<void> {
+  if (!app.connection.getState().isConnected) {
+    logger.debug('pruneSlabs', 'skipped', { reason: 'not_connected' })
+    return
+  }
+  try {
+    await internal.requireSdk().pruneSlabs()
+    logger.info('pruneSlabs', 'pruned')
+  } catch (e) {
+    logger.warn('pruneSlabs', 'prune_failed', { error: e as Error })
+  }
+}

--- a/packages/node-adapters/src/sdk.ts
+++ b/packages/node-adapters/src/sdk.ts
@@ -364,5 +364,9 @@ export function createNodeSdkAdapter(sdk: Sdk): SdkAdapter {
         lastUsed: info.lastUsed,
       }
     },
+
+    async pruneSlabs(): Promise<void> {
+      await sdk.pruneSlabs()
+    },
   }
 }

--- a/packages/sdk-mock/src/index.ts
+++ b/packages/sdk-mock/src/index.ts
@@ -202,6 +202,7 @@ class MockPacker implements PackedUploadRef {
 export class MockSdk implements SdkAdapter {
   private storage: MockIndexerStorage
   private connected = true
+  pruneSlabsCallCount = 0
 
   constructor(storage?: MockIndexerStorage) {
     this.storage = storage ?? createEmptyIndexerStorage()
@@ -368,6 +369,11 @@ export class MockSdk implements SdkAdapter {
       },
       lastUsed: new Date(),
     }
+  }
+
+  async pruneSlabs(): Promise<void> {
+    if (!this.connected) throw new Error('Network unavailable')
+    this.pruneSlabsCallCount++
   }
 
   injectMetadataChange(objectId: string, changes: Partial<FileMetadata>): void {


### PR DESCRIPTION
Deleting a file removes its object from the indexer but leaves the file's slabs pinned to the account, so the storage it occupied is never reclaimed.This adds a background service that periodically calls `pruneSlabs`.

https://github.com/SiaFoundation/sia-storage-app/issues/764