### PR TITLE
chore(mobile): bump react-native-sia to 0.15.1

### DIFF
--- a/.changeset/android-32-bit-launch-fix.md
+++ b/.changeset/android-32-bit-launch-fix.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Fix a white screen on launch on some 32-bit Android devices by restoring the 32-bit ARM build.

--- a/.changeset/react-native-sia-faster-transfers.md
+++ b/.changeset/react-native-sia-faster-transfers.md
@@ -1,0 +1,5 @@
+---
+mobile: patch
+---
+
+Faster, more reliable Sia transfers: large downloads now ramp up and route around slow hosts to cut latency, transfer concurrency adapts to network conditions, and crashes under heavy parallel load are fixed.

--- a/.changeset/remove-maxinflight-transfer-concurrency.md
+++ b/.changeset/remove-maxinflight-transfer-concurrency.md
@@ -1,0 +1,6 @@
+---
+core: patch
+node-adapters: patch
+---
+
+Remove the `maxInflight` transfer-concurrency option from the SDK adapter and the `DOWNLOAD_MAX_INFLIGHT`/`UPLOAD_MAX_INFLIGHT` config constants. Transfer concurrency is now managed by the SDK.

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -90,7 +90,7 @@
     "react-native-safe-area-context": "5.6.2",
     "react-native-screens": "4.23.0",
     "react-native-share": "12.2.5",
-    "react-native-sia": "0.14.0",
+    "react-native-sia": "0.15.1",
     "react-native-svg": "15.15.3",
     "react-native-view-shot": "^5.1.0",
     "react-native-webview": "13.16.0",

--- a/apps/mobile/src/adapters/downloadObject.ts
+++ b/apps/mobile/src/adapters/downloadObject.ts
@@ -1,5 +1,4 @@
 import type { DownloadObjectAdapter } from '@siastorage/core/app'
-import { DOWNLOAD_MAX_INFLIGHT } from '@siastorage/core/config'
 import { PinnedObject } from 'react-native-sia'
 import { streamToCache } from '../lib/streamToCache'
 import { getAppKeyForIndexer } from '../stores/appKey'
@@ -13,7 +12,6 @@ export function createDownloadAdapter(): DownloadObjectAdapter {
 
       const pinnedObject = PinnedObject.open(appKey, object)
       const dl = await sdk.download(pinnedObject, {
-        maxInflight: DOWNLOAD_MAX_INFLIGHT,
         offset: BigInt(0),
         length: undefined,
       })
@@ -33,7 +31,6 @@ export function createDownloadAdapter(): DownloadObjectAdapter {
       const sharedObject = await sdk.sharedObject(url)
       const totalSize = Number(sharedObject.size())
       const dl = await sdk.download(sharedObject, {
-        maxInflight: DOWNLOAD_MAX_INFLIGHT,
         offset: BigInt(0),
         length: undefined,
       })

--- a/apps/mobile/src/adapters/sdk.ts
+++ b/apps/mobile/src/adapters/sdk.ts
@@ -40,7 +40,6 @@ export class MobileSdkAdapter implements SdkAdapter {
   async downloadByObjectId(objectId: string): Promise<ArrayBuffer> {
     const obj = await this.sdk.object(objectId)
     const dl = this.sdk.download(obj, {
-      maxInflight: 1,
       offset: 0n,
       length: undefined,
     })

--- a/apps/mobile/src/managers/uploader.test.ts
+++ b/apps/mobile/src/managers/uploader.test.ts
@@ -4,7 +4,6 @@ const MOCK_SLAB_SIZE = 4 * 1024 * 1024 * 10 // 40 MiB (SECTOR_SIZE * DATA_SHARDS
 
 jest.mock('@siastorage/core/config', () => ({
   __esModule: true,
-  UPLOAD_MAX_INFLIGHT: 15,
   UPLOAD_DATA_SHARDS: 10,
   UPLOAD_PARITY_SHARDS: 0,
   SECTOR_SIZE: 4 * 1024 * 1024,
@@ -27,7 +26,6 @@ import {
   SLAB_SIZE,
   STORAGE_FULL_POLL_INTERVAL,
   UPLOAD_DATA_SHARDS,
-  UPLOAD_MAX_INFLIGHT,
   UPLOAD_PARITY_SHARDS,
 } from '@siastorage/core/config'
 import type { ShardProgress } from '@siastorage/core/adapters'
@@ -160,7 +158,6 @@ describe('UploadManager', () => {
   const realConfig = jest.requireActual('@siastorage/core/config') as Record<string, any>
   const savedConfig: Record<string, any> = {}
   const configPatches: Record<string, any> = {
-    UPLOAD_MAX_INFLIGHT: 15,
     UPLOAD_DATA_SHARDS: 10,
     UPLOAD_PARITY_SHARDS: 0,
     SECTOR_SIZE: 4 * 1024 * 1024,
@@ -240,7 +237,6 @@ describe('UploadManager', () => {
       await manager.__testProcessFiles([createFileEntry('file1')])
 
       expect(mockSdk.uploadPacked).toHaveBeenCalledWith({
-        maxInflight: UPLOAD_MAX_INFLIGHT,
         dataShards: UPLOAD_DATA_SHARDS,
         parityShards: UPLOAD_PARITY_SHARDS,
         shardUploaded: expect.any(Object),

--- a/apps/mobile/src/managers/uploaderEfficiency.test.ts
+++ b/apps/mobile/src/managers/uploaderEfficiency.test.ts
@@ -4,7 +4,6 @@ const MOCK_SLAB_SIZE = 4 * 1024 * 1024 * 10 // 40 MiB (SECTOR_SIZE * DATA_SHARDS
 
 jest.mock('@siastorage/core/config', () => ({
   __esModule: true,
-  UPLOAD_MAX_INFLIGHT: 15,
   UPLOAD_DATA_SHARDS: 10,
   UPLOAD_PARITY_SHARDS: 0,
   SECTOR_SIZE: 4 * 1024 * 1024,
@@ -185,7 +184,6 @@ describe('UploadManager packing efficiency', () => {
   const realConfig = jest.requireActual('@siastorage/core/config') as Record<string, any>
   const savedConfig: Record<string, any> = {}
   const configPatches: Record<string, any> = {
-    UPLOAD_MAX_INFLIGHT: 15,
     UPLOAD_DATA_SHARDS: 10,
     UPLOAD_PARITY_SHARDS: 0,
     SECTOR_SIZE: 4 * 1024 * 1024,

--- a/bun.lock
+++ b/bun.lock
@@ -129,7 +129,7 @@
         "react-native-safe-area-context": "5.6.2",
         "react-native-screens": "4.23.0",
         "react-native-share": "12.2.5",
-        "react-native-sia": "0.14.0",
+        "react-native-sia": "0.15.1",
         "react-native-svg": "15.15.3",
         "react-native-view-shot": "^5.1.0",
         "react-native-webview": "13.16.0",
@@ -191,7 +191,7 @@
       "name": "@siastorage/node-adapters",
       "version": "0.0.1",
       "dependencies": {
-        "@siafoundation/sia-storage": "0.0.10",
+        "@siafoundation/sia-storage": "0.0.13",
         "@siastorage/core": "workspace:*",
         "@siastorage/logger": "workspace:*",
         "better-sqlite3": "12.6.2",
@@ -880,17 +880,17 @@
 
     "@react-navigation/routers": ["@react-navigation/routers@7.5.3", "", { "dependencies": { "nanoid": "^3.3.11" } }, "sha512-1tJHg4KKRJuQ1/EvJxatrMef3NZXEPzwUIUZ3n1yJ2t7Q97siwRtbynRpQG9/69ebbtiZ8W3ScOZF/OmhvM4Rg=="],
 
-    "@siafoundation/sia-storage": ["@siafoundation/sia-storage@0.0.10", "", { "optionalDependencies": { "@siafoundation/sia-storage-darwin-arm64": "0.0.10", "@siafoundation/sia-storage-darwin-x64": "0.0.10", "@siafoundation/sia-storage-linux-arm64-gnu": "0.0.10", "@siafoundation/sia-storage-linux-x64-gnu": "0.0.10", "@siafoundation/sia-storage-win32-x64-msvc": "0.0.10" } }, "sha512-WW179GzCDIdDQd/9kO5I8FwWt38Pbb2uyTgSSKr4cXGRhMwFTXpDM5OjoEHv4twdh/IahbJITSZseDvyHMrPVA=="],
+    "@siafoundation/sia-storage": ["@siafoundation/sia-storage@0.0.13", "", { "optionalDependencies": { "@siafoundation/sia-storage-darwin-arm64": "0.0.13", "@siafoundation/sia-storage-darwin-x64": "0.0.13", "@siafoundation/sia-storage-linux-arm64-gnu": "0.0.13", "@siafoundation/sia-storage-linux-x64-gnu": "0.0.13", "@siafoundation/sia-storage-win32-x64-msvc": "0.0.13" } }, "sha512-pu1l8oBpnlUe5Pz/KnZTDisKOUoSmYWPiIycg5Fc5TlEvMFoAvEDdhqOmlrJbWP5H5QhOM0YVH3s49qW+Uv7QA=="],
 
-    "@siafoundation/sia-storage-darwin-arm64": ["@siafoundation/sia-storage-darwin-arm64@0.0.10", "", { "os": "darwin", "cpu": "arm64" }, "sha512-P6aNBo9hdr+M+zlFdr8rakre43AoxJmDah4boURO88k7b/PxPI7Cj2eo7alvLlOGFr+2qx07uXIS/kJEZd7PlA=="],
+    "@siafoundation/sia-storage-darwin-arm64": ["@siafoundation/sia-storage-darwin-arm64@0.0.13", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Dt0OKVFDx829JULNJ8CcNUmDbi7nI1hBMEkOpRMqpHJ+jJLeg9hcqcdgp1GLWvsDrWZ4wUO9zI1Z+F57kv0Pcw=="],
 
-    "@siafoundation/sia-storage-darwin-x64": ["@siafoundation/sia-storage-darwin-x64@0.0.10", "", { "os": "darwin", "cpu": "x64" }, "sha512-419nwdAXh4f8nrq46k81boYIANIP8Pvm1kc8AYt1nfRI0/QKciLrd2BzqOoEnQYc4dmsbk70xwQiKxDExcJmbA=="],
+    "@siafoundation/sia-storage-darwin-x64": ["@siafoundation/sia-storage-darwin-x64@0.0.13", "", { "os": "darwin", "cpu": "x64" }, "sha512-gkgTzBYWYEiqPmAlgrgmXSq2xctbhWX89QmHNENyiRRRgwjwP7Fxbx1fUkZ4bIB7op+cc6L0jwTTXwo0/xcd4g=="],
 
-    "@siafoundation/sia-storage-linux-arm64-gnu": ["@siafoundation/sia-storage-linux-arm64-gnu@0.0.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-39lstPbB6dv3cuT5no3pXIsWRFBb1YvwJVw6zXLla7XLoR4QfupwuDYgdLB9lHKkW0vWiOtzDPHPOTp3gzF0bQ=="],
+    "@siafoundation/sia-storage-linux-arm64-gnu": ["@siafoundation/sia-storage-linux-arm64-gnu@0.0.13", "", { "os": "linux", "cpu": "arm64" }, "sha512-OGbtV4gJuE3Ns7WfEW4OTpO9IkGjEGMra14j+86E61g2H67JqmLfV9uh5PkpGPdpHo1o3sgqmfhJeP7gqvDQHg=="],
 
-    "@siafoundation/sia-storage-linux-x64-gnu": ["@siafoundation/sia-storage-linux-x64-gnu@0.0.10", "", { "os": "linux", "cpu": "x64" }, "sha512-ZXbJTTt6HZ1SXpZp3MHUDzCn5jx49E8FhrKxPrpaXUQUJmQoQ6E30fDcXr3GJ694H7iJltyWLrEq9xF5Egur6A=="],
+    "@siafoundation/sia-storage-linux-x64-gnu": ["@siafoundation/sia-storage-linux-x64-gnu@0.0.13", "", { "os": "linux", "cpu": "x64" }, "sha512-xP9oRO3Z8ka/mjj/xcKesELkDGA8ZqEX4wTwoj4k5NrtqyeIhUg8uaxQu12RKHJsbtcY2x2Bj4DeT3jKdJcifQ=="],
 
-    "@siafoundation/sia-storage-win32-x64-msvc": ["@siafoundation/sia-storage-win32-x64-msvc@0.0.10", "", { "os": "win32", "cpu": "x64" }, "sha512-O1CaLc4Pvkd+/NB1i44KEtf4y92Svmn73YRMZmSWAoLkPhnm7MmC/S37MKQO8xMfrxY2N4r2Ge9txTExYigF8g=="],
+    "@siafoundation/sia-storage-win32-x64-msvc": ["@siafoundation/sia-storage-win32-x64-msvc@0.0.13", "", { "os": "win32", "cpu": "x64" }, "sha512-3Bp4RKYqYuMiU7L8WibnORRcWdz4RnVTKqVK9jXqDEA56rkDSfv8p7zDnJ2cgmiF0OpPAJA10iitt41bSTPpUg=="],
 
     "@siastorage/benchmark": ["@siastorage/benchmark@workspace:apps/benchmark"],
 
@@ -1976,7 +1976,7 @@
 
     "react-native-share": ["react-native-share@12.2.5", "", {}, "sha512-2uwd/PdlUyvpsSBfL7OMiL4sD0Ja51wu5m62JSIXjrtlF+uSTUOGsMrE49ncIRYziqAfYUeI195WwhpvqXB0ww=="],
 
-    "react-native-sia": ["react-native-sia@0.14.0", "", { "dependencies": { "uniffi-bindgen-react-native": "0.31.0-2" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-LaAN47C6/Jx9BhrnQBxGtJLlsjdcu4hKP7UKjk55MKfLcTgqCW3+u2Oh+zx+zlNGLEbQPxtCDTlFzibnwxfBuA=="],
+    "react-native-sia": ["react-native-sia@0.15.1", "", { "dependencies": { "uniffi-bindgen-react-native": "0.31.0-2" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-Qu/oI4ivqXRHBmQIco4qW4I5OwsiLUg7GCBYJUZMx+451puS1yx0kMqJdSfuJReWPXcyQIIkwGDVYgjwuPPyZw=="],
 
     "react-native-svg": ["react-native-svg@15.15.3", "", { "dependencies": { "css-select": "^5.1.0", "css-tree": "^1.1.3", "warn-once": "0.1.1" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-/k4KYwPBLGcx2f5d4FjE+vCScK7QOX14cl2lIASJ28u4slHHtIhL0SZKU7u9qmRBHxTCKPoPBtN6haT1NENJNA=="],
 

--- a/packages/core/src/adapters/sdk.ts
+++ b/packages/core/src/adapters/sdk.ts
@@ -72,7 +72,6 @@ export interface ShardProgress {
 }
 
 export interface UploadOptions {
-  maxInflight: number
   dataShards: number
   parityShards: number
   shardUploaded?: {
@@ -81,7 +80,6 @@ export interface UploadOptions {
 }
 
 export interface DownloadOptions {
-  maxInflight: number
   offset: bigint
   length: bigint | undefined
   shardDownloaded?: {

--- a/packages/core/src/app/namespaces/shares.ts
+++ b/packages/core/src/app/namespaces/shares.ts
@@ -1,6 +1,5 @@
 import type { DatabaseAdapter } from '../../adapters/db'
 import type { SdkAdapter } from '../../adapters/sdk'
-import { DOWNLOAD_MAX_INFLIGHT } from '../../config'
 import * as ops from '../../db/operations'
 import { sealPinnedObject } from '../../lib/localObjects'
 import type { AppService } from '../service'
@@ -34,7 +33,6 @@ export function buildSharesNamespace(
       const sdk = requireSdk()
       const obj = await sdk.sharedObject(url)
       const dl = await sdk.download(obj, {
-        maxInflight: DOWNLOAD_MAX_INFLIGHT,
         offset: BigInt(0),
         length: BigInt(byteCount),
       })

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -17,10 +17,6 @@ export const DEFAULT_MAX_UPLOADS = 1
 export const DEFAULT_MAX_DOWNLOADS = 2
 // Max queued auto-priority downloads before oldest are evicted.
 export const MAX_AUTO_DOWNLOAD_QUEUE = 20
-// Max inflight per download.
-export const DOWNLOAD_MAX_INFLIGHT = 15
-// Max inflight per upload.
-export const UPLOAD_MAX_INFLIGHT = 15
 // Data shards for uploads.
 export const UPLOAD_DATA_SHARDS = 10
 // Parity shards for uploads.

--- a/packages/core/src/services/uploader.ts
+++ b/packages/core/src/services/uploader.ts
@@ -14,7 +14,6 @@ import {
   SLAB_SIZE,
   STORAGE_FULL_POLL_INTERVAL,
   UPLOAD_DATA_SHARDS,
-  UPLOAD_MAX_INFLIGHT,
   UPLOAD_PARITY_SHARDS,
 } from '../config'
 import { encodeFileMetadata } from '../encoding/fileMetadata'
@@ -644,7 +643,6 @@ export class UploadManager {
         }
         this.batch = batch
         this.packer = await sdk.uploadPacked({
-          maxInflight: UPLOAD_MAX_INFLIGHT,
           dataShards: UPLOAD_DATA_SHARDS,
           parityShards: UPLOAD_PARITY_SHARDS,
           shardUploaded: {

--- a/packages/node-adapters/package.json
+++ b/packages/node-adapters/package.json
@@ -29,7 +29,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@siafoundation/sia-storage": "0.0.10",
+    "@siafoundation/sia-storage": "0.0.13",
     "@siastorage/core": "workspace:*",
     "@siastorage/logger": "workspace:*",
     "better-sqlite3": "12.6.2"

--- a/packages/node-adapters/src/download.ts
+++ b/packages/node-adapters/src/download.ts
@@ -1,6 +1,5 @@
 import type { DownloadLikeRef } from '@siastorage/core/adapters'
 import type { DownloadObjectAdapter } from '@siastorage/core/app'
-import { DOWNLOAD_MAX_INFLIGHT } from '@siastorage/core/config'
 import type { FsIOAdapter } from '@siastorage/core/services/fsFileUri'
 import { createWriteStream } from 'fs'
 import { unlink } from 'fs/promises'
@@ -65,7 +64,6 @@ export function createNodeDownloadAdapter(deps: {
       const pinnedObject = sdk.openPinnedObject(appKey, object)
 
       const dl = await sdk.download(pinnedObject, {
-        maxInflight: DOWNLOAD_MAX_INFLIGHT,
         offset: BigInt(0),
         length: undefined,
       })
@@ -76,7 +74,6 @@ export function createNodeDownloadAdapter(deps: {
     async downloadFromShareUrl({ file, url, sdk, onProgress, signal }) {
       const sharedObject = await sdk.sharedObject(url)
       const dl = await sdk.download(sharedObject, {
-        maxInflight: DOWNLOAD_MAX_INFLIGHT,
         offset: BigInt(0),
         length: undefined,
       })

--- a/packages/node-adapters/src/sdk.ts
+++ b/packages/node-adapters/src/sdk.ts
@@ -267,7 +267,6 @@ export function createNodeSdkAdapter(sdk: Sdk): SdkAdapter {
     ): Promise<DownloadLikeRef> {
       const native = requireNativePinnedObject(pinnedObject)
       const stream = sdk.download(native, {
-        maxInflight: options.maxInflight,
         offset: options.offset,
         length: options.length,
         onShardDownloaded: bridgeShardCallback(options.shardDownloaded),
@@ -277,7 +276,6 @@ export function createNodeSdkAdapter(sdk: Sdk): SdkAdapter {
 
     async uploadPacked(options: UploadOptions): Promise<PackedUploadRef> {
       const packed = sdk.uploadPacked({
-        maxInflight: options.maxInflight,
         dataShards: options.dataShards,
         parityShards: options.parityShards,
         onShardUploaded: bridgeShardCallback(options.shardUploaded),
@@ -327,7 +325,7 @@ export function createNodeSdkAdapter(sdk: Sdk): SdkAdapter {
      */
     async downloadByObjectId(objectId: string): Promise<ArrayBuffer> {
       const obj = await sdk.object(objectId)
-      const stream = sdk.download(obj, { maxInflight: 1, offset: BigInt(0), length: undefined })
+      const stream = sdk.download(obj, { offset: BigInt(0), length: undefined })
       return consumeStreamToBuffer(stream)
     },
 

--- a/packages/node-adapters/test/sdk.test.ts
+++ b/packages/node-adapters/test/sdk.test.ts
@@ -182,7 +182,6 @@ describe('createNodeSdkAdapter', () => {
     // First get a pinned object through the adapter so it's registered in WeakMap
     const obj = await adapter.getPinnedObject('test')
     const dl = await adapter.download(obj, {
-      maxInflight: 1,
       offset: BigInt(0),
       length: undefined,
     })
@@ -202,7 +201,6 @@ describe('createNodeSdkAdapter', () => {
     const mockSdk = createMockSdk()
     const adapter = createNodeSdkAdapter(mockSdk as any)
     const packed = await adapter.uploadPacked({
-      maxInflight: 10,
       dataShards: 10,
       parityShards: 3,
     })
@@ -215,7 +213,6 @@ describe('createNodeSdkAdapter', () => {
     const mockSdk = createMockSdk()
     const adapter = createNodeSdkAdapter(mockSdk as any)
     const packed = await adapter.uploadPacked({
-      maxInflight: 10,
       dataShards: 10,
       parityShards: 3,
     })


### PR DESCRIPTION
Bumps `react-native-sia` and `@siafoundation/sia-storage`, pulling in the Sia Rust SDK (`sia-sdk-rs` / `sia_storage_ffi`) v0.9.0.

## changes from sia-sdk-rs

- Faster large downloads: requests ramp up to cut round trips, and extra shards are fetched in parallel to route around slow hosts and reduce tail latency.
- Smarter host selection: hosts ranked by current upload/download load; fallback hosts used only when a transfer genuinely lags.
- Adaptive transfer concurrency: upload/download concurrency auto-tunes to network conditions instead of fixed limits.
- More reliable under heavy parallel load: fixed high-concurrency crashes (dropped `rayon`) and improved connection cleanup.
- Removed the now-unsupported `maxInflight` knob and `DOWNLOAD_MAX_INFLIGHT`/`UPLOAD_MAX_INFLIGHT` config across the SDK adapter, mobile, and node-adapters — concurrency is SDK-managed now.

## changes from react-native-sia

- Restored the 32-bit ARM (armeabi-v7a) Android build, fixing a white screen on launch on some 32-bit devices. [https://github.com/SiaFoundation/sia-storage-app/issues/76](https://github.com/SiaFoundation/sia-storage-app/issues/766)