### PR TITLE
feat(core): domain database

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -15,10 +15,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "cc"
@@ -35,6 +56,26 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "fallible-iterator"
@@ -55,6 +96,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,6 +138,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,6 +188,21 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -134,6 +256,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,10 +300,18 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 name = "sia-storage-core"
 version = "0.0.1"
 dependencies = [
+ "chrono",
  "rusqlite",
  "thiserror",
  "tokio",
+ "tracing",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -207,6 +372,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,6 +419,110 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "zerocopy"

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -9,9 +9,11 @@ license = "Apache-2.0"
 publish = false
 
 [workspace.dependencies]
+chrono = { version = "0.4", features = ["serde"] }
 rusqlite = { version = "0.32", features = ["bundled", "array"] }
 thiserror = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync"] }
+tracing = "0.1"
 
 [workspace.lints.rust]
 unused_imports = "warn"

--- a/crates/sia-storage-core/Cargo.toml
+++ b/crates/sia-storage-core/Cargo.toml
@@ -7,9 +7,11 @@ license.workspace = true
 publish.workspace = true
 
 [dependencies]
+chrono.workspace = true
 rusqlite.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+tracing.workspace = true
 
 [lints]
 workspace = true

--- a/crates/sia-storage-core/src/db.rs
+++ b/crates/sia-storage-core/src/db.rs
@@ -1,9 +1,15 @@
 //! The SQLite layer: the [`Db`](database::Db) handle and a few SQL utilities. Operations take a
 //! `&Connection` (reads and writes) or `&mut Transaction` (to open a savepoint) and run inside
-//! the transaction that `Db::transaction` opens for them.
+//! the transaction that `Db::transaction` opens for them. Migrations are internal: opening the
+//! database runs them.
 
 pub mod database;
+mod migrations;
+mod runner;
 pub mod sql;
+mod types;
+
+pub use types::{MigrationProgress, MigrationProgressFn};
 
 /// A database-layer error: a SQLite failure, a blocking-thread join failure, or an ad-hoc message.
 #[derive(Debug, thiserror::Error)]

--- a/crates/sia-storage-core/src/db/database.rs
+++ b/crates/sia-storage-core/src/db/database.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use rusqlite::{Connection, InterruptHandle, Transaction};
 use tokio::sync::Mutex;
 
-use crate::db::DbError;
+use crate::db::{DbError, MigrationProgressFn, migrations, runner};
 
 /// The SQLite database: one connection plus a thread-safe interrupt handle.
 ///
@@ -16,18 +16,30 @@ pub struct Db {
 }
 
 impl Db {
-    /// Open the database at `path`, creating if absent. WAL mode, foreign keys on.
-    pub async fn open(path: &str) -> Result<Self, DbError> {
+    /// Open the database at `path`, creating if absent. WAL mode, foreign keys on. Runs any
+    /// pending migrations; `on_progress` fires per migration so a startup screen can show
+    /// which one is running.
+    pub async fn open(
+        path: &str,
+        on_progress: Option<MigrationProgressFn>,
+    ) -> Result<Self, DbError> {
         let path = path.to_string();
-        tokio::task::spawn_blocking(move || Self::from_conn(Connection::open(path)?)).await?
+        tokio::task::spawn_blocking(move || {
+            Self::from_conn(Connection::open(path)?, on_progress.as_ref())
+        })
+        .await?
     }
 
-    /// Open a private in-memory database with the same pragmas. For tests and ephemeral use.
+    /// Open a private in-memory database with the same pragmas and migrations. For tests and
+    /// ephemeral use.
     pub async fn open_in_memory() -> Result<Self, DbError> {
-        tokio::task::spawn_blocking(|| Self::from_conn(Connection::open_in_memory()?)).await?
+        tokio::task::spawn_blocking(|| Self::from_conn(Connection::open_in_memory()?, None)).await?
     }
 
-    fn from_conn(conn: Connection) -> Result<Self, DbError> {
+    fn from_conn(
+        mut conn: Connection,
+        on_progress: Option<&MigrationProgressFn>,
+    ) -> Result<Self, DbError> {
         conn.pragma_update(None, "journal_mode", "WAL")?;
         // Drops the per-commit fsync (the slowest part of a write); the cost is that a
         // full-OS crash can lose the newest commits, though never corrupt the database.
@@ -41,6 +53,7 @@ impl Db {
         conn.pragma_update(None, "foreign_keys", "ON")?;
         // Registers rarray() so `WHERE col IN rarray(?)` can bind an id list as one parameter.
         rusqlite::vtab::array::load_module(&conn)?;
+        runner::run_migrations(&mut conn, migrations::CORE_MIGRATIONS, on_progress)?;
         let interrupt = conn.get_interrupt_handle();
         Ok(Self {
             conn: Arc::new(Mutex::new(conn)),

--- a/crates/sia-storage-core/src/db/migrations.rs
+++ b/crates/sia-storage-core/src/db/migrations.rs
@@ -1,0 +1,117 @@
+mod m0001_init_schema;
+mod m0002_object_needs_sync_up;
+
+use crate::db::types::Migration;
+
+/// The ordered chain of schema migrations. Each names the migration it builds on; the runner
+/// applies them in order and refuses to run one whose parent isn't the current applied head, so
+/// a migration can never run against a schema state it wasn't written for.
+pub(crate) const CORE_MIGRATIONS: &[Migration] = &[
+    Migration {
+        id: "0001_init_schema",
+        description: "Initialize storage schema.",
+        parent: None,
+        up: m0001_init_schema::up,
+    },
+    Migration {
+        id: "0002_object_needs_sync_up",
+        description: "Add a per-object needsSyncUp dirty flag for sync-up.",
+        parent: Some("0001_init_schema"),
+        up: m0002_object_needs_sync_up::up,
+    },
+];
+
+/// A fresh in-memory connection with foreign keys on and the full core schema applied.
+#[cfg(test)]
+pub(crate) fn migrated_conn() -> rusqlite::Connection {
+    let mut conn = rusqlite::Connection::open_in_memory().unwrap();
+    conn.pragma_update(None, "foreign_keys", "ON").unwrap();
+    rusqlite::vtab::array::load_module(&conn).unwrap();
+    crate::db::runner::run_migrations(&mut conn, CORE_MIGRATIONS, None).unwrap();
+    conn
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    fn applied_ids(conn: &Connection) -> Vec<String> {
+        let mut stmt = conn
+            .prepare("SELECT id FROM migrations ORDER BY id")
+            .unwrap();
+        stmt.query_map([], |r| r.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap()
+    }
+
+    #[test]
+    fn migrations_build_the_schema_and_record_themselves() {
+        let conn = migrated_conn();
+        assert_eq!(
+            applied_ids(&conn),
+            ["0001_init_schema", "0002_object_needs_sync_up"]
+        );
+        for table in [
+            "directories",
+            "files",
+            "objects",
+            "fs",
+            "logs",
+            "tags",
+            "file_tags",
+        ] {
+            let count: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?",
+                    [table],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(count, 1, "missing table {table}");
+        }
+        let has_needs_sync_up = conn
+            .prepare("PRAGMA table_info(objects)")
+            .unwrap()
+            .query_map([], |r| r.get::<_, String>(1))
+            .unwrap()
+            .filter_map(Result::ok)
+            .any(|name| name == "needsSyncUp");
+        assert!(has_needs_sync_up, "objects.needsSyncUp missing");
+
+        let favorites: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM tags WHERE id = 'sys:favorites'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(favorites, 1, "Favorites system tag seeded");
+    }
+
+    // The list must be a single linear chain: one root, each `parent` the previous id, no
+    // duplicates. A fork (two migrations sharing a parent) or a misordering breaks this, so a
+    // bad merge is caught in CI instead of on a user's device.
+    #[test]
+    fn core_migrations_form_a_single_linear_chain() {
+        let mut expected_parent: Option<&str> = None;
+        let mut seen = std::collections::HashSet::new();
+        for m in CORE_MIGRATIONS {
+            assert_eq!(
+                m.parent, expected_parent,
+                "migration {} has the wrong parent",
+                m.id
+            );
+            assert!(seen.insert(m.id), "duplicate migration id {}", m.id);
+            expected_parent = Some(m.id);
+        }
+    }
+
+    #[test]
+    fn re_running_migrations_is_a_noop() {
+        let mut conn = migrated_conn();
+        crate::db::runner::run_migrations(&mut conn, CORE_MIGRATIONS, None).unwrap();
+        assert_eq!(applied_ids(&conn).len(), 2);
+    }
+}

--- a/crates/sia-storage-core/src/db/migrations/m0001_init_schema.rs
+++ b/crates/sia-storage-core/src/db/migrations/m0001_init_schema.rs
@@ -1,0 +1,141 @@
+use rusqlite::{Connection, params};
+
+use crate::db::DbError;
+
+const SCHEMA: &str = r"
+CREATE TABLE IF NOT EXISTS directories (
+    id TEXT PRIMARY KEY,
+    path TEXT NOT NULL UNIQUE,
+    createdAt INTEGER NOT NULL,
+    nameSortKey TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_directories_nameSortKey ON directories(nameSortKey);
+
+CREATE TABLE IF NOT EXISTS files (
+    id TEXT PRIMARY KEY,
+    localId TEXT UNIQUE,
+    addedAt INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    size INTEGER NOT NULL,
+    type TEXT NOT NULL,
+    kind TEXT NOT NULL DEFAULT 'file',
+    createdAt INTEGER NOT NULL,
+    updatedAt INTEGER NOT NULL,
+    hash TEXT NOT NULL,
+    thumbForId TEXT,
+    thumbSize INTEGER,
+    directoryId TEXT REFERENCES directories(id) ON DELETE SET NULL,
+    trashedAt INTEGER,
+    deletedAt INTEGER,
+    lostReason TEXT,
+    nameSortKey TEXT,
+    -- Marks the live version of a file: among rows sharing (name, directoryId), exactly one
+    -- has current = 1. The idx_files_current_* partial indexes below cover the visible-file
+    -- queries that filter on it.
+    current INTEGER NOT NULL DEFAULT 1
+);
+CREATE INDEX IF NOT EXISTS idx_files_createdAt_id ON files(createdAt, id);
+CREATE INDEX IF NOT EXISTS idx_files_fileType ON files(type);
+CREATE INDEX IF NOT EXISTS idx_files_updatedAt_id ON files(updatedAt, id);
+CREATE INDEX IF NOT EXISTS idx_files_hash ON files(hash);
+CREATE INDEX IF NOT EXISTS idx_files_kind ON files(kind);
+CREATE INDEX IF NOT EXISTS idx_files_thumbForId_thumbSize ON files(thumbForId, thumbSize);
+CREATE INDEX IF NOT EXISTS idx_files_directoryId ON files(directoryId);
+CREATE INDEX IF NOT EXISTS idx_files_trashedAt ON files(trashedAt);
+CREATE INDEX IF NOT EXISTS idx_files_deletedAt ON files(deletedAt);
+CREATE INDEX IF NOT EXISTS idx_files_addedAt_id ON files(addedAt, id);
+CREATE INDEX IF NOT EXISTS idx_files_nameSortKey_id ON files(nameSortKey, id);
+CREATE INDEX IF NOT EXISTS idx_files_current_nameSortKey
+    ON files(nameSortKey, id)
+    WHERE current = 1 AND kind = 'file' AND trashedAt IS NULL AND deletedAt IS NULL;
+CREATE INDEX IF NOT EXISTS idx_files_version_group
+    ON files(name, directoryId, updatedAt DESC, id DESC)
+    WHERE kind = 'file' AND trashedAt IS NULL AND deletedAt IS NULL;
+CREATE INDEX IF NOT EXISTS idx_files_current_createdAt
+    ON files(createdAt DESC, id DESC)
+    WHERE current = 1 AND kind = 'file' AND trashedAt IS NULL AND deletedAt IS NULL;
+CREATE INDEX IF NOT EXISTS idx_files_current_addedAt
+    ON files(addedAt DESC, id DESC)
+    WHERE current = 1 AND kind = 'file' AND trashedAt IS NULL AND deletedAt IS NULL;
+CREATE INDEX IF NOT EXISTS idx_files_current_size
+    ON files(size DESC, id DESC)
+    WHERE current = 1 AND kind = 'file' AND trashedAt IS NULL AND deletedAt IS NULL;
+CREATE INDEX IF NOT EXISTS idx_files_current_type
+    ON files(type)
+    WHERE current = 1 AND kind = 'file' AND trashedAt IS NULL AND deletedAt IS NULL;
+CREATE INDEX IF NOT EXISTS idx_files_current_directoryId
+    ON files(directoryId)
+    WHERE current = 1 AND kind = 'file' AND trashedAt IS NULL AND deletedAt IS NULL;
+CREATE INDEX IF NOT EXISTS idx_files_current_name_directoryId
+    ON files(name, directoryId)
+    WHERE current = 1 AND kind = 'file' AND trashedAt IS NULL AND deletedAt IS NULL;
+
+CREATE TABLE IF NOT EXISTS objects (
+    fileId TEXT NOT NULL,
+    indexerURL TEXT NOT NULL,
+    id TEXT NOT NULL,
+    slabs TEXT NOT NULL,
+    encryptedDataKey TEXT NOT NULL,
+    encryptedMetadataKey TEXT NOT NULL,
+    encryptedMetadata TEXT NOT NULL,
+    dataSignature TEXT NOT NULL,
+    metadataSignature TEXT NOT NULL,
+    createdAt INTEGER NOT NULL,
+    updatedAt INTEGER NOT NULL,
+    PRIMARY KEY (indexerURL, id),
+    FOREIGN KEY (fileId) REFERENCES files(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_objects_id ON objects(id);
+CREATE INDEX IF NOT EXISTS idx_objects_fileId ON objects(fileId);
+
+-- Local filesystem cache. No FK on fileId: the cache outlives FK guarantees and is reconciled by
+-- orphan and eviction scanners.
+CREATE TABLE IF NOT EXISTS fs (
+    fileId TEXT PRIMARY KEY,
+    size INTEGER NOT NULL,
+    addedAt INTEGER NOT NULL,
+    usedAt INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_fs_addedAt ON fs(addedAt);
+CREATE INDEX IF NOT EXISTS idx_fs_usedAt ON fs(usedAt);
+
+CREATE TABLE IF NOT EXISTS logs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp TEXT NOT NULL,
+    level TEXT NOT NULL,
+    scope TEXT NOT NULL,
+    message TEXT NOT NULL,
+    createdAt INTEGER NOT NULL,
+    data TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_logs_level_scope ON logs(level, scope);
+CREATE INDEX IF NOT EXISTS idx_logs_createdAt ON logs(createdAt);
+
+CREATE TABLE IF NOT EXISTS tags (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    createdAt INTEGER NOT NULL,
+    usedAt INTEGER NOT NULL,
+    system INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_tags_usedAt ON tags(usedAt);
+
+CREATE TABLE IF NOT EXISTS file_tags (
+    fileId TEXT NOT NULL,
+    tagId TEXT NOT NULL,
+    PRIMARY KEY (fileId, tagId),
+    FOREIGN KEY (fileId) REFERENCES files(id) ON DELETE CASCADE,
+    FOREIGN KEY (tagId) REFERENCES tags(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_file_tags_tagId ON file_tags(tagId);
+";
+
+pub(crate) fn up(conn: &Connection) -> Result<(), DbError> {
+    conn.execute_batch(SCHEMA)?;
+    let now = chrono::Utc::now().timestamp_millis();
+    conn.execute(
+        "INSERT OR IGNORE INTO tags (id, name, createdAt, usedAt, system) VALUES (?, ?, ?, ?, 1)",
+        params!["sys:favorites", "Favorites", now, now],
+    )?;
+    Ok(())
+}

--- a/crates/sia-storage-core/src/db/migrations/m0002_object_needs_sync_up.rs
+++ b/crates/sia-storage-core/src/db/migrations/m0002_object_needs_sync_up.rs
@@ -1,0 +1,54 @@
+use rusqlite::Connection;
+
+use crate::db::DbError;
+
+pub(crate) fn up(conn: &Connection) -> Result<(), DbError> {
+    // Flag every existing object once so the first post-upgrade sync-up pass reconciles it (a
+    // no-diff pass clears it). Never-uploaded files have no object row, so they are excluded.
+    // The partial index covers the sync-up batch query (`indexerURL = ? AND needsSyncUp = 1`).
+    conn.execute_batch(
+        r"ALTER TABLE objects ADD COLUMN needsSyncUp INTEGER NOT NULL DEFAULT 0;
+          UPDATE objects SET needsSyncUp = 1;
+          CREATE INDEX IF NOT EXISTS idx_objects_needs_sync_up
+              ON objects(indexerURL, id)
+              WHERE needsSyncUp = 1;",
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::db::migrations::CORE_MIGRATIONS;
+    use crate::db::runner::run_migrations;
+    use rusqlite::Connection;
+
+    #[test]
+    fn backfill_flags_existing_objects_as_needing_sync_up() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        run_migrations(&mut conn, &CORE_MIGRATIONS[..1], None).unwrap();
+        conn.execute(
+            "INSERT INTO files (id, addedAt, name, size, type, createdAt, updatedAt, hash) \
+             VALUES ('file-1', 0, 'f', 0, 'file', 0, 0, '')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO objects (fileId, indexerURL, id, slabs, encryptedDataKey, \
+             encryptedMetadataKey, encryptedMetadata, dataSignature, metadataSignature, \
+             createdAt, updatedAt) VALUES (?, ?, ?, '[]', '', '', '', '', '', 0, 0)",
+            rusqlite::params!["file-1", "https://indexer", "obj-1"],
+        )
+        .unwrap();
+
+        run_migrations(&mut conn, CORE_MIGRATIONS, None).unwrap();
+
+        let needs_sync_up: i64 = conn
+            .query_row(
+                "SELECT needsSyncUp FROM objects WHERE id = 'obj-1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(needs_sync_up, 1);
+    }
+}

--- a/crates/sia-storage-core/src/db/runner.rs
+++ b/crates/sia-storage-core/src/db/runner.rs
@@ -1,0 +1,212 @@
+use rusqlite::Connection;
+use tracing::{debug, info};
+
+use crate::db::DbError;
+use crate::db::types::{Migration, MigrationProgress, MigrationProgressFn};
+
+/// Apply every not-yet-applied migration in chain order, each in its own transaction, recording
+/// its id. Idempotent: already-applied ids are skipped.
+///
+/// Two invariants make out-of-order execution impossible rather than merely unlikely: the applied
+/// migrations must form an unbroken prefix of the chain, and each pending migration's `parent`
+/// must equal the current applied head. So a migration can only ever run immediately after the one
+/// it declares it builds on; a mid-list insert, or a database that already ran a later migration,
+/// errors loudly instead of silently running against the wrong schema. A failing migration rolls
+/// back and is left unrecorded, so the next run retries it.
+pub(crate) fn run_migrations(
+    conn: &mut Connection,
+    migrations: &[Migration],
+    on_progress: Option<&MigrationProgressFn>,
+) -> Result<(), DbError> {
+    debug!(target: "db", "checking_migrations");
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS migrations (id TEXT PRIMARY KEY, appliedAt INTEGER NOT NULL);",
+    )?;
+    let applied: std::collections::HashSet<String> = {
+        let mut stmt = conn.prepare("SELECT id FROM migrations")?;
+        let ids = stmt.query_map([], |r| r.get::<_, String>(0))?;
+        ids.collect::<rusqlite::Result<_>>()?
+    };
+
+    // The applied set must be an unbroken prefix of the chain: walk in order, and once we reach
+    // the first unapplied migration, nothing after it may be applied. An applied migration behind
+    // an unapplied one means the database ran migrations out of order (a corrupt or downgraded
+    // DB); refuse rather than "repair" it into a worse state.
+    let mut head: Option<&'static str> = None;
+    let mut pending_from: Option<usize> = None;
+    for (i, m) in migrations.iter().enumerate() {
+        if applied.contains(m.id) {
+            if pending_from.is_some() {
+                return Err(DbError::Message(format!(
+                    "migration {} is applied but an earlier migration is not; \
+                     the database is in an inconsistent state",
+                    m.id
+                )));
+            }
+            head = Some(m.id);
+        } else if pending_from.is_none() {
+            pending_from = Some(i);
+        }
+    }
+
+    let pending = &migrations[pending_from.unwrap_or(migrations.len())..];
+    if !pending.is_empty() {
+        info!(target: "db", count = pending.len(), "migrations_pending");
+    }
+    for (offset, m) in pending.iter().enumerate() {
+        // A migration may only attach to the current head. This is what makes out-of-order
+        // execution unrepresentable, not just detectable.
+        if m.parent != head {
+            return Err(DbError::Message(format!(
+                "migration {} expects parent {:?} but the applied head is {:?}",
+                m.id, m.parent, head
+            )));
+        }
+        info!(target: "db", id = m.id, description = m.description, "applying_migration");
+        if let Some(f) = on_progress {
+            f(MigrationProgress {
+                id: m.id,
+                description: m.description,
+                index: offset + 1,
+                total: pending.len(),
+            });
+        }
+        let tx = conn.transaction()?;
+        (m.up)(&tx)?;
+        tx.execute(
+            "INSERT INTO migrations (id, appliedAt) VALUES (?, ?)",
+            rusqlite::params![m.id, chrono::Utc::now().timestamp_millis()],
+        )?;
+        tx.commit()?;
+        head = Some(m.id);
+    }
+    info!(target: "db", "migrations_complete");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_a(c: &Connection) -> Result<(), DbError> {
+        c.execute_batch("CREATE TABLE a (x INTEGER)")?;
+        Ok(())
+    }
+    fn create_b(c: &Connection) -> Result<(), DbError> {
+        c.execute_batch("CREATE TABLE b (x INTEGER)")?;
+        Ok(())
+    }
+
+    fn chain() -> [Migration; 2] {
+        [
+            Migration {
+                id: "0001",
+                description: "a",
+                parent: None,
+                up: create_a,
+            },
+            Migration {
+                id: "0002",
+                description: "b",
+                parent: Some("0001"),
+                up: create_b,
+            },
+        ]
+    }
+
+    fn migration_count(conn: &Connection) -> i64 {
+        conn.query_row("SELECT COUNT(*) FROM migrations", [], |r| r.get(0))
+            .unwrap()
+    }
+
+    #[test]
+    fn applies_pending_in_order_and_is_idempotent() {
+        let migrations = chain();
+        let mut conn = Connection::open_in_memory().unwrap();
+        run_migrations(&mut conn, &migrations, None).unwrap();
+        run_migrations(&mut conn, &migrations, None).unwrap();
+        assert_eq!(migration_count(&conn), 2);
+        assert!(
+            conn.execute_batch("SELECT x FROM a; SELECT x FROM b;")
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn progress_fires_once_per_pending_migration_only() {
+        let migrations = chain();
+        let mut conn = Connection::open_in_memory().unwrap();
+        run_migrations(&mut conn, &migrations[..1], None).unwrap();
+
+        // 0001 is already applied, so a full run reports only 0002, as 1 of 1.
+        let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = events.clone();
+        let on_progress: crate::db::MigrationProgressFn = Box::new(move |p| {
+            sink.lock()
+                .unwrap()
+                .push((p.id.to_string(), p.index, p.total));
+        });
+        run_migrations(&mut conn, &migrations, Some(&on_progress)).unwrap();
+        assert_eq!(*events.lock().unwrap(), [("0002".to_string(), 1, 1)]);
+    }
+
+    #[test]
+    fn a_failing_migration_rolls_back_and_is_not_recorded() {
+        fn bad(c: &Connection) -> Result<(), DbError> {
+            c.execute_batch("CREATE TABLE a (x INTEGER)")?;
+            Err("boom".into())
+        }
+        let migrations = [Migration {
+            id: "0001",
+            description: "bad",
+            parent: None,
+            up: bad,
+        }];
+        let mut conn = Connection::open_in_memory().unwrap();
+        assert!(run_migrations(&mut conn, &migrations, None).is_err());
+        assert!(
+            conn.execute_batch("SELECT x FROM a").is_err(),
+            "table a rolled back"
+        );
+        assert_eq!(migration_count(&conn), 0);
+    }
+
+    // A migration whose parent isn't the current head can't run: it errors rather than applying
+    // against a schema state it wasn't written for.
+    #[test]
+    fn a_migration_whose_parent_is_not_the_head_is_rejected() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        run_migrations(&mut conn, &chain()[..1], None).unwrap(); // head = 0001
+        let bad_chain = [
+            Migration {
+                id: "0001",
+                description: "a",
+                parent: None,
+                up: create_a,
+            },
+            // 0003 claims to build on 0002, which was never applied.
+            Migration {
+                id: "0003",
+                description: "c",
+                parent: Some("0002"),
+                up: create_b,
+            },
+        ];
+        let err = run_migrations(&mut conn, &bad_chain, None).unwrap_err();
+        assert!(format!("{err}").contains("expects parent"));
+    }
+
+    // A database that already ran a later migration but is missing an earlier one is refused,
+    // not silently repaired.
+    #[test]
+    fn a_gap_in_the_applied_prefix_is_rejected() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE migrations (id TEXT PRIMARY KEY, appliedAt INTEGER NOT NULL);
+             INSERT INTO migrations (id, appliedAt) VALUES ('0002', 0);",
+        )
+        .unwrap();
+        let err = run_migrations(&mut conn, &chain(), None).unwrap_err();
+        assert!(format!("{err}").contains("inconsistent state"));
+    }
+}

--- a/crates/sia-storage-core/src/db/types.rs
+++ b/crates/sia-storage-core/src/db/types.rs
@@ -1,0 +1,31 @@
+use rusqlite::Connection;
+
+use crate::db::DbError;
+
+/// A schema migration. `up` runs the migration's statements; the runner wraps them in a
+/// transaction and records the id. `parent` is the id of the migration this one builds on
+/// (`None` for the first). The runner checks each pending migration's `parent` against the
+/// applied head, so a migration can only ever run in its one intended position, never out of
+/// order. Internal: an app opens a database via `Db::open`, it never touches migrations.
+pub(crate) struct Migration {
+    pub id: &'static str,
+    pub description: &'static str,
+    pub parent: Option<&'static str>,
+    pub up: fn(&Connection) -> Result<(), DbError>,
+}
+
+/// Migration progress: fired as each pending migration starts, carrying its position
+/// (`index` of `total`, 1-based, counting only this run's pending set), so a startup
+/// screen can show "running migration 2 of 3". A migration is one opaque SQL batch, so
+/// there is no finer-grained progress within one.
+#[derive(Debug, Clone, Copy)]
+pub struct MigrationProgress<'a> {
+    pub id: &'a str,
+    pub description: &'a str,
+    pub index: usize,
+    pub total: usize,
+}
+
+/// Progress callback for [`MigrationProgress`]. Runs on the blocking thread that applies
+/// the migrations, so it must not block on the async runtime.
+pub type MigrationProgressFn = Box<dyn Fn(MigrationProgress<'_>) + Send>;

--- a/crates/sia-storage-core/src/encoding.rs
+++ b/crates/sia-storage-core/src/encoding.rs
@@ -1,0 +1,1 @@
+pub mod timestamp;

--- a/crates/sia-storage-core/src/encoding/timestamp.rs
+++ b/crates/sia-storage-core/src/encoding/timestamp.rs
@@ -1,0 +1,32 @@
+use chrono::{DateTime, TimeZone, Utc};
+
+/// The one gateway from the DB's `i64`-ms timestamps to the domain `DateTime`.
+/// Out-of-range values fall back to the Unix epoch.
+pub fn decode_epoch_ms(value: i64) -> DateTime<Utc> {
+    Utc.timestamp_millis_opt(value)
+        .single()
+        .unwrap_or(DateTime::<Utc>::UNIX_EPOCH)
+}
+
+pub fn encode_epoch_ms(date: DateTime<Utc>) -> i64 {
+    date.timestamp_millis()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_known_timestamp() {
+        let ms = 1_700_000_000_000i64;
+        let dt = decode_epoch_ms(ms);
+        assert_eq!(encode_epoch_ms(dt), ms);
+    }
+
+    #[test]
+    fn out_of_range_falls_back_to_unix_epoch() {
+        let dt = decode_epoch_ms(i64::MAX);
+        assert_eq!(dt, DateTime::<Utc>::UNIX_EPOCH);
+        assert_eq!(encode_epoch_ms(dt), 0);
+    }
+}

--- a/crates/sia-storage-core/src/lib.rs
+++ b/crates/sia-storage-core/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod db;
+pub mod encoding;


### PR DESCRIPTION
The core schema and the migration runner, plus the epoch-ms timestamp codec the ops share. Two migrations build the tables and indexes and seed the Favorites tag.

Migrations are an internal detail of the db module: opening the database runs them, and no caller sees the runner or the migration list. Each migration is sync, it runs its statements and the runner wraps them in a transaction:

```rust
fn up(conn: &Connection) -> Result<(), DbError> {
    conn.execute_batch(SCHEMA)?;
    Ok(())
}
```

The runner applies each pending migration in its own transaction and records its id, so already-applied ids are skipped and a failed migration retries on the next open. `open` takes an optional per-migration progress callback (`MigrationProgress`: id, description, index, total) so callers can surface migration progress; the mobile app displays it during init.

The one non-migration piece is the timestamp codec: the DB stores timestamps as epoch-ms `i64`, and `encode_epoch_ms` / `decode_epoch_ms` convert to and from the domain `DateTime`. It lives here because more than one ops file needs it (files and local-objects). The stored types themselves (`LocalObject` and the slab codec) live with their only consumer in the local-objects PR.

What it adds:

- `0001`: the full schema (files / directories / objects / fs / logs / tags / file_tags plus indexes) and the Favorites system tag.
- `0002`: the per-object `needsSyncUp` dirty flag and its partial index.
- The runner: each pending migration in its own transaction, recorded, idempotent; wired into `Db::open` with the optional progress callback.
- The epoch-ms timestamp codec (`encode_epoch_ms` / `decode_epoch_ms`), shared by the ops that read and write timestamps.
