### PR TITLE
feat(core): database engine

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -3,5 +3,243 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "cc"
+version = "1.2.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "sia-storage-core"
 version = "0.0.1"
+dependencies = [
+ "rusqlite",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "syn"
+version = "2.0.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -8,5 +8,10 @@ rust-version = "1.96"
 license = "Apache-2.0"
 publish = false
 
+[workspace.dependencies]
+rusqlite = { version = "0.32", features = ["bundled", "array"] }
+thiserror = "2"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync"] }
+
 [workspace.lints.rust]
 unused_imports = "warn"

--- a/crates/sia-storage-core/Cargo.toml
+++ b/crates/sia-storage-core/Cargo.toml
@@ -6,6 +6,11 @@ rust-version.workspace = true
 license.workspace = true
 publish.workspace = true
 
+[dependencies]
+rusqlite.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+
 [lints]
 workspace = true
 

--- a/crates/sia-storage-core/src/db.rs
+++ b/crates/sia-storage-core/src/db.rs
@@ -1,0 +1,29 @@
+//! The SQLite layer: the [`Db`](database::Db) handle and a few SQL utilities. Operations take a
+//! `&Connection` (reads and writes) or `&mut Transaction` (to open a savepoint) and run inside
+//! the transaction that `Db::transaction` opens for them.
+
+pub mod database;
+pub mod sql;
+
+/// A database-layer error: a SQLite failure, a blocking-thread join failure, or an ad-hoc message.
+#[derive(Debug, thiserror::Error)]
+pub enum DbError {
+    #[error(transparent)]
+    Sqlite(#[from] rusqlite::Error),
+    #[error(transparent)]
+    Join(#[from] tokio::task::JoinError),
+    #[error("{0}")]
+    Message(String),
+}
+
+impl From<&str> for DbError {
+    fn from(s: &str) -> Self {
+        DbError::Message(s.to_string())
+    }
+}
+
+impl From<String> for DbError {
+    fn from(s: String) -> Self {
+        DbError::Message(s)
+    }
+}

--- a/crates/sia-storage-core/src/db/database.rs
+++ b/crates/sia-storage-core/src/db/database.rs
@@ -1,0 +1,177 @@
+use std::sync::Arc;
+
+use rusqlite::{Connection, InterruptHandle, Transaction};
+use tokio::sync::Mutex;
+
+use crate::db::DbError;
+
+/// The SQLite database: one connection plus a thread-safe interrupt handle.
+///
+/// [`transaction`](Db::transaction) runs its closure on a blocking thread so the synchronous
+/// rusqlite calls never block the async runtime. The connection is behind an async mutex, so
+/// concurrent callers wait as parked futures; only the holder occupies a blocking thread.
+pub struct Db {
+    conn: Arc<Mutex<Connection>>,
+    interrupt: InterruptHandle,
+}
+
+impl Db {
+    /// Open the database at `path`, creating if absent. WAL mode, foreign keys on.
+    pub async fn open(path: &str) -> Result<Self, DbError> {
+        let path = path.to_string();
+        tokio::task::spawn_blocking(move || Self::from_conn(Connection::open(path)?)).await?
+    }
+
+    /// Open a private in-memory database with the same pragmas. For tests and ephemeral use.
+    pub async fn open_in_memory() -> Result<Self, DbError> {
+        tokio::task::spawn_blocking(|| Self::from_conn(Connection::open_in_memory()?)).await?
+    }
+
+    fn from_conn(conn: Connection) -> Result<Self, DbError> {
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+        // Drops the per-commit fsync (the slowest part of a write); the cost is that a
+        // full-OS crash can lose the newest commits, though never corrupt the database.
+        conn.pragma_update(None, "synchronous", "NORMAL")?;
+        // Checkpoint at ~2MB, half the default: bounds the on-disk WAL and keeps each
+        // checkpoint's fsync short.
+        conn.pragma_update(None, "wal_autocheckpoint", 500)?;
+        // Multiple processes share this file: wait up to 5s for a lock instead of
+        // failing immediately with SQLITE_BUSY.
+        conn.pragma_update(None, "busy_timeout", 5000)?;
+        conn.pragma_update(None, "foreign_keys", "ON")?;
+        // Registers rarray() so `WHERE col IN rarray(?)` can bind an id list as one parameter.
+        rusqlite::vtab::array::load_module(&conn)?;
+        let interrupt = conn.get_interrupt_handle();
+        Ok(Self {
+            conn: Arc::new(Mutex::new(conn)),
+            interrupt,
+        })
+    }
+
+    /// Abort the statement currently running on the connection, callable from any thread. The
+    /// interrupted statement errors, and the open transaction's `Drop` rolls back and releases the
+    /// WAL write lock in the same unwind. A no-op when the connection is idle.
+    pub fn interrupt(&self) {
+        self.interrupt.interrupt();
+    }
+
+    /// Runs a closure in one transaction: commits on `Ok`, rolls back on `Err` or panic. Reads and
+    /// writes both go through here, so a read-only closure sees a consistent snapshot across its
+    /// statements. A caller cancelled while still waiting for the connection never starts; once
+    /// the closure is spawned, a dropped future still finishes the transaction on its blocking
+    /// thread rather than leaving it open.
+    pub async fn transaction<T, F>(&self, f: F) -> Result<T, DbError>
+    where
+        F: FnOnce(&mut Transaction) -> Result<T, DbError> + Send + 'static,
+        T: Send + 'static,
+    {
+        // Acquired before spawn_blocking: waiters park as futures, and only the
+        // lock holder occupies a blocking-pool thread.
+        let mut guard = self.conn.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || {
+            let mut tx = guard.transaction()?;
+            let value = f(&mut tx)?;
+            tx.commit()?;
+            Ok(value)
+        })
+        .await?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn seeded() -> Db {
+        let db = Db::open_in_memory().await.unwrap();
+        db.transaction(|tx| {
+            tx.execute_batch("CREATE TABLE t (id TEXT)")?;
+            Ok(())
+        })
+        .await
+        .unwrap();
+        db
+    }
+
+    async fn ids(db: &Db) -> Vec<String> {
+        db.transaction(|tx| {
+            let mut stmt = tx.prepare("SELECT id FROM t ORDER BY id")?;
+            let rows = stmt.query_map([], |r| r.get(0))?;
+            Ok(rows.collect::<rusqlite::Result<Vec<String>>>()?)
+        })
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn commits_on_ok() {
+        let db = seeded().await;
+        db.transaction(|tx| {
+            tx.execute("INSERT INTO t (id) VALUES ('a')", [])?;
+            Ok(())
+        })
+        .await
+        .unwrap();
+        assert_eq!(ids(&db).await, ["a"]);
+    }
+
+    #[tokio::test]
+    async fn rolls_back_the_whole_unit_on_error() {
+        let db = seeded().await;
+        let r = db
+            .transaction(|tx| {
+                tx.execute("INSERT INTO t (id) VALUES ('a')", [])?;
+                Err::<(), DbError>("boom".into())
+            })
+            .await;
+        assert!(r.is_err());
+        assert!(
+            ids(&db).await.is_empty(),
+            "the failed unit left nothing behind"
+        );
+    }
+
+    #[tokio::test]
+    async fn savepoint_rolls_back_only_its_substep() {
+        let db = seeded().await;
+        db.transaction(|tx| {
+            tx.execute("INSERT INTO t (id) VALUES ('a')", [])?;
+            let sp = tx.savepoint()?;
+            sp.execute("INSERT INTO t (id) VALUES ('b')", [])?;
+            drop(sp); // no commit -> ROLLBACK TO, undoing 'b' but not the outer 'a'
+            Ok(())
+        })
+        .await
+        .unwrap();
+        assert_eq!(ids(&db).await, ["a"]);
+    }
+
+    // Concurrent transactions serialize on the connection; both land.
+    #[tokio::test]
+    async fn concurrent_transactions_serialize() {
+        let db = std::sync::Arc::new(seeded().await);
+        let a = {
+            let db = db.clone();
+            tokio::spawn(async move {
+                db.transaction(|tx| {
+                    tx.execute("INSERT INTO t (id) VALUES ('a')", [])?;
+                    Ok(())
+                })
+                .await
+            })
+        };
+        let b = {
+            let db = db.clone();
+            tokio::spawn(async move {
+                db.transaction(|tx| {
+                    tx.execute("INSERT INTO t (id) VALUES ('b')", [])?;
+                    Ok(())
+                })
+                .await
+            })
+        };
+        a.await.unwrap().unwrap();
+        b.await.unwrap().unwrap();
+        assert_eq!(ids(&db).await, ["a", "b"]);
+    }
+}

--- a/crates/sia-storage-core/src/db/sql.rs
+++ b/crates/sia-storage-core/src/db/sql.rs
@@ -1,0 +1,64 @@
+//! Small SQL utilities. Statements are written out at their call sites; these only cover what a
+//! literal can't say: binding an id list to `rarray`, escaping LIKE patterns, and placeholder
+//! lists for the rare `IN (...)` that can't use `rarray`.
+
+use std::rc::Rc;
+
+use rusqlite::types::Value;
+
+/// `?, ?, ?` for `n` slots, for an `IN (...)` list whose params mix with other bind values.
+pub fn placeholders(n: usize) -> String {
+    std::iter::repeat_n("?", n).collect::<Vec<_>>().join(", ")
+}
+
+/// The given ids as one array value bindable to `rarray(?)`, for `WHERE col IN rarray(?)`. The
+/// connection must be opened through [`Db`](super::database::Db), which registers the `rarray` module.
+pub fn id_array(ids: &[String]) -> Rc<Vec<Value>> {
+    Rc::new(ids.iter().map(|s| Value::Text(s.clone())).collect())
+}
+
+/// Escape `%`, `_`, and `\` for a `LIKE ? ESCAPE '\'` pattern.
+pub fn escape_like_pattern(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        if matches!(c, '%' | '_' | '\\') {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escape_like_pattern_escapes_wildcards_and_backslash() {
+        assert_eq!(escape_like_pattern("normal"), "normal");
+        assert_eq!(escape_like_pattern("50%_off"), "50\\%\\_off");
+        assert_eq!(escape_like_pattern("a\\b"), "a\\\\b");
+    }
+
+    #[test]
+    fn id_array_filters_an_in_clause() {
+        let c = rusqlite::Connection::open_in_memory().unwrap();
+        rusqlite::vtab::array::load_module(&c).unwrap();
+        c.execute_batch("CREATE TABLE t (id TEXT PRIMARY KEY)")
+            .unwrap();
+        for id in ["a", "b", "c"] {
+            c.execute("INSERT INTO t (id) VALUES (?)", rusqlite::params![id])
+                .unwrap();
+        }
+        let ids = vec!["a".to_string(), "c".to_string()];
+        let mut stmt = c
+            .prepare("SELECT id FROM t WHERE id IN rarray(?) ORDER BY id")
+            .unwrap();
+        let got: Vec<String> = stmt
+            .query_map([id_array(&ids)], |r| r.get(0))
+            .unwrap()
+            .map(Result::unwrap)
+            .collect();
+        assert_eq!(got, ["a", "c"]);
+    }
+}

--- a/crates/sia-storage-core/src/lib.rs
+++ b/crates/sia-storage-core/src/lib.rs
@@ -1,1 +1,1 @@
-
+pub mod db;


### PR DESCRIPTION
The SQLite engine. Ops are plain sync functions that take a `Connection` and write their statements as literal SQL, and a unit of work gets wrapped in `db.transaction`, where everything inside is one transaction. Async only lives at that boundary: the closure runs on a blocking thread so the synchronous rusqlite calls don't stall the runtime. It leans on rusqlite directly and keeps the transaction boundary explicit, which is the idiomatic shape and leaves fewer ways to misuse it, no ambient state and no surprise nesting.

The everyday shape, a composed write:

```rust
db.transaction(|tx| {
    update_file(tx, &update)?;
    insert_object(tx, &object)?;
    Ok(())
}).await?;
```

Commits if the closure returns `Ok`, rolls back on any error or panic (it's rusqlite's `Transaction`). Reads use the same method, so a multi-statement read sees one consistent snapshot:

```rust
let files = db.transaction(|tx| query_files(tx, &opts)).await?;
```

What it adds:

- `Db` with async `open` / `open_in_memory` (WAL, synchronous=NORMAL, wal_autocheckpoint=500, busy_timeout=5000, foreign keys on, the same pragmas the TS app uses on the shared file), one writer connection behind a `tokio::sync::Mutex`: concurrent transactions queue as parked futures, and only the lock holder occupies a blocking-pool thread.
- `transaction(|tx| ...)`: acquires the connection, then runs one transaction on a blocking thread, commit on `Ok`, rollback on `Err` or panic. Reads and writes both go through it, so a multi-statement read sees a consistent snapshot. The body is sync, so a dropped future can't strand a spawned transaction half-open.
- `interrupt()`: aborts the in-flight statement from any thread for suspend, with the rollback and WAL-lock release in the same unwind.
- `sql`: three small utilities, `escape_like_pattern` for `LIKE` patterns, `id_array` to bind an id list to `rarray(?)` for `IN` membership, and `placeholders` for the rare `IN (...)` whose params mix with other bind values. Everything else is written as literal SQL at the call site.

The migration runner lives in the domain PR with the schema it applies; opening the database runs the migrations.
