### PR TITLE
ci(release): automate TestFlight and Play tester distribution

### DIFF
--- a/apps/mobile/.gitignore
+++ b/apps/mobile/.gitignore
@@ -25,6 +25,9 @@ modules/*/android/build/
 *.pem
 android-release.keystore
 
+# Fastlane: releaseAndroid.ts generates the Play "What's new" changelog per release
+fastlane/metadata/android/*/changelogs/
+
 # Metro
 .metro-health-check*
 

--- a/apps/mobile/fastlane/Fastfile
+++ b/apps/mobile/fastlane/Fastfile
@@ -176,11 +176,18 @@ platform :ios do
     
     app_store_connect_api_key(api_key_params)
     
+    # External tester groups for this build, passed by releaseIos.ts; an empty
+    # list means internal testers only.
+    external_groups = ENV["IOS_EXTERNAL_GROUPS"] ? JSON.parse(ENV["IOS_EXTERNAL_GROUPS"]) : []
+    has_external = !external_groups.empty?
+
     upload_to_testflight(
       ipa: IOS_RELEASE_IPA_PATH,
       skip_waiting_for_build_processing: false, # Wait for processing - ensures build is ready before command completes (takes 10-30 min)
-      distribute_external: false, # Don't auto-distribute externally - we manually manage tester groups in TestFlight
-      notify_external_testers: false # Don't notify testers - we control when to send notifications manually
+      changelog: ENV["IOS_WHATS_NEW"], # "What to Test" - releaseIos.ts sets it to the version's release-notes link
+      distribute_external: has_external, # External groups go through Beta App Review; internal testers always auto-receive
+      groups: has_external ? external_groups : nil,
+      notify_external_testers: has_external
     )
   end
 end
@@ -281,16 +288,23 @@ platform :android do
     if !File.exist?(ANDROID_AAB_PATH)
       UI.user_error!("AAB file not found at #{ANDROID_AAB_PATH}. Run 'bun run release:android:build' first.")
     end
-    
+
+    # releaseAndroid.ts writes this before calling the lane; invoking the lane
+    # on its own (not via the script) leaves it absent, so skip changelogs then.
+    metadata_path = File.expand_path("metadata/android", __dir__)
+    changelog_present = File.exist?(File.join(metadata_path, "en-US/changelogs/default.txt"))
+
     upload_to_play_store(
       track: "internal", # Internal track - for testing
       aab: ANDROID_AAB_PATH,
-      release_status: "draft", # Use draft status until app is published in Play Console
+      release_status: "completed", # Activate on the internal track - no manual Play Console step
       skip_upload_apk: true, # Don't upload APK - Google Play requires AAB format for new apps (smaller size, better optimization)
       skip_upload_aab: false, # Upload AAB - this is the required format for Play Store distribution
-      skip_upload_metadata: true, # Don't upload metadata - we manage descriptions, changelogs, etc. manually in Play Console
+      skip_upload_metadata: true, # Don't upload listing metadata - we manage descriptions, etc. manually in Play Console
+      skip_upload_changelogs: !changelog_present, # Upload "What's new" when releaseAndroid.ts generated it
       skip_upload_images: true, # Don't upload images - we manage app icons and feature graphics manually
       skip_upload_screenshots: true, # Don't upload screenshots - we manage them manually in Play Console
+      metadata_path: metadata_path,
       json_key_data: google_play_service_account_key
     )
   end

--- a/apps/mobile/scripts/releaseAndroid.ts
+++ b/apps/mobile/scripts/releaseAndroid.ts
@@ -17,9 +17,12 @@
  *   GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_JSON - Google Play service account key
  */
 
+import { mkdirSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 import { $ } from 'bun'
+import pkg from '../package.json'
 import { resolveVariant } from '../variants'
+import { whatsNewText } from './releaseNotes'
 
 const projectRoot = path.resolve(import.meta.dir, '..')
 
@@ -77,6 +80,11 @@ if (Bun.env.DRY_RUN === 'true') {
 } else {
   console.log(`Step 3/3: Uploading to Play Store (${track} track)...`)
   if (track === 'internal') {
+    // supply has no inline release-notes option; it reads "What's new" from a
+    // per-locale changelog file. default.txt applies to any versionCode.
+    const changelogDir = path.join(projectRoot, 'fastlane/metadata/android/en-US/changelogs')
+    mkdirSync(changelogDir, { recursive: true })
+    writeFileSync(path.join(changelogDir, 'default.txt'), whatsNewText(pkg.version))
     await $`fastlane android distribute_internal`
   } else {
     await $`fastlane android distribute_play_store`

--- a/apps/mobile/scripts/releaseIos.ts
+++ b/apps/mobile/scripts/releaseIos.ts
@@ -16,7 +16,9 @@
 
 import path from 'node:path'
 import { $ } from 'bun'
+import pkg from '../package.json'
 import { resolveVariant } from '../variants'
+import { whatsNewText } from './releaseNotes'
 
 const projectRoot = path.resolve(import.meta.dir, '..')
 
@@ -73,6 +75,10 @@ if (Bun.env.DRY_RUN === 'true') {
 } else {
   console.log(`Step 3/3: Uploading to App Store Connect (${track})...`)
   if (track === 'testflight') {
+    // Fastfile reads both via ENV: the "What to Test" link and the variant's
+    // external tester groups.
+    process.env.IOS_WHATS_NEW = whatsNewText(pkg.version)
+    process.env.IOS_EXTERNAL_GROUPS = JSON.stringify(variant.testflightExternalGroups)
     await $`fastlane ios distribute_testflight`
   } else {
     await $`fastlane ios distribute_app_store`

--- a/apps/mobile/scripts/releaseNotes.ts
+++ b/apps/mobile/scripts/releaseNotes.ts
@@ -1,0 +1,17 @@
+/**
+ * Release-notes link for an internal build's "What to Test" / "What's new".
+ *
+ * knope publishes a GitHub Release per `mobile/v<version>` tag with the
+ * version's changelog as the body. CI links to it instead of summarizing the
+ * changelog, and the short link keeps Android under Play's 500-char limit.
+ */
+
+const REPO_SLUG = 'SiaFoundation/sia-storage-app'
+
+function releaseNotesUrl(version: string): string {
+  return `https://github.com/${REPO_SLUG}/releases/tag/mobile/v${version}`
+}
+
+export function whatsNewText(version: string): string {
+  return `Read what's new in ${version}:\n${releaseNotesUrl(version)}`
+}

--- a/apps/mobile/variants.d.ts
+++ b/apps/mobile/variants.d.ts
@@ -15,6 +15,7 @@ export interface ResolvedVariant {
   appGroup: string
   iosProfileName: string
   shareExtProfileName: string
+  testflightExternalGroups: string[]
   isReleaseVariant: boolean
 }
 

--- a/apps/mobile/variants.js
+++ b/apps/mobile/variants.js
@@ -42,6 +42,8 @@ const VARIANTS = {
     bundleId: 'sia.storage',
     iosIcon: './assets/app-icon-ios.png',
     androidIcon: './assets/app-icon-android.png',
+    // Must match the TestFlight external group names in App Store Connect exactly.
+    testflightExternalGroups: ['Beacons', 'Hackers', 'Marketing'],
   },
 }
 
@@ -61,6 +63,7 @@ function resolveVariant(name = process.env.APP_VARIANT) {
     // Developer portal — derived from the display name so they stay in lockstep.
     iosProfileName: `${variant.name} Distribution`,
     shareExtProfileName: `${variant.name} Share Extension Distribution`,
+    testflightExternalGroups: variant.testflightExternalGroups || [],
     // dev builds are debug-signed; beta and prod are release-signed.
     isReleaseVariant: key !== 'dev',
   }


### PR DESCRIPTION
Each release currently requries a bunch of manual steps like hand-entering the release notes, assigning the TestFlight tester groups, and clicking through the Play Console to activate the build, this was already tedius but is now 2x because we added a seperate Beta testflight app (so you can have testflight and app store installed at the same time). With these changes CI now handles it all. The testflight notes now link to that version's GitHub release page (with knope managed changelog). We link out because Android has a 500 character limit, the knope changelog almost always exceeds this.

**TestFlight (iOS)**

- Sets "What to Test" to the release link
- Distributes to each app's internal and external groups, with notify on

**Play (Android)**

- Sets "What's new" to the release link
- Ships the internal build as `completed` so it activates without Play Console clicks

**Both patforms**

- Runs automatically for main app and beta, so nothing above is done twice by hand

**Unchanged**

- App Store and Play production release process and notes stay manual