### PR TITLE
feat(mobile): detect new photos by library insertion

### DIFF
--- a/.changeset/new-photos-insertion-detection.md
+++ b/.changeset/new-photos-insertion-detection.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Automatic photo sync now detects new photos by what the system actually added to your library instead of inferring from photo dates. Photos that arrive with an old date — saved, AirDropped, or synced from another device or iCloud — and photos with no capture date on Android are no longer missed.

--- a/apps/mobile/.gitignore
+++ b/apps/mobile/.gitignore
@@ -8,6 +8,9 @@ expo-env.d.ts
 /android/
 /ios/
 .kotlin/
+# Gradle build output. Git already ignores it via the root .gitignore; repeated
+# here so oxfmt — which reads only this directory's .gitignore — skips it too.
+modules/*/android/build/
 
 # Build cache
 .build-cache/

--- a/apps/mobile/jest.config.cjs
+++ b/apps/mobile/jest.config.cjs
@@ -24,6 +24,7 @@ module.exports = {
     '^expo-keep-awake$': '<rootDir>/test/mocks/expo-keep-awake.ts',
     '^react-native-sia$': '<rootDir>/test/mocks/react-native-sia.ts',
     '^thumbnailer$': '<rootDir>/test/mocks/thumbnailer.ts',
+    '^media-observer$': '<rootDir>/test/mocks/media-observer.ts',
     '^\\.\\./lib/sharedContainer$': '<rootDir>/test/mocks/sharedContainer.ts',
     '^\\.\\./\\.\\./lib/sharedContainer$': '<rootDir>/test/mocks/sharedContainer.ts',
   },

--- a/apps/mobile/modules/media-observer/android/build.gradle
+++ b/apps/mobile/modules/media-observer/android/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+  id 'com.android.library'
+  id 'expo-module-gradle-plugin'
+}
+
+group = 'expo.modules.mediaobserver'
+version = '0.0.0'
+
+android {
+  namespace "expo.modules.mediaobserver"
+  defaultConfig {
+    versionCode 1
+    versionName "0.0.0"
+  }
+}

--- a/apps/mobile/modules/media-observer/android/src/main/AndroidManifest.xml
+++ b/apps/mobile/modules/media-observer/android/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/apps/mobile/modules/media-observer/android/src/main/java/expo/modules/mediaobserver/MediaObserverModule.kt
+++ b/apps/mobile/modules/media-observer/android/src/main/java/expo/modules/mediaobserver/MediaObserverModule.kt
@@ -1,0 +1,104 @@
+package expo.modules.mediaobserver
+
+import android.content.Context
+import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
+import expo.modules.kotlin.exception.CodedException
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+
+// The photo library's insertion cursor, via MediaStore.
+//
+// `changesSince` returns the ids of images/videos added since a persisted
+// cursor, so additions made while the app was not running are still reported. On
+// API 30+ the cursor is MediaStore's monotonic generation — GENERATION_ADDED
+// advances only on insert, so a metadata edit is not reported; below 30 it falls
+// back to DATE_ADDED. Only the primary shared volume is observed (a removable SD
+// card has its own generation counter), which covers the camera roll.
+class MediaObserverModule : Module() {
+  override fun definition() = ModuleDefinition {
+    Name("MediaObserver")
+
+    AsyncFunction("currentCursor") { currentCursor() }
+
+    AsyncFunction("changesSince") { cursor: String? -> changesSince(cursor) }
+  }
+
+  private fun currentCursor(): String =
+    if (hasGeneration()) "$VERSION:gen:${MediaStore.getGeneration(context(), VOLUME)}"
+    else "$VERSION:date:${System.currentTimeMillis() / 1000}"
+
+  private fun changesSince(cursor: String?): Map<String, Any> {
+    val parsed = parse(cursor) ?: return anchor()
+    val (mode, since) = parsed
+    // A cursor minted in the other mode (OS upgraded across API 30) isn't
+    // comparable; re-anchor.
+    if ((mode == "gen") != hasGeneration()) return anchor()
+
+    return try {
+      if (mode == "gen") {
+        // Read the authoritative "now" before querying so a row inserted mid-query
+        // is reported again next tick rather than skipped.
+        val now = MediaStore.getGeneration(context(), VOLUME)
+        // A stored cursor above the current generation means the counter reset
+        // (MediaProvider storage cleared); re-anchor rather than hide additions.
+        if (since > now) return anchor()
+        result(idsAddedSince("${MediaStore.MediaColumns.GENERATION_ADDED} > ?", since), "$VERSION:gen:$now")
+      } else {
+        val now = System.currentTimeMillis() / 1000
+        // A stored cursor far in the future (clock skew) would hide later
+        // additions until the clock caught up; re-anchor instead.
+        if (since > now + DATE_SLOP) return anchor()
+        result(idsAddedSince("${MediaStore.MediaColumns.DATE_ADDED} >= ?", since), "$VERSION:date:$now")
+      }
+    } catch (_: SecurityException) {
+      throw CodedException("media-observer: media permission denied")
+    }
+  }
+
+  private fun idsAddedSince(predicate: String, since: Long): List<String> {
+    val uri = MediaStore.Files.getContentUri(if (hasGeneration()) VOLUME else "external")
+    val ids = ArrayList<String>()
+    context().contentResolver
+      .query(uri, arrayOf(MediaStore.MediaColumns._ID), "$predicate AND $MEDIA_TYPE", arrayOf(since.toString()), null)
+      ?.use { c ->
+        val col = c.getColumnIndexOrThrow(MediaStore.MediaColumns._ID)
+        while (c.moveToNext()) ids.add(c.getLong(col).toString())
+      }
+    return ids
+  }
+
+  private fun result(ids: List<String>, cursor: String): Map<String, Any> =
+    // A delta this large is cheaper to reconcile via the archive than to marshal.
+    if (ids.size > MAX_INSERTS) anchor()
+    else mapOf("inserted" to ids.distinct(), "cursor" to cursor)
+
+  private fun anchor(): Map<String, Any> = mapOf("inserted" to emptyList<String>(), "cursor" to currentCursor())
+
+  private fun parse(cursor: String?): Pair<String, Long>? {
+    val parts = cursor?.split(":", limit = 3) ?: return null
+    if (parts.size != 3 || parts[0] != VERSION || (parts[1] != "gen" && parts[1] != "date")) return null
+    return parts[1] to (parts[2].toLongOrNull() ?: return null)
+  }
+
+  private fun hasGeneration(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
+
+  private fun context(): Context =
+    appContext.reactContext ?: throw CodedException("media-observer: react context unavailable")
+
+  companion object {
+    private const val VERSION = "v1"
+    private const val MAX_INSERTS = 10_000
+    private const val DATE_SLOP = 300L
+
+    // VOLUME_EXTERNAL_PRIMARY is API 29+; used only on the generation path (30+).
+    private val VOLUME: String
+      get() = MediaStore.VOLUME_EXTERNAL_PRIMARY
+
+    // Images (1) and videos (3) only — the media the photo sync ingests.
+    private val MEDIA_TYPE =
+      "${MediaStore.Files.FileColumns.MEDIA_TYPE} IN " +
+        "(${MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE}, ${MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO})"
+  }
+}

--- a/apps/mobile/modules/media-observer/expo-module.config.json
+++ b/apps/mobile/modules/media-observer/expo-module.config.json
@@ -1,0 +1,9 @@
+{
+  "platforms": ["apple", "android"],
+  "apple": {
+    "modules": ["MediaObserverModule"]
+  },
+  "android": {
+    "modules": ["expo.modules.mediaobserver.MediaObserverModule"]
+  }
+}

--- a/apps/mobile/modules/media-observer/index.ts
+++ b/apps/mobile/modules/media-observer/index.ts
@@ -1,0 +1,48 @@
+import { requireOptionalNativeModule } from 'expo'
+
+/**
+ * media-observer — the photo library's insertion cursor.
+ *
+ * `changesSince(cursor)` returns the asset ids added to the library since the
+ * cursor, plus the cursor to use next time. The cursor is an opaque bookmark
+ * into the platform's change history (iOS PhotoKit change token, Android
+ * MediaStore generation), so additions made while the app was not running are
+ * still reported on the next call — a live change observer cannot do that.
+ *
+ * Detection is by what the system actually added, so an old-dated photo just
+ * AirDropped/iCloud-synced (iOS) or a file with no capture date (Android) is
+ * reported, while a metadata change to an existing photo is not. Ids match
+ * expo-media-library's `Asset.id`.
+ */
+export type MediaChanges = {
+  /** Asset ids added since the cursor. */
+  inserted: string[]
+  /** Opaque cursor to persist and pass to the next call. */
+  cursor: string
+}
+
+type NativeModule = {
+  currentCursor(): Promise<string>
+  changesSince(cursor: string | null): Promise<MediaChanges>
+}
+
+const native = requireOptionalNativeModule<NativeModule>('MediaObserver')
+
+/** A cursor anchored at the current library state, reporting no additions. */
+export function currentCursor(): Promise<string> {
+  return nativeModule().currentCursor()
+}
+
+/**
+ * Asset ids added since `cursor`, plus the next cursor. A cursor that can't be
+ * honored (first run, expired, too large) reports no additions and returns a
+ * fresh cursor anchored at now — the gap is the archive sync's job.
+ */
+export function changesSince(cursor: string | null): Promise<MediaChanges> {
+  return nativeModule().changesSince(cursor)
+}
+
+function nativeModule(): NativeModule {
+  if (native) return native
+  throw new Error('media-observer: native module missing — run expo prebuild --clean.')
+}

--- a/apps/mobile/modules/media-observer/ios/MediaObserver.podspec
+++ b/apps/mobile/modules/media-observer/ios/MediaObserver.podspec
@@ -1,0 +1,29 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name           = 'MediaObserver'
+  s.version        = package['version']
+  s.summary        = 'Durable, insertion-keyed change cursor over the photo library.'
+  s.description    = 'Local Expo module exposing PhotoKit change history (fetchPersistentChanges) as a durable cursor of inserted asset ids, so the new-photos feature detects additions by what was actually added rather than by timestamp heuristics.'
+  s.license        = { :type => 'MIT' }
+  s.author         = { 'sia-storage-app' => 'noreply@sia.tech' }
+  s.homepage       = 'https://github.com/SiaFoundation/sia-storage-app'
+  # Must match the Podfile's declared target (15.1) or Expo autolinking skips the
+  # pod via supports_platform?; the ios-target-16 plugin forces the actual build
+  # to 16.0 in post_install, where the iOS 16 PhotoKit change-history APIs resolve.
+  s.platforms      = { :ios => '15.1' }
+  s.swift_version  = '5.9'
+  s.source         = { :path => '.' }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+    'SWIFT_COMPILATION_MODE' => 'wholemodule'
+  }
+
+  s.source_files = '**/*.{h,m,swift}'
+end

--- a/apps/mobile/modules/media-observer/ios/MediaObserverModule.swift
+++ b/apps/mobile/modules/media-observer/ios/MediaObserverModule.swift
@@ -1,0 +1,82 @@
+import ExpoModulesCore
+import Photos
+
+// The photo library's insertion cursor, via PhotoKit change history.
+//
+// `changesSince` returns the local identifiers inserted since a persisted token,
+// so additions made while the app was not running are still reported. A metadata
+// bump on an existing photo is an update, not an insert, so it is not reported.
+// The app targets iOS 16, where change history is always available.
+public class MediaObserverModule: Module {
+  private static let version = "v1"
+  private static let maxInserts = 10_000
+
+  public func definition() -> ModuleDefinition {
+    Name("MediaObserver")
+
+    AsyncFunction("currentCursor") { () -> String in
+      Self.encode(PHPhotoLibrary.shared().currentChangeToken)
+    }
+
+    AsyncFunction("changesSince") { (cursor: String?) -> [String: Any] in
+      self.changesSince(cursor)
+    }
+  }
+
+  private func changesSince(_ cursor: String?) -> [String: Any] {
+    guard let cursor, let token = Self.decode(cursor) else { return anchor() }
+
+    let changes: PHPersistentChangeFetchResult
+    do {
+      changes = try PHPhotoLibrary.shared().fetchPersistentChanges(since: token)
+    } catch {
+      // Expired/invalid token: re-anchor and let the archive sync cover the gap.
+      return anchor()
+    }
+
+    var inserted: [String] = []
+    var last = token
+    for change in changes {
+      let details: PHPersistentObjectChangeDetails?
+      do {
+        details = try change.changeDetails(for: .asset)
+      } catch {
+        // History pruned mid-walk — a partial delta can't be trusted.
+        return anchor()
+      }
+      if let details {
+        inserted.append(contentsOf: details.insertedLocalIdentifiers)
+      }
+      last = change.changeToken
+      if inserted.count > Self.maxInserts { return anchor() }
+    }
+    return ["inserted": Self.dedupe(inserted), "cursor": Self.encode(last)]
+  }
+
+  private func anchor() -> [String: Any] {
+    ["inserted": [String](), "cursor": Self.encode(PHPhotoLibrary.shared().currentChangeToken)]
+  }
+
+  private static func dedupe(_ ids: [String]) -> [String] {
+    var seen = Set<String>()
+    return ids.filter { seen.insert($0).inserted }
+  }
+
+  // PHPersistentChangeToken conforms to NSSecureCoding; archive it to base64
+  // behind a version prefix so JS can treat the cursor as opaque and persist it.
+  // A nil or unarchivable token yields an empty cursor, which re-anchors next read.
+  private static func encode(_ token: PHPersistentChangeToken?) -> String {
+    guard let token,
+      let data = try? NSKeyedArchiver.archivedData(withRootObject: token, requiringSecureCoding: true)
+    else { return version + ":" }
+    return version + ":" + data.base64EncodedString()
+  }
+
+  private static func decode(_ cursor: String) -> PHPersistentChangeToken? {
+    let parts = cursor.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+    guard parts.count == 2, parts[0] == version, !parts[1].isEmpty,
+      let data = Data(base64Encoded: String(parts[1]))
+    else { return nil }
+    return try? NSKeyedUnarchiver.unarchivedObject(ofClass: PHPersistentChangeToken.self, from: data)
+  }
+}

--- a/apps/mobile/modules/media-observer/package.json
+++ b/apps/mobile/modules/media-observer/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "media-observer",
+  "version": "0.0.0",
+  "private": true,
+  "main": "index.ts",
+  "types": "index.ts"
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -68,6 +68,7 @@
     "expo-video": "55.0.10",
     "lucide-react-native": "0.543.0",
     "markdown-it": "14.1.1",
+    "media-observer": "file:./modules/media-observer",
     "react": "19.2.0",
     "react-native": "0.83.2",
     "react-native-background-fetch": "4.3.0",

--- a/apps/mobile/src/managers/backgroundTasks.ts
+++ b/apps/mobile/src/managers/backgroundTasks.ts
@@ -361,10 +361,6 @@ async function runBackgroundWork(config: TaskConfig, state: TaskState) {
   if (getLifecycle() === 'background' && config.type !== 'BGAppRefreshTask') {
     void scheduleAfter(secondsInMs(30), signal, async (s) => {
       await runFsEvictionScanner({ signal: s })
-      if (s.aborted) return
-      // Disabled for now — need to evaluate how this works and what
-      // user-facing settings should gate it before re-enabling.
-      // await triggerRecentScanIfNeeded()
     })
   }
 

--- a/apps/mobile/src/managers/syncNewPhotos.test.ts
+++ b/apps/mobile/src/managers/syncNewPhotos.test.ts
@@ -1,203 +1,168 @@
 import { SYNC_NEW_PHOTOS_INTERVAL } from '@siastorage/core/config'
 import { shutdownAllServiceIntervals } from '@siastorage/core/lib/serviceInterval'
 import * as MediaLibrary from 'expo-media-library'
+import * as mediaObserver from 'media-observer'
 import { syncAssets } from '../lib/assetImports'
 import { app } from '../stores/appService'
-import {
-  initSyncNewPhotos,
-  run,
-  setAutoSyncNewPhotos,
-  setSyncNewPhotosEnabledAt,
-} from './syncNewPhotos'
+import { initSyncNewPhotos, run, setAutoSyncNewPhotos } from './syncNewPhotos'
 
 jest.useFakeTimers()
 
 jest.mock('expo-media-library', () => ({
-  getAssetsAsync: jest.fn(),
-  SortBy: {
-    creationTime: 'creationTime',
-    modificationTime: 'modificationTime',
-  },
+  getAssetInfoAsync: jest.fn(),
   MediaType: { photo: 'photo', video: 'video' },
+}))
+jest.mock('media-observer', () => ({
+  currentCursor: jest.fn(async () => 'v1:now'),
+  changesSince: jest.fn(async () => ({ inserted: [], cursor: 'v1:now' })),
 }))
 jest.mock('../lib/mediaLibraryPermissions', () => ({
   ensureMediaLibraryPermission: jest.fn(),
   getMediaLibraryPermissions: jest.fn().mockResolvedValue(true),
-  mediaLibraryPermissionsCache: {
-    key: jest.fn(() => ['mediaLibraryPermissions']),
-    invalidate: jest.fn(),
-    set: jest.fn(),
-  },
+  mediaLibraryPermissionsCache: { invalidate: jest.fn() },
 }))
-jest.mock('../lib/assetImports', () => ({
-  syncAssets: jest.fn(),
-}))
+jest.mock('../lib/assetImports', () => ({ syncAssets: jest.fn() }))
 
-const getAssetsAsyncMock = jest.mocked(MediaLibrary.getAssetsAsync)
+const getAssetInfoAsyncMock = jest.mocked(MediaLibrary.getAssetInfoAsync)
 const syncAssetsMock = jest.mocked(syncAssets)
+const currentCursorMock = jest.mocked(mediaObserver.currentCursor)
+const changesSinceMock = jest.mocked(mediaObserver.changesSince)
 
-function asset(
-  id: string,
-  name: string,
-  opts: { creationTime?: number; modificationTime?: number },
-): MediaLibrary.Asset {
+const CURSOR_KEY = 'syncNewPhotosCursor'
+
+function asset(id: string, name = `${id}.jpg`): MediaLibrary.AssetInfo {
   return {
     id,
     filename: name,
     uri: `file://${id}`,
     mediaType: MediaLibrary.MediaType.photo,
-    creationTime: opts.creationTime ?? 0,
-    modificationTime: opts.modificationTime ?? 0,
+    creationTime: 1_000,
+    modificationTime: 0,
     width: 1,
     height: 1,
     duration: 0,
   }
 }
 
-function page(
-  assets: MediaLibrary.Asset[],
-  endCursor = '',
-): MediaLibrary.PagedInfo<MediaLibrary.Asset> {
-  return {
-    assets,
-    endCursor,
-    hasNextPage: false,
-    totalCount: assets.length,
-  }
-}
-
-function mockProcessAssetsSuccess() {
-  syncAssetsMock.mockResolvedValue({
-    files: [{ id: '1' }] as never,
-    updatedFiles: [],
-    warnings: [],
-  })
-}
+const storedCursor = () => app().storage.getItem(CURSOR_KEY)
 
 describe('syncNewPhotos', () => {
   beforeEach(async () => {
     jest.clearAllMocks()
-    getAssetsAsyncMock.mockReset()
+    currentCursorMock.mockResolvedValue('v1:now')
+    changesSinceMock.mockResolvedValue({ inserted: [], cursor: 'v1:now' })
+    getAssetInfoAsyncMock.mockImplementation(async (id) => asset(String(id)))
+    syncAssetsMock.mockResolvedValue({ files: [], updatedFiles: [], warnings: [] })
+    await app().storage.setItem('autoSyncNewPhotos', 'true')
+    await app().storage.setItem(CURSOR_KEY, 'v1:saved')
+  })
+
+  it('anchors the cursor at enable-time', async () => {
+    currentCursorMock.mockResolvedValue('v1:anchored')
     await setAutoSyncNewPhotos(true)
-    await setSyncNewPhotosEnabledAt(0)
-    mockProcessAssetsSuccess()
+    expect(await storedCursor()).toBe('v1:anchored')
   })
 
-  it('sorts by creationTime DESC', async () => {
-    getAssetsAsyncMock.mockResolvedValueOnce(page([asset('a1', '1.jpg', { creationTime: 5_000 })]))
-    await run()
-    expect(getAssetsAsyncMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sortBy: [['creationTime', false]],
-      }),
-    )
-  })
+  it('imports the inserted assets and advances the cursor', async () => {
+    changesSinceMock.mockResolvedValue({ inserted: ['a1', 'a2'], cursor: 'v1:next' })
 
-  it('does not pass createdBefore or createdAfter', async () => {
-    getAssetsAsyncMock.mockResolvedValueOnce(page([asset('a1', '1.jpg', { creationTime: 5_000 })]))
     await run()
-    const opts = getAssetsAsyncMock.mock.calls[0][0]
-    expect(opts).not.toHaveProperty('createdAfter')
-    expect(opts).not.toHaveProperty('createdBefore')
-  })
 
-  it('only processes assets with creationTime >= enabledAt', async () => {
-    await setSyncNewPhotosEnabledAt(3_000)
-    getAssetsAsyncMock.mockResolvedValueOnce(
-      page([
-        asset('a1', 'new1.jpg', { creationTime: 5_000 }),
-        asset('a2', 'new2.jpg', { creationTime: 4_000 }),
-        asset('a3', 'exact.jpg', { creationTime: 3_000 }),
-        asset('a4', 'old.jpg', { creationTime: 2_000 }),
-      ]),
-    )
-    await run()
+    expect(changesSinceMock).toHaveBeenCalledWith('v1:saved')
     expect(syncAssetsMock).toHaveBeenCalledWith(
-      [
-        expect.objectContaining({ id: 'a1', name: 'new1.jpg' }),
-        expect.objectContaining({ id: 'a2', name: 'new2.jpg' }),
-        expect.objectContaining({ id: 'a3', name: 'exact.jpg' }),
-      ],
+      [expect.objectContaining({ id: 'a1' }), expect.objectContaining({ id: 'a2' })],
+      'file',
+      { addToImportDirectory: true, skipExistingUpdates: true },
+      undefined,
+    )
+    expect(await storedCursor()).toBe('v1:next')
+  })
+
+  it('stamps an Android no-date photo with modificationTime, not 1970', async () => {
+    changesSinceMock.mockResolvedValue({ inserted: ['a1'], cursor: 'v1:next' })
+    getAssetInfoAsyncMock.mockResolvedValue({
+      ...asset('a1'),
+      creationTime: 0,
+      modificationTime: 5_000,
+    })
+
+    await run()
+
+    expect(syncAssetsMock).toHaveBeenCalledWith(
+      [expect.objectContaining({ timestamp: new Date(5_000).toISOString() })],
       'file',
       { addToImportDirectory: true, skipExistingUpdates: true },
       undefined,
     )
   })
 
-  it('skips processing when all photos are before enabledAt', async () => {
-    await setSyncNewPhotosEnabledAt(10_000)
-    getAssetsAsyncMock.mockResolvedValueOnce(
-      page([
-        asset('a1', '1.jpg', { creationTime: 5_000 }),
-        asset('a2', '2.jpg', { creationTime: 3_000 }),
-      ]),
-    )
+  it('advances the cursor when there are no inserts', async () => {
+    changesSinceMock.mockResolvedValue({ inserted: [], cursor: 'v1:next' })
+
     await run()
+
     expect(syncAssetsMock).not.toHaveBeenCalled()
+    expect(await storedCursor()).toBe('v1:next')
   })
 
-  it('no photos returns early without processing', async () => {
-    getAssetsAsyncMock.mockResolvedValueOnce(page([]))
+  it('does NOT advance the cursor when ingest fails, so the ids replay', async () => {
+    changesSinceMock.mockResolvedValue({ inserted: ['a1'], cursor: 'v1:next' })
+    syncAssetsMock.mockRejectedValueOnce(new Error('boom'))
+
     await run()
-    expect(syncAssetsMock).not.toHaveBeenCalled()
+
+    expect(await storedCursor()).toBe('v1:saved')
   })
 
-  it('does not paginate even when page is full', async () => {
-    const fullPage = Array.from({ length: 50 }, (_, i) =>
-      asset(`a${i}`, `${i}.jpg`, { creationTime: 10_000 - i }),
+  it('resolves assets without forcing an iCloud network download', async () => {
+    changesSinceMock.mockResolvedValue({ inserted: ['a1'], cursor: 'v1:next' })
+
+    await run()
+
+    expect(getAssetInfoAsyncMock).toHaveBeenCalledWith('a1', { shouldDownloadFromNetwork: false })
+  })
+
+  it('drops ids that no longer resolve, still advancing the cursor', async () => {
+    changesSinceMock.mockResolvedValue({ inserted: ['present', 'gone'], cursor: 'v1:next' })
+    getAssetInfoAsyncMock.mockImplementation(async (id) => {
+      if (String(id) === 'gone') throw new Error('deleted')
+      return asset(String(id))
+    })
+
+    await run()
+
+    expect(syncAssetsMock).toHaveBeenCalledWith(
+      [expect.objectContaining({ id: 'present' })],
+      'file',
+      { addToImportDirectory: true, skipExistingUpdates: true },
+      undefined,
     )
-    getAssetsAsyncMock.mockResolvedValueOnce(page(fullPage, 'cursor-page-1'))
+    expect(await storedCursor()).toBe('v1:next')
+  })
+
+  it('skips when disabled', async () => {
+    await app().storage.setItem('autoSyncNewPhotos', 'false')
     await run()
-    expect(getAssetsAsyncMock).toHaveBeenCalledTimes(1)
-    expect(syncAssetsMock).toHaveBeenCalledTimes(1)
-    expect(syncAssetsMock.mock.calls[0][0]).toHaveLength(50)
+    expect(changesSinceMock).not.toHaveBeenCalled()
   })
 
-  it('excludes old photo with AI-bumped modificationTime', async () => {
-    await setSyncNewPhotosEnabledAt(10_000)
-    getAssetsAsyncMock.mockResolvedValueOnce(
-      page([
-        asset('a1', 'ai-bumped.jpg', {
-          creationTime: 1_000,
-          modificationTime: 20_000,
-        }),
-      ]),
-    )
-    await run()
-    expect(syncAssetsMock).not.toHaveBeenCalled()
-  })
-
-  it('setAutoSyncNewPhotos saves enablement timestamp', async () => {
-    jest.setSystemTime(new Date(1_700_000_000_000))
-    await setAutoSyncNewPhotos(true)
-    const enabledAt = Number(await app().storage.getItem('syncNewPhotosEnabledAt'))
-    expect(enabledAt).toBe(1_700_000_000_000)
-  })
-
-  it('aborts before syncAssets when shutdown is called mid-tick', async () => {
-    const getAssetsAsyncMock = jest.mocked(MediaLibrary.getAssetsAsync)
-    const syncAssetsMock = jest.mocked(syncAssets)
-
-    await setAutoSyncNewPhotos(true)
-
-    let resolveGetAssets: ((v: any) => void) | null = null
-    getAssetsAsyncMock.mockReturnValue(
+  it('does not advance the cursor when aborted mid-tick', async () => {
+    let resolveChanges: ((v: { inserted: string[]; cursor: string }) => void) | null = null
+    changesSinceMock.mockReturnValue(
       new Promise((resolve) => {
-        resolveGetAssets = resolve
+        resolveChanges = resolve
       }),
     )
 
     initSyncNewPhotos()
     await jest.advanceTimersByTimeAsync(SYNC_NEW_PHOTOS_INTERVAL)
 
-    // Worker is now blocked on getAssetsAsync.
-    const shutdownPromise = shutdownAllServiceIntervals()
-
-    // Resolve getAssetsAsync — worker will see signal.aborted and return.
-    resolveGetAssets!(page([asset('a1', '1.jpg', { modificationTime: 1000 })]))
+    const shutdown = shutdownAllServiceIntervals()
+    resolveChanges!({ inserted: ['a1'], cursor: 'v1:next' })
     await jest.advanceTimersByTimeAsync(0)
-    await shutdownPromise
+    await shutdown
 
     expect(syncAssetsMock).not.toHaveBeenCalled()
+    expect(await storedCursor()).toBe('v1:saved')
   })
 })

--- a/apps/mobile/src/managers/syncNewPhotos.ts
+++ b/apps/mobile/src/managers/syncNewPhotos.ts
@@ -1,24 +1,16 @@
 /*
- * syncNewPhotos — polls every 10s, fetches 1 page of 50 photos.
+ * syncNewPhotos — imports photos added to the library since the feature was
+ * enabled, while the app is foregrounded.
  *
- * Runs in the foreground while the user is active. Kept lightweight
- * (small page, longer interval) to minimize jank. Only processes
- * photos with creationTime >= enabledAt so that historic photos
- * don't appear unexpectedly — the archive handles the backfill.
- * As time passes, the enabledAt floor stays fixed so the window of
- * "new" photos grows naturally.
+ * On enable we anchor a media-observer cursor at the current library state. Each
+ * tick we import the asset ids it reports as added since the stored cursor, then
+ * advance the cursor. Detection is by what the system actually added, so an
+ * old-dated photo just AirDropped/iCloud-synced, or an Android file with no
+ * capture date, is caught where a creationTime scan would miss it, and metadata
+ * bumps on existing photos are ignored. Historic photos are the archive's job.
  *
- * Catches newly taken photos near the top of the sorted list. The
- * deep historical tail is handled by the archive sync.
- *
- * Sorts by creationTime DESC rather than modificationTime because
- * iOS background processing (face recognition, scene detection, Live
- * Photo adjustments) bumps modificationTime on old photos, causing
- * them to appear "new". creationTime is always populated on iOS. On
- * Android, DATE_TAKEN can be NULL (creationTime=0) for imported or
- * downloaded files — these sort to the end and may be caught by
- * archive, otherwise the user can manually import them.
- *
+ * The cursor lives in one storage key (same name on both platforms); the native
+ * module is stateless.
  */
 
 import { useApp } from '@siastorage/core/app'
@@ -26,75 +18,86 @@ import { SYNC_NEW_PHOTOS_INTERVAL } from '@siastorage/core/config'
 import { createServiceInterval } from '@siastorage/core/lib/serviceInterval'
 import { logger } from '@siastorage/logger'
 import * as MediaLibrary from 'expo-media-library'
+import * as mediaObserver from 'media-observer'
 import useSWR from 'swr'
+import { syncAssets } from '../lib/assetImports'
 import {
   ensureMediaLibraryPermission,
   getMediaLibraryPermissions,
   mediaLibraryPermissionsCache,
 } from '../lib/mediaLibraryPermissions'
-import { syncAssets } from '../lib/assetImports'
 import { app } from '../stores/appService'
 
-const PAGE_SIZE = 50
+const CURSOR_KEY = 'syncNewPhotosCursor'
 
 export async function run(signal?: AbortSignal): Promise<void> {
-  if (!(await getAutoSyncNewPhotos())) {
-    logger.debug('syncNewPhotos', 'skipped', { reason: 'disabled' })
-    return
-  }
-  if (!(await getMediaLibraryPermissions())) {
-    logger.debug('syncNewPhotos', 'skipped', { reason: 'no_permission' })
-    return
-  }
-  // Hard gate: hold off ingesting new camera-roll photos during the
-  // initial sync window, just for resource coordination.
-  if (app().sync.getState().syncGateStatus === 'active') {
-    logger.debug('syncNewPhotos', 'skipped', { reason: 'sync_gate_active' })
-    return
-  }
+  if (!(await getAutoSyncNewPhotos())) return
+  if (!(await getMediaLibraryPermissions())) return
+  // Hold off while the initial sync window is active, for resource coordination.
+  if (app().sync.getState().syncGateStatus === 'active') return
   if (signal?.aborted) return
-  const enabledAt = await getSyncNewPhotosEnabledAt()
 
   try {
-    const page = await MediaLibrary.getAssetsAsync({
-      first: PAGE_SIZE,
-      sortBy: [[MediaLibrary.SortBy.creationTime, false]],
-      mediaType: [MediaLibrary.MediaType.photo, MediaLibrary.MediaType.video],
-    })
+    const { inserted, cursor } = await mediaObserver.changesSince(await getCursor())
     if (signal?.aborted) return
-    const assets = page.assets.filter((a) => a.creationTime >= enabledAt)
-    if (assets.length === 0) {
-      logger.debug('syncNewPhotos', 'no_new_photos')
-      return
-    }
 
-    logger.info('syncNewPhotos', 'batch', {
-      assets: assets.length,
-      totalOnPage: page.assets.length,
-    })
+    const assets = await resolveAssets(inserted)
     if (signal?.aborted) return
-    const { files } = await syncAssets(
-      assets.map((asset) => ({
-        id: asset.id,
-        sourceUri: asset.uri,
-        name: asset.filename,
-        type: undefined,
-        size: undefined,
-        timestamp: new Date(asset.creationTime).toISOString(),
-      })),
-      'file',
-      { addToImportDirectory: true, skipExistingUpdates: true },
-      signal,
-    )
-    if (files.length > 0) {
-      await app().caches.library.invalidateAll()
-      app().caches.libraryVersion.invalidate()
+    if (assets.length > 0) {
+      logger.info('syncNewPhotos', 'import', { count: assets.length })
+      await ingest(assets, signal)
+      if (signal?.aborted) return
     }
+    // Advance only after a durable ingest, so a thrown/aborted tick replays the
+    // same ids next time. syncAssets dedups by asset id then content hash.
+    await setCursor(cursor)
   } catch (e) {
-    logger.error('syncNewPhotos', 'batch_error', {
-      error: e as Error,
-    })
+    logger.error('syncNewPhotos', 'tick_failed', { error: e as Error })
   }
+}
+
+// Resolve detected ids to library assets, dropping any deleted between detection
+// and now. shouldDownloadFromNetwork:false avoids pulling full-resolution bytes
+// for iCloud assets here; syncAssets pulls bytes on demand for dedup survivors.
+async function resolveAssets(ids: string[]): Promise<MediaLibrary.AssetInfo[]> {
+  const resolved = await Promise.all(
+    ids.map((id) =>
+      MediaLibrary.getAssetInfoAsync(id, { shouldDownloadFromNetwork: false }).catch(() => null),
+    ),
+  )
+  return resolved.filter((a): a is MediaLibrary.AssetInfo => a !== null && a !== undefined)
+}
+
+async function ingest(assets: MediaLibrary.Asset[], signal?: AbortSignal): Promise<void> {
+  const { files } = await syncAssets(
+    assets.map((asset) => ({
+      id: asset.id,
+      sourceUri: asset.uri,
+      name: asset.filename,
+      type: undefined,
+      size: undefined,
+      // Fall back to modificationTime when creationTime is 0 — Android files with
+      // no capture date (the case the cursor newly catches) would otherwise be
+      // stamped 1970. Matches the archive walk.
+      timestamp: new Date(asset.creationTime || asset.modificationTime).toISOString(),
+    })),
+    'file',
+    { addToImportDirectory: true, skipExistingUpdates: true },
+    signal,
+  )
+  if (files.length > 0) {
+    await app().caches.library.invalidateAll()
+    app().caches.libraryVersion.invalidate()
+  }
+}
+
+async function getCursor(): Promise<string | null> {
+  const raw = await app().storage.getItem(CURSOR_KEY)
+  return raw === null || raw === '' ? null : raw
+}
+
+async function setCursor(cursor: string): Promise<void> {
+  await app().storage.setItem(CURSOR_KEY, cursor)
 }
 
 export const { init: initSyncNewPhotos } = createServiceInterval({
@@ -104,8 +107,7 @@ export const { init: initSyncNewPhotos } = createServiceInterval({
 })
 
 export async function getAutoSyncNewPhotos(): Promise<boolean> {
-  const raw = await app().storage.getItem('autoSyncNewPhotos')
-  return raw === null ? false : raw === 'true'
+  return (await app().storage.getItem('autoSyncNewPhotos')) === 'true'
 }
 
 export function useAutoSyncNewPhotos() {
@@ -117,25 +119,13 @@ export async function setAutoSyncNewPhotos(value: boolean) {
   await app().storage.setItem('autoSyncNewPhotos', String(value))
   app().caches.settings.invalidate('autoSyncNewPhotos')
   if (value) {
-    await setSyncNewPhotosEnabledAt(Date.now())
+    // Anchor at enable-time so only later additions import; re-enabling re-anchors.
+    await setCursor(await mediaObserver.currentCursor())
     ensureMediaLibraryPermission()
   }
   mediaLibraryPermissionsCache.invalidate()
 }
 
 export async function toggleAutoSyncNewPhotos() {
-  const current = await getAutoSyncNewPhotos()
-  const next = !current
-  await setAutoSyncNewPhotos(next)
-}
-
-export async function getSyncNewPhotosEnabledAt(): Promise<number> {
-  const raw = await app().storage.getItem('syncNewPhotosEnabledAt')
-  const n = raw ? Number(raw) : 0
-  return Number.isFinite(n) ? n : 0
-}
-
-export async function setSyncNewPhotosEnabledAt(value: number) {
-  await app().storage.setItem('syncNewPhotosEnabledAt', String(value))
-  app().caches.settings.invalidate('syncNewPhotosEnabledAt')
+  await setAutoSyncNewPhotos(!(await getAutoSyncNewPhotos()))
 }

--- a/apps/mobile/src/managers/syncPhotosArchive.test.ts
+++ b/apps/mobile/src/managers/syncPhotosArchive.test.ts
@@ -1,13 +1,8 @@
-import {
-  SYNC_ARCHIVE_RECENT_SCAN_INTERVAL,
-  SYNC_ARCHIVE_RECENT_SCAN_LOOKBACK,
-} from '@siastorage/core/config'
 import * as MediaLibrary from 'expo-media-library'
 import { catalogAssets } from '../lib/assetImports'
 import { clearActiveBgTask, setActiveBgTask } from './bgTaskContext'
 import {
   getArchiveSyncCompletedAt,
-  getLastRecentScanAt,
   getPhotosArchiveCursor,
   getPhotosArchiveDisplayDate,
   isArchiveWalkActive,
@@ -15,9 +10,7 @@ import {
   resumeArchiveSync,
   run,
   setArchiveSyncCompletedAt,
-  setLastRecentScanAt,
   setPhotosArchiveCursor,
-  triggerRecentScanIfNeeded,
 } from './syncPhotosArchive'
 
 jest.useFakeTimers()
@@ -94,7 +87,6 @@ describe('syncPhotosArchive', () => {
     jest.clearAllMocks()
     jest.setSystemTime(new Date(NOW))
     getAssetsAsyncMock.mockReset()
-    await setLastRecentScanAt(0)
     await setArchiveSyncCompletedAt(0)
     await restartPhotosArchiveCursor()
     mockProcessAssetsSuccess()
@@ -261,71 +253,8 @@ describe('syncPhotosArchive', () => {
     })
   })
 
-  describe('triggerRecentScanIfNeeded', () => {
-    it('triggers when archive is done, previously completed, and interval elapsed', async () => {
-      await setPhotosArchiveCursor('done')
-      await setArchiveSyncCompletedAt(NOW - 1_000_000)
-      await setLastRecentScanAt(0)
-      const triggered = await triggerRecentScanIfNeeded()
-      expect(triggered).toBe(true)
-      expect(await getPhotosArchiveCursor()).toBe('start')
-    })
-
-    it('skips when archive has never completed', async () => {
-      await setPhotosArchiveCursor('done')
-      await setArchiveSyncCompletedAt(0)
-      await setLastRecentScanAt(0)
-      const triggered = await triggerRecentScanIfNeeded()
-      expect(triggered).toBe(false)
-      expect(await getPhotosArchiveCursor()).toBe('done')
-    })
-
-    it('skips when archive is mid-walk', async () => {
-      await setPhotosArchiveCursor('some-ref')
-      await setArchiveSyncCompletedAt(NOW - 1_000_000)
-      await setLastRecentScanAt(0)
-      const triggered = await triggerRecentScanIfNeeded()
-      expect(triggered).toBe(false)
-      expect(await getPhotosArchiveCursor()).toBe('some-ref')
-    })
-
-    it('skips when last scan was recent', async () => {
-      await setPhotosArchiveCursor('done')
-      await setArchiveSyncCompletedAt(NOW - 1_000_000)
-      await setLastRecentScanAt(NOW - SYNC_ARCHIVE_RECENT_SCAN_INTERVAL + 1_000)
-      const triggered = await triggerRecentScanIfNeeded()
-      expect(triggered).toBe(false)
-      expect(await getPhotosArchiveCursor()).toBe('done')
-    })
-  })
-
-  describe('bounded recent scan', () => {
-    it('stops at boundary during recent scan', async () => {
-      await setPhotosArchiveCursor('done')
-      await setArchiveSyncCompletedAt(NOW - 1_000_000)
-      await setLastRecentScanAt(0)
-      await triggerRecentScanIfNeeded()
-
-      const boundary = NOW - SYNC_ARCHIVE_RECENT_SCAN_LOOKBACK
-
-      getAssetsAsyncMock.mockResolvedValueOnce(
-        page(
-          [
-            asset('a1', '1.jpg', { modificationTime: NOW - 1_000 }),
-            asset('a2', '2.jpg', { modificationTime: boundary - 1_000 }),
-          ],
-          'ref1',
-        ),
-      )
-      await run()
-
-      expect(catalogAssetsMock).toHaveBeenCalledTimes(1)
-      expect(await getPhotosArchiveCursor()).toBe('done')
-      expect(await getPhotosArchiveDisplayDate()).toBe(0)
-      expect(await getLastRecentScanAt()).toBe(NOW)
-    })
-
-    it('continues normally when not in recent scan mode', async () => {
+  describe('walk', () => {
+    it('advances the cursor and display date through a page', async () => {
       await setPhotosArchiveCursor('start')
 
       getAssetsAsyncMock.mockResolvedValueOnce(
@@ -341,33 +270,6 @@ describe('syncPhotosArchive', () => {
 
       expect(await getPhotosArchiveCursor()).toBe('ref2')
       expect(await getPhotosArchiveDisplayDate()).toBe(1_000)
-    })
-
-    it('processes the boundary-crossing batch before stopping', async () => {
-      await setPhotosArchiveCursor('done')
-      await setArchiveSyncCompletedAt(NOW - 1_000_000)
-      await setLastRecentScanAt(0)
-      await triggerRecentScanIfNeeded()
-
-      const boundary = NOW - SYNC_ARCHIVE_RECENT_SCAN_LOOKBACK
-
-      getAssetsAsyncMock.mockResolvedValueOnce(
-        page(
-          [
-            asset('a1', '1.jpg', { modificationTime: boundary + 5_000 }),
-            asset('a2', '2.jpg', { modificationTime: boundary - 5_000 }),
-          ],
-          'ref1',
-        ),
-      )
-      await run()
-
-      expect(catalogAssetsMock).toHaveBeenCalledWith(
-        [expect.objectContaining({ id: 'a1' }), expect.objectContaining({ id: 'a2' })],
-        'file',
-        { addToImportDirectory: true },
-        undefined,
-      )
     })
   })
 })

--- a/apps/mobile/src/managers/syncPhotosArchive.ts
+++ b/apps/mobile/src/managers/syncPhotosArchive.ts
@@ -1,31 +1,17 @@
 /*
- * syncPhotosArchive — one-shot walk of the photo library.
+ * syncPhotosArchive — one-shot backfill walk of the photo library.
  *
- * Two modes of operation:
- *
- * 1. Initial walk: walks the entire photo library from newest to oldest
- *    by endCursor, stopping when all photos have been visited
- *    (cursor = 'done'). Runs back-to-back with only a yieldToEventLoop()
- *    between pages.
- *
- * 2. Bounded recent re-scan: after the initial walk completes, a
- *    periodic re-scan is triggered during background tasks (every ~3h)
- *    to catch photos synced from other devices (e.g. iCloud) that
- *    appear with old timestamps in the middle of the sorted list where
- *    syncNewPhotos (which only sees the top 50) misses them. The
- *    re-scan walks from the top and stops when it crosses a 14-day
- *    boundary. This runs during background tasks where the device is
- *    idle and heavier DB work is free.
+ * Walks the entire library from newest to oldest by endCursor, stopping
+ * when all photos have been visited (cursor = 'done'), running back-to-back
+ * with only a yieldToEventLoop() between pages. This covers the historical
+ * tail; photos added later are caught incrementally by syncNewPhotos's
+ * insertion cursor.
  *
  * Sorts by modificationTime DESC because:
  * - Android: DATE_TAKEN can be NULL for imported/downloaded photos,
  *   silently excluding them from createdAfter/createdBefore queries.
  * - iOS: creationDate can be an old EXIF date; modificationDate is the
  *   iCloud-synced metadata timestamp (not local arrival time).
- *
- * Catches: the full historical tail plus periodic re-scans of the
- * recent window for cross-device synced photos.
- * Misses: newly taken photos (covered by syncNewPhotos).
  *
  * Suspension signal policy: accepts AbortSignal. DB-holding walk loop
  * — writes via catalogAssets on each page. NOT driven by the service
@@ -35,10 +21,6 @@
  */
 
 import { useApp } from '@siastorage/core/app'
-import {
-  SYNC_ARCHIVE_RECENT_SCAN_INTERVAL,
-  SYNC_ARCHIVE_RECENT_SCAN_LOOKBACK,
-} from '@siastorage/core/config'
 import { getErrorMessage } from '@siastorage/core/lib/errors'
 import { yieldToEventLoop } from '@siastorage/core/lib/yieldToEventLoop'
 import { logger } from '@siastorage/logger'
@@ -54,7 +36,6 @@ const PAGE_SIZE = 500
 const CURSOR_DONE = 'done'
 const CURSOR_START = 'start'
 
-let recentScanBoundary = 0
 let activeWalk: Promise<void> | null = null
 let walkAbortController: AbortController | null = null
 let photosAddedCount = 0
@@ -213,18 +194,6 @@ export async function run(signal?: AbortSignal) {
         totalAssets: assets.length,
       })
     }
-
-    if (recentScanBoundary > 0 && oldestModTime < recentScanBoundary) {
-      logger.info('syncPhotosArchive', 'recent_scan_boundary_reached', {
-        oldestModTime: new Date(oldestModTime).toISOString(),
-        boundary: new Date(recentScanBoundary).toISOString(),
-      })
-      recentScanBoundary = 0
-      await setPhotosArchiveCursor(CURSOR_DONE)
-      await setPhotosArchiveDisplayDate(0)
-      await setLastRecentScanAt(Date.now())
-      await setArchiveSyncCompletedAt(Date.now())
-    }
   } catch (e) {
     const msg = getErrorMessage(e)
     if (cursor !== CURSOR_START && msg.includes('cursor')) {
@@ -258,7 +227,6 @@ export async function setPhotosArchiveCursor(value: string) {
 }
 
 export async function restartPhotosArchiveCursor() {
-  recentScanBoundary = 0
   logger.info('syncPhotosArchive', 'cursor_restart')
   await setPhotosArchiveCursor(CURSOR_START)
   await setPhotosArchiveDisplayDate(0)
@@ -306,17 +274,6 @@ export function useArchiveSyncCompletedAt() {
   )
 }
 
-export async function getLastRecentScanAt(): Promise<number> {
-  const raw = await app().storage.getItem('lastRecentScanAt')
-  const n = raw ? Number(raw) : 0
-  return Number.isFinite(n) ? n : 0
-}
-
-export async function setLastRecentScanAt(value: number) {
-  await app().storage.setItem('lastRecentScanAt', String(value))
-  app().caches.settings.invalidate('lastRecentScanAt')
-}
-
 export async function getPhotosAddedCount(): Promise<number> {
   const raw = await app().storage.getItem('photosAddedCount')
   const n = raw ? Number(raw) : 0
@@ -347,20 +304,4 @@ export function usePhotosExistingCount() {
 export async function setPhotosExistingCount(value: number) {
   await app().storage.setItem('photosExistingCount', String(value))
   app().caches.settings.invalidate('photosExistingCount')
-}
-
-export async function triggerRecentScanIfNeeded(): Promise<boolean> {
-  const cursor = await getPhotosArchiveCursor()
-  if (cursor !== CURSOR_DONE) return false
-
-  // Only re-scan if the user has completed at least one full archive sync.
-  const completedAt = await getArchiveSyncCompletedAt()
-  if (completedAt === 0) return false
-
-  const lastScan = await getLastRecentScanAt()
-  if (Date.now() - lastScan < SYNC_ARCHIVE_RECENT_SCAN_INTERVAL) return false
-
-  await restartPhotosArchiveCursor()
-  recentScanBoundary = Date.now() - SYNC_ARCHIVE_RECENT_SCAN_LOOKBACK
-  return true
 }

--- a/apps/mobile/test/mocks/media-observer.ts
+++ b/apps/mobile/test/mocks/media-observer.ts
@@ -1,0 +1,12 @@
+// Stub for the native media-observer module. The real module reads PhotoKit /
+// MediaStore change history in native code, which can't run under jest; tests
+// that exercise the cursor mock this module inline (jest.mock).
+export type MediaChanges = { inserted: string[]; cursor: string }
+
+export async function currentCursor(): Promise<string> {
+  return 'v1:mock'
+}
+
+export async function changesSince(_cursor: string | null): Promise<MediaChanges> {
+  return { inserted: [], cursor: 'v1:mock' }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -107,6 +107,7 @@
         "expo-video": "55.0.10",
         "lucide-react-native": "0.543.0",
         "markdown-it": "14.1.1",
+        "media-observer": "file:./modules/media-observer",
         "react": "19.2.0",
         "react-native": "0.83.2",
         "react-native-background-fetch": "4.3.0",
@@ -2378,6 +2379,8 @@
     "@react-native/community-cli-plugin/metro-core": ["metro-core@0.83.5", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "lodash.throttle": "^4.1.1", "metro-resolver": "0.83.5" } }, "sha512-YcVcLCrf0ed4mdLa82Qob0VxYqfhmlRxUS8+TO4gosZo/gLwSvtdeOjc/Vt0pe/lvMNrBap9LlmvZM8FIsMgJQ=="],
 
     "@siastorage/mobile/background-time-remaining": ["background-time-remaining@file:apps/mobile/modules/background-time-remaining", {}],
+
+    "@siastorage/mobile/media-observer": ["media-observer@file:apps/mobile/modules/media-observer", {}],
 
     "@siastorage/mobile/thumbnailer": ["thumbnailer@file:apps/mobile/modules/thumbnailer", {}],
 

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -48,10 +48,6 @@ export const SYNC_EVENTS_INTERVAL = secondsInMs(10) // 10 seconds
 export const SYNC_NEW_PHOTOS_INTERVAL = secondsInMs(10) // 10 seconds
 // Resume fetching archive photos when pending local-only bytes drop below this threshold.
 export const SYNC_ARCHIVE_RESUME_THRESHOLD = 4 * SLAB_SIZE
-// Minimum interval between bounded recent re-scans of the archive.
-export const SYNC_ARCHIVE_RECENT_SCAN_INTERVAL = minutesInMs(180) // 3 hours
-// How far back the bounded recent re-scan walks.
-export const SYNC_ARCHIVE_RECENT_SCAN_LOOKBACK = daysInMs(14) // 14 days
 // Import scanner interval.
 export const IMPORT_SCANNER_INTERVAL = secondsInMs(3) // 3 seconds
 // Max files requiring copy and hash allowed in the upload backlog before throttling.


### PR DESCRIPTION
Auto-import missed photos that land in the library with an old or missing capture date, because new-photo detection scanned by photo timestamp and those never sorted to the top of the list. This adds a small native module that reads the platform's own record of library insertions (iOS PhotoKit change history, Android MediaStore generation) and imports the assets added since a saved cursor, so detection keys on what the system actually added rather than on a date; the disabled archive re-scan that previously existed only to paper over the same gap is removed as redundant.

https://github.com/SiaFoundation/sia-storage-app/issues/763