### PR TITLE
feat(core): local-object db operations

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,10 +34,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bip39"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
+dependencies = [
+ "bitcoin_hashes",
+ "serde",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
+dependencies = [
+ "hex-conservative",
+]
 
 [[package]]
 name = "bitflags"
@@ -36,10 +96,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "blake2b_simd"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cc"
@@ -58,6 +177,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.4",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cipher 0.5.2",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20 0.9.1",
+ "cipher 0.4.4",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,10 +233,267 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
+ "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "fallible-iterator"
@@ -90,16 +508,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -114,10 +579,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "slab",
 ]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -129,12 +671,159 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "hashlink"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-conservative"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -160,6 +849,180 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
@@ -191,10 +1054,90 @@ dependencies = [
 ]
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "memchr"
+version = "2.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -206,10 +1149,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -218,10 +1192,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -233,12 +1252,229 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20 0.10.1",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -256,10 +1492,96 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -268,6 +1590,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -291,6 +1614,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,10 +1692,131 @@ name = "sia-storage-core"
 version = "0.0.1"
 dependencies = [
  "chrono",
+ "hex",
  "rusqlite",
+ "serde",
+ "serde_json",
+ "sia_storage",
  "thiserror",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "sia_core"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "283b08069d1cd8f62d24a37a4bdd2c9844c6c01c8c4be3ea472cc1db18bab301"
+dependencies = [
+ "base64",
+ "bip39",
+ "blake2",
+ "blake2b_simd",
+ "bytes",
+ "chrono",
+ "ed25519-dalek",
+ "hex",
+ "num-bigint",
+ "num-rational",
+ "num-traits",
+ "rayon",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sia_core_derive",
+ "thiserror",
+ "tokio",
+ "uint",
+ "zeroize",
+]
+
+[[package]]
+name = "sia_core_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be79c90e1acc58de1787a54f4bfca36a33be9c6a4b5ac0be98de7eca1ef5926"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sia_mux"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c51594a4e1de4d21d09ffae9912ba88941d581505ce0d1a824a3f526d80f664"
+dependencies = [
+ "blake2b_simd",
+ "bytes",
+ "ed25519-dalek",
+ "rand_core 0.6.4",
+ "ring",
+ "thiserror",
+ "tokio",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "sia_reed_solomon"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "967b01469aa6c06d6206051341e13559fff7888f5689ff4992f5110cdbda2009"
+dependencies = [
+ "cfg-if",
+ "rayon",
+ "thiserror",
+]
+
+[[package]]
+name = "sia_storage"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abce6316361e955422cb24022d01b99127b15416bda48dc6887407e8aca109bd"
+dependencies = [
+ "base64",
+ "blake2",
+ "blake2b_simd",
+ "bytes",
+ "chacha20 0.10.1",
+ "chacha20poly1305",
+ "chrono",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "getrandom 0.4.3",
+ "hex",
+ "hkdf",
+ "instant",
+ "js-sys",
+ "log",
+ "rand 0.10.1",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sia_core",
+ "sia_mux",
+ "sia_reed_solomon",
+ "sysinfo",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -320,6 +1832,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,6 +1884,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.39.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8bd2130a9b60bee2581bf82cfe89ee836424d1f37dcfa4ce21509611684673"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
 ]
 
 [[package]]
@@ -351,13 +1941,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
+ "bytes",
+ "libc",
+ "mio",
  "pin-project-lite",
+ "socket2",
  "tokio-macros",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -370,6 +2020,75 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -403,10 +2122,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "uint"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "vcpkg"
@@ -421,6 +2208,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,6 +2242,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -466,6 +2287,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,6 +2369,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -507,6 +2411,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,6 +2436,218 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -543,3 +2669,83 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -10,7 +10,11 @@ publish = false
 
 [workspace.dependencies]
 chrono = { version = "0.4", features = ["serde"] }
+hex = "0.4"
 rusqlite = { version = "0.32", features = ["bundled", "array"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sia_storage = "0.10"
 thiserror = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync"] }
 tracing = "0.1"

--- a/crates/sia-storage-core/Cargo.toml
+++ b/crates/sia-storage-core/Cargo.toml
@@ -8,7 +8,11 @@ publish.workspace = true
 
 [dependencies]
 chrono.workspace = true
+hex.workspace = true
 rusqlite.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sia_storage.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/sia-storage-core/src/db.rs
+++ b/crates/sia-storage-core/src/db.rs
@@ -5,6 +5,7 @@
 
 pub mod database;
 mod migrations;
+pub mod operations;
 mod runner;
 pub mod sql;
 mod types;

--- a/crates/sia-storage-core/src/db/operations.rs
+++ b/crates/sia-storage-core/src/db/operations.rs
@@ -1,0 +1,3 @@
+//! The database operations: every query and mutation against the schema, grouped by table area.
+
+pub mod local_objects;

--- a/crates/sia-storage-core/src/db/operations/local_objects.rs
+++ b/crates/sia-storage-core/src/db/operations/local_objects.rs
@@ -1,0 +1,887 @@
+//! The local object store: each file's indexer objects plus the per-object `needsSyncUp` dirty flag.
+//!
+//! Objects are keyed `(indexerURL, id)`, so the same id under two indexers is two independent rows
+//! and every read and delete is indexer-scoped. The app currently assumes one indexer, but the
+//! schema and ops allow for multi-indexer / indexer-migration features in the future.
+
+use std::collections::HashMap;
+use std::str::FromStr;
+
+use rusqlite::{Connection, params};
+use sia_storage::{SealedObject, Signature};
+
+use crate::db::DbError;
+use crate::db::sql;
+use crate::encoding::slabs::{slabs_from_storage_string, slabs_to_storage_string};
+use crate::encoding::timestamp::{decode_epoch_ms, encode_epoch_ms};
+use crate::types::local_object::{LocalObject, LocalObjectRef};
+
+fn local_object_ref_from_db_row(r: &rusqlite::Row) -> rusqlite::Result<LocalObjectRef> {
+    Ok(LocalObjectRef {
+        id: r.get("id")?,
+        file_id: r.get("fileId")?,
+        indexer_url: r.get("indexerURL")?,
+        created_at: decode_epoch_ms(r.get("createdAt")?),
+        updated_at: decode_epoch_ms(r.get("updatedAt")?),
+    })
+}
+
+fn local_object_from_db_row(r: &rusqlite::Row) -> rusqlite::Result<LocalObject> {
+    // A stored field that fails to decode means a corrupt row; surface it rather than load a
+    // blanked object that fails confusingly at download or decrypt.
+    fn corrupt(field: &str) -> rusqlite::Error {
+        rusqlite::Error::InvalidColumnType(0, field.to_string(), rusqlite::types::Type::Text)
+    }
+    let unhex = |col: &'static str, s: String| hex::decode(s).map_err(|_| corrupt(col));
+    let sig = |col: &'static str, s: String| Signature::from_str(&s).map_err(|_| corrupt(col));
+    Ok(LocalObject {
+        id: r.get("id")?,
+        file_id: r.get("fileId")?,
+        indexer_url: r.get("indexerURL")?,
+        sealed: SealedObject {
+            encrypted_data_key: unhex("encryptedDataKey", r.get("encryptedDataKey")?)?,
+            slabs: slabs_from_storage_string(&r.get::<_, String>("slabs")?)
+                .ok_or_else(|| corrupt("slabs"))?,
+            data_signature: sig("dataSignature", r.get("dataSignature")?)?,
+            encrypted_metadata_key: unhex("encryptedMetadataKey", r.get("encryptedMetadataKey")?)?,
+            encrypted_metadata: unhex("encryptedMetadata", r.get("encryptedMetadata")?)?,
+            metadata_signature: sig("metadataSignature", r.get("metadataSignature")?)?,
+            created_at: decode_epoch_ms(r.get("createdAt")?),
+            updated_at: decode_epoch_ms(r.get("updatedAt")?),
+        },
+    })
+}
+
+/// Returns the lightweight object refs (id/file/indexer/timestamps, no slabs or
+/// crypto fields) for one file.
+pub fn query_object_refs_for_file(
+    conn: &Connection,
+    file_id: &str,
+) -> Result<Vec<LocalObjectRef>, DbError> {
+    let mut stmt = conn.prepare(
+        "SELECT id, fileId, indexerURL, createdAt, updatedAt FROM objects WHERE fileId = ?",
+    )?;
+    let out = stmt
+        .query_map(params![file_id], local_object_ref_from_db_row)?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(out)
+}
+
+/// Returns the full decoded objects (slabs plus the still-encrypted crypto fields) for one
+/// file.
+pub fn query_objects_for_file(
+    conn: &Connection,
+    file_id: &str,
+) -> Result<Vec<LocalObject>, DbError> {
+    let mut stmt = conn.prepare(
+        "SELECT id, fileId, indexerURL, createdAt, updatedAt, encryptedDataKey,
+                 encryptedMetadataKey, encryptedMetadata, dataSignature, metadataSignature, slabs
+          FROM objects WHERE fileId = ?",
+    )?;
+    let out = stmt
+        .query_map(params![file_id], local_object_from_db_row)?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(out)
+}
+
+/// Upserts one object via `INSERT OR REPLACE`: an existing row is overwritten, not
+/// duplicated. Every create/re-upload inserts the object dirty (needsSyncUp = 1), so the
+/// next sync-up pass reconciles it.
+pub fn upsert_object(conn: &Connection, o: &LocalObject) -> Result<(), DbError> {
+    conn.execute(
+        "INSERT OR REPLACE INTO objects (fileId, indexerURL, id, slabs, encryptedDataKey,
+            encryptedMetadataKey, encryptedMetadata, dataSignature, metadataSignature,
+            createdAt, updatedAt, needsSyncUp)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)",
+        params![
+            o.file_id,
+            o.indexer_url,
+            o.id,
+            slabs_to_storage_string(&o.sealed.slabs),
+            hex::encode(&o.sealed.encrypted_data_key),
+            hex::encode(&o.sealed.encrypted_metadata_key),
+            hex::encode(&o.sealed.encrypted_metadata),
+            o.sealed.data_signature.to_string(),
+            o.sealed.metadata_signature.to_string(),
+            encode_epoch_ms(o.sealed.created_at),
+            encode_epoch_ms(o.sealed.updated_at),
+        ],
+    )?;
+    Ok(())
+}
+
+/// Deletes one object row, scoped to (object_id, indexer_url).
+pub fn delete_object(conn: &Connection, object_id: &str, indexer_url: &str) -> Result<(), DbError> {
+    conn.execute(
+        "DELETE FROM objects WHERE id = ? AND indexerURL = ?",
+        params![object_id, indexer_url],
+    )?;
+    Ok(())
+}
+
+/// Returns the number of object rows belonging to one file (across all indexers).
+/// Consumed by the facade's file-details read (upstack).
+pub fn count_objects_for_file(conn: &Connection, file_id: &str) -> Result<i64, DbError> {
+    Ok(conn.query_row(
+        "SELECT COUNT(*) FROM objects WHERE fileId = ?",
+        params![file_id],
+        |r| r.get(0),
+    )?)
+}
+
+/// Deletes every object row for one file, regardless of indexer. Consumed by the
+/// facade's permanent-delete flow (upstack).
+pub fn delete_objects_for_file(conn: &Connection, file_id: &str) -> Result<(), DbError> {
+    conn.execute("DELETE FROM objects WHERE fileId = ?", params![file_id])?;
+    Ok(())
+}
+
+/// Bulk variant of [`query_object_refs_for_file`]: returns lightweight object refs
+/// for many files, keyed by file id. Consumed by the facade's bulk file reads (upstack).
+pub fn query_object_refs_for_files(
+    conn: &Connection,
+    file_ids: &[String],
+) -> Result<HashMap<String, Vec<LocalObjectRef>>, DbError> {
+    if file_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let mut stmt = conn.prepare(
+        "SELECT id, fileId, indexerURL, createdAt, updatedAt FROM objects
+          WHERE fileId IN rarray(?)",
+    )?;
+    let rows = stmt
+        .query_map([sql::id_array(file_ids)], local_object_ref_from_db_row)?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    let mut map: HashMap<String, Vec<LocalObjectRef>> = HashMap::new();
+    for lo in rows {
+        map.entry(lo.file_id.clone()).or_default().push(lo);
+    }
+    Ok(map)
+}
+
+/// What an object upsert does to the `needsSyncUp` flag on conflict.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NeedsSyncUp {
+    /// On conflict, leave the existing `needsSyncUp` untouched (preserve a pending push); a fresh
+    /// insert defaults it to 0 (clean).
+    Leave,
+    /// Set `needsSyncUp = 1` (dirty, needs a remote push).
+    Set,
+    /// Set `needsSyncUp = 0` (clean, already in sync).
+    Clear,
+}
+
+impl NeedsSyncUp {
+    /// The `needsSyncUp` value written on a fresh insert.
+    fn insert_value(self) -> i64 {
+        match self {
+            NeedsSyncUp::Set => 1,
+            NeedsSyncUp::Leave | NeedsSyncUp::Clear => 0,
+        }
+    }
+
+    /// Whether a conflict overwrites the existing flag; `Leave` preserves a pending push.
+    fn updates_flag(self) -> bool {
+        self != NeedsSyncUp::Leave
+    }
+}
+
+/// Upserts many objects with one prepared statement (metadata refreshed on a `(indexerURL, id)`
+/// conflict). `sync_up`: upload passes `Set`; sync-down passes `Leave`, which omits
+/// `needsSyncUp` from the update set so a conflicting row keeps its pending dirty flag.
+pub fn upsert_many_objects(
+    conn: &Connection,
+    objects: &[LocalObject],
+    sync_up: NeedsSyncUp,
+) -> Result<(), DbError> {
+    if objects.is_empty() {
+        return Ok(());
+    }
+    let update_flag = if sync_up.updates_flag() {
+        ", needsSyncUp = excluded.needsSyncUp"
+    } else {
+        ""
+    };
+    let mut stmt = conn.prepare(&format!(
+        "INSERT INTO objects (fileId, indexerURL, id, slabs, encryptedDataKey,
+            encryptedMetadataKey, encryptedMetadata, dataSignature, metadataSignature,
+            createdAt, updatedAt, needsSyncUp)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(indexerURL, id) DO UPDATE SET
+            fileId = excluded.fileId,
+            slabs = excluded.slabs,
+            encryptedDataKey = excluded.encryptedDataKey,
+            encryptedMetadataKey = excluded.encryptedMetadataKey,
+            encryptedMetadata = excluded.encryptedMetadata,
+            dataSignature = excluded.dataSignature,
+            metadataSignature = excluded.metadataSignature,
+            createdAt = excluded.createdAt,
+            updatedAt = excluded.updatedAt{update_flag}"
+    ))?;
+    for o in objects {
+        stmt.execute(params![
+            o.file_id,
+            o.indexer_url,
+            o.id,
+            slabs_to_storage_string(&o.sealed.slabs),
+            hex::encode(&o.sealed.encrypted_data_key),
+            hex::encode(&o.sealed.encrypted_metadata_key),
+            hex::encode(&o.sealed.encrypted_metadata),
+            o.sealed.data_signature.to_string(),
+            o.sealed.metadata_signature.to_string(),
+            encode_epoch_ms(o.sealed.created_at),
+            encode_epoch_ms(o.sealed.updated_at),
+            sync_up.insert_value(),
+        ])?;
+    }
+    Ok(())
+}
+
+/// Flag every object of the given files dirty (the local-mutation entry point).
+pub fn flag_objects_for_files(conn: &Connection, file_ids: &[String]) -> Result<(), DbError> {
+    if file_ids.is_empty() {
+        return Ok(());
+    }
+    conn.execute(
+        "UPDATE objects SET needsSyncUp = 1 WHERE fileId IN rarray(?)",
+        [sql::id_array(file_ids)],
+    )?;
+    Ok(())
+}
+
+/// Compare-and-swap clear: clears the flag only if the file's edit clock
+/// (files.updatedAt) still matches the value observed before the sync round-trip,
+/// so an edit that landed mid-round-trip keeps the object flagged for the next
+/// pass. Resolution is updatedAt's millisecond; a second edit within the same
+/// millisecond can clear with that edit unpushed.
+pub fn clear_object_if_unchanged(
+    conn: &Connection,
+    object_id: &str,
+    indexer_url: &str,
+    expected_file_updated_at: i64,
+) -> Result<(), DbError> {
+    conn.execute(
+        r"UPDATE objects SET needsSyncUp = 0
+            WHERE id = ? AND indexerURL = ?
+              AND (SELECT updatedAt FROM files WHERE files.id = objects.fileId) = ?",
+        params![object_id, indexer_url, expected_file_updated_at],
+    )?;
+    Ok(())
+}
+
+/// Clear the flag on specific objects (sync-down remote-newer winners), scoped to one
+/// indexer.
+pub fn clear_objects(
+    conn: &Connection,
+    indexer_url: &str,
+    object_ids: &[String],
+) -> Result<(), DbError> {
+    if object_ids.is_empty() {
+        return Ok(());
+    }
+    conn.execute(
+        "UPDATE objects SET needsSyncUp = 0 WHERE indexerURL = ? AND id IN rarray(?)",
+        params![indexer_url, sql::id_array(object_ids)],
+    )?;
+    Ok(())
+}
+
+/// Flag every object dirty (the advanced "resync metadata" escape hatch).
+pub fn flag_all_objects(conn: &Connection) -> Result<(), DbError> {
+    conn.execute("UPDATE objects SET needsSyncUp = 1", [])?;
+    Ok(())
+}
+
+/// One dirty object at an indexer, joined to its file to build the sync-up push:
+/// the file's edit clock (`file_updated_at`, for the compare-and-swap clear) and
+/// its `deleted_at`, which decides the push, a delete when the file is gone,
+/// otherwise an upsert of the object's metadata.
+pub struct SyncUpObjectRow {
+    pub object_id: String,
+    pub file_id: String,
+    pub file_name: String,
+    pub file_updated_at: i64,
+    pub deleted_at: Option<i64>,
+}
+
+fn sync_up_object_from_db_row(r: &rusqlite::Row) -> rusqlite::Result<SyncUpObjectRow> {
+    Ok(SyncUpObjectRow {
+        object_id: r.get("objectId")?,
+        file_id: r.get("fileId")?,
+        file_name: r.get("fileName")?,
+        file_updated_at: r.get("fileUpdatedAt")?,
+        deleted_at: r.get("deletedAt")?,
+    })
+}
+
+/// Dirty objects at the given indexer (one row per push target, so LIMIT
+/// bounds work items exactly). Ordered by `o.id`, the index key, not updatedAt.
+pub fn query_sync_up_objects(
+    conn: &Connection,
+    indexer_url: &str,
+    limit: i64,
+) -> Result<Vec<SyncUpObjectRow>, DbError> {
+    let mut stmt = conn.prepare(
+        r"SELECT o.id AS objectId, o.fileId AS fileId, f.name AS fileName,
+            f.updatedAt AS fileUpdatedAt, f.deletedAt AS deletedAt
+          FROM objects o JOIN files f ON f.id = o.fileId
+          WHERE o.indexerURL = ? AND o.needsSyncUp = 1
+          ORDER BY o.id
+          LIMIT ?",
+    )?;
+    let out = stmt
+        .query_map(params![indexer_url, limit], sync_up_object_from_db_row)?
+        .collect::<rusqlite::Result<Vec<SyncUpObjectRow>>>()?;
+    Ok(out)
+}
+
+/// Count of dirty objects at the given indexer (sync-up progress total plus the
+/// post-batch "remaining == 0" termination check).
+pub fn count_sync_up_objects(conn: &Connection, indexer_url: &str) -> Result<i64, DbError> {
+    Ok(conn.query_row(
+        "SELECT COUNT(*) FROM objects WHERE indexerURL = ? AND needsSyncUp = 1",
+        params![indexer_url],
+        |r| r.get(0),
+    )?)
+}
+
+/// Deletes many object rows by id, all scoped to a single `indexer_url`.
+pub fn delete_many_objects_by_ids(
+    conn: &Connection,
+    object_ids: &[String],
+    indexer_url: &str,
+) -> Result<(), DbError> {
+    if object_ids.is_empty() {
+        return Ok(());
+    }
+    conn.execute(
+        "DELETE FROM objects WHERE indexerURL = ? AND id IN rarray(?)",
+        params![indexer_url, sql::id_array(object_ids)],
+    )?;
+    Ok(())
+}
+
+/// Returns the subset of the given file ids that have no object rows.
+pub fn query_files_with_no_objects(
+    conn: &Connection,
+    file_ids: &[String],
+) -> Result<Vec<String>, DbError> {
+    if file_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let q = r"SELECT id FROM files WHERE id IN rarray(?)
+              AND NOT EXISTS (SELECT 1 FROM objects WHERE fileId = files.id)";
+    let mut stmt = conn.prepare(q)?;
+    let out = stmt
+        .query_map([sql::id_array(file_ids)], |r| r.get("id"))?
+        .collect::<rusqlite::Result<Vec<String>>>()?;
+    Ok(out)
+}
+
+/// Deletes all objects for the given files in one statement. Consumed by the facade's
+/// bulk permanent-delete flow (upstack).
+pub fn delete_many_objects_for_files(
+    conn: &Connection,
+    file_ids: &[String],
+) -> Result<(), DbError> {
+    if file_ids.is_empty() {
+        return Ok(());
+    }
+    conn.execute(
+        "DELETE FROM objects WHERE fileId IN rarray(?)",
+        [sql::id_array(file_ids)],
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::migrations::migrated_conn;
+    use chrono::{TimeZone, Utc};
+
+    fn seed_file(conn: &Connection, id: &str) {
+        // The real schema makes name/size/type/hash/addedAt/createdAt/updatedAt
+        // NOT NULL with no default; these ops only read `FROM files`, so the
+        // values don't matter here: supply 0/'' placeholders.
+        seed_file_with_name_and_updated_at(conn, id, "", 0);
+    }
+
+    fn seed_file_with_name_and_updated_at(
+        conn: &Connection,
+        id: &str,
+        name: &str,
+        updated_at: i64,
+    ) {
+        conn.execute(
+            "INSERT INTO files (id, addedAt, name, size, type, createdAt, updatedAt, hash) \
+              VALUES (?, 0, ?, 0, '', 0, ?, '')",
+            params![id, name, updated_at],
+        )
+        .unwrap();
+    }
+
+    // Builds a test object with a DISTINCT value in every sealed field, so a swapped
+    // bind in the 12-column writes fails the round-trip assertions.
+    fn make_local_object(file_id: &str, indexer_url: &str, object_id: &str) -> LocalObject {
+        LocalObject {
+            id: object_id.into(),
+            file_id: file_id.into(),
+            indexer_url: indexer_url.into(),
+            sealed: SealedObject {
+                encrypted_data_key: vec![0x11, 0x12],
+                slabs: Vec::new(),
+                data_signature: Signature::try_from(&[0x21u8; 64][..]).unwrap(),
+                encrypted_metadata_key: vec![0x31, 0x32],
+                encrypted_metadata: vec![0x41, 0x42],
+                metadata_signature: Signature::try_from(&[0x51u8; 64][..]).unwrap(),
+                created_at: Utc.timestamp_millis_opt(1000).unwrap(),
+                updated_at: Utc.timestamp_millis_opt(2000).unwrap(),
+            },
+        }
+    }
+
+    #[test]
+    fn query_object_refs_for_files_returns_map_keyed_by_file_id_without_slabs() {
+        let conn = migrated_conn();
+        seed_file(&conn, "f1");
+        seed_file(&conn, "f2");
+        upsert_object(&conn, &make_local_object("f1", "https://a.com", "obj1")).unwrap();
+        upsert_object(&conn, &make_local_object("f2", "https://a.com", "obj2")).unwrap();
+
+        let map = query_object_refs_for_files(&conn, &["f1".into(), "f2".into()]).unwrap();
+        assert_eq!(map.get("f1").unwrap().len(), 1);
+        assert_eq!(map.get("f1").unwrap()[0].id, "obj1");
+        assert_eq!(map.get("f2").unwrap().len(), 1);
+        assert_eq!(map.get("f2").unwrap()[0].id, "obj2");
+    }
+
+    #[test]
+    fn query_object_refs_for_files_returns_empty_map_for_empty_input() {
+        let conn = migrated_conn();
+        let map = query_object_refs_for_files(&conn, &[]).unwrap();
+        assert!(map.is_empty());
+    }
+
+    // Reads back the raw needsSyncUp column for one object (the ops never decode it
+    // into LocalObject), so the flag-behavior tests can assert on it directly.
+    fn read_needs_sync_up(conn: &Connection, object_id: &str, indexer_url: &str) -> i64 {
+        conn.query_row(
+            "SELECT needsSyncUp FROM objects WHERE id = ? AND indexerURL = ?",
+            params![object_id, indexer_url],
+            |r| r.get::<_, i64>(0),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn upsert_many_objects_inserts_all_and_reads_back() {
+        let conn = migrated_conn();
+        seed_file(&conn, "f1");
+        seed_file(&conn, "f2");
+        let objects = vec![
+            make_local_object("f1", "https://a.com", "obj1"),
+            make_local_object("f1", "https://b.com", "obj2"),
+            make_local_object("f2", "https://a.com", "obj3"),
+        ];
+        upsert_many_objects(&conn, &objects, NeedsSyncUp::Set).unwrap();
+
+        let f1 = query_objects_for_file(&conn, "f1").unwrap();
+        assert_eq!(f1.len(), 2);
+        let mut f1_ids: Vec<String> = f1.iter().map(|o| o.id.clone()).collect();
+        f1_ids.sort();
+        assert_eq!(f1_ids, vec!["obj1".to_string(), "obj2".to_string()]);
+
+        let f2 = query_objects_for_file(&conn, "f2").unwrap();
+        assert_eq!(f2.len(), 1);
+        assert_eq!(f2[0].id, "obj3");
+        assert_eq!(f2[0].indexer_url, "https://a.com");
+
+        // Every sealed field round-trips with its distinct fixture value.
+        let sealed = &f2[0].sealed;
+        assert_eq!(sealed.encrypted_data_key, vec![0x11, 0x12]);
+        assert_eq!(sealed.encrypted_metadata_key, vec![0x31, 0x32]);
+        assert_eq!(sealed.encrypted_metadata, vec![0x41, 0x42]);
+        assert_eq!(
+            sealed.data_signature,
+            Signature::try_from(&[0x21u8; 64][..]).unwrap()
+        );
+        assert_eq!(
+            sealed.metadata_signature,
+            Signature::try_from(&[0x51u8; 64][..]).unwrap()
+        );
+        assert_eq!(sealed.created_at.timestamp_millis(), 1000);
+        assert_eq!(sealed.updated_at.timestamp_millis(), 2000);
+    }
+
+    #[test]
+    fn upsert_many_objects_empty_is_noop() {
+        let conn = migrated_conn();
+        upsert_many_objects(&conn, &[], NeedsSyncUp::Set).unwrap();
+        assert!(query_objects_for_file(&conn, "f1").unwrap().is_empty());
+    }
+
+    #[test]
+    fn upsert_many_objects_on_conflict_refreshes_fields_without_duplicating() {
+        let conn = migrated_conn();
+        seed_file(&conn, "f1");
+        upsert_many_objects(
+            &conn,
+            &[make_local_object("f1", "https://a.com", "obj1")],
+            NeedsSyncUp::Set,
+        )
+        .unwrap();
+        // Same (indexerURL, id) with changed sealed fields: the DO UPDATE SET must
+        // refresh every column, not insert a second row.
+        let mut changed = make_local_object("f1", "https://a.com", "obj1");
+        changed.sealed.encrypted_data_key = vec![0x99];
+        changed.sealed.encrypted_metadata = vec![0x98];
+        changed.sealed.updated_at = Utc.timestamp_millis_opt(9000).unwrap();
+        upsert_many_objects(&conn, &[changed], NeedsSyncUp::Set).unwrap();
+
+        assert_eq!(count_objects_for_file(&conn, "f1").unwrap(), 1);
+        let read = &query_objects_for_file(&conn, "f1").unwrap()[0];
+        assert_eq!(read.sealed.encrypted_data_key, vec![0x99]);
+        assert_eq!(read.sealed.encrypted_metadata, vec![0x98]);
+        assert_eq!(read.sealed.updated_at.timestamp_millis(), 9000);
+    }
+
+    #[test]
+    fn upsert_many_objects_with_leave_preserves_conflicting_pending_flag() {
+        let conn = migrated_conn();
+        seed_file(&conn, "f1");
+        upsert_many_objects(
+            &conn,
+            &[make_local_object("f1", "https://a.com", "obj1")],
+            NeedsSyncUp::Set,
+        )
+        .unwrap();
+        assert_eq!(read_needs_sync_up(&conn, "obj1", "https://a.com"), 1);
+
+        upsert_many_objects(
+            &conn,
+            &[make_local_object("f1", "https://a.com", "obj1")],
+            NeedsSyncUp::Leave,
+        )
+        .unwrap();
+        assert_eq!(read_needs_sync_up(&conn, "obj1", "https://a.com"), 1);
+    }
+
+    #[test]
+    fn upsert_many_objects_with_clear_clears_conflicting_flag() {
+        let conn = migrated_conn();
+        seed_file(&conn, "f1");
+        upsert_many_objects(
+            &conn,
+            &[make_local_object("f1", "https://a.com", "obj1")],
+            NeedsSyncUp::Set,
+        )
+        .unwrap();
+        upsert_many_objects(
+            &conn,
+            &[make_local_object("f1", "https://a.com", "obj1")],
+            NeedsSyncUp::Clear,
+        )
+        .unwrap();
+        assert_eq!(read_needs_sync_up(&conn, "obj1", "https://a.com"), 0);
+    }
+
+    // Leave on a FRESH insert (no conflicting row) defaults the flag to clean.
+    #[test]
+    fn upsert_many_objects_with_leave_inserts_fresh_rows_clean() {
+        let conn = migrated_conn();
+        seed_file(&conn, "f1");
+        upsert_many_objects(
+            &conn,
+            &[make_local_object("f1", "https://a.com", "obj1")],
+            NeedsSyncUp::Leave,
+        )
+        .unwrap();
+        assert_eq!(read_needs_sync_up(&conn, "obj1", "https://a.com"), 0);
+    }
+
+    #[test]
+    fn upsert_object_inserts_flagged_and_round_trips() {
+        let conn = migrated_conn();
+        seed_file(&conn, "f1");
+        upsert_object(&conn, &make_local_object("f1", "https://a.com", "obj1")).unwrap();
+        assert_eq!(read_needs_sync_up(&conn, "obj1", "https://a.com"), 1);
+
+        // upsert_object binds its own 11-column statement (separate from
+        // upsert_many_objects), so its fields round-trip too.
+        let read = &query_objects_for_file(&conn, "f1").unwrap()[0];
+        assert_eq!(read.indexer_url, "https://a.com");
+        let sealed = &read.sealed;
+        assert_eq!(sealed.encrypted_data_key, vec![0x11, 0x12]);
+        assert_eq!(sealed.encrypted_metadata_key, vec![0x31, 0x32]);
+        assert_eq!(sealed.encrypted_metadata, vec![0x41, 0x42]);
+        assert_eq!(
+            sealed.data_signature,
+            Signature::try_from(&[0x21u8; 64][..]).unwrap()
+        );
+        assert_eq!(
+            sealed.metadata_signature,
+            Signature::try_from(&[0x51u8; 64][..]).unwrap()
+        );
+        assert_eq!(sealed.created_at.timestamp_millis(), 1000);
+        assert_eq!(sealed.updated_at.timestamp_millis(), 2000);
+    }
+
+    #[test]
+    fn clear_object_if_unchanged_clears_only_when_files_updated_at_matches() {
+        let conn = migrated_conn();
+        // The compare-and-swap clear keys off files.updatedAt: seed a non-zero clock.
+        seed_file_with_name_and_updated_at(&conn, "f1", "", 5000);
+        upsert_object(&conn, &make_local_object("f1", "https://a.com", "obj1")).unwrap();
+        assert_eq!(read_needs_sync_up(&conn, "obj1", "https://a.com"), 1);
+
+        // Stale expectation (file's live updatedAt is 5000, not 4000): no-op.
+        clear_object_if_unchanged(&conn, "obj1", "https://a.com", 4000).unwrap();
+        assert_eq!(read_needs_sync_up(&conn, "obj1", "https://a.com"), 1);
+
+        clear_object_if_unchanged(&conn, "obj1", "https://a.com", 5000).unwrap();
+        assert_eq!(read_needs_sync_up(&conn, "obj1", "https://a.com"), 0);
+    }
+
+    #[test]
+    fn clear_objects_clears_unconditionally() {
+        let conn = migrated_conn();
+        seed_file(&conn, "f1");
+        upsert_object(&conn, &make_local_object("f1", "https://a.com", "obj1")).unwrap();
+        upsert_object(&conn, &make_local_object("f1", "https://a.com", "obj2")).unwrap();
+        // Same id under a different indexer must not be cleared (indexer-scoped).
+        upsert_object(&conn, &make_local_object("f1", "https://b.com", "obj1")).unwrap();
+
+        clear_objects(&conn, "https://a.com", &["obj1".into()]).unwrap();
+
+        assert_eq!(read_needs_sync_up(&conn, "obj1", "https://a.com"), 0);
+        assert_eq!(read_needs_sync_up(&conn, "obj2", "https://a.com"), 1);
+        assert_eq!(read_needs_sync_up(&conn, "obj1", "https://b.com"), 1);
+    }
+
+    #[test]
+    fn clear_objects_empty_is_noop() {
+        let conn = migrated_conn();
+        seed_file(&conn, "f1");
+        upsert_object(&conn, &make_local_object("f1", "https://a.com", "obj1")).unwrap();
+        clear_objects(&conn, "https://a.com", &[]).unwrap();
+        assert_eq!(read_needs_sync_up(&conn, "obj1", "https://a.com"), 1);
+    }
+
+    #[test]
+    fn flag_all_objects_flags_every_object() {
+        let conn = migrated_conn();
+        seed_file(&conn, "f1");
+        // Insert via upsert with NeedsSyncUp::Clear so both start cleared.
+        upsert_many_objects(
+            &conn,
+            &[
+                make_local_object("f1", "https://a.com", "obj1"),
+                make_local_object("f1", "https://b.com", "obj2"),
+            ],
+            NeedsSyncUp::Clear,
+        )
+        .unwrap();
+        assert_eq!(read_needs_sync_up(&conn, "obj1", "https://a.com"), 0);
+        assert_eq!(read_needs_sync_up(&conn, "obj2", "https://b.com"), 0);
+
+        flag_all_objects(&conn).unwrap();
+
+        assert_eq!(read_needs_sync_up(&conn, "obj1", "https://a.com"), 1);
+        assert_eq!(read_needs_sync_up(&conn, "obj2", "https://b.com"), 1);
+    }
+
+    #[test]
+    fn flag_objects_for_files_sets_needs_sync_up() {
+        let conn = migrated_conn();
+        seed_file(&conn, "f1");
+        seed_file(&conn, "f2");
+        // Both start clean (needsSyncUp = 0) via NeedsSyncUp::Clear.
+        upsert_many_objects(
+            &conn,
+            &[
+                make_local_object("f1", "https://a.com", "obj1"),
+                make_local_object("f2", "https://a.com", "obj2"),
+            ],
+            NeedsSyncUp::Clear,
+        )
+        .unwrap();
+        assert_eq!(read_needs_sync_up(&conn, "obj1", "https://a.com"), 0);
+        assert_eq!(read_needs_sync_up(&conn, "obj2", "https://a.com"), 0);
+
+        flag_objects_for_files(&conn, &["f1".into()]).unwrap();
+
+        // f1's object is flagged; f2's object (a different file) stays clean.
+        assert_eq!(read_needs_sync_up(&conn, "obj1", "https://a.com"), 1);
+        assert_eq!(read_needs_sync_up(&conn, "obj2", "https://a.com"), 0);
+    }
+
+    #[test]
+    fn query_sync_up_objects_returns_only_flagged_ordered_by_id() {
+        let conn = migrated_conn();
+        seed_file_with_name_and_updated_at(&conn, "f1", "name1", 7000);
+        seed_file_with_name_and_updated_at(&conn, "f2", "name2", 8000);
+        // obj_b and obj_a are flagged for https://a.com; obj_c is cleared; obj_z
+        // is on a different indexer.
+        upsert_object(&conn, &make_local_object("f1", "https://a.com", "obj_b")).unwrap();
+        upsert_object(&conn, &make_local_object("f2", "https://a.com", "obj_a")).unwrap();
+        upsert_many_objects(
+            &conn,
+            &[make_local_object("f1", "https://a.com", "obj_c")],
+            NeedsSyncUp::Clear,
+        )
+        .unwrap();
+        upsert_object(&conn, &make_local_object("f1", "https://b.com", "obj_z")).unwrap();
+
+        let rows = query_sync_up_objects(&conn, "https://a.com", 10).unwrap();
+        // Only the two flagged a.com objects, ORDER BY o.id → obj_a before obj_b.
+        let ids: Vec<String> = rows.iter().map(|r| r.object_id.clone()).collect();
+        assert_eq!(ids, vec!["obj_a".to_string(), "obj_b".to_string()]);
+        assert_eq!(rows[0].file_id, "f2");
+        assert_eq!(rows[0].file_name, "name2");
+        assert_eq!(rows[0].file_updated_at, 8000);
+        assert_eq!(rows[0].deleted_at, None);
+        assert_eq!(rows[1].file_id, "f1");
+        assert_eq!(rows[1].file_name, "name1");
+        assert_eq!(rows[1].file_updated_at, 7000);
+
+        // LIMIT bounds the work items.
+        let limited = query_sync_up_objects(&conn, "https://a.com", 1).unwrap();
+        assert_eq!(limited.len(), 1);
+        assert_eq!(limited[0].object_id, "obj_a");
+    }
+
+    #[test]
+    fn count_sync_up_objects_counts_flagged_per_indexer() {
+        let conn = migrated_conn();
+        seed_file(&conn, "f1");
+        upsert_object(&conn, &make_local_object("f1", "https://a.com", "obj1")).unwrap();
+        upsert_object(&conn, &make_local_object("f1", "https://a.com", "obj2")).unwrap();
+        upsert_many_objects(
+            &conn,
+            &[make_local_object("f1", "https://a.com", "obj3")],
+            NeedsSyncUp::Clear,
+        )
+        .unwrap();
+        upsert_object(&conn, &make_local_object("f1", "https://b.com", "obj4")).unwrap();
+
+        assert_eq!(count_sync_up_objects(&conn, "https://a.com").unwrap(), 2);
+        assert_eq!(count_sync_up_objects(&conn, "https://b.com").unwrap(), 1);
+    }
+
+    #[test]
+    fn delete_many_objects_by_ids_only_targets_matching_indexer() {
+        let conn = migrated_conn();
+        seed_file(&conn, "f1");
+        upsert_object(&conn, &make_local_object("f1", "https://a.com", "shared")).unwrap();
+        upsert_object(&conn, &make_local_object("f1", "https://b.com", "shared")).unwrap();
+        assert_eq!(count_objects_for_file(&conn, "f1").unwrap(), 2);
+
+        delete_many_objects_by_ids(&conn, &["shared".into()], "https://a.com").unwrap();
+
+        // Only the a.com row is gone; the b.com row with the same id survives.
+        let remaining = query_object_refs_for_file(&conn, "f1").unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].id, "shared");
+        assert_eq!(remaining[0].indexer_url, "https://b.com");
+    }
+
+    #[test]
+    fn delete_many_objects_by_ids_empty_is_noop() {
+        let conn = migrated_conn();
+        seed_file(&conn, "f1");
+        upsert_object(&conn, &make_local_object("f1", "https://a.com", "obj1")).unwrap();
+        delete_many_objects_by_ids(&conn, &[], "https://a.com").unwrap();
+        assert_eq!(count_objects_for_file(&conn, "f1").unwrap(), 1);
+    }
+
+    #[test]
+    fn delete_object_only_targets_matching_indexer() {
+        // delete_object binds both id and indexerURL, so the b.com row with the
+        // same id must survive.
+        let conn = migrated_conn();
+        seed_file(&conn, "f1");
+        upsert_object(&conn, &make_local_object("f1", "https://a.com", "shared")).unwrap();
+        upsert_object(&conn, &make_local_object("f1", "https://b.com", "shared")).unwrap();
+        assert_eq!(count_objects_for_file(&conn, "f1").unwrap(), 2);
+
+        delete_object(&conn, "shared", "https://a.com").unwrap();
+
+        let remaining = query_object_refs_for_file(&conn, "f1").unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].id, "shared");
+        assert_eq!(remaining[0].indexer_url, "https://b.com");
+    }
+
+    #[test]
+    fn query_files_with_no_objects_returns_files_lacking_objects() {
+        let conn = migrated_conn();
+        seed_file(&conn, "f1");
+        seed_file(&conn, "f2");
+        seed_file(&conn, "f3");
+        upsert_object(&conn, &make_local_object("f1", "https://a.com", "obj1")).unwrap();
+
+        let mut result =
+            query_files_with_no_objects(&conn, &["f1".into(), "f2".into(), "f3".into()]).unwrap();
+        result.sort();
+        assert_eq!(result, vec!["f2".to_string(), "f3".to_string()]);
+    }
+
+    #[test]
+    fn query_files_with_no_objects_empty_input_returns_empty() {
+        let conn = migrated_conn();
+        let result = query_files_with_no_objects(&conn, &[]).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn delete_objects_for_file_deletes_all_objects_for_a_file() {
+        let conn = migrated_conn();
+        seed_file(&conn, "f1");
+        upsert_object(&conn, &make_local_object("f1", "https://a.com", "obj1")).unwrap();
+        upsert_object(&conn, &make_local_object("f1", "https://b.com", "obj2")).unwrap();
+
+        delete_objects_for_file(&conn, "f1").unwrap();
+        assert!(query_object_refs_for_file(&conn, "f1").unwrap().is_empty());
+    }
+
+    #[test]
+    fn delete_many_objects_for_files_batch_deletes_across_files_leaving_f3() {
+        let conn = migrated_conn();
+        seed_file(&conn, "f1");
+        seed_file(&conn, "f2");
+        seed_file(&conn, "f3");
+        upsert_object(&conn, &make_local_object("f1", "https://a.com", "obj1")).unwrap();
+        upsert_object(&conn, &make_local_object("f2", "https://a.com", "obj2")).unwrap();
+        upsert_object(&conn, &make_local_object("f3", "https://a.com", "obj3")).unwrap();
+
+        delete_many_objects_for_files(&conn, &["f1".into(), "f2".into()]).unwrap();
+
+        assert!(query_object_refs_for_file(&conn, "f1").unwrap().is_empty());
+        assert!(query_object_refs_for_file(&conn, "f2").unwrap().is_empty());
+        assert_eq!(query_object_refs_for_file(&conn, "f3").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn delete_many_objects_for_files_empty_is_noop() {
+        let conn = migrated_conn();
+        seed_file(&conn, "f1");
+        upsert_object(&conn, &make_local_object("f1", "https://a.com", "obj1")).unwrap();
+        delete_many_objects_for_files(&conn, &[]).unwrap();
+        assert_eq!(count_objects_for_file(&conn, "f1").unwrap(), 1);
+    }
+
+    #[test]
+    fn flag_objects_for_files_empty_is_noop() {
+        let conn = migrated_conn();
+        seed_file(&conn, "f1");
+        upsert_many_objects(
+            &conn,
+            &[make_local_object("f1", "https://a.com", "obj1")],
+            NeedsSyncUp::Clear,
+        )
+        .unwrap();
+        flag_objects_for_files(&conn, &[]).unwrap();
+        assert_eq!(read_needs_sync_up(&conn, "obj1", "https://a.com"), 0);
+    }
+}

--- a/crates/sia-storage-core/src/encoding.rs
+++ b/crates/sia-storage-core/src/encoding.rs
@@ -1,1 +1,2 @@
+pub mod slabs;
 pub mod timestamp;

--- a/crates/sia-storage-core/src/encoding/slabs.rs
+++ b/crates/sia-storage-core/src/encoding/slabs.rs
@@ -1,0 +1,141 @@
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+use sia_storage::{EncryptionKey, Hash256, PublicKey, Sector, Slab};
+
+/// The stored form of a sector: Merkle root and host key as their string encodings.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct StoredSector {
+    root: String,
+    host_key: String,
+}
+
+/// The stored form of a slab: encryption key hex, sectors as strings. The exact shape the shared
+/// database expects, so the SDK types are converted through this rather than serialized directly
+/// (the SDK's own serde is base64 / `ed25519:`-prefixed and would not match on disk).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct StoredSlab {
+    encryption_key: String,
+    min_shards: u8,
+    sectors: Vec<StoredSector>,
+    offset: u32,
+    length: u32,
+}
+
+fn slab_to_stored(slab: &Slab) -> StoredSlab {
+    StoredSlab {
+        encryption_key: hex::encode(slab.encryption_key.as_ref()),
+        min_shards: slab.min_shards,
+        sectors: slab
+            .sectors
+            .iter()
+            .map(|s| StoredSector {
+                root: s.root.to_string(),
+                host_key: s.host_key.to_string(),
+            })
+            .collect(),
+        offset: slab.offset,
+        length: slab.length,
+    }
+}
+
+fn slab_from_stored(stored: StoredSlab) -> Option<Slab> {
+    let key: [u8; 32] = hex::decode(&stored.encryption_key).ok()?.try_into().ok()?;
+    let sectors = stored
+        .sectors
+        .into_iter()
+        .map(|s| {
+            Some(Sector {
+                root: Hash256::from_str(&s.root).ok()?,
+                host_key: PublicKey::from_str(&s.host_key).ok()?,
+            })
+        })
+        .collect::<Option<Vec<Sector>>>()?;
+    Some(Slab {
+        encryption_key: EncryptionKey::from(key),
+        min_shards: stored.min_shards,
+        sectors,
+        offset: stored.offset,
+        length: stored.length,
+    })
+}
+
+pub fn slabs_to_storage_string(slabs: &[Slab]) -> String {
+    let stored: Vec<StoredSlab> = slabs.iter().map(slab_to_stored).collect();
+    serde_json::to_string(&stored).expect("slab storage serializes")
+}
+
+/// Decode a JSON slab list. Returns `None` on malformed JSON or a bad slab (bad hex, bad
+/// root/key) so the caller can reject a corrupt row rather than load empty slabs.
+pub fn slabs_from_storage_string(stored: &str) -> Option<Vec<Slab>> {
+    let items: Vec<StoredSlab> = serde_json::from_str(stored).ok()?;
+    items.into_iter().map(slab_from_stored).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_slab() -> Slab {
+        Slab {
+            encryption_key: EncryptionKey::from([0xab; 32]),
+            min_shards: 10,
+            sectors: vec![Sector {
+                root: Hash256::from_str(&"cd".repeat(32)).unwrap(),
+                host_key: PublicKey::from_str(&format!("ed25519:{}", "ef".repeat(32))).unwrap(),
+            }],
+            offset: 0,
+            length: 4_194_304,
+        }
+    }
+
+    #[test]
+    fn round_trip_via_storage() {
+        let original = sample_slab();
+        let s = slabs_to_storage_string(std::slice::from_ref(&original));
+        let back = slabs_from_storage_string(&s).unwrap();
+        assert_eq!(back.len(), 1);
+        assert_eq!(
+            back[0].encryption_key.as_ref(),
+            original.encryption_key.as_ref()
+        );
+        assert_eq!(back[0].min_shards, original.min_shards);
+        assert_eq!(back[0].sectors[0].root, original.sectors[0].root);
+        assert_eq!(back[0].sectors[0].host_key, original.sectors[0].host_key);
+        assert_eq!(back[0].offset, original.offset);
+        assert_eq!(back[0].length, original.length);
+    }
+
+    // The exact on-disk bytes: hex key, camelCase, bare-hex root, ed25519-prefixed host key.
+    #[test]
+    fn storage_string_field_shape_is_stable() {
+        let s = slabs_to_storage_string(std::slice::from_ref(&sample_slab()));
+        let expected = format!(
+            r#"[{{"encryptionKey":"{}","minShards":10,"sectors":[{{"root":"{}","hostKey":"ed25519:{}"}}],"offset":0,"length":4194304}}]"#,
+            "ab".repeat(32),
+            "cd".repeat(32),
+            "ef".repeat(32),
+        );
+        assert_eq!(s, expected);
+    }
+
+    #[test]
+    fn invalid_json_returns_none() {
+        assert!(slabs_from_storage_string("not json").is_none());
+    }
+
+    #[test]
+    fn one_bad_root_returns_none() {
+        let json = format!(
+            r#"[{{"encryptionKey":"{}","minShards":1,"sectors":[{{"root":"nothex","hostKey":"ed25519:{}"}}],"offset":0,"length":1}}]"#,
+            "ab".repeat(32),
+            "ef".repeat(32),
+        );
+        assert!(
+            slabs_from_storage_string(&json).is_none(),
+            "a bad sector root must reject the whole list"
+        );
+    }
+}

--- a/crates/sia-storage-core/src/lib.rs
+++ b/crates/sia-storage-core/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod db;
 pub mod encoding;
+pub mod types;

--- a/crates/sia-storage-core/src/types.rs
+++ b/crates/sia-storage-core/src/types.rs
@@ -1,0 +1,1 @@
+pub mod local_object;

--- a/crates/sia-storage-core/src/types/local_object.rs
+++ b/crates/sia-storage-core/src/types/local_object.rs
@@ -1,0 +1,22 @@
+use chrono::{DateTime, Utc};
+use sia_storage::SealedObject;
+
+/// The local representation of a file's object on the indexer.
+#[derive(Debug, Clone)]
+pub struct LocalObject {
+    pub id: String,
+    pub file_id: String,
+    pub indexer_url: String,
+    pub sealed: SealedObject,
+}
+
+/// Slim reference form: identity + indexer + timestamps; omits the heavy
+/// crypto/slab fields.
+#[derive(Debug, Clone)]
+pub struct LocalObjectRef {
+    pub id: String,
+    pub file_id: String,
+    pub indexer_url: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}


### PR DESCRIPTION
The local object store: each file's indexer objects (slabs, encrypted keys and metadata, data and metadata signatures) plus the per-object `needsSyncUp` dirty flag that drives sync-up. The primary key is `(indexerURL, id)`, so the same object under two indexers is two rows and every delete is indexer-scoped. The app pins to one indexer today, so multi-indexer is a schema capability the store keeps clean, not something the UX drives yet.

This PR also brings the types it operates on, since it is their only consumer: `LocalObject` (the SDK's `SealedObject` plus `id`/`file_id`/`indexer_url`), its slim `LocalObjectRef` projection, and the slab storage codec (`StoredSlab`/`StoredSector`, converting the SDK `Slab`/`Sector` to and from the exact on-disk JSON). A row that won't decode (bad hex, bad slab JSON, bad signature) fails the read rather than loading a blanked object.

```rust
db.transaction(|tx| upsert_object(tx, &object)).await?;
let objects = db.transaction(|tx| query_objects_for_file(tx, &file_id)).await?;
```

Overview of where every op is used:

Reads (listing, file detail, download, share):

- `query_object_refs_for_file`: lightweight refs (id, indexer, timestamps, no slabs/crypto), for building a file record and resolving thumbnail parents.
- `query_object_refs_for_files`: the same refs in bulk, keyed by file id, for loading a whole listing at once.
- `query_objects_for_file`: full objects with slabs and crypto, for download (needs the slabs), share, and the file-detail advanced panel.
- `count_objects_for_file`: object count for a file across all indexers.

Create and upload:

- `upsert_object`: upsert one row, inserted dirty so the next sync-up reconciles it, for the single-transaction create-file and add-version paths.
- `upsert_many_objects`: bulk upsert carrying the `NeedsSyncUp` mode. The post-upload batch write passes `Set`; sync-down apply passes `Leave` to keep a conflicting row's pending flag (a plain replace would reset it).

Local mutation (rename, move, tags, trash, re-push metadata):

- `flag_objects_for_files`: mark a file's objects dirty so sync-up re-pushes them, the entry point for every local mutation (rename, move, edit metadata, add-version, tag add/remove, trash and restore).
- `flag_all_objects`: flag every object dirty. For triggering a full resync, only for advanced debugging.

Sync-up:

- `query_sync_up_objects`: one bounded batch of dirty objects at an indexer, joined to their file for the push payload (name, edit clock, deletedAt to route delete-vs-push).
- `count_sync_up_objects`: dirty count at an indexer, for the sync-up progress total and the remaining-zero stop check.
- `clear_object_if_unchanged`: compare-and-swap clear against the file's `updatedAt` after a successful push, so an edit that lands mid-round-trip stays flagged for the next pass.
- `delete_object`: delete one row scoped to (id, indexer), used when a pushed object's file is deleted, to drop the local row after the delete goes out.

Sync-down:

- `clear_objects`: clear the flag on specific objects, indexer-scoped, for the remote-newer winners in a sync-down.
- `delete_many_objects_by_ids`: bulk delete by id scoped to one indexer, for a remote delete batch.
- `query_files_with_no_objects`: of the given file ids, those left with no object rows, run after a delete batch to find files to tombstone and clean up.

Bulk delete and cleanup:

- `delete_objects_for_file`: every object row for one file, any indexer.
- `delete_many_objects_for_files`: every object row for many files in one statement.

The `NeedsSyncUp` mode (`Set` / `Leave` / `Clear`) is available on upserts because sync-up and sync-down need different on-conflict behavior for the flag.
